### PR TITLE
Fix endpoint for RDS in us-east-1

### DIFF
--- a/botocore/data/aws/_services.json
+++ b/botocore/data/aws/_services.json
@@ -157,7 +157,7 @@
         },
         "rds": {
             "regions": {
-                "us-east-1": null,
+                "us-east-1": "https://rds.amazonaws.com",
                 "ap-northeast-1": null,
                 "sa-east-1": null,
                 "ap-southeast-1": null,


### PR DESCRIPTION
RDS uses an odd endpoint for us-east-1.  Update the service mapping

(awscli)[jeremy@bespin ~]$ aws --region us-east-1 rds describe-db-security-groups 
hostname 'rds.us-east-1.amazonaws.com' doesn't match u'rds.amazonaws.com'
