### PR TITLE
Fix find_packages() to not include tests packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='garnaat@amazon.com',
     url='https://github.com/boto/botocore',
     scripts=[],
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests*']),
     package_data={'botocore': ['data/*.json', 'data/aws/*.json'],
                   'botocore.vendored.requests': ['*.pem']},
     package_dir={'botocore': 'botocore'},


### PR DESCRIPTION
The list of packages we install with find_packages() is now:

```
>>> pprint(find_packages(exclude=['tests*']))
['botocore',
 'botocore.vendored',
 'botocore.vendored.requests',
 'botocore.vendored.requests.packages',
 'botocore.vendored.requests.packages.charade',
 'botocore.vendored.requests.packages.urllib3',
 'botocore.vendored.requests.packages.urllib3.contrib',
 'botocore.vendored.requests.packages.urllib3.packages',
 'botocore.vendored.requests.packages.urllib3.packages.ssl_match_hostname']
```

Also manually verified we don't install `tests` with this change.
