### PR TITLE
Revert update to requests 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.0.0
+requests==1.2.3
 six==1.1.0
 tox==1.4
 Sphinx==1.1.3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ packages = [
     'botocore',
 ]
 
-requires = ['requests==2.0.0',
+requires = ['requests==1.2.3',
             'six>=1.1.0',
             'jmespath==0.0.3',
             'python-dateutil>=2.1']


### PR DESCRIPTION
Requests 2.0.0 requires httpretty 0.7.0 but that seems to be broken for Python 3.3.  Reverting for now till we resolve the httpretty dependency.
