### PR TITLE
Explicitly sort contents of directory

### DIFF
--- a/botocore/base.py
+++ b/botocore/base.py
@@ -93,7 +93,7 @@ def _load_data(session, data_path):
             logger.debug('Found data dir: %s', dir_path)
             try:
                 data = []
-                for pn in glob.glob(os.path.join(dir_path, '*.json')):
+                for pn in sorted(glob.glob(os.path.join(dir_path, '*.json'))):
                     fn = os.path.split(pn)[1]
                     fn = os.path.splitext(fn)[0]
                     if not fn.startswith('_'):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -101,6 +101,11 @@ class SessionTest(BaseSessionTest):
         session = botocore.session.get_session(self.env_vars)
         self.assertIsNone(session.get_variable('foo/bar'))
 
+    def test_get_aws_services_in_alphabetical_order(self):
+        session = botocore.session.get_session(self.env_vars)
+        services = session.get_data('aws')
+        self.assertEqual(sorted(services), services)
+
     def test_profile_does_not_exist_with_default_profile(self):
         session = botocore.session.get_session(self.env_vars)
         config = session.get_config()


### PR DESCRIPTION
os.listdir depends on the ordering of the filesystem,
and not all filesystems list the directory contents in
alphabetical order.

To test this, I commited just the test and watched it fail on travis: https://travis-ci.org/jamesls/botocore/jobs/8957523

Then I rebased in the fix and watched it pass on travis: https://travis-ci.org/jamesls/botocore/builds/8957679
