### PR TITLE
fix: build_parameter_query can't decode utf-8 charcters in parameters.py

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -79,7 +79,11 @@ class Parameter(BotoCoreObject):
             label = label.format(label=self.get_label())
         else:
             label = self.get_label()
-        built_params[label] = six.text_type(value)
+
+        try:
+            built_params[label] = six.text_type(value)
+        except UnicodeDecodeError:
+            built_params[label] = str(value)
 
     def build_parameter_query(self, value, built_params, label=''):
         value = self.validate(value)

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -108,6 +108,16 @@ class TestParameters(unittest.TestCase):
     def test_utf8_string(self):
         p = botocore.parameters.StringParameter(None, name='foo')
         d = {}
+        value = u'\u65e5\u672c\u8a9e'.encode('utf-8')
+        p.build_parameter_query(value, d)
+        self.assertEqual(d['foo'], value)
+        with self.assertRaises(botocore.exceptions.ValidationError):
+            p.build_parameter_query(value=1,
+                                    built_params=d)
+
+    def test_unicode_string(self):
+        p = botocore.parameters.StringParameter(None, name='foo')
+        d = {}
         value = u'\u65e5\u672c\u8a9e'
         p.build_parameter_query(value, d)
         self.assertEqual(d['foo'], value)


### PR DESCRIPTION
Hi,
I found utf-8 probrem when I execute `aws elasticbeanstalk create-application-version` 
with argument  `--description=[UTF-8 CHARACTERS]`.

It seems this bug  is related to https://github.com/aws/aws-cli/issues/593,  so
I modify `build_parameter_query` in order to decode utf-8 characters.

Thanks.
