### PR TITLE
fix json -> xml request payload conversion

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -115,7 +115,10 @@ class Parameter(BotoCoreObject):
     def to_xml(self, value, label=None):
         if not label:
             label = self.name
-        return '<%s>%s</%s>' % (label, value, label)
+        if value is None:
+            return '<%s></%s>' % (label, label)
+        else:
+            return '<%s>%s</%s>' % (label, value, label)
 
 
 class IntegerParameter(Parameter):


### PR DESCRIPTION
When creating request payload from json data, json `null` will now be converted to empty string '' not string 'None'.

This bug will fix the bug reported at aws/aws-cli#637
