### PR TITLE
Change XML name of tags to match EC2 documentation

### DIFF
--- a/botocore/data/aws/ec2.json
+++ b/botocore/data/aws/ec2.json
@@ -3542,7 +3542,7 @@
                 }
               },
               "documentation": "\n    <p>\n    Represents metadata to associate with Amazon EC2 resources.\n    Each tag consists of a user-defined key and value.\n    Use tags to categorize EC2 resources, such as by purpose,\n    owner, or environment.\n    </p>\n   ",
-              "xmlname": "Item"
+              "xmlname": "Tag"
             },
             "documentation": "\n    <p>\n    The tags to add or overwrite for the specified resources. Each tag item consists of a key-value pair.\n    </p>\n   ",
             "required": true,


### PR DESCRIPTION
Change the XML name of tags to `Tag` from `Item`.

I'm using botocore through aws-cli and found that CreateTags didn't work. It set the tag URL parameter to be Item.1.Key rather than Tag.1.Key as it should be.
