### PR TITLE
Allowed ``~`` to be a safe character.

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -183,7 +183,7 @@ class RestEndpoint(Endpoint):
             if pc:
                 pc = six.text_type(pc).format(**params['uri_params'])
             path_components.append(pc)
-        path = quote('/'.join(path_components).encode('utf-8'))
+        path = quote('/'.join(path_components).encode('utf-8'), safe='/~')
         query_param_components = []
         for qpc in query_params.split('&'):
             if qpc:

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -257,6 +257,15 @@ class TestRestEndpoint(unittest.TestCase):
         built_uri = endpoint.build_uri(operation, params)
         self.assertEqual(built_uri, '/%E2%9C%93/bar?')
 
+    def test_quote_uri_safe_key(self):
+        uri = '/{foo}/{bar}'
+        operation = Mock()
+        operation.http = {'uri': uri}
+        params = {'uri_params': {'foo': 'foo', 'bar': 'bar~'}}
+        endpoint = RestEndpoint(Mock(), None, None, None)
+        built_uri = endpoint.build_uri(operation, params)
+        self.assertEqual(built_uri, '/foo/bar~?')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before, any operation on a file or S3 object with `~` in its name would return a key signing error.
