### PR TITLE
Decode response body before parsing json

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -318,7 +318,8 @@ class JSONResponse(Response):
 
     def parse(self, s, encoding):
         try:
-            self.value = json.loads(s, encoding=encoding)
+            decoded = s.decode('utf-8')
+            self.value = json.loads(decoded)
             self.get_response_errors()
         except Exception as err:
             logger.debug('Error loading JSON response body, %r', err)

--- a/tests/unit/response_parsing/test_response_parsing.py
+++ b/tests/unit/response_parsing/test_response_parsing.py
@@ -98,9 +98,8 @@ def test_json_parsing():
             sn, opname = basename.split('-', 1)
             operation = service.get_operation(opname)
             r = JSONResponse(session, operation)
-            fp = open(inputfile)
-            jsondoc = fp.read()
-            fp.close()
+            with open(inputfile, 'rb') as fp:
+                jsondoc = fp.read()
             r.parse(jsondoc, 'utf-8')
             save_jsonfile(outputfile, r)
             fp = open(outputfile)


### PR DESCRIPTION
The encoding argument to `json.loads` is deprecated in python3
and fails silently:

```
The ``encoding`` argument is ignored and deprecated.
```

So instead the bytestring is decoded before being handed
off to the json parser.

The response parsing tests are updated to load the file as a bytestring and then hand it off to the parser.  This simulates what happens with `response.content`.  I verified that without the change to response.py the json parsing tests would fail.

I'll also add a basic smoke test to the CLI to ensure we run a JSON service end to end.

cc @garnaat @toastdriven
