### PR TITLE
Mark Cloudfront required params

### DIFF
--- a/botocore/data/aws/cloudfront.json
+++ b/botocore/data/aws/cloudfront.json
@@ -2650,7 +2650,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The origin access identity's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "IfMatch": {
                         "shape_name": "string",
@@ -2742,7 +2743,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The distribution id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "IfMatch": {
                         "shape_name": "string",
@@ -2834,7 +2836,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The distribution id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "IfMatch": {
                         "shape_name": "string",
@@ -2925,7 +2928,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The identity's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n    The request to get an origin access identity's information.\n  "
@@ -3025,7 +3029,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The identity's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n    The request to get an origin access identity's configuration.\n  "
@@ -3106,7 +3111,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The distribution's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n    The request to get a distribution's information.\n  "
@@ -3883,7 +3889,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The distribution's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n    The request to get a distribution configuration.\n  "
@@ -4699,7 +4706,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The streaming distribution's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n    The request to get a streaming distribution's information.\n  "
@@ -4992,7 +5000,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The streaming distribution's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     }
                 },
                 "documentation": "\n    To request to get a streaming distribution configuration.\n  "
@@ -6442,7 +6451,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The identity's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "IfMatch": {
                         "shape_name": "string",
@@ -7238,7 +7248,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The distribution's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "IfMatch": {
                         "shape_name": "string",
@@ -8462,7 +8473,8 @@
                         "shape_name": "string",
                         "type": "string",
                         "documentation": "\n    The streaming distribution's id.\n  ",
-                        "location": "uri"
+                        "location": "uri",
+                        "required": true
                     },
                     "IfMatch": {
                         "shape_name": "string",

--- a/services/cloudfront.extra.json
+++ b/services/cloudfront.extra.json
@@ -41,5 +41,115 @@
     "operation-name": {
       "remove": "\\d{4}_\\d{2}_\\d{2}"
     }
+  },
+  "operations": {
+    "DeleteCloudFrontOriginAccessIdentity": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "DeleteDistribution": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "DeleteStreamingDistribution": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "GetCloudFrontOriginAccessIdentity": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "GetCloudFrontOriginAccessIdentityConfig": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "GetDistribution": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "GetDistributionConfig": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "GetStreamingDistribution": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "GetStreamingDistributionConfig": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "UpdateCloudFrontOriginAccessIdentity": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "UpdateDistribution": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    },
+    "UpdateStreamingDistribution": {
+      "input": {
+        "members": {
+          "Id": {
+            "required": true
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Similar to #246, this adds required traits to parameters for Cloudfront. Also went through and checked Route53 and S3, but they have all required URI template params marked as required already. This _should_ mean all services are now up to date.

@jamesls, please review.
