### PR TITLE
Update botocore to use dev branch of jmespath

### DIFF
--- a/botocore/data/aws/s3.json
+++ b/botocore/data/aws/s3.json
@@ -2736,7 +2736,7 @@
             "pagination": {
                 "more_key": "IsTruncated",
                 "limit_key": "MaxKeys",
-                "output_token": "NextMarker or Contents[-1].Key",
+                "output_token": "NextMarker || Contents[-1].Key",
                 "input_token": "Marker",
                 "result_key": [
                     "Contents",
@@ -4293,7 +4293,7 @@
         "ListObjects": {
             "more_key": "IsTruncated",
             "limit_key": "MaxKeys",
-            "output_token": "NextMarker or Contents[-1].Key",
+            "output_token": "NextMarker || Contents[-1].Key",
             "input_token": "Marker",
             "result_key": [
                 "Contents",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ Sphinx==1.1.3
 python-dateutil==2.1
 nose==1.3.0
 mock==1.0.1
-jmespath==0.0.2
+-e git://github.com/boto/jmespath.git@develop#egg=jmespath

--- a/services/s3.extra.json
+++ b/services/s3.extra.json
@@ -71,7 +71,7 @@
     "ListObjects": {
       "more_key": "IsTruncated",
       "limit_key": "MaxKeys",
-      "output_token": "NextMarker or Contents[-1].Key",
+      "output_token": "NextMarker || Contents[-1].Key",
       "input_token": "Marker",
       "result_key": [
         "Contents",


### PR DESCRIPTION
This also required a change to the s3 page configs.  Based
on feedback, the 'or' token was replaced with '||' a while back.
