### PR TITLE
Change set_stream_logger to set logger at DEBUG

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -424,7 +424,7 @@ class Session(object):
 
         """
         log = logging.getLogger(logger_name)
-        log.setLevel(log_level)
+        log.setLevel(logging.DEBUG)
 
         ch = logging.StreamHandler(stream)
         ch.setLevel(log_level)
@@ -453,7 +453,7 @@ class Session(object):
             if it doesn't already exist.
         """
         log = logging.getLogger(logger_name)
-        log.setLevel(log_level)
+        log.setLevel(logging.DEBUG)
 
         # create console handler and set level to debug
         ch = logging.FileHandler(path)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -218,7 +218,7 @@ class SessionTest(BaseSessionTest):
     def test_general_purpose_logger(self, formatter, file_handler, get_logger):
         self.session.set_stream_logger('foo.bar', 'ERROR', format_string='foo')
         get_logger.assert_called_with('foo.bar')
-        get_logger.return_value.setLevel.assert_called_with('ERROR')
+        get_logger.return_value.setLevel.assert_called_with(logging.DEBUG)
         formatter.assert_called_with('foo')
 
     def test_register_with_unique_id(self):


### PR DESCRIPTION
The issue is that in some situations we weren't getting debug logs
from botocore or the CLI.  The issue is that by setting the stream
logger to a level of ERROR, we'll never get any debug logs emitted.

This change sets the logger to have a level of DEBUG, but leaves the
associated StreamHandler to have the associated level that's been passed
in.  This should result in no noticeable changes (`--debug` still has
the same result), but this has the benefit that you can add addtional
handlers that record at the DEBUG level (say in a plugin).

This particular situation was noticed because when a test fails, nose
normally captures all the log messages, which is helpful in diagnosing
what went wrong.  However, because clidriver calls set_stream_logger with
a level of ERROR, nose's log handlers can't capture any debug logs.
