### PR TITLE
Fixes list parameter's label on building queries.

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -242,12 +242,12 @@ class ListParameter(Parameter):
                     label = member_type.xmlname
             else:
                 if label:
-                    label = label.format(label=self.get_label)
+                    label = label.format(label=self.get_label())
                 else:
                     label = self.get_label()
         else:
             if label:
-                label.format(label=self.get_label())
+                label = label.format(label=self.get_label())
             else:
                 label = self.get_label()
             label = '%s.%s' % (label, 'member')


### PR DESCRIPTION
On botocore-0.5.3, `cloudwarch.put_metrics_data.call` returns `<HttpResponse 400>`.
Because there are no label for `Dimensions`.
