### PR TITLE
Allow bytearrays as valid blob types

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -295,14 +295,14 @@ class StringParameter(Parameter):
 class BlobParameter(Parameter):
 
     def validate(self, value):
+        allowed_types = six.string_types + (bytes, bytearray,)
         if self.payload and self.streaming:
             # Streaming blobs should be file-like objects or be strings.
-            if not hasattr(value, 'read') and not isinstance(value,
-                                                             six.string_types):
+            if not hasattr(value, 'read') and not isinstance(allowed_types):
                 raise ValidationError(value=str(value), type_name='blob',
                                       param=self)
         else:
-            if not isinstance(value, six.string_types):
+            if not isinstance(value, allowed_types):
                 raise ValidationError(value=str(value), type_name='string',
                                       param=self)
             if not hasattr(self, 'payload') or self.payload is False:

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -260,6 +260,22 @@ class TestParameters(unittest.TestCase):
                               'bar.2': 'is',
                               'bar.3': 'a'})
 
+    def test_type_blob_validation(self):
+        p = botocore.parameters.BlobParameter(
+            operation=None, name='Foo', payload=True)
+        bytearray_type = bytearray(b'foo')
+        byte_type = bytes(b'foo')
+        str_type = str('foo')
+        self.assertEqual(p.validate(str_type), str_type)
+        self.assertEqual(p.validate(byte_type), byte_type)
+        self.assertEqual(p.validate(bytearray_type), bytearray_type)
+
+    def test_blob_conversion_to_base64(self):
+        # Blobs that are not in the payload should be base64-encoded
+        p = botocore.parameters.BlobParameter(
+            operation=None, name='Foo', payload=False)
+        self.assertEqual(p.validate('foo'), 'Zm9v')
+
 
 class TestStructureParamaters(unittest.TestCase):
 


### PR DESCRIPTION
This allows a user to pass a `bytearray` for a blob param value.
