### PR TITLE
Fix setting socket timeout in py3

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -34,6 +34,15 @@ if six.PY3:
     from urllib.parse import parse_qsl
     from io import IOBase as _IOBase
     file_type = _IOBase
+
+    def set_socket_timeout(http_response, timeout):
+        """Set the timeout of the socket from an HTTPResponse.
+
+        :param http_response: An instance of ``httplib.HTTPResponse``
+
+        """
+        http_response._fp.fp.raw._sock.settimeout(timeout)
+
 else:
     from urllib import quote
     from urllib import unquote
@@ -50,6 +59,14 @@ else:
         def __iter__(self):
             for field, value in self._headers:
                 yield field
+
+    def set_socket_timeout(http_response, timeout):
+        """Set the timeout of the socket from an HTTPResponse.
+
+        :param http_response: An instance of ``httplib.HTTPResponse``
+
+        """
+        http_response._fp.fp._sock.settimeout(timeout)
 
 try:
     from collections import OrderedDict

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -26,7 +26,7 @@ import logging
 
 from botocore import ScalarTypes
 from botocore.hooks import first_non_none_response
-from botocore.compat import json
+from botocore.compat import json, set_socket_timeout
 from botocore.exceptions import IncompleteReadError
 
 
@@ -421,9 +421,12 @@ class StreamingBody(object):
         # putting in a check here so in case this interface goes away, we'll
         # know.
         try:
-            self._raw_stream._fp.fp._sock.settimeout(timeout)
+            # To further complicate things, the way to grab the
+            # underlying socket object from an HTTPResponse is different
+            # in py2 and py3.  So this code has been pushed to botocore.compat.
+            set_socket_timeout(self._raw_stream, timeout)
         except AttributeError:
-            LOGGER.error("Cannot access the socket object of "
+            logger.error("Cannot access the socket object of "
                          "a streaming response.  It's possible "
                          "the interface has changed.", exc_info=True)
             raise


### PR DESCRIPTION
Unsurprisingly, the internal details vary from py2
to py3 regarding how to get a socket object from an
HTTPResponse class, as the integration tests have
pointed out.
