### PR TITLE
Ensure HTTP 200 response when querying instance meta-data for IAMs role

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -54,7 +54,7 @@ def _search_md(url='http://169.254.169.254/latest/meta-data/iam/'):
     d = {}
     try:
         r = requests.get(url, timeout=.1)
-        if r.content:
+        if r.status_code == 200 and r.content:
             fields = r.content.split('\n')
             for field in fields:
                 if field.endswith('/'):


### PR DESCRIPTION
When botocore looks for credentials it queries the AWS meta-data service over HTTP. If the instance doesn't have an IAMs role, this will return a 404 and cause an exception.

The fix is to check the response for a 200 first.

The symptoms for this were mentioned in issue #12.
