### PR TITLE
add us-gov-west-1 to metadata regions enabling cloud formation

### DIFF
--- a/botocore/data/aws/cloudformation.json
+++ b/botocore/data/aws/cloudformation.json
@@ -1266,6 +1266,7 @@
             "sa-east-1": null,
             "ap-southeast-1": null,
             "ap-southeast-2": null,
+            "us-gov-west-1": null,
             "us-west-2": null,
             "us-west-1": null,
             "eu-west-1": null


### PR DESCRIPTION
Cloudformation is now available in the US GovCloud region this enables the service in the AWS CLI
