### PR TITLE
Add event handler to quote the x-amz-copy-source header value as expected by S3.

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -31,7 +31,7 @@ import re
 
 import six
 
-from botocore.compat import urlsplit, urlunsplit, unquote, json
+from botocore.compat import urlsplit, urlunsplit, unquote, json, quote
 from botocore import retryhandler
 import botocore.auth
 
@@ -75,6 +75,13 @@ def calculate_md5(event_name, params, **kwargs):
         md5.update(six.b(params['payload'].getvalue()))
         value = base64.b64encode(md5.digest()).decode('utf-8')
         params['headers']['Content-MD5'] = value
+
+
+def quote_source_header(event_name, params, **kwargs):
+    if params['headers'] and 'x-amz-copy-source' in params['headers']:
+        value = params['headers']['x-amz-copy-source']
+        value = quote(value.encode('utf-8'), safe='/~')
+        params['headers']['x-amz-copy-source'] = value
 
 
 def check_dns_name(bucket_name):
@@ -200,6 +207,8 @@ BUILTIN_HANDLERS = [
     ('before-call.s3.PutBucketLifecycle', calculate_md5),
     ('before-call.s3.PutBucketCors', calculate_md5),
     ('before-call.s3.DeleteObjects', calculate_md5),
+    ('before-call.s3.UploadPartCopy', quote_source_header),
+    ('before-call.s3.CopyObject', quote_source_header),
     ('before-auth.s3', fix_s3_host),
     ('service-created', register_retries_for_service),
     ('creating-endpoint.s3', maybe_switch_to_s3sigv4),

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -64,6 +64,14 @@ class TestHandlers(unittest.TestCase):
         converted_value = first_non_none_response(rv)
         self.assertEqual(converted_value, {'foo':'bar'})
 
+    def test_quote_source_header(self):
+        for op in ('UploadPartCopy', 'CopyObject'):
+            event = self.session.create_event(
+                'before-call', 's3', op)
+            params = {'headers': {'x-amz-copy-source': 'foo++bar.txt'}}
+            self.session.emit(event, params=params)
+            self.assertEqual(
+                params['headers']['x-amz-copy-source'], 'foo%2B%2Bbar.txt')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/614.  Depends on https://github.com/aws/aws-cli/pull/615
