### PR TITLE
Choose proper XML label for structured payload

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -397,7 +397,7 @@ class ListParameter(Parameter):
         inner_xml = ''
         for item in value:
             xmlname = self.xmlname
-            if not xmlname:
+            if self.members.xmlname:
                 xmlname = self.members.xmlname
             inner_xml += self.members.to_xml(item, xmlname)
         if self.flattened:
@@ -548,7 +548,7 @@ class StructParameter(Parameter):
         xml += '>'
         for member in self.members:
             if member.name in value and not hasattr(member, 'xmlattribute'):
-                xml += member.to_xml(value[member.name], member.name)
+                xml += member.to_xml(value[member.name], member.get_label())
         xml += '</%s>' % label
         return xml
 


### PR DESCRIPTION
Some XML payloads built for requesting REST API are not compatible with syntax.

Sample request from aws-cli:

```
aws s3api put-object-acl --bucket some-bucket-name --key some-key --access-control-policy '
{
    "Grants": [
        {
            "Grantee": {
                "ID": "3423e6294e24539a765a1430979cc6c619499eeb75ff49a134c851a87998ec28d569965bfbc868db0720ee92ce0cb01b",
                "Type": "CanonicalUser"
            }, 
            "Permission": "READ"
        }
    ],
    "Owner": {
        "ID": "1a4fa782449409d942e59e1082d3140d67df45d5eb4fffe68e7734519c30c202"
    }
}'
```

The following XML payload is expected for this request:
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html#RESTObjectPUTacl-requests

```
<AccessControlPolicy>
  <AccessControlList>
    <Grant>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>3423e6294e24539a765a1430979cc6c619499eeb75ff49a134c851a87998ec28d569965bfbc868db0720ee92ce0cb01b</ID>
      </Grantee>
      <Permission>READ</Permission>
    </Grant>
  </AccessControlList>
  <Owner>
    <ID>1a4fa782449409d942e59e1082d3140d67df45d5eb4fffe68e7734519c30c202</ID>
  </Owner>
</AccessControlPolicy>
```

but given:

```
<AccessControlPolicy>
  <Grants>
    <AccessControlList>
      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
        <ID>3423e6294e24539a765a1430979cc6c619499eeb75ff49a134c851a87998ec28d569965bfbc868db0720ee92ce0cb01b</ID>
      </Grantee>
      <Permission>READ</Permission>
    </AccessControlList>
  </Grants>
  <Owner>
    <ID>1a4fa782449409d942e59e1082d3140d67df45d5eb4fffe68e7734519c30c202</ID>
  </Owner>
</AccessControlPolicy>
```
