### PR TITLE
Don't look at region vars for global endpoints

### DIFF
--- a/botocore/service.py
+++ b/botocore/service.py
@@ -94,7 +94,7 @@ class Service(object):
             computed endpoint name with this parameter.
         """
         if region_name is None:
-            if self.global_endpoint and not self.session.profile:
+            if self.global_endpoint:
                 endpoint_url = self.build_endpoint_url(self.global_endpoint,
                                                        is_secure)
                 region_name = 'us-east-1'

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+import unittest
+import botocore.session
+
+
+class TestService(unittest.TestCase):
+
+    def setUp(self):
+        self.session = botocore.session.get_session()
+
+    def test_get_endpoint_with_no_region(self):
+        # Test global endpoint service such as iam.
+        self.session.profile = 'default'
+        service = self.session.get_service('iam')
+        endpoint = service.get_endpoint()
+        self.assertEqual(endpoint.host, 'https://iam.amazonaws.com/')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If a profile is specified, then trying to access a global endpoint
will result in an exception about the endpoint either not being valid,
or if a profile doesn't have a region, then it will complain that
there's no region set for the instance.

An example of how a user can encounter this:
- Have a default region of us-west-2 via `export AWS_DEFAULT_REGION=us-west-2`
- Have a config file with a profile that just has access/secret keys (no region var):

```
[profile production]
aws_access_key_id =foo
aws_secret_access_key=bar
```

Trying to access a global endpoint such as IAM works without a profile specified:

```
$ aws iam list-groups
[ ... response ...]
```

But if you specify a profile you can an error:

```
$ aws --profile production iam list-groups
Service iam not available in region us-west-2
```

This PR fixes this last case.
