### PR TITLE
follow http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/...

### DIFF
--- a/services/elasticache.json
+++ b/services/elasticache.json
@@ -161,20 +161,17 @@
           "NumCacheNodes": {
             "shape_name": "IntegerOptional",
             "type": "integer",
-            "documentation": "\n        <p>The initial number of cache nodes that the cache cluster will have.</p>\n        <p>For a Memcached cluster, valid values are between 1 and 20. If you need to exceed this\n            limit, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\"></a> .</p>\n        <p>For Redis, only single-node cache clusters are supported at this time, so the value for\n            this parameter must be 1.</p>\n    ",
-            "required": true
+            "documentation": "\n        <p>The initial number of cache nodes that the cache cluster will have.</p>\n        <p>For a Memcached cluster, valid values are between 1 and 20. If you need to exceed this\n            limit, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\"></a> .</p>\n        <p>For Redis, only single-node cache clusters are supported at this time, so the value for\n            this parameter must be 1.</p>\n    "
           },
           "CacheNodeType": {
             "shape_name": "String",
             "type": "string",
-            "documentation": "\n        <p>The compute and memory capacity of the nodes in the cache cluster.</p> \n<p>Valid values for Memcached:</p>\n    <p>\n        <code>cache.t1.micro</code> |  \n        <code>cache.m1.small</code> | \n        <code>cache.m1.medium</code> |\n        <code>cache.m1.large</code> | \n        <code>cache.m1.xlarge</code> | \n        <code>cache.m3.xlarge</code> | \n        <code>cache.m3.2xlarge</code> | \n        <code>cache.m2.xlarge</code> | \n        <code>cache.m2.2xlarge</code> |\n        <code>cache.m2.4xlarge</code> | \n        <code>cache.c1.xlarge</code>\n    </p>\n    <p>Valid values for Redis:</p>\n    <p>\n       <code>cache.t1.micro</code> | \n       <code>cache.m1.small</code> | \n       <code>cache.m1.medium</code> |\n       <code>cache.m1.large</code> | \n       <code>cache.m1.xlarge</code> |  \n       <code>cache.m2.xlarge</code> | \n       <code>cache.m2.2xlarge</code> | \n       <code>cache.m2.4xlarge</code> | \n       <code>cache.c1.xlarge</code>\n    </p>\n<p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/\"/>.</p>\n ",
-            "required": true
+            "documentation": "\n        <p>The compute and memory capacity of the nodes in the cache cluster.</p> \n<p>Valid values for Memcached:</p>\n    <p>\n        <code>cache.t1.micro</code> |  \n        <code>cache.m1.small</code> | \n        <code>cache.m1.medium</code> |\n        <code>cache.m1.large</code> | \n        <code>cache.m1.xlarge</code> | \n        <code>cache.m3.xlarge</code> | \n        <code>cache.m3.2xlarge</code> | \n        <code>cache.m2.xlarge</code> | \n        <code>cache.m2.2xlarge</code> |\n        <code>cache.m2.4xlarge</code> | \n        <code>cache.c1.xlarge</code>\n    </p>\n    <p>Valid values for Redis:</p>\n    <p>\n       <code>cache.t1.micro</code> | \n       <code>cache.m1.small</code> | \n       <code>cache.m1.medium</code> |\n       <code>cache.m1.large</code> | \n       <code>cache.m1.xlarge</code> |  \n       <code>cache.m2.xlarge</code> | \n       <code>cache.m2.2xlarge</code> | \n       <code>cache.m2.4xlarge</code> | \n       <code>cache.c1.xlarge</code>\n    </p>\n<p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/\"/>.</p>\n "
           },
           "Engine": {
             "shape_name": "String",
             "type": "string",
-            "documentation": "\n        <p>The name of the cache engine to be used for this cache cluster.</p>\n        <p>Valid values for this parameter are:</p>\n            <p><code>memcached</code> | <code>redis</code></p>\n    ",
-            "required": true
+            "documentation": "\n        <p>The name of the cache engine to be used for this cache cluster.</p>\n        <p>Valid values for this parameter are:</p>\n            <p><code>memcached</code> | <code>redis</code></p>\n    "
           },
           "EngineVersion": {
             "shape_name": "String",


### PR DESCRIPTION
Removed required fields - CacheNodeType, Engine, NumCacheNodes from the CreateCacheCluster operation. An possible issue is cli confliction when add a read-only node into replication group.
