### PR TITLE
Fix a bug in the response parser

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -208,13 +208,18 @@ class XmlResponse(Response):
 
     def _handle_structure(self, elem, shape):
         new_data = {}
+        xmlname = shape.get('xmlname')
+        if xmlname:
+            tagname = self.get_element_base_tag(elem)
+            if xmlname != tagname:
+                return new_data
         for member_name in shape['members']:
             member_shape = shape['members'][member_name]
             xmlname = member_shape.get('xmlname', member_name)
             child = self.find(elem, xmlname)
             if child is not None:
-                new_data[member_name] = self.handle_elem(member_name, child,
-                                                         member_shape)
+                new_data[member_name] = self.handle_elem(
+                    member_name, child, member_shape)
         return new_data
 
     def _handle_list(self, elem, shape):

--- a/tests/unit/response_parsing/xml/responses/ec2-describe-instance-attribute.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-describe-instance-attribute.json
@@ -1,0 +1,18 @@
+{
+    "UserData": {}, 
+    "ResponseMetadata": {
+        "RequestId": "4c94c806-ef28-4f4c-b1c7-3e601fe39497"
+    }, 
+    "ProductCodes": [], 
+    "InstanceId": "i-12345678", 
+    "InstanceInitiatedShutdownBehavior": {}, 
+    "RootDeviceName": {
+        "Value": "/dev/sda1"
+    }, 
+    "EbsOptimized": {}, 
+    "BlockDeviceMappings": [], 
+    "KernelId": {}, 
+    "RamdiskId": {}, 
+    "DisableApiTermination": {}, 
+    "InstanceType": {}
+}

--- a/tests/unit/response_parsing/xml/responses/ec2-describe-instance-attribute.xml
+++ b/tests/unit/response_parsing/xml/responses/ec2-describe-instance-attribute.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DescribeInstanceAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+    <requestId>4c94c806-ef28-4f4c-b1c7-3e601fe39497</requestId>
+    <instanceId>i-12345678</instanceId>
+    <rootDeviceName>
+        <value>/dev/sda1</value>
+    </rootDeviceName>
+</DescribeInstanceAttributeResponse>
+


### PR DESCRIPTION
The bug involves multiple members of a structure all having the same xmlname.  This occurs in responses like DescribeInstanceAttribute where the output structure contains an explicit member for each possible attribute but only one attribute is included in the response.  The value of the one returned response was being duplicated to all of the members of the structure.  Fixes #173.
