### PR TITLE
urlencode values in query string

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -196,8 +196,10 @@ class RestEndpoint(Endpoint):
                     value_name = value_name.strip('{}')
                     if value_name in params['uri_params']:
                         value = params['uri_params'][value_name]
-                        query_param_components.append('%s=%s' % (key_name,
-                                                                 value))
+                        if isinstance(value, six.string_types):
+                            value = quote(value.encode('utf-8'), safe='/~')
+                        query_param_components.append('%s=%s' % (
+                            key_name, value))
                 else:
                     query_param_components.append(key_name)
         query_params = '&'.join(query_param_components)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -85,6 +85,25 @@ class TestS3Objects(BaseS3Test):
                         self.endpoint, upload_id=upload_id,
                         bucket=self.bucket_name, key=key_name)
 
+    def test_can_delete_urlencoded_object(self):
+        key_name = 'a+b/foo'
+        self.create_object(key_name=key_name)
+        self.keys.pop()
+        bucket_contents = self.service.get_operation('ListObjects').call(
+            self.endpoint, bucket=self.bucket_name)[1]['Contents']
+        self.assertEqual(len(bucket_contents), 1)
+        self.assertEqual(bucket_contents[0]['Key'], 'a+b/foo')
+
+        subdir_contents = self.service.get_operation('ListObjects').call(
+            self.endpoint, bucket=self.bucket_name, prefix='a+b')[1]['Contents']
+        self.assertEqual(len(subdir_contents), 1)
+        self.assertEqual(subdir_contents[0]['Key'], 'a+b/foo')
+
+        operation = self.service.get_operation('DeleteObject')
+        response = operation.call(self.endpoint, bucket=self.bucket_name,
+                                  key=key_name)[0]
+        self.assertEqual(response.status_code, 204)
+
     def test_can_paginate(self):
         for i in range(5):
             key_name = 'key%s' % i

--- a/tests/unit/test_s3_operations.py
+++ b/tests/unit/test_s3_operations.py
@@ -58,7 +58,7 @@ POLICY = ('{"Version": "2008-10-17","Statement": [{"Sid": "AddPerm",'
 class TestS3Operations(BaseEnvVar):
 
     maxDiff = None
-    
+
     def setUp(self):
         super(TestS3Operations, self).setUp()
         self.environ['AWS_ACCESS_KEY_ID'] = 'foo'


### PR DESCRIPTION
Fixes the case where you have key names like "a+b/foo"

This fixes aws/aws-cli#314
