### PR TITLE
Improve parsing of JSON and XML parsers by passing the encoding directly...

### DIFF
--- a/tests/unit/response_parsing/test_response_parsing.py
+++ b/tests/unit/response_parsing/test_response_parsing.py
@@ -37,7 +37,7 @@ def test_response_parsing():
             fp = open(xmlfile)
             xml = fp.read()
             fp.close()
-            r.parse(xml)
+            r.parse(xml, 'utf-8')
             # This is a little convenience when creating new tests.
             # You just have to drop the XML file into the data directory
             # and then, if not JSON file is present, this code will


### PR DESCRIPTION
... to the parsers.

This fixes an issue with JSON parser on Python3, but also utilizes the corresponding parser's encoding features.
