### PR TITLE
Relax float param validation

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -23,8 +23,11 @@
 import logging
 import base64
 import datetime
+import decimal
+
 import six
 import dateutil.parser
+
 from botocore import BotoCoreObject
 from botocore.exceptions import ValidationError, RangeError, UnknownKeyError
 from botocore.exceptions import MissingParametersError
@@ -147,9 +150,27 @@ class IntegerParameter(Parameter):
 class FloatParameter(Parameter):
 
     def validate(self, value):
-        if not isinstance(value, float):
+        original_value = value
+        # So isinstance(True, int) -> True.
+        # For a float parameter we should not allow a bool.
+        if isinstance(value, bool):
             raise ValidationError(value=str(value), type_name='float',
                                   param=self)
+        elif not isinstance(value, float):
+            # If the value is a float, that's good enough for a float
+            # param.  Also you can't go directly from a float -> Decimal
+            # in python2.6.
+            # Otherwise the value has to look like a decimal,
+            # so we just need to validate that it converts to a
+            # decimal without issue and then run it through the min
+            # max range validations.
+            try:
+                # We don't want to type convert here, but we need
+                # to convert it to something we can use < and > against.
+                value = decimal.Decimal(value)
+            except (decimal.InvalidOperation, TypeError):
+                raise ValidationError(value=str(value), type_name='float',
+                                    param=self)
         if self.min:
             if value < self.min:
                 raise RangeError(value=value,
@@ -162,7 +183,7 @@ class FloatParameter(Parameter):
                                  param=self,
                                  min_value=self.min,
                                  max_value=self.max)
-        return value
+        return original_value
 
 
 class DoubleParameter(Parameter):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,6 +33,9 @@ else:
     import unittest
 
 
+import botocore.session
+
+
 class BaseEnvVar(unittest.TestCase):
     def setUp(self):
         # Automatically patches out os.environ for you
@@ -63,3 +66,17 @@ class BaseSessionTest(BaseEnvVar):
         super(BaseSessionTest, self).setUp()
         self.environ['AWS_ACCESS_KEY_ID'] = 'access_key'
         self.environ['AWS_SECRET_ACCESS_KEY'] = 'secret_key'
+
+
+class TestParamSerialization(BaseSessionTest):
+    def setUp(self):
+        super(TestParamSerialization, self).setUp()
+        self.session = botocore.session.get_session()
+
+    def assert_params_serialize_to(self, dotted_name, input_params,
+                                   serialized_params):
+        service_name, operation_name = dotted_name.split('.')
+        service = self.session.get_service(service_name)
+        operation = service.get_operation(operation_name)
+        serialized = operation.build_parameters(**input_params)
+        self.assertDictEqual(serialized, serialized_params)

--- a/tests/unit/test_cloudwatch_operations.py
+++ b/tests/unit/test_cloudwatch_operations.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+from decimal import Decimal
+from tests import TestParamSerialization
+
+import botocore.session
+from botocore.exceptions import ValidationError
+
+
+class TestCloudwatchOperations(TestParamSerialization):
+
+    def assert_is_valid_float_value(self, value):
+        # We don't really care about the specific operation,
+        # just that an operation that has a float param
+        # can accept the specified value passed in.
+        # We're using put-metric-data as the operation here.
+        input_metric_data = [
+            {"MetricName": "FreeMemoryBytes", "Dimensions": [],
+             "Unit": "Bytes",
+             "Timestamp": "2013-07-30T00:58:11.284Z",
+             # The "Value" param is specified as type "float"
+             # in the model.
+             "Value": value}]
+        serialized_params = {
+            'MetricData.member.1.MetricName':
+            'FreeMemoryBytes',
+            'MetricData.member.1.Timestamp':
+                '2013-07-30T00:58:11.284000+00:00',
+            'MetricData.member.1.Unit': 'Bytes',
+            'MetricData.member.1.Value': str(value),
+            'Namespace': 'System/Linux'
+        }
+        self.assert_params_serialize_to(
+            'cloudwatch.PutMetricData',
+            input_params={'namespace': 'System/Linux',
+                          'metric_data': input_metric_data},
+            serialized_params=serialized_params)
+
+    def test_float_validation(self):
+        self.assert_is_valid_float_value(9130160128.0)
+
+    def test_integers_allowed_for_floats(self):
+        self.assert_is_valid_float_value(9130160128)
+
+    def test_string_type_is_allowed(self):
+        self.assert_is_valid_float_value("9130160128.123")
+
+    def test_decimal_type_is_allowed(self):
+        self.assert_is_valid_float_value(Decimal("9130160128.123"))
+
+    def test_bad_float_value(self):
+        bad_value = 'notafloat'
+        input_metric_data = [
+            {"MetricName": "FreeMemoryBytes", "Dimensions": [],
+             "Unit": "Bytes",
+             "Timestamp": "2013-07-30T00:58:11.284Z",
+             "Value": bad_value}]
+        op = self.session.get_service(
+            'cloudwatch').get_operation('PutMetricData')
+        with self.assertRaises(ValidationError):
+            op.build_parameters(namespace='System/Linux',
+                                metric_data=input_metric_data)
+        # Empty dict is also a bad value for a float param.
+        input_metric_data[0]['Value'] = {}
+        with self.assertRaises(ValidationError):
+            op.build_parameters(namespace='System/Linux',
+                                metric_data=input_metric_data)


### PR DESCRIPTION
If we can convert it to a decimal, we call it good enough.
This means that ints, and numbers as strs "123.245" can be
used.  This also gets around float precision loss.

Fixes aws/aws-cli#197

cc @garnaat @toastdriven
