### PR TITLE
Don't store http responses from paginated results

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -111,12 +111,7 @@ class PageIterator(object):
         self._starting_token = starting_token
         self._endpoint = endpoint
         self._op_kwargs = op_kwargs
-        self._http_responses = []
         self._resume_token = None
-
-    @property
-    def http_responses(self):
-        return self._http_responses
 
     @property
     def resume_token(self):
@@ -142,7 +137,6 @@ class PageIterator(object):
         while True:
             http_response, parsed = self._operation.call(endpoint,
                                                          **current_kwargs)
-            self._http_responses.append(http_response)
             if first_request:
                 # The first request is handled differently.  We could
                 # possibly have a resume/starting token that tells us where

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -274,7 +274,6 @@ class TestKeyIterators(unittest.TestCase):
         self.assertEqual(len(iterators), 1)
         self.assertEqual(list(iterators[0]),
                          ["User1", "User2", "User3"])
-        self.assertEqual(len(pages.http_responses), 3)
 
     def test_build_full_result_with_single_key(self):
         responses = [


### PR DESCRIPTION
This is really bad if you are paginating over a large
set of data (like s3 objects).

This was previously used to check for error responses, but this
is no longer used by anything.  The error handling is all event
based now (via `after-call` events).

Fixes https://github.com/aws/aws-cli/issues/326.  Note that one other
commit to the CLI is needed to cap memory usage and fix
https://github.com/aws/aws-cli/issues/326.
