### PR TITLE
Fix unicode error in URI paths

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -182,7 +182,7 @@ class RestEndpoint(Endpoint):
             if pc:
                 pc = pc.format(**params['uri_params'])
             path_components.append(pc)
-        path = quote('/'.join(path_components))
+        path = quote('/'.join(path_components).encode('utf-8'))
         query_param_components = []
         for qpc in query_params.split('&'):
             if qpc:

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -204,11 +204,15 @@ class TestS3Objects(BaseS3Test):
 
     def test_unicode_key_put_list(self):
         # Verify we can upload a key with a unicode char and list it as well.
-        self.create_object('\u2713')
+        key_name = u'\u2713'
+        self.create_object(key_name)
         operation = self.service.get_operation('ListObjects')
         parsed = operation.call(self.endpoint, bucket=self.bucket_name)[1]
         self.assertEqual(len(parsed['Contents']), 1)
-        self.assertEqual(parsed['Contents'][0]['Key'], '\u2713')
+        self.assertEqual(parsed['Contents'][0]['Key'], key_name)
+        operation = self.service.get_operation('GetObject')
+        parsed = operation.call(self.endpoint, bucket=self.bucket_name, key=key_name)[1]
+        self.assertEqual(parsed['Body'].read().decode('utf-8'), 'foo')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If a key name is provided that is unicode we need to encode the path
components before sending it to quote().

This was noticed during the high level s3 integration in the AWS CLI.

cc @garnaat @kyleknap
