### PR TITLE
Clean up log messages

### DIFF
--- a/botocore/base.py
+++ b/botocore/base.py
@@ -82,7 +82,7 @@ _search_paths = []
 
 
 def _load_data(session, data_path):
-    logger.debug('Attempting to Load: %s' % data_path)
+    logger.debug('Attempting to load: %s', data_path)
     data = {}
     file_name = data_path + '.json'
     for path in get_search_path(session):
@@ -90,7 +90,7 @@ def _load_data(session, data_path):
         dir_path = os.path.join(path, data_path)
         # Is the path a directory?
         if os.path.isdir(dir_path):
-            logger.debug('Found data dir: %s' % dir_path)
+            logger.debug('Found data dir: %s', dir_path)
             try:
                 data = []
                 for pn in glob.glob(os.path.join(dir_path, '*.json')):
@@ -99,7 +99,7 @@ def _load_data(session, data_path):
                     if not fn.startswith('_'):
                         data.append(fn)
             except:
-                logger.error('Unable to load dir: %s' % dir_path,
+                logger.error('Unable to load dir: %s', dir_path,
                              exc_info=True)
             break
         elif os.path.isfile(file_path):
@@ -111,17 +111,17 @@ def _load_data(session, data_path):
                 else:
                     new_data = json.load(fp, object_pairs_hook=OrderedDict)
                 fp.close()
-                logger.debug('Found data file: %s' % file_path)
+                logger.debug('Found data file: %s', file_path)
                 if data is not None:
                     data.update(new_data)
                 else:
                     data = new_data
                 break
             except:
-                logger.error('Unable to load file: %s' % file_path,
+                logger.error('Unable to load file: %s', file_path,
                              exc_info=True)
         else:
-            logger.error('Unable to find file: %s' % file_path)
+            logger.error('Unable to find file: %s', file_path)
     if data:
         _data_cache[data_path] = data
     return data

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -84,7 +84,7 @@ def search_iam_role(**kwargs):
                                       metadata[role_name]['SecretAccessKey'],
                                       metadata[role_name]['Token'])
             credentials.method = 'iam-role'
-            logger.info('Found IAM Role: %s' % role_name)
+            logger.info('Found IAM Role: %s', role_name)
     return credentials
 
 
@@ -100,7 +100,7 @@ def search_environment(**kwargs):
     if access_key and secret_key:
         credentials = Credentials(access_key, secret_key, token)
         credentials.method = 'env'
-        logger.info('Found credentials in Environment variables')
+        logger.info('Found credentials in Environment variables.')
     return credentials
 
 
@@ -114,7 +114,7 @@ def search_credentials_file(**kwargs):
         try:
             lines = map(str.strip, open(full_path).readlines())
         except IOError:
-            logger.warn('Unable to load AWS_CREDENTIAL_FILE (%s)', full_path)
+            logger.warn('Unable to load AWS_CREDENTIAL_FILE (%s).', full_path)
         else:
             config = dict(line.split('=', 1) for line in lines if '=' in line)
             access_key = config.get('AWSAccessKeyId')
@@ -122,7 +122,7 @@ def search_credentials_file(**kwargs):
             if access_key and secret_key:
                 credentials = Credentials(access_key, secret_key)
                 credentials.method = 'credentials-file'
-                logger.info('Found credentials in AWS_CREDENTIAL_FILE')
+                logger.info('Found credentials in AWS_CREDENTIAL_FILE.')
     return credentials
 
 
@@ -139,7 +139,7 @@ def search_file(**kwargs):
     if access_key and secret_key:
         credentials = Credentials(access_key, secret_key, token)
         credentials.method = 'config'
-        logger.info('Found credentials in config file')
+        logger.info('Found credentials in config file.')
     return credentials
 
 
@@ -164,7 +164,7 @@ def search_boto_config(**kwargs):
     if access_key and secret_key:
         credentials = Credentials(access_key, secret_key)
         credentials.method = 'boto'
-        logger.info('Found credentials in boto config file')
+        logger.info('Found credentials in boto config file.')
     return credentials
 
 AllCredentialFunctions = [search_environment,

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -169,14 +169,15 @@ class JSONEndpoint(Endpoint):
 class RestEndpoint(Endpoint):
 
     def build_uri(self, operation, params):
+        logger.debug('Building URI for rest endpoint.')
         uri = operation.http['uri']
         if '?' in uri:
             path, query_params = uri.split('?')
         else:
             path = uri
             query_params = ''
-        logger.debug('path: %s' % path)
-        logger.debug('query_params: %s' % query_params)
+        logger.debug('Templated URI path: %s', path)
+        logger.debug('Templated URI query_params: %s', query_params)
         path_components = []
         for pc in path.split('/'):
             if pc:
@@ -200,8 +201,8 @@ class RestEndpoint(Endpoint):
                 else:
                     query_param_components.append(key_name)
         query_params = '&'.join(query_param_components)
-        logger.debug('path: %s' % path)
-        logger.debug('query_params: %s' % query_params)
+        logger.debug('Rendered path: %s', path)
+        logger.debug('Rendered query_params: %s', query_params)
         return path + '?' + query_params
 
     def _create_request_object(self, operation, params):

--- a/botocore/operation.py
+++ b/botocore/operation.py
@@ -119,7 +119,6 @@ class Operation(BotoCoreObject):
         given operation formatted as required to pass to the service
         in a request.
         """
-        logger.debug(kwargs)
         built_params = self._get_built_params()
         missing = []
         for param in self.params:

--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -100,9 +100,8 @@ class Parameter(BotoCoreObject):
                 built_params['payload'] = {}
             self.store_value_json(value, built_params['payload'], label)
         elif style == 'rest-xml' and not self.streaming:
-            logger.debug('XML Payload found')
             xml_payload = self.to_xml(value)
-            logger.debug(xml_payload)
+            logger.debug('XML Payload found: %s', xml_payload)
             built_params['payload'] = xml_payload
         else:
             built_params['payload'] = value
@@ -300,8 +299,8 @@ class ListParameter(Parameter):
             self.members = get_parameter(self.operation, None, self.members)
 
     def build_parameter_query(self, value, built_params, label=''):
-        logger.debug('name: %s' % self.get_label())
-        logger.debug('label: %s' % label)
+        logger.debug("Building parameter for query service, name: %r, label: %r",
+                  self.get_label(), label)
         value = self.validate(value)
         # If this is not a flattened list, find the label for member
         # items in the list.

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -268,7 +268,7 @@ class XmlResponse(Response):
             value = self.emit_event(key, shape, value)
             return value
         else:
-            logger.debug('Unhandled type: %s' % shape['type'])
+            logger.debug('Unhandled type: %s', shape['type'])
 
     def fake_shape(self, elem):
         shape = {}
@@ -291,7 +291,6 @@ class XmlResponse(Response):
         return shape
 
     def start(self, elem):
-        logger.debug('start')
         self.value = {}
         if self.operation.output:
             for member_name in self.operation.output['members']:
@@ -375,13 +374,13 @@ def get_response(session, operation, http_response):
     content_type = http_response.headers['content-type']
     if content_type and ';' in content_type:
         content_type = content_type.split(';')[0]
-    logger.debug('content-type=%s' % content_type)
+        logger.debug('Content type from response: %s', content_type)
     if operation.is_streaming():
         streaming_response = StreamingResponse(session, operation)
         streaming_response.parse(http_response.headers, http_response.raw)
         return (http_response, streaming_response.get_value())
     body = http_response.text
-    logger.debug("Response Body: %s", body)
+    logger.debug("Response Body:\n%s", body)
     if not body:
         return (http_response, body)
     if content_type in ('application/x-amz-json-1.0',


### PR DESCRIPTION
This is just a general sweep of the log messages to update them
so they're all consistent.  The general changes are:
- Use log args instead of performing string interpolation of the
  message (``.debug('foo: %s', 'bar') not .debug('foo: %s' % bar))
- Remove log messages that log the name of the method.  This can
  be done via the log formatter if a dev needs this info.
- Made sure the module level loggers were all called `logger`, for
  consistency (retryhandler was the only one with a logger called
  `log`).
- Try to keep the log format to be: "Capitalized full sentence."
  where appropriate.
