### PR TITLE
Add a "mock" region for which the endpoint URL is not rewritten

### DIFF
--- a/botocore/data/aws/_regions.json
+++ b/botocore/data/aws/_regions.json
@@ -28,5 +28,8 @@
     },
     "fips-us-gov-west-1": {
         "description": "AWS GovCloud (FIPS 140-2) S3 Only"
+    },
+    "mock": {
+        "description": "Fake region used for emulation / tests"
     }
 }

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -40,6 +40,7 @@ LABEL_RE = re.compile('[a-z0-9][a-z0-9\-]*[a-z0-9]')
 RESTRICTED_REGIONS = [
     'us-gov-west-1',
     'fips-gov-west-1',
+    'mock'
 ]
 
 


### PR DESCRIPTION
For offline testing (like, when you're on a train), it's nice to be able to use a fake S3 server (eg fakes3).
However, the fix_s3_host function in handlers.py rewrites them to things like http://test.s3.amazonaws.com

This commit adds a fake "mock" region in the RESTRICTED_REGIONS so that custom endpoint_url used with this fake region are not rewritten to valid S3 endpoints. (this may not be the best way to do it, but it has the advantage to be super simple and have little chance to break anything).

