### PR TITLE
Reintroduce the upgrade to requests 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==1.2.3
+requests==2.0.0
 six==1.1.0
 tox==1.4
 Sphinx==1.1.3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ packages = [
     'botocore',
 ]
 
-requires = ['requests==1.2.3',
+requires = ['requests==2.0.0',
             'six>=1.1.0',
             'jmespath==0.0.3',
             'python-dateutil>=2.1']


### PR DESCRIPTION
Should be good to go now that we don't need httpretty
in the CLI tests.
