### PR TITLE
Retry 400 RequestTimeouts from S3

### DIFF
--- a/botocore/data/aws/_retry.json
+++ b/botocore/data/aws/_retry.json
@@ -267,6 +267,20 @@
           }
         }
       }
+    },
+    "s3": {
+      "__default__": {
+        "policies": {
+          "timeouts": {
+            "applies_when": {
+              "response": {
+                "http_status_code": 400,
+                "service_error_code": "RequestTimeout"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/botocore/data/aws/s3.json
+++ b/botocore/data/aws/s3.json
@@ -4348,6 +4348,14 @@
                             "http_status_code": 509
                         }
                     }
+                },
+                "timeouts": {
+                    "applies_when": {
+                        "response": {
+                            "http_status_code": 400,
+                            "service_error_code": "RequestTimeout"
+                        }
+                    }
                 }
             }
         }

--- a/services/_retry.json
+++ b/services/_retry.json
@@ -267,6 +267,20 @@
           }
         }
       }
+    },
+    "s3": {
+      "__default__": {
+        "policies": {
+          "timeouts": {
+            "applies_when": {
+              "response": {
+                "http_status_code": 400,
+                "service_error_code": "RequestTimeout"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes the number of issues we were seeing with S3 timeout's in the CLI.  This wasn't initially being caught because we're seeing a 400 response that indicates a RequestTimeout.  Verified this on a t1.micro.
