### PR TITLE
Add starting_token and max_items to paginators

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -85,48 +85,153 @@ class Paginator(object):
         a tuple of (``http_response``, ``parsed_result``).
 
         """
+        page_params = self._extract_paging_params(kwargs)
         return PageIterator(self._operation, self._input_token,
                             self._output_token, self._more_results,
-                            self._result_key, endpoint, kwargs)
+                            self._result_key, page_params['max_items'],
+                            page_params['starting_token'],
+                            endpoint, kwargs)
 
+
+    def _extract_paging_params(self, kwargs):
+        return {
+            'max_items': kwargs.pop('max_items', None),
+            'starting_token': kwargs.pop('starting_token', None),
+        }
 
 
 class PageIterator(object):
     def __init__(self, operation, input_token, output_token, more_results,
-                 result_key, endpoint, op_kwargs):
+                 result_key, max_items, starting_token, endpoint, op_kwargs):
         self._operation = operation
         self._input_token = input_token
         self._output_token = output_token
         self._more_results = more_results
         self._result_key = result_key
+        self._max_items = max_items
+        self._starting_token = starting_token
         self._endpoint = endpoint
         self._op_kwargs = op_kwargs
         self._http_responses = []
+        self._resume_token = None
 
     @property
     def http_responses(self):
         return self._http_responses
 
+    @property
+    def resume_token(self):
+        """Token to specify to resume pagination."""
+        return self._resume_token
+
+    @resume_token.setter
+    def resume_token(self, value):
+        if isinstance(value, list):
+            self._resume_token = '___'.join([str(v) for v in value])
+
     def __iter__(self):
         current_kwargs = self._op_kwargs
         endpoint = self._endpoint
         previous_next_token = None
+        next_token = [None for _ in range(len(self._input_token))]
+        # The number of items from result_key we've seen so far.
+        total_items = 0
+        first_request = True
+        primary_result_key = self._result_key[0]
+        starting_truncation = 0
+        self._inject_starting_token(current_kwargs)
         while True:
             http_response, parsed = self._operation.call(endpoint,
                                                          **current_kwargs)
             self._http_responses.append(http_response)
-            yield http_response, parsed
-            next_token = self._get_next_token(parsed)
-            if all(t is None for t in next_token):
+            if first_request:
+                # The first request is handled differently.  We could
+                # possibly have a resume/starting token that tells us where
+                # to index into the retrieved page.
+                if self._starting_token is not None:
+                    starting_truncation = self._handle_first_request(
+                        parsed, primary_result_key, starting_truncation)
+                first_request = False
+            num_current_response = len(parsed.get(primary_result_key, []))
+            truncate_amount = 0
+            if self._max_items is not None:
+                truncate_amount = (total_items + num_current_response) \
+                        - self._max_items
+            if truncate_amount > 0:
+                self._truncate_response(parsed, primary_result_key,
+                                        truncate_amount, starting_truncation,
+                                        next_token)
+                yield http_response, parsed
                 break
-            if previous_next_token is not None and \
-                    previous_next_token == next_token:
-                message = ("The same next token was received "
-                           "twice: %s" % next_token)
-                raise PaginationError(message=message)
-            for name, token in zip(self._input_token, next_token):
-                current_kwargs[name] = token
-            previous_next_token = next_token
+            else:
+                yield http_response, parsed
+                total_items += num_current_response
+                next_token = self._get_next_token(parsed)
+                if all(t is None for t in next_token):
+                    break
+                if self._max_items is not None and \
+                        total_items == self._max_items:
+                    # We're on a page boundary so we can set the current
+                    # next token to be the resume token.
+                    self.resume_token = next_token
+                    break
+                if previous_next_token is not None and \
+                        previous_next_token == next_token:
+                    message = ("The same next token was received "
+                            "twice: %s" % next_token)
+                    raise PaginationError(message=message)
+                self._inject_token_into_kwargs(current_kwargs, next_token)
+                previous_next_token = next_token
+
+    def _inject_starting_token(self, op_kwargs):
+        # If the user has specified a starting token we need to
+        # inject that into the operation's kwargs.
+        if self._starting_token is not None:
+            # Don't need to do anything special if there is no starting
+            # token specified.
+            next_token = self._parse_starting_token()[0]
+            self._inject_token_into_kwargs(op_kwargs, next_token)
+
+    def _inject_token_into_kwargs(self, op_kwargs, next_token):
+        for name, token in zip(self._input_token, next_token):
+            if token is None or token == 'None':
+                continue
+            op_kwargs[name] = token
+
+    def _handle_first_request(self, parsed, primary_result_key, starting_truncation):
+        # First we need to slice into the array and only return
+        # the truncated amount.
+        starting_truncation = self._parse_starting_token()[1]
+        parsed[primary_result_key] = parsed[
+                                         primary_result_key][starting_truncation:]
+        # We also need to truncate any secondary result keys
+        # because they were not truncated in the previous last
+        # response.
+        for token in self._result_key:
+            if token == primary_result_key:
+                continue
+            parsed[token] = []
+        return starting_truncation
+
+    def _truncate_response(self, parsed, primary_result_key, truncate_amount,
+                           starting_truncation, next_token):
+        original = parsed.get(primary_result_key, [])
+        amount_to_keep = len(original) - truncate_amount
+        truncated = original[:amount_to_keep]
+        parsed[primary_result_key] = truncated
+        # The issue here is that even though we know how much we've truncated
+        # we need to account for this globally including any starting
+        # left truncation. For example:
+        # Raw response: [0,1,2,3]
+        # Starting index: 1
+        # Max items: 1
+        # Starting left truncation: [1, 2, 3]
+        # End right truncation for max items: [1]
+        # However, even though we only kept 1, this is post
+        # left truncation so the next starting index should be 2, not 1
+        # (left_truncation + amount_to_keep).
+        next_token.append(str(amount_to_keep + starting_truncation))
+        self.resume_token = next_token
 
     def _get_next_token(self, parsed):
         if self._more_results is not None:
@@ -144,18 +249,36 @@ class PageIterator(object):
 
     def build_full_result(self):
         iterators = self.result_key_iters()
-        if len(iterators) > 1:
-           response = {}
-           key_names = [i.result_key for i in iterators]
-           for key in key_names:
-               response[key] = []
-           for vals in zip_longest(*iterators):
-               for k, val in zip(key_names, vals):
-                   if val is not None:
-                       response[k].append(val)
-        else:
-            response = list(iterators[0])
+        response = {}
+        key_names = [i.result_key for i in iterators]
+        for key in key_names:
+            response[key] = []
+        for vals in zip_longest(*iterators):
+            for k, val in zip(key_names, vals):
+                if val is not None:
+                    response[k].append(val)
+        if self.resume_token is not None:
+            response['NextToken'] = self.resume_token
         return response
+
+    def _parse_starting_token(self):
+        if self._starting_token is None:
+            return None
+        parts = self._starting_token.split('___')
+        next_token = []
+        index = 0
+        if len(parts) == len(self._input_token) + 1:
+            try:
+                index = int(parts.pop())
+            except ValueError:
+                raise ValueError("Bad starting token: %s" %
+                                 self._starting_token)
+        for part in parts:
+            if part == 'None':
+                next_token.append(None)
+            else:
+                next_token.append(part)
+        return next_token, index
 
 
 class ResultKeyIterator(object):

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -34,6 +34,7 @@ class TestPagination(unittest.TestCase):
         self.paginate_config = {
             'output_token': 'NextToken',
             'py_input_token': 'NextToken',
+            'result_key': 'Foo',
         }
         self.operation.pagination = self.paginate_config
         self.paginator = Paginator(self.operation)
@@ -82,6 +83,7 @@ class TestPagination(unittest.TestCase):
         self.operation.pagination = {
             'output_token': 'NextToken or NextToken2',
             'py_input_token': 'NextToken',
+            'result_key': 'Foo',
         }
         self.paginator = Paginator(self.operation)
         # Verify that despite varying between NextToken and NextToken2
@@ -111,17 +113,15 @@ class TestPagination(unittest.TestCase):
             'more_results': 'IsTruncated',
             'output_token': 'NextToken',
             'py_input_token': 'NextToken',
+            'result_key': 'Foo',
         }
         self.operation.pagination = self.paginate_config
         self.paginator = Paginator(self.operation)
         responses = [
-            (None, {'IsTruncated': True, 'NextToken': 'token1'}),
-            (None, {'IsTruncated': True, 'NextToken': 'token2'}),
-            # The first match found wins, so because NextToken is
-            # listed before NextToken2 in the 'output_tokens' config,
-            # 'token3' is chosen over 'token4'.
-            (None, {'IsTruncated': False, 'NextToken': 'token3'}),
-            (None, {'not_next_token': 'foo'}),
+            (None, {'Foo': [1], 'IsTruncated': True, 'NextToken': 'token1'}),
+            (None, {'Foo': [2], 'IsTruncated': True, 'NextToken': 'token2'}),
+            (None, {'Foo': [3], 'IsTruncated': False, 'NextToken': 'token3'}),
+            (None, {'Foo': [4], 'not_next_token': 'foo'}),
         ]
         self.operation.call.side_effect = responses
         list(self.paginator.paginate(None))
@@ -136,6 +136,7 @@ class TestPagination(unittest.TestCase):
             'more_results': 'Foo.IsTruncated',
             'output_token': 'NextToken',
             'py_input_token': 'NextToken',
+            'result_key': 'Bar',
         }
         self.operation.pagination = self.paginate_config
         self.paginator = Paginator(self.operation)
@@ -182,6 +183,7 @@ class TestPaginatorWithPathExpressions(unittest.TestCase):
             'output_token': [
                 'NextMarker or ListBucketResult.Contents[-1].Key'],
             'py_input_token': 'next_marker',
+            'result_key': 'Contents',
         }
         self.operation.pagination = self.paginate_config
         self.paginator = Paginator(self.operation)
@@ -221,18 +223,19 @@ class TestMultipleTokens(unittest.TestCase):
         self.paginate_config = {
             "output_token": ["ListBucketResults.NextKeyMarker",
                              "ListBucketResults.NextUploadIdMarker"],
-            "py_input_token": ["key_marker", "upload_id_marker"]
+            "py_input_token": ["key_marker", "upload_id_marker"],
+            "result_key": 'Foo',
         }
         self.operation.pagination = self.paginate_config
         self.paginator = Paginator(self.operation)
 
     def test_s3_list_multipart_uploads(self):
         responses = [
-            (None, {"ListBucketResults": {"NextKeyMarker": "key1",
+            (None, {"Foo": [1], "ListBucketResults": {"NextKeyMarker": "key1",
                     "NextUploadIdMarker": "up1"}}),
-            (None, {"ListBucketResults": {"NextKeyMarker": "key2",
+            (None, {"Foo": [2], "ListBucketResults": {"NextKeyMarker": "key2",
                     "NextUploadIdMarker": "up2"}}),
-            (None, {"ListBucketResults": {"NextKeyMarker": "key3",
+            (None, {"Foo": [3], "ListBucketResults": {"NextKeyMarker": "key3",
                     "NextUploadIdMarker": "up3"}}),
             (None, {}),
         ]
@@ -282,7 +285,91 @@ class TestKeyIterators(unittest.TestCase):
         self.operation.call.side_effect = responses
         pages = self.paginator.paginate(None)
         complete = pages.build_full_result()
-        self.assertEqual(complete, ['User1', 'User2', 'User3'])
+        self.assertEqual(complete, {'Users': ['User1', 'User2', 'User3']})
+
+    def test_max_items_can_be_specified(self):
+        paginator = Paginator(self.operation)
+        responses = [
+            (None, {"Users": ["User1"], "Marker": "m1"}),
+            (None, {"Users": ["User2"], "Marker": "m2"}),
+            (None, {"Users": ["User3"]}),
+        ]
+        self.operation.call.side_effect = responses
+        self.assertEqual(
+            paginator.paginate(None, max_items=1).build_full_result(),
+            {'Users': ['User1'], 'NextToken': 'm1'})
+
+    def test_next_token_on_page_boundary(self):
+        paginator = Paginator(self.operation)
+        responses = [
+            (None, {"Users": ["User1"], "Marker": "m1"}),
+            (None, {"Users": ["User2"], "Marker": "m2"}),
+            (None, {"Users": ["User3"]}),
+        ]
+        self.operation.call.side_effect = responses
+        self.assertEqual(
+            paginator.paginate(None, max_items=2).build_full_result(),
+            {'Users': ['User1', 'User2'], 'NextToken': 'm2'})
+
+    def test_max_items_can_be_specified_truncates_response(self):
+        # We're saying we only want 4 items, but notice that the second
+        # page of results returns users 4-6 so we have to truncated
+        # part of that second page.
+        paginator = Paginator(self.operation)
+        responses = [
+            (None, {"Users": ["User1", "User2", "User3"], "Marker": "m1"}),
+            (None, {"Users": ["User4", "User5", "User6"], "Marker": "m2"}),
+            (None, {"Users": ["User7"]}),
+        ]
+        self.operation.call.side_effect = responses
+        self.assertEqual(
+            paginator.paginate(None, max_items=4).build_full_result(),
+            {'Users': ['User1', 'User2', 'User3', 'User4'],
+             'NextToken': 'm1___1'})
+
+    def test_resume_next_marker_mid_page(self):
+        # This is a simulation of picking up from the response
+        # from test_max_items_can_be_specified_truncates_response
+        # We got the first 4 users, when we pick up we should get
+        # User5 - User7.
+        paginator = Paginator(self.operation)
+        responses = [
+            (None, {"Users": ["User4", "User5", "User6"], "Marker": "m2"}),
+            (None, {"Users": ["User7"]}),
+        ]
+        self.operation.call.side_effect = responses
+        self.assertEqual(
+            paginator.paginate(None, starting_token='m1___1').build_full_result(),
+            {'Users': ['User5', 'User6', 'User7']})
+        self.assertEqual(
+            self.operation.call.call_args_list,
+            [mock.call(None, Marker='m1'),
+             mock.call(None, Marker='m2'),])
+
+    def test_max_items_exceeds_actual_amount(self):
+        # Because MaxItems=10 > number of users (3), we should just return
+        # all of the users.
+        paginator = Paginator(self.operation)
+        responses = [
+            (None, {"Users": ["User1"], "Marker": "m1"}),
+            (None, {"Users": ["User2"], "Marker": "m2"}),
+            (None, {"Users": ["User3"]}),
+        ]
+        self.operation.call.side_effect = responses
+        self.assertEqual(
+            paginator.paginate(None, max_items=10).build_full_result(),
+            {'Users': ['User1', 'User2', 'User3']})
+
+    def test_bad_input_tokens(self):
+        responses = [
+            (None, {"Users": ["User1"], "Marker": "m1"}),
+            (None, {"Users": ["User2"], "Marker": "m2"}),
+            (None, {"Users": ["User3"]}),
+        ]
+        self.operation.call.side_effect = responses
+        with self.assertRaisesRegexp(ValueError, 'Bad starting token'):
+            self.paginator.paginate(
+                None, starting_token='bad___notanint').build_full_result()
 
 
 class TestMultipleResultKeys(unittest.TestCase):
@@ -324,7 +411,6 @@ class TestMultipleResultKeys(unittest.TestCase):
                          {"Users": ['User1'],
                           "Groups": ['Group1', 'Group2', 'Group3']})
 
-
     def test_build_full_result_with_zero_length_result_key(self):
         responses = [
             # In this case the 'Users' key is always empty but we should
@@ -340,6 +426,91 @@ class TestMultipleResultKeys(unittest.TestCase):
         self.assertEqual(complete,
                          {"Users": [],
                           "Groups": ['Group1', 'Group2', 'Group3']})
+
+    def test_build_result_with_secondary_keys(self):
+        responses = [
+            (None, {"Users": ["User1", "User2"],
+                    "Groups": ["Group1", "Group2"],
+                    "Marker": "m1"}),
+            (None, {"Users": ["User3"], "Groups": ["Group3"], "Marker": "m2"}),
+            (None, {"Users": ["User4"], "Groups": ["Group4"], }),
+        ]
+        self.operation.call.side_effect = responses
+        pages = self.paginator.paginate(None, max_items=1)
+        complete = pages.build_full_result()
+        self.assertEqual(complete,
+                         {"Users": ["User1"], "Groups": ["Group1", "Group2"],
+                          "NextToken": "None___1"})
+
+    def test_resume_with_secondary_keys(self):
+        # This is simulating a continutation of the previous test,
+        # test_build_result_with_secondary_keys.  We use the
+        # token specified in the response "None___1" to continue where we
+        # left off.
+        responses = [
+            (None, {"Users": ["User1", "User2"],
+                    "Groups": ["Group1", "Group2"],
+                    "Marker": "m1"}),
+            (None, {"Users": ["User3"], "Groups": ["Group3"], "Marker": "m2"}),
+            (None, {"Users": ["User4"], "Groups": ["Group4"], }),
+        ]
+        self.operation.call.side_effect = responses
+        pages = self.paginator.paginate(None, max_items=1,
+                                        starting_token="None___1")
+        complete = pages.build_full_result()
+        # Note that the secondary keys ("Groups") are all truncated because
+        # they were in the original (first) response.
+        self.assertEqual(complete,
+                         {"Users": ["User2"], "Groups": [],
+                          "NextToken": "m1"})
+
+
+class TestMultipleInputKeys(unittest.TestCase):
+    def setUp(self):
+        self.operation = mock.Mock()
+        # Probably the most complicated example we'll see:
+        # multiple input/output/result keys.
+        self.paginate_config = {
+            "output_token": ["Marker1", "Marker2"],
+            "py_input_token": ["InMarker1", "InMarker2"],
+            "result_key": ["Users", "Groups"],
+        }
+        self.operation.pagination = self.paginate_config
+        self.paginator = Paginator(self.operation)
+
+    def test_build_full_result_with_multiple_input_keys(self):
+        responses = [
+            (None, {"Users": ["User1", "User2"], "Groups": ["Group1"],
+                    "Marker1": "m1", "Marker2": "m2"}),
+            (None, {"Users": ["User3", "User4"], "Groups": ["Group2"],
+                    "Marker1": "m3", "Marker2": "m4"}),
+            (None, {"Users": ["User5"], "Groups": ["Group3"], }),
+        ]
+        self.operation.call.side_effect = responses
+        pages = self.paginator.paginate(None, max_items=3)
+        complete = pages.build_full_result()
+        self.assertEqual(complete,
+                         {"Users": ['User1', 'User2', 'User3'],
+                          "Groups": ['Group1', 'Group2'],
+                          "NextToken": "m1___m2___1"})
+
+    def test_resume_with_multiple_input_keys(self):
+        responses = [
+            (None, {"Users": ["User3", "User4"], "Groups": ["Group2"],
+                    "Marker1": "m3", "Marker2": "m4"}),
+            (None, {"Users": ["User5"], "Groups": ["Group3"], }),
+        ]
+        self.operation.call.side_effect = responses
+        pages = self.paginator.paginate(None, max_items=1,
+                                        starting_token='m1___m2___1')
+        complete = pages.build_full_result()
+        self.assertEqual(complete,
+                         {"Users": ['User4'],
+                          "Groups": [],
+                          "NextToken": "m3___m4"})
+        self.assertEqual(
+            self.operation.call.call_args_list,
+            [mock.call(None, InMarker1='m1', InMarker2='m2'),])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When calling .paginate() on an operation you can specify two
additional parameters:
- starting_token - Indicates where to start in the pagination
- max_items - Indicates the total number of results to return.

The results are based on the primary result key (the first item
  if there are more than one result key).

Also, we expose a `resume_token` property that presents an opaque
token the user can specify in subsequent requests via `start_token` that
instructs the paginator where to pick up.  This works with multiple input
tokens as well as indexing into an existing page.  This means that
the user only has to deal with a single `resume_token` instead of
multiple next tokens as well as an index.  `build_full_result` was
also updated to inject this arg as `NextToken` into the complete
response.

As part of this change, the pagination results always return a dictionary,
even if there is only a single result key.

cc @garnaat @toastdriven
