### PR TITLE
Log HTTP response headers in debug logs

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -401,6 +401,9 @@ def get_response(session, operation, http_response):
         streaming_response.parse(http_response.headers, http_response.raw)
         return (http_response, streaming_response.get_value())
     body = http_response.content
+    logger.debug(
+        "Response Headers:\n%s",
+        '\n'.join("%s: %s" % (k, v) for k, v in http_response.headers.items()))
     logger.debug("Response Body:\n%s", body)
     if operation.service.type == 'json':
         json_response = JSONResponse(session, operation)


### PR DESCRIPTION
We've had requests to log the HTTP response headers
in the debug log, as it helps with troubleshooting.

Sample output:

```
2014-01-02 18:24:58,728 - botocore.response - DEBUG - Response Headers:
x-amz-id-2: foobar
x-amz-meta-customfoo: foobar
content-type: text/plain
server: AmazonS3
date: Fri, 03 Jan 2014 02:24:59 GMT
last-modified: Fri, 03 Jan 2014 00:51:32 GMT
accept-ranges: bytes
x-amz-request-id: requestid
content-length: 12
etag: "someetag"
2014-01-02 18:24:58,728 - botocore.response - DEBUG - Response Body:
```
