### PR TITLE
Fix a bug that some XML element values are parsed as empty string.

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -39,7 +39,7 @@ _first_cap_regex = re.compile('(.)([A-Z][a-z]+)')
 _number_cap_regex = re.compile('([a-z])([0-9]+)')
 _end_cap_regex = re.compile('([a-z0-9])([A-Z])')
 
-ScalarTypes = ('string', 'integer', 'boolean', 'timestamp', 'float')
+ScalarTypes = ('string', 'integer', 'boolean', 'timestamp', 'float', 'double')
 
 
 def xform_name(name, sep='_'):


### PR DESCRIPTION
XML element that defined as a type of double is not correctly parsed.
This is because Element.set_value does not recognize the 'double' element type definition.

To reproduce this bug, execute "aws rds describe-reserved-db-instances-offerings" on aws-cli
and see 'FixedPrice' value is empty.
