### PR TITLE
No virtual-hosting addressing with bucket names containing a period.

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -76,28 +76,24 @@ def check_dns_name(bucket_name):
     Check to see if the ``bucket_name`` complies with the
     restricted DNS naming conventions necessary to allow
     access via virtual-hosting style.
+
+    Even though "." characters are perfectly valid in this DNS
+    naming scheme, we are going to punt on any name containing a
+    "." character because these will cause SSL cert validation
+    problems if we try to use virtual-hosting style addressing.
     """
+    if '.' in bucket_name:
+        return False
     n = len(bucket_name)
     if n < 3 or n > 63:
         # Wrong length
         return False
-    labels = bucket_name.split('.')
-    if len(labels) == 4:
-        # Must make sure this is not formatted like an IP address
-        if all([(d.isdigit() and int(d) < 256) for d in labels]):
+    if n == 1:
+        if not bucket_name.isalnum():
             return False
-    for label in bucket_name.split('.'):
-        if len(label) == 0:
-            # Must be two '.' in a row
-            return False
-        if len(label) == 1:
-            if label.isalnum():
-                continue
-            # Any single character label must be alphanumeric
-            return False
-        match = LabelRE.match(label)
-        if match is None or match.end() != len(label):
-            return False
+    match = LabelRE.match(bucket_name)
+    if match is None or match.end() != len(bucket_name):
+        return False
     return True
 
 
@@ -115,15 +111,15 @@ def fix_s3_host(event_name, endpoint, request, auth, **kwargs):
     auth.auth_path = parts.path
     path_parts = parts.path.split('/')
     if len(path_parts) > 1:
-        # If the operation is on a bucket, the auth_path must be
-        # terminated with a '/' character.
-        if len(path_parts) == 2:
-            if auth.auth_path[-1] != '/':
-                auth.auth_path += '/'
         bucket_name = path_parts[1]
         logger.debug('Checking for DNS compatible bucket for: %s',
                      request.url)
         if check_dns_name(bucket_name):
+            # If the operation is on a bucket, the auth_path must be
+            # terminated with a '/' character.
+            if len(path_parts) == 2:
+                if auth.auth_path[-1] != '/':
+                    auth.auth_path += '/'
             path_parts.remove(bucket_name)
             host = bucket_name + '.' + endpoint.service.global_endpoint
             new_tuple = (parts.scheme, host, '/'.join(path_parts),

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -92,7 +92,7 @@ class TestS3Addressing(BaseEnvVar):
                                      content_type='text/plain')
         prepared_request = self.get_prepared_request(op, params)
         self.assertEqual(prepared_request.url,
-                         'https://my.valid.name.s3.amazonaws.com/mykeyname')
+                         'https://s3-us-west-2.amazonaws.com/my.valid.name/mykeyname')
         fp.close()
 
     def test_put_object_dns_name_classic(self):
@@ -109,7 +109,7 @@ class TestS3Addressing(BaseEnvVar):
                                      content_type='text/plain')
         prepared_request = self.get_prepared_request(op, params)
         self.assertEqual(prepared_request.url,
-                         'https://my.valid.name.s3.amazonaws.com/mykeyname')
+                         'https://s3.amazonaws.com/my.valid.name/mykeyname')
         fp.close()
 
     def test_put_object_dns_name_single_letter_non_classic(self):
@@ -126,7 +126,7 @@ class TestS3Addressing(BaseEnvVar):
                                      content_type='text/plain')
         prepared_request = self.get_prepared_request(op, params)
         self.assertEqual(prepared_request.url,
-                         'https://a.valid.name.s3.amazonaws.com/mykeyname')
+                         'https://s3-us-west-2.amazonaws.com/a.valid.name/mykeyname')
         fp.close()
 
     def test_get_object_non_dns_name_non_classic(self):
@@ -164,7 +164,7 @@ class TestS3Addressing(BaseEnvVar):
                                      key='mykeyname')
         prepared_request = self.get_prepared_request(op, params)
         self.assertEqual(prepared_request.url,
-                         'https://192.168.5.256.s3.amazonaws.com/mykeyname')
+                         'https://s3.amazonaws.com/192.168.5.256/mykeyname')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR will use path-style addressing for all bucket names containing periods but will require users to know the correct endpoint to connect to.

We need to do more work in awscli to fully integrate the 301 redirect error we will receive if the wrong endpoint is chosen into a reasonable error message for the end user but this PR can go into botocore now without causing any problems.
