### PR TITLE
added SimpleDB support ( Issue #135 )

### DIFF
--- a/services/sdb.json
+++ b/services/sdb.json
@@ -1158,6 +1158,12 @@
     ]
   },
   "pagination": {
+    "ListDomains": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Domain",
+      "py_input_token": "next_token"
+    }
   },
   "retry": {
     "__default__": {


### PR DESCRIPTION
Hello,

Me and tottokug imported service definition file for Amazon SImpleDB from AWS SDK for Ruby.
We confirmed it is working fine with AWS CLI.

Could you consider to merge it, please?

https://github.com/boto/botocore/issues/135
https://github.com/j3tm0t0/aws-cli-sdb
