### PR TITLE
Expose result_keys on PageIterator object

### DIFF
--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -514,6 +514,13 @@ class TestMultipleInputKeys(unittest.TestCase):
             self.operation.call.call_args_list,
             [mock.call(None, InMarker1='m1', InMarker2='m2'),])
 
+    def test_result_key_exposed_on_paginator(self):
+        self.assertEqual(self.paginator.result_keys, ['Users', 'Groups'])
+
+    def test_result_key_exposed_on_page_iterator(self):
+        pages = self.paginator.paginate(None, max_items=3)
+        self.assertEqual(pages.result_keys, ['Users', 'Groups'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This was expose on the Paginator object, but also needs to be
exposed through the PageIterator object.

Fixes aws/aws-cli#442.
