### PR TITLE
Mark Elastic Transcoder required params

### DIFF
--- a/botocore/data/aws/elastictranscoder.json
+++ b/botocore/data/aws/elastictranscoder.json
@@ -23,7 +23,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p>The identifier of the job that you want to cancel. </p>\n        <p>To get a list of the jobs (including their <code>jobId</code>) that have a status of\n                <code>Submitted</code>, use the <a>ListJobsByStatus</a> API action.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": " \n        <p>The <code>CancelJobRequest</code> structure.</p>\n    "
@@ -2196,7 +2197,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p>The identifier of the pipeline that you want to delete.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n        <p>The <code>DeletePipelineRequest</code> structure.</p>\n    "
@@ -2263,7 +2265,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p>The identifier of the preset for which you want to get detailed information.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n        <p>The <code>DeletePresetRequest</code> structure.</p>\n    "
@@ -2323,7 +2326,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p> The ID of the pipeline for which you want to get job information. </p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "Ascending": {
                         "shape_name": "Ascending",
@@ -2936,7 +2940,8 @@
                         "type": "string",
                         "pattern": "(^Submitted$)|(^Progressing$)|(^Complete$)|(^Canceled$)|(^Error$)",
                         "documentation": "\n        <p>To get information about all of the jobs associated with the current AWS account that\n            have a given status, specify the following status: <code>Submitted</code>,\n                <code>Progressing</code>, <code>Complete</code>, <code>Canceled</code>, or\n                <code>Error</code>.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "Ascending": {
                         "shape_name": "Ascending",
@@ -4222,7 +4227,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p>The identifier of the job for which you want to get detailed information.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n        <p>The <code>ReadJobRequest</code> structure.</p>\n    "
@@ -4804,7 +4810,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p>The identifier of the pipeline to read.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n        <p>The <code>ReadPipelineRequest</code> structure.</p>\n    "
@@ -5059,7 +5066,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p>The identifier of the preset for which you want to get detailed information.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n        <p>The <code>ReadPresetRequest</code> structure.</p>\n    "
@@ -5970,7 +5978,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p> The identifier of the pipeline for which you want to change notification settings. </p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "Notifications": {
                         "shape_name": "Notifications",
@@ -6262,7 +6271,8 @@
                         "type": "string",
                         "pattern": "^\\d{13}-\\w{6}$",
                         "documentation": "\n        <p>The identifier of the pipeline to update.</p>\n    ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "Status": {
                         "shape_name": "PipelineStatus",

--- a/services/elastictranscoder.extra.json
+++ b/services/elastictranscoder.extra.json
@@ -15,11 +15,110 @@
     }
   },
   "operations": {
+    "CancelJob": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
     "CreateJob": {
       "input": {
         "members": {
           "Output": {
             "cli_name": "job-output"
+          }
+        }
+      }
+    },
+    "DeletePipeline": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "DeletePreset": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "ListJobsByPipeline": {
+      "input": {
+        "members": {
+          "PipelineId": {
+            "required": true
+          }
+        }
+      }
+    },
+    "ListJobsByStatus": {
+      "input": {
+        "members": {
+          "Status": {
+            "required": true
+          }
+        }
+      }
+    },
+    "ReadJob": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "ReadPipeline": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "ReadPreset": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "UpdatePipeline": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "UpdatePipelineNotifications": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "UpdatePipelineStatus": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
           }
         }
       }


### PR DESCRIPTION
This PR supersedes #244, fixes #214 and marks all the required Elastic Transcoder params as such via its `.extra.json` file. After the change the CLI looks like:

``` bash
$ ./bin/aws elastictranscoder delete-pipeline
usage: aws [options] <command> <subcommand> [parameters]
aws: error: argument --id is required
```

Raw botocore looks like:

``` python
>>> import botocore.session
>>> s = botocore.session.get_session()
>>> e = s.get_service('elastictranscoder')
>>> op = e.get_operation('DeletePipeline')
>>> endpoint = e.get_endpoint('us-east-1')
>>> op.call(endpoint)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "botocore/operation.py", line 62, in call
    params = self.build_parameters(**kwargs)
  File "botocore/operation.py", line 172, in build_parameters
    object_name=self)
botocore.exceptions.MissingParametersError: The following required parameters are missing for Operation:DeletePipeline: id
```

This is my first edit of the `.extra.json` files so let me know if anything else needs to be done @jamesls.

It looks like Elastic Transcoder is the only service marked as `rest-json`.
