### PR TITLE
Raise ProfileNotFound if explicit profile does not exist

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -35,7 +35,7 @@ import botocore.config
 import botocore.credentials
 import botocore.base
 import botocore.service
-from botocore.exceptions import ConfigNotFound, EventNotFound
+from botocore.exceptions import ConfigNotFound, EventNotFound, ProfileNotFound
 from botocore.hooks import HierarchicalEmitter, first_non_none_response
 from botocore import __version__
 from botocore import handlers
@@ -54,7 +54,7 @@ is the formatting string used to construct a new event.
 
 
 EnvironmentVariables = {
-    'profile': (None, 'BOTO_DEFAULT_PROFILE', 'default'),
+    'profile': (None, 'BOTO_DEFAULT_PROFILE', None),
     'region': ('region', 'BOTO_DEFAULT_REGION', None),
     'data_path': ('data_path', 'BOTO_DATA_PATH', None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config'),
@@ -233,15 +233,28 @@ class Session(object):
         Note that this configuration is specific to a single profile (the
         ``profile`` session variable).
 
+        If the ``profile`` session variable is set and the profile does
+        not exist in the config file, a ``ProfileNotFound`` exception
+        will be raised.
 
-        :raises: ConfigNotFound, ConfigParseError
+        :raises: ConfigNotFound, ConfigParseError, ProfileNotFound
         :rtype: dict
         """
         config = self.full_config
         profile_name = self.get_variable('profile')
-        if not profile_name:
-            profile_name = 'default'
-        return self._build_profile_map().get(profile_name, {})
+        profile_map = self._build_profile_map()
+        # If a profile is not explicitly set return the default
+        # profile config or an empty config dict if we don't have
+        # a default profile.
+        if profile_name is None:
+            return profile_map.get('default', {})
+        elif profile_name not in profile_map:
+            # Otherwise if they specified a profile, it has to
+            # exist (even if it's the default profile) otherwise
+            # we complain.
+            raise ProfileNotFound(profile=profile_name)
+        else:
+            return profile_map[profile_name]
 
     @property
     def full_config(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,7 +37,7 @@ class TestConfig(BaseEnvVar):
         super(TestConfig, self).setUp()
         self.env_vars = {
             'config_file': (None, 'FOO_CONFIG_FILE', None),
-            'profile': (None, 'FOO_DEFAULT_PROFILE', 'default'),
+            'profile': (None, 'FOO_DEFAULT_PROFILE', None),
         }
 
     def test_config_not_found(self):

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -31,7 +31,6 @@ class TestService(unittest.TestCase):
 
     def test_get_endpoint_with_no_region(self):
         # Test global endpoint service such as iam.
-        self.session.profile = 'default'
         service = self.session.get_service('iam')
         endpoint = service.get_endpoint()
         self.assertEqual(endpoint.host, 'https://iam.amazonaws.com/')


### PR DESCRIPTION
This accomdates these cases:

No --profile specified, use the default profile but don't error
if it doesn't exist.

If a --profile is specified, it has to exist or else we raise an
ProfileNotFound exception.  This includes the case where a user
explicitly says --profile default and the default profile does not
exist.  I've added tests for all three cases.

Additionally, I've changed the default value in the EnvironmentVariables
dict to have a None default value for the 'profile' var.  This is
consistent with how this is defined the the awscli.EnvironmentVariables
dict.  This resulted in me updating a testcase that specified its
own EnvironmentVariables dict.

This came about because of aws/aws-cli#133
