### PR TITLE
Remove all bare except clauses

### DIFF
--- a/botocore/base.py
+++ b/botocore/base.py
@@ -96,7 +96,7 @@ def _load_data(session, data_path):
                     fn = os.path.splitext(fn)[0]
                     if not fn.startswith('_'):
                         data.append(fn)
-            except:
+            except Exception:
                 logger.error('Unable to load dir: %s', dir_path,
                              exc_info=True)
             break
@@ -111,7 +111,7 @@ def _load_data(session, data_path):
                 else:
                     data = new_data
                 break
-            except:
+            except Exception:
                 logger.error('Unable to load file: %s', file_path,
                              exc_info=True)
         else:

--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -261,12 +261,12 @@ class TimestampParameter(Parameter):
     def validate(self, value):
         try:
             return dateutil.parser.parse(value)
-        except:
+        except Exception:
             pass
         try:
             # Might be specified as an epoch time
             return datetime.datetime.utcfromtimestamp(value)
-        except:
+        except Exception:
             pass
         raise ValidationError(value=str(value), type_name='timestamp',
                               param=self)

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -154,7 +154,7 @@ class XmlResponse(Response):
         if not children:
             try:
                 children = parent.findall('*/%s' % cn)
-            except:
+            except Exception:
                 pass
         return children
 


### PR DESCRIPTION
While investigating aws/aws-cli#628 I noticed that I'd still
occasionally get tracebacks, particularly a DataNotFoundError
from botocore's base.py module.  After further investigation,
this was because the bare except clauses were catching the
KeyboardInterrupts and swallowing them.  This resulted in a
traceback somewhere downstream.

The specific error I hit from aws/aws-cli#628 was from base.py,
but I did a quick search through the code and for the time being
at least replaced the bare excepts with except Exception.  There's
potential to switch some of these to more specific exceptions later.
