### PR TITLE
Force unicode for path components in RestEndpoint

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -26,6 +26,7 @@ import time
 
 from requests.sessions import Session
 from requests.utils import get_environ_proxies
+import six
 
 import botocore.response
 import botocore.exceptions
@@ -180,7 +181,7 @@ class RestEndpoint(Endpoint):
         path_components = []
         for pc in path.split('/'):
             if pc:
-                pc = pc.format(**params['uri_params'])
+                pc = six.text_type(pc).format(**params['uri_params'])
             path_components.append(pc)
         path = quote('/'.join(path_components).encode('utf-8'))
         query_param_components = []

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -246,5 +246,17 @@ class TestRetryInterface(BaseSessionTest):
         self.assertEqual(self.total_calls, 3)
 
 
+class TestRestEndpoint(unittest.TestCase):
+
+    def test_encode_uri_params_unicode(self):
+        uri = '/{foo}/{bar}'
+        operation = Mock()
+        operation.http = {'uri': uri}
+        params = {'uri_params': {'foo': u'\u2713', 'bar': 'bar'}}
+        endpoint = RestEndpoint(Mock(), None, None, None)
+        built_uri = endpoint.build_uri(operation, params)
+        self.assertEqual(built_uri, '/%E2%9C%93/bar?')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
2.6 is broken if you use .format() with unicode params on a str type.  This
just forces pc to be unicode.

cc @kyleknap @garnaat
