### PR TITLE
Assign the CloudWatch API endpoint URLs.

### DIFF
--- a/botocore/data/aws/_services.json
+++ b/botocore/data/aws/_services.json
@@ -39,15 +39,15 @@
         },
         "cloudwatch": {
             "regions": {
-                "us-east-1": null,
-                "ap-northeast-1": null,
-                "sa-east-1": null,
-                "ap-southeast-1": null,
-                "ap-southeast-2": null,
-                "us-west-2": null,
-                "us-west-1": null,
-                "eu-west-1": null,
-		"us-gov-west-1": null
+                "us-east-1": "https://monitoring.us-east-1.amazonaws.com",
+                "ap-northeast-1": "https://monitoring.ap-northeast-1.amazonaws.com",
+                "sa-east-1": "https://monitoring.sa-east-1.amazonaws.com",
+                "ap-southeast-1": "https://monitoring.ap-southeast-1.amazonaws.com",
+                "ap-southeast-2": "https://monitoring.ap-southeast-2.amazonaws.com",
+                "us-west-2": "https://monitoring.us-west-2.amazonaws.com",
+                "us-west-1": "https://monitoring.us-west-1.amazonaws.com",
+                "eu-west-1": "https://monitoring.eu-west-1.amazonaws.com",
+		"us-gov-west-1": "https://monitoring.us-gov-west-1.amazonaws.com"
             },
             "authentication": "sigv2",
             "protocols": [


### PR DESCRIPTION
This fix is to avoid not to connect to the wrong URLs like
cloudwatch.ap-northeast-1.awsamazon.com but to connect to
the right URLs like monitoring.ap-northeast-1.awsamazon.com.
