### PR TITLE
Readd empty documentation key

### DIFF
--- a/botocore/data/aws/s3.json
+++ b/botocore/data/aws/s3.json
@@ -9,6 +9,7 @@
     "global_endpoint": "s3.amazonaws.com",
     "endpoint_prefix": "s3",
     "xmlnamespace": "http://s3.amazonaws.com/doc/2006-03-01/",
+    "documentation": "",
     "operations": {
         "AbortMultipartUpload": {
             "name": "AbortMultipartUpload",

--- a/services/s3.json
+++ b/services/s3.json
@@ -9,6 +9,7 @@
   "global_endpoint": "s3.amazonaws.com",
   "endpoint_prefix": "s3",
   "xmlnamespace": "http://s3.amazonaws.com/doc/2006-03-01/",
+  "documentation": "",
   "operations": {
     "AbortMultipartUpload": {
       "name": "AbortMultipartUpload",


### PR DESCRIPTION
Doc generation depends on a documentation key existing, this was
inadvertently removed in the previous model update.
