### PR TITLE
Special case several CamelCase->SnakeCase conversions

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -35,8 +35,15 @@ _end_cap_regex = re.compile('([a-z0-9])([A-Z])')
 _xform_cache = {
     ('SwapEnvironmentCNAMEs', '_'): 'swap_environment_cnames',
     ('SwapEnvironmentCNAMEs', '-'): 'swap-environment-cnames',
+    ('CreateCachediSCSIVolume', '_'): 'create_cached_iscsi_volume',
+    ('CreateCachediSCSIVolume', '-'): 'create-cached-iscsi-volume',
+    ('DescribeCachediSCSIVolumes', '_'): 'describe_cached_iscsi_volumes',
+    ('DescribeCachediSCSIVolumes', '-'): 'describe-cached-iscsi-volumes',
+    ('DescribeStorediSCSIVolumes', '_'): 'describe_stored_iscsi_volumes',
+    ('DescribeStorediSCSIVolumes', '-'): 'describe-stored-iscsi-volumes',
+    ('CreateStorediSCSIVolume', '_'): 'create_stored_iscsi_volume',
+    ('CreateStorediSCSIVolume', '-'): 'create-stored-iscsi-volume',
 }
-
 ScalarTypes = ('string', 'integer', 'boolean', 'timestamp', 'float', 'double')
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -63,6 +63,10 @@ class TestTransformName(unittest.TestCase):
         # Some patterns don't actually match the rules we expect.
         self.assertEqual(xform_name('SwapEnvironmentCNAMEs'), 'swap_environment_cnames')
         self.assertEqual(xform_name('SwapEnvironmentCNAMEs', '-'), 'swap-environment-cnames')
+        self.assertEqual(xform_name('CreateCachediSCSIVolume', '-'), 'create-cached-iscsi-volume')
+        self.assertEqual(xform_name('DescribeCachediSCSIVolumes', '-'), 'describe-cached-iscsi-volumes')
+        self.assertEqual(xform_name('DescribeStorediSCSIVolumes', '-'), 'describe-stored-iscsi-volumes')
+        self.assertEqual(xform_name('CreateStorediSCSIVolume', '-'), 'create-stored-iscsi-volume')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Our algorithm for converting CamelCase to snake_case is wrong for a few special cases:

```
SwapEnvironmentCNAMEs – swap_environment_cnam_es
CreateCachediSCSIVolume – create_cachedi_scsi_volume
DescribeCachediSCSIVolumes - describe_cachedi_scsi_volumes
DescribeStorediSCSIVolumes - describe_storedi_scsi_volumes
CreateStorediSCSIVolume – create_storedi_scsi_volume
```

Rather than add special casing logic into the actual `xform_name` function, I instead introduced a cache, and prepopulated the cache with these special cases.

This will actually speed up performance for repeated cases, and for the CLI it's no slower.

Note that this cache is uncapped, but evaluating the difference in memory before/after this change, caching every single service/operation/parameter resulted in an additional 260K, so I don't think this will be an issue.

For CLI compat, we can reintroduce the wrong/original casings as aliases and mark them as undocumented, but that would be a separate pull request to the CLI.
