### PR TITLE
Removed presumably redundant/outdated attributes of directconnect. 

### DIFF
--- a/botocore/data/aws/_services.json
+++ b/botocore/data/aws/_services.json
@@ -56,22 +56,20 @@
             "name": "Cloudwatch",
             "api_version": "2010-08-01"
         },
-	"directconnect": {
-	      "name": "AWS Direct Connect Overture Service",
-	      "short_name": "directconnect",
-	      "authentication": "sigv4",
-  	      "type": "json",
-  	      "api_version": "2012-10-25",
-  	      "regions": {
-    	          "us-east-1": null,
-    		  "eu-west-1": null,
-    		  "us-west-1": null,
-    		  "sa-east-1": null,
-    		  "ap-northeast-1": null,
-    		  "ap-southeast-1": null
+        "directconnect": {
+              "regions": {
+                  "us-east-1": null,
+                  "eu-west-1": null,
+                  "us-west-1": null,
+                  "sa-east-1": null,
+                  "ap-northeast-1": null,
+                  "ap-southeast-1": null
               },
-  	      "protocols": ["https"]
-  	  },
+              "authentication": "sigv4",
+              "protocols": ["https"],
+              "name": "Direct Connect",
+              "api_version": "2012-10-25"
+        },
         "ec2": {
             "regions": {
                 "us-east-1": null,


### PR DESCRIPTION
This is a bit out of thin air, but both attributes _short_name_ and _type_ are only listed for _Direct Connect_ and are implied in the resource name and format respectively.

While at it, I've rearranged the attribute order to match the apparently canonical one in place with all other services.

Also, I've replaced the apparently accidental tabs sprinkled in there (sorry for the resulting diff readability, but it seemed odd to split that into a separate pull request).

Finally, I've adjusted the name from _AWS Direct Connect Overture Service_ to just _Direct Connect_, i.e. matching the official name without the AWS/Amazon prefix, similar to all other services.
