### PR TITLE
Handle 307 redirect for file-like object, don't use isinstance check

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -82,9 +82,12 @@ class AWSPreparedRequest(models.PreparedRequest):
 
     def reset_stream_on_redirect(self, response, **kwargs):
         if response.status_code in REDIRECT_STATI and \
-                isinstance(self.body, file_type):
+                self._looks_like_file(self.body):
             logger.debug("Redirect received, rewinding stream: %s", self.body)
             self.reset_stream()
+
+    def _looks_like_file(self, body):
+        return hasattr(body, 'read') and hasattr(body, 'seek')
 
     def reset_stream(self):
         # Trying to reset a stream when there is a no stream will


### PR DESCRIPTION
This fixes aws/aws-cli#544 and aws/aws-cli#654

The issue here is that the CLI uses a file like object
that implements .read() and .seek(), but doesn't actually
inherit from the file/_IOBase.

This means that we weren't rewinding the stream in the case of 307 redirects
when using multipart uploads in the CLI.
