### PR TITLE
Update S3 model to use shapes

### DIFF
--- a/botocore/data/aws/s3.json
+++ b/botocore/data/aws/s3.json
@@ -9,7 +9,7 @@
     "global_endpoint": "s3.amazonaws.com",
     "endpoint_prefix": "s3",
     "xmlnamespace": "http://s3.amazonaws.com/doc/2006-03-01/",
-    "documentation": "",
+    "documentation": null,
     "operations": {
         "AbortMultipartUpload": {
             "name": "AbortMultipartUpload",
@@ -18,35 +18,44 @@
                 "uri": "/{Bucket}/{Key}?uploadId={UploadId}"
             },
             "input": {
+                "shape_name": "AbortMultipartUploadRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "UploadId": {
+                        "shape_name": "MultipartUploadId",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [
                 {
                     "shape_name": "NoSuchUpload",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The specified multipart upload does not exist."
                 }
             ],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html",
-            "documentation": "<p>Aborts a multipart upload.</p><p>To verify that all parts have been removed, so you don't get charged for the part storage, you should call the List Parts operation and ensure the parts list is empty.</p>"
+            "documentation": "<p>Aborts a multipart upload.</p>\n<p>To verify that all parts have been removed, so you don't get charged for the part storage, you should call the List Parts operation and ensure the parts list is empty.</p>",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html"
         },
         "CompleteMultipartUpload": {
             "name": "CompleteMultipartUpload",
@@ -55,108 +64,134 @@
                 "uri": "/{Bucket}/{Key}?uploadId={UploadId}"
             },
             "input": {
+                "shape_name": "CompleteMultipartUploadRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "MultipartUpload": {
+                        "shape_name": "CompletedMultipartUpload",
                         "type": "structure",
-                        "payload": true,
-                        "xmlname": "CompleteMultipartUpload",
                         "members": {
                             "Parts": {
+                                "shape_name": "CompletedPartList",
                                 "type": "list",
-                                "xmlname": "Part",
                                 "members": {
+                                    "shape_name": "CompletedPart",
                                     "type": "structure",
                                     "members": {
                                         "ETag": {
+                                            "shape_name": "ETag",
                                             "type": "string",
                                             "documentation": "Entity tag returned when the part was uploaded."
                                         },
                                         "PartNumber": {
+                                            "shape_name": "PartNumber",
                                             "type": "integer",
                                             "documentation": "Part number that identifies the part."
                                         }
-                                    }
+                                    },
+                                    "documentation": null
                                 },
-                                "flattened": true
+                                "flattened": true,
+                                "documentation": null,
+                                "xmlname": "Part"
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "xmlname": "CompleteMultipartUpload",
+                        "payload": true
                     },
                     "UploadId": {
+                        "shape_name": "MultipartUploadId",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "CompleteMultipartUploadOutput",
                 "type": "structure",
                 "members": {
+                    "Location": {
+                        "shape_name": "Location",
+                        "type": "string",
+                        "documentation": null
+                    },
                     "Bucket": {
-                        "type": "string"
+                        "shape_name": "BucketName",
+                        "type": "string",
+                        "documentation": null
+                    },
+                    "Key": {
+                        "shape_name": "ObjectKey",
+                        "type": "string",
+                        "documentation": null
+                    },
+                    "Expiration": {
+                        "shape_name": "Expiration",
+                        "type": "timestamp",
+                        "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded.",
+                        "location": "header",
+                        "location_name": "x-amz-expiration"
                     },
                     "ETag": {
+                        "shape_name": "ETag",
                         "type": "string",
                         "documentation": "Entity tag of the object."
                     },
-                    "Expiration": {
-                        "type": "timestamp",
-                        "location": "header",
-                        "location_name": "x-amz-expiration",
-                        "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded."
-                    },
-                    "Key": {
-                        "type": "string"
-                    },
-                    "Location": {
-                        "type": "string"
-                    },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     },
                     "VersionId": {
+                        "shape_name": "ObjectVersionId",
                         "type": "string",
+                        "documentation": "Version of the object.",
                         "location": "header",
-                        "location_name": "x-amz-version-id",
-                        "documentation": "Version of the object."
+                        "location_name": "x-amz-version-id"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html",
-            "documentation": "Completes a multipart upload by assembling previously uploaded parts."
+            "documentation": "Completes a multipart upload by assembling previously uploaded parts.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html"
         },
         "CopyObject": {
             "name": "CopyObject",
-            "alias": "PutObjectCopy",
             "http": {
                 "method": "PUT",
                 "uri": "/{Bucket}/{Key}"
             },
             "input": {
+                "shape_name": "CopyObjectRequest",
                 "type": "structure",
                 "members": {
                     "ACL": {
+                        "shape_name": "ObjectCannedACL",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-acl",
                         "enum": [
                             "private",
                             "public-read",
@@ -165,107 +200,128 @@
                             "bucket-owner-read",
                             "bucket-owner-full-control"
                         ],
-                        "documentation": "The canned ACL to apply to the object."
+                        "documentation": "The canned ACL to apply to the object.",
+                        "location": "header",
+                        "location_name": "x-amz-acl"
                     },
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "CacheControl": {
+                        "shape_name": "CacheControl",
                         "type": "string",
+                        "documentation": "Specifies caching behavior along the request/reply chain.",
                         "location": "header",
-                        "location_name": "Cache-Control",
-                        "documentation": "Specifies caching behavior along the request/reply chain."
+                        "location_name": "Cache-Control"
                     },
                     "ContentDisposition": {
+                        "shape_name": "ContentDisposition",
                         "type": "string",
+                        "documentation": "Specifies presentational information for the object.",
                         "location": "header",
-                        "location_name": "Content-Disposition",
-                        "documentation": "Specifies presentational information for the object."
+                        "location_name": "Content-Disposition"
                     },
                     "ContentEncoding": {
+                        "shape_name": "ContentEncoding",
                         "type": "string",
+                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
                         "location": "header",
-                        "location_name": "Content-Encoding",
-                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
+                        "location_name": "Content-Encoding"
                     },
                     "ContentLanguage": {
+                        "shape_name": "ContentLanguage",
                         "type": "string",
+                        "documentation": "The language the content is in.",
                         "location": "header",
-                        "location_name": "Content-Language",
-                        "documentation": "The language the content is in."
+                        "location_name": "Content-Language"
                     },
                     "ContentType": {
+                        "shape_name": "ContentType",
                         "type": "string",
+                        "documentation": "A standard MIME type describing the format of the object data.",
                         "location": "header",
-                        "location_name": "Content-Type",
-                        "documentation": "A standard MIME type describing the format of the object data."
+                        "location_name": "Content-Type"
                     },
                     "CopySource": {
+                        "shape_name": "CopySource",
                         "type": "string",
+                        "pattern": "\\/.+\\/.+",
+                        "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
                         "required": true,
                         "location": "header",
-                        "location_name": "x-amz-copy-source",
-                        "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
-                        "pattern": "\\/.+\\/.+"
+                        "location_name": "x-amz-copy-source"
                     },
                     "CopySourceIfMatch": {
+                        "shape_name": "CopySourceIfMatch",
                         "type": "timestamp",
+                        "documentation": "Copies the object if its entity tag (ETag) matches the specified tag.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-match",
-                        "documentation": "Copies the object if its entity tag (ETag) matches the specified tag."
+                        "location_name": "x-amz-copy-source-if-match"
                     },
                     "CopySourceIfModifiedSince": {
+                        "shape_name": "CopySourceIfModifiedSince",
                         "type": "timestamp",
+                        "documentation": "Copies the object if it has been modified since the specified time.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-modified-since",
-                        "documentation": "Copies the object if it has been modified since the specified time."
+                        "location_name": "x-amz-copy-source-if-modified-since"
                     },
                     "CopySourceIfNoneMatch": {
+                        "shape_name": "CopySourceIfNoneMatch",
                         "type": "timestamp",
+                        "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-none-match",
-                        "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag."
+                        "location_name": "x-amz-copy-source-if-none-match"
                     },
                     "CopySourceIfUnmodifiedSince": {
+                        "shape_name": "CopySourceIfUnmodifiedSince",
                         "type": "timestamp",
+                        "documentation": "Copies the object if it hasn't been modified since the specified time.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-unmodified-since",
-                        "documentation": "Copies the object if it hasn't been modified since the specified time."
+                        "location_name": "x-amz-copy-source-if-unmodified-since"
                     },
                     "Expires": {
+                        "shape_name": "Expires",
                         "type": "timestamp",
+                        "documentation": "The date and time at which the object is no longer cacheable.",
                         "location": "header",
-                        "location_name": "Expires",
-                        "documentation": "The date and time at which the object is no longer cacheable."
+                        "location_name": "Expires"
                     },
                     "GrantFullControl": {
+                        "shape_name": "GrantFullControl",
                         "type": "string",
+                        "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.",
                         "location": "header",
-                        "location_name": "x-amz-grant-full-control",
-                        "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."
+                        "location_name": "x-amz-grant-full-control"
                     },
                     "GrantRead": {
+                        "shape_name": "GrantRead",
                         "type": "string",
+                        "documentation": "Allows grantee to read the object data and its metadata.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read",
-                        "documentation": "Allows grantee to read the object data and its metadata."
+                        "location_name": "x-amz-grant-read"
                     },
                     "GrantReadACP": {
+                        "shape_name": "GrantReadACP",
                         "type": "string",
+                        "documentation": "Allows grantee to read the object ACL.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read-acp",
-                        "documentation": "Allows grantee to read the object ACL."
+                        "location_name": "x-amz-grant-read-acp"
                     },
                     "GrantWriteACP": {
+                        "shape_name": "GrantWriteACP",
                         "type": "string",
+                        "documentation": "Allows grantee to write the ACL for the applicable object.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write-acp",
-                        "documentation": "Allows grantee to write the ACL for the applicable object."
+                        "location_name": "x-amz-grant-write-acp"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
@@ -273,136 +329,156 @@
                         "type": "map",
                         "location": "header",
                         "location_name": "x-amz-meta-",
+                        "keys": {
+                            "type": "string",
+                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+                        },
                         "members": {
                             "type": "string",
                             "documentation": "The metadata value."
                         },
-                        "documentation": "A map of metadata to store with the object in S3.",
-                        "keys": {
-                            "type": "string",
-                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-                        }
+                        "documentation": "A map of metadata to store with the object in S3."
                     },
                     "MetadataDirective": {
+                        "shape_name": "MetadataDirective",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-metadata-directive",
                         "enum": [
                             "COPY",
                             "REPLACE"
                         ],
-                        "documentation": "Specifies whether the metadata is copied from the source object or replaced with metadata provided in the request."
+                        "documentation": "Specifies whether the metadata is copied from the source object or replaced with metadata provided in the request.",
+                        "location": "header",
+                        "location_name": "x-amz-metadata-directive"
                     },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     },
                     "StorageClass": {
+                        "shape_name": "StorageClassOptions",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-storage-class",
                         "enum": [
                             "STANDARD",
                             "REDUCED_REDUNDANCY"
                         ],
-                        "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'."
+                        "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'.",
+                        "location": "header",
+                        "location_name": "x-amz-storage-class"
                     },
                     "WebsiteRedirectLocation": {
+                        "shape_name": "WebsiteRedirectLocation",
                         "type": "string",
+                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
                         "location": "header",
                         "location_name": "x-amz-website-redirect-location",
-                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
                         "no_paramfile": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "CopyObjectOutput",
                 "type": "structure",
                 "members": {
                     "CopyObjectResult": {
+                        "shape_name": "CopyObjectResult",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "ETag": {
-                                "type": "string"
+                                "shape_name": "ETag",
+                                "type": "string",
+                                "documentation": null
                             },
                             "LastModified": {
-                                "type": "string"
+                                "shape_name": "LastModified",
+                                "type": "timestamp",
+                                "documentation": null
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "payload": true
+                    },
+                    "Expiration": {
+                        "shape_name": "Expiration",
+                        "type": "timestamp",
+                        "documentation": "If the object expiration is configured, the response includes this header.",
+                        "location": "header",
+                        "location_name": "x-amz-expiration"
                     },
                     "CopySourceVersionId": {
+                        "shape_name": "CopySourceVersionId",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "x-amz-copy-source-version-id"
                     },
-                    "Expiration": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-expiration",
-                        "documentation": "If the object expiration is configured, the response includes this header."
-                    },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [
                 {
                     "shape_name": "ObjectNotInActiveTierError",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The source object of the COPY operation is not in the active tier and is only stored in Amazon Glacier."
                 }
             ],
+            "documentation": "Creates a copy of an object that is already stored in Amazon S3.",
             "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html",
-            "documentation": "Creates a copy of an object that is already stored in Amazon S3."
+            "alias": "PutObjectCopy"
         },
         "CreateBucket": {
             "name": "CreateBucket",
-            "alias": "PutBucket",
             "http": {
                 "method": "PUT",
                 "uri": "/{Bucket}"
             },
             "input": {
+                "shape_name": "CreateBucketRequest",
                 "type": "structure",
                 "members": {
                     "ACL": {
+                        "shape_name": "BucketCannedACL",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-acl",
                         "enum": [
                             "private",
                             "public-read",
                             "public-read-write",
-                            "authenticated-read",
-                            "bucket-owner-read",
-                            "bucket-owner-full-control"
+                            "authenticated-read"
                         ],
-                        "documentation": "The canned ACL to apply to the bucket."
+                        "documentation": "The canned ACL to apply to the bucket.",
+                        "location": "header",
+                        "location_name": "x-amz-acl"
                     },
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "CreateBucketConfiguration": {
+                        "shape_name": "CreateBucketConfiguration",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "LocationConstraint": {
+                                "shape_name": "BucketLocationConstraint",
                                 "type": "string",
                                 "enum": [
                                     "EU",
@@ -417,75 +493,87 @@
                                 ],
                                 "documentation": "Specifies the region where the bucket will be created."
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "payload": true
                     },
                     "GrantFullControl": {
+                        "shape_name": "GrantFullControl",
                         "type": "string",
+                        "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-full-control",
-                        "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."
+                        "location_name": "x-amz-grant-full-control"
                     },
                     "GrantRead": {
+                        "shape_name": "GrantRead",
                         "type": "string",
+                        "documentation": "Allows grantee to list the objects in the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read",
-                        "documentation": "Allows grantee to list the objects in the bucket."
+                        "location_name": "x-amz-grant-read"
                     },
                     "GrantReadACP": {
+                        "shape_name": "GrantReadACP",
                         "type": "string",
+                        "documentation": "Allows grantee to read the bucket ACL.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read-acp",
-                        "documentation": "Allows grantee to read the bucket ACL."
+                        "location_name": "x-amz-grant-read-acp"
                     },
                     "GrantWrite": {
+                        "shape_name": "GrantWrite",
                         "type": "string",
+                        "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write",
-                        "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket."
+                        "location_name": "x-amz-grant-write"
                     },
                     "GrantWriteACP": {
+                        "shape_name": "GrantWriteACP",
                         "type": "string",
+                        "documentation": "Allows grantee to write the ACL for the applicable bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write-acp",
-                        "documentation": "Allows grantee to write the ACL for the applicable bucket."
+                        "location_name": "x-amz-grant-write-acp"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "CreateBucketOutput",
                 "type": "structure",
                 "members": {
                     "Location": {
+                        "shape_name": "Location",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Location"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [
                 {
                     "shape_name": "BucketAlreadyExists",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again."
                 }
             ],
+            "documentation": "Creates a new bucket.",
             "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html",
-            "documentation": "Creates a new bucket."
+            "alias": "PutBucket"
         },
         "CreateMultipartUpload": {
             "name": "CreateMultipartUpload",
-            "alias": "InitiateMultipartUpload",
             "http": {
                 "method": "POST",
                 "uri": "/{Bucket}/{Key}?uploads"
             },
             "input": {
+                "shape_name": "CreateMultipartUploadRequest",
                 "type": "structure",
                 "members": {
                     "ACL": {
+                        "shape_name": "ObjectCannedACL",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-acl",
                         "enum": [
                             "private",
                             "public-read",
@@ -494,75 +582,91 @@
                             "bucket-owner-read",
                             "bucket-owner-full-control"
                         ],
-                        "documentation": "The canned ACL to apply to the object."
+                        "documentation": "The canned ACL to apply to the object.",
+                        "location": "header",
+                        "location_name": "x-amz-acl"
                     },
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "CacheControl": {
+                        "shape_name": "CacheControl",
                         "type": "string",
+                        "documentation": "Specifies caching behavior along the request/reply chain.",
                         "location": "header",
-                        "location_name": "Cache-Control",
-                        "documentation": "Specifies caching behavior along the request/reply chain."
+                        "location_name": "Cache-Control"
                     },
                     "ContentDisposition": {
+                        "shape_name": "ContentDisposition",
                         "type": "string",
+                        "documentation": "Specifies presentational information for the object.",
                         "location": "header",
-                        "location_name": "Content-Disposition",
-                        "documentation": "Specifies presentational information for the object."
+                        "location_name": "Content-Disposition"
                     },
                     "ContentEncoding": {
+                        "shape_name": "ContentEncoding",
                         "type": "string",
+                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
                         "location": "header",
-                        "location_name": "Content-Encoding",
-                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
+                        "location_name": "Content-Encoding"
                     },
                     "ContentLanguage": {
+                        "shape_name": "ContentLanguage",
                         "type": "string",
+                        "documentation": "The language the content is in.",
                         "location": "header",
-                        "location_name": "Content-Language",
-                        "documentation": "The language the content is in."
+                        "location_name": "Content-Language"
                     },
                     "ContentType": {
+                        "shape_name": "ContentType",
                         "type": "string",
+                        "documentation": "A standard MIME type describing the format of the object data.",
                         "location": "header",
-                        "location_name": "Content-Type",
-                        "documentation": "A standard MIME type describing the format of the object data."
+                        "location_name": "Content-Type"
                     },
                     "Expires": {
+                        "shape_name": "Expires",
                         "type": "timestamp",
+                        "documentation": "The date and time at which the object is no longer cacheable.",
                         "location": "header",
-                        "location_name": "Expires",
-                        "documentation": "The date and time at which the object is no longer cacheable."
+                        "location_name": "Expires"
                     },
                     "GrantFullControl": {
+                        "shape_name": "GrantFullControl",
                         "type": "string",
+                        "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.",
                         "location": "header",
-                        "location_name": "x-amz-grant-full-control",
-                        "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."
+                        "location_name": "x-amz-grant-full-control"
                     },
                     "GrantRead": {
+                        "shape_name": "GrantRead",
                         "type": "string",
+                        "documentation": "Allows grantee to read the object data and its metadata.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read",
-                        "documentation": "Allows grantee to read the object data and its metadata."
+                        "location_name": "x-amz-grant-read"
                     },
                     "GrantReadACP": {
+                        "shape_name": "GrantReadACP",
                         "type": "string",
+                        "documentation": "Allows grantee to read the object ACL.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read-acp",
-                        "documentation": "Allows grantee to read the object ACL."
+                        "location_name": "x-amz-grant-read-acp"
                     },
                     "GrantWriteACP": {
+                        "shape_name": "GrantWriteACP",
                         "type": "string",
+                        "documentation": "Allows grantee to write the ACL for the applicable object.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write-acp",
-                        "documentation": "Allows grantee to write the ACL for the applicable object."
+                        "location_name": "x-amz-grant-write-acp"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
@@ -570,75 +674,85 @@
                         "type": "map",
                         "location": "header",
                         "location_name": "x-amz-meta-",
+                        "keys": {
+                            "type": "string",
+                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+                        },
                         "members": {
                             "type": "string",
                             "documentation": "The metadata value."
                         },
-                        "documentation": "A map of metadata to store with the object in S3.",
-                        "keys": {
-                            "type": "string",
-                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-                        }
+                        "documentation": "A map of metadata to store with the object in S3."
                     },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     },
                     "StorageClass": {
+                        "shape_name": "StorageClassOptions",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-storage-class",
                         "enum": [
                             "STANDARD",
                             "REDUCED_REDUNDANCY"
                         ],
-                        "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'."
+                        "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'.",
+                        "location": "header",
+                        "location_name": "x-amz-storage-class"
                     },
                     "WebsiteRedirectLocation": {
+                        "shape_name": "WebsiteRedirectLocation",
                         "type": "string",
+                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
                         "location": "header",
                         "location_name": "x-amz-website-redirect-location",
-                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
                         "no_paramfile": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "CreateMultipartUploadOutput",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
-                        "xmlname": "Bucket",
-                        "documentation": "Name of the bucket to which the multipart upload was initiated."
+                        "documentation": "Name of the bucket to which the multipart upload was initiated.",
+                        "xmlname": "Bucket"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
                         "documentation": "Object key for which the multipart upload was initiated."
                     },
-                    "ServerSideEncryption": {
+                    "UploadId": {
+                        "shape_name": "MultipartUploadId",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
+                        "documentation": "ID for the initiated multipart upload."
+                    },
+                    "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
+                        "type": "string",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
-                    },
-                    "UploadId": {
-                        "type": "string",
-                        "documentation": "ID for the initiated multipart upload."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
+            "documentation": "<p>Initiates a multipart upload and returns an upload ID.</p>\n<p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>",
             "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html",
-            "documentation": "<p>Initiates a multipart upload and returns an upload ID.</p><p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>"
+            "alias": "InitiateMultipartUpload"
         },
         "DeleteBucket": {
             "name": "DeleteBucket",
@@ -647,19 +761,23 @@
                 "uri": "/{Bucket}"
             },
             "input": {
+                "shape_name": "DeleteBucketRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETE.html",
-            "documentation": "Deletes the bucket. All objects (including all object versions and Delete Markers) in the bucket must be deleted before the bucket itself can be deleted."
+            "documentation": "Deletes the bucket. All objects (including all object versions and Delete Markers) in the bucket must be deleted before the bucket itself can be deleted.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETE.html"
         },
         "DeleteBucketCors": {
             "name": "DeleteBucketCors",
@@ -668,19 +786,23 @@
                 "uri": "/{Bucket}?cors"
             },
             "input": {
+                "shape_name": "DeleteBucketCorsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEcors.html",
-            "documentation": "Deletes the cors configuration information set for the bucket."
+            "documentation": "Deletes the cors configuration information set for the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEcors.html"
         },
         "DeleteBucketLifecycle": {
             "name": "DeleteBucketLifecycle",
@@ -689,19 +811,23 @@
                 "uri": "/{Bucket}?lifecycle"
             },
             "input": {
+                "shape_name": "DeleteBucketLifecycleRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETElifecycle.html",
-            "documentation": "Deletes the lifecycle configuration from the bucket."
+            "documentation": "Deletes the lifecycle configuration from the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETElifecycle.html"
         },
         "DeleteBucketPolicy": {
             "name": "DeleteBucketPolicy",
@@ -710,19 +836,23 @@
                 "uri": "/{Bucket}?policy"
             },
             "input": {
+                "shape_name": "DeleteBucketPolicyRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEpolicy.html",
-            "documentation": "Deletes the policy from the bucket."
+            "documentation": "Deletes the policy from the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEpolicy.html"
         },
         "DeleteBucketTagging": {
             "name": "DeleteBucketTagging",
@@ -731,19 +861,23 @@
                 "uri": "/{Bucket}?tagging"
             },
             "input": {
+                "shape_name": "DeleteBucketTaggingRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEtagging.html",
-            "documentation": "Deletes the tags from the bucket."
+            "documentation": "Deletes the tags from the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEtagging.html"
         },
         "DeleteBucketWebsite": {
             "name": "DeleteBucketWebsite",
@@ -752,19 +886,23 @@
                 "uri": "/{Bucket}?website"
             },
             "input": {
+                "shape_name": "DeleteBucketWebsiteRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEwebsite.html",
-            "documentation": "This operation removes the website configuration from the bucket."
+            "documentation": "This operation removes the website configuration from the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEwebsite.html"
         },
         "DeleteObject": {
             "name": "DeleteObject",
@@ -773,159 +911,209 @@
                 "uri": "/{Bucket}/{Key}?versionId={VersionId}"
             },
             "input": {
+                "shape_name": "DeleteObjectRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "MFA": {
+                        "shape_name": "MFA",
                         "type": "string",
+                        "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device.",
                         "location": "header",
-                        "location_name": "x-amz-mfa",
-                        "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."
+                        "location_name": "x-amz-mfa"
                     },
                     "VersionId": {
+                        "shape_name": "ObjectVersionId",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "VersionId used to reference a specific version of the object."
+                        "documentation": "VersionId used to reference a specific version of the object.",
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "DeleteObjectOutput",
                 "type": "structure",
                 "members": {
                     "DeleteMarker": {
+                        "shape_name": "DeleteMarker",
                         "type": "boolean",
+                        "documentation": "Specifies whether the versioned object that was permanently deleted was (true) or was not (false) a delete marker.",
                         "location": "header",
-                        "location_name": "x-amz-delete-marker",
-                        "documentation": "Specifies whether the versioned object that was permanently deleted was (true) or was not (false) a delete marker."
+                        "location_name": "x-amz-delete-marker"
                     },
                     "VersionId": {
+                        "shape_name": "ObjectVersionId",
                         "type": "string",
+                        "documentation": "Returns the version ID of the delete marker created as a result of the DELETE operation.",
                         "location": "header",
-                        "location_name": "x-amz-version-id",
-                        "documentation": "Returns the version ID of the delete marker created as a result of the DELETE operation."
+                        "location_name": "x-amz-version-id"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html",
-            "documentation": "Removes the null version (if there is one) of an object and inserts a delete marker, which becomes the latest version of the object. If there isn't a null version, Amazon S3 does not remove any objects."
+            "documentation": "Removes the null version (if there is one) of an object and inserts a delete marker, which becomes the latest version of the object. If there isn't a null version, Amazon S3 does not remove any objects.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html"
         },
         "DeleteObjects": {
             "name": "DeleteObjects",
-            "alias": "DeleteMultipleObjects",
             "http": {
                 "method": "POST",
                 "uri": "/{Bucket}?delete"
             },
             "input": {
+                "shape_name": "DeleteObjectsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Delete": {
+                        "shape_name": "Delete",
                         "type": "structure",
-                        "payload": true,
-                        "required": true,
                         "members": {
                             "Objects": {
+                                "shape_name": "ObjectIdentifierList",
                                 "type": "list",
-                                "required": true,
-                                "xmlname": "Object",
                                 "members": {
+                                    "shape_name": "ObjectIdentifier",
                                     "type": "structure",
                                     "members": {
                                         "Key": {
+                                            "shape_name": "ObjectKey",
                                             "type": "string",
-                                            "required": true,
-                                            "documentation": "Key name of the object to delete."
+                                            "documentation": "Key name of the object to delete.",
+                                            "required": true
                                         },
                                         "VersionId": {
+                                            "shape_name": "ObjectVersionId",
                                             "type": "string",
                                             "documentation": "VersionId for the specific version of the object to delete."
                                         }
-                                    }
+                                    },
+                                    "documentation": null
                                 },
-                                "flattened": true
+                                "flattened": true,
+                                "documentation": null,
+                                "required": true,
+                                "xmlname": "Object"
                             },
                             "Quiet": {
+                                "shape_name": "Quiet",
                                 "type": "boolean",
                                 "documentation": "Element to enable quiet mode for the request. When you add this element, you must set its value to true."
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "required": true,
+                        "payload": true
                     },
                     "MFA": {
+                        "shape_name": "MFA",
                         "type": "string",
+                        "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device.",
                         "location": "header",
-                        "location_name": "x-amz-mfa",
-                        "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."
+                        "location_name": "x-amz-mfa"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "DeleteObjectsOutput",
                 "type": "structure",
                 "members": {
                     "Deleted": {
+                        "shape_name": "DeletedObjects",
                         "type": "list",
                         "members": {
+                            "shape_name": "DeletedObject",
                             "type": "structure",
                             "members": {
+                                "Key": {
+                                    "shape_name": "ObjectKey",
+                                    "type": "string",
+                                    "documentation": null
+                                },
+                                "VersionId": {
+                                    "shape_name": "ObjectVersionId",
+                                    "type": "string",
+                                    "documentation": null
+                                },
                                 "DeleteMarker": {
-                                    "type": "boolean"
+                                    "shape_name": "DeleteMarker",
+                                    "type": "boolean",
+                                    "documentation": null
                                 },
                                 "DeleteMarkerVersionId": {
-                                    "type": "string"
-                                },
-                                "Key": {
-                                    "type": "string"
-                                },
-                                "VersionId": {
-                                    "type": "string"
+                                    "shape_name": "DeleteMarkerVersionId",
+                                    "type": "string",
+                                    "documentation": null
                                 }
-                            }
+                            },
+                            "documentation": null
                         },
-                        "flattened": true
+                        "flattened": true,
+                        "documentation": null
                     },
                     "Errors": {
+                        "shape_name": "Errors",
                         "type": "list",
-                        "xmlname": "Error",
                         "members": {
+                            "shape_name": "Error",
                             "type": "structure",
                             "members": {
-                                "Code": {
-                                    "type": "string"
-                                },
                                 "Key": {
-                                    "type": "string"
-                                },
-                                "Message": {
-                                    "type": "string"
+                                    "shape_name": "ObjectKey",
+                                    "type": "string",
+                                    "documentation": null
                                 },
                                 "VersionId": {
-                                    "type": "string"
+                                    "shape_name": "ObjectVersionId",
+                                    "type": "string",
+                                    "documentation": null
+                                },
+                                "Code": {
+                                    "shape_name": "Code",
+                                    "type": "string",
+                                    "documentation": null
+                                },
+                                "Message": {
+                                    "shape_name": "Message",
+                                    "type": "string",
+                                    "documentation": null
                                 }
-                            }
+                            },
+                            "documentation": null
                         },
-                        "flattened": true
+                        "flattened": true,
+                        "documentation": null,
+                        "xmlname": "Error"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
+            "documentation": "This operation enables you to delete multiple objects from a bucket using a single HTTP request. You may specify up to 1000 keys.",
             "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html",
-            "documentation": "This operation enables you to delete multiple objects from a bucket using a single HTTP request. You may specify up to 1000 keys."
+            "alias": "DeleteMultipleObjects"
         },
         "GetBucketAcl": {
             "name": "GetBucketAcl",
@@ -934,63 +1122,93 @@
                 "uri": "/{Bucket}?acl"
             },
             "input": {
+                "shape_name": "GetBucketAclRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketAclOutput",
                 "type": "structure",
                 "members": {
-                    "Grants": {
-                        "type": "list",
-                        "xmlname": "AccessControlList",
+                    "Owner": {
+                        "shape_name": "Owner",
+                        "type": "structure",
                         "members": {
+                            "DisplayName": {
+                                "shape_name": "DisplayName",
+                                "type": "string",
+                                "documentation": null
+                            },
+                            "ID": {
+                                "shape_name": "ID",
+                                "type": "string",
+                                "documentation": null
+                            }
+                        },
+                        "documentation": null
+                    },
+                    "Grants": {
+                        "shape_name": "Grants",
+                        "type": "list",
+                        "members": {
+                            "shape_name": "Grant",
                             "type": "structure",
-                            "xmlname": "Grant",
                             "members": {
                                 "Grantee": {
-                                    "xmlnamespace": {
-                                        "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                                        "prefix": "xsi"
-                                    },
+                                    "shape_name": "Grantee",
                                     "type": "structure",
                                     "members": {
                                         "DisplayName": {
+                                            "shape_name": "DisplayName",
                                             "type": "string",
                                             "documentation": "Screen name of the grantee."
                                         },
                                         "EmailAddress": {
+                                            "shape_name": "EmailAddress",
                                             "type": "string",
                                             "documentation": "Email address of the grantee."
                                         },
                                         "ID": {
+                                            "shape_name": "ID",
                                             "type": "string",
                                             "documentation": "The canonical user ID of the grantee."
                                         },
                                         "Type": {
+                                            "shape_name": "Type",
                                             "type": "string",
-                                            "xmlname": "xsi:type",
-                                            "xmlattribute": true,
                                             "enum": [
                                                 "CanonicalUser",
                                                 "AmazonCustomerByEmail",
                                                 "Group"
                                             ],
-                                            "documentation": "Type of grantee"
+                                            "documentation": "Type of grantee",
+                                            "required": true,
+                                            "xmlattribute": true,
+                                            "xmlname": "xsi:type"
                                         },
                                         "URI": {
+                                            "shape_name": "URI",
                                             "type": "string",
                                             "documentation": "URI of the grantee group."
                                         }
+                                    },
+                                    "documentation": null,
+                                    "xmlnamespace": {
+                                        "prefix": "xsi",
+                                        "uri": "http://www.w3.org/2001/XMLSchema-instance"
                                     }
                                 },
                                 "Permission": {
+                                    "shape_name": "Permission",
                                     "type": "string",
                                     "enum": [
                                         "FULL_CONTROL",
@@ -1001,26 +1219,19 @@
                                     ],
                                     "documentation": "Specifies the permission given to the grantee."
                                 }
-                            }
-                        },
-                        "documentation": "A list of grants."
-                    },
-                    "Owner": {
-                        "type": "structure",
-                        "members": {
-                            "DisplayName": {
-                                "type": "string"
                             },
-                            "ID": {
-                                "type": "string"
-                            }
-                        }
+                            "documentation": null,
+                            "xmlname": "Grant"
+                        },
+                        "documentation": "A list of grants.",
+                        "xmlname": "AccessControlList"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETacl.html",
-            "documentation": "Gets the access control policy for the bucket."
+            "documentation": "Gets the access control policy for the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETacl.html"
         },
         "GetBucketCors": {
             "name": "GetBucketCors",
@@ -1029,74 +1240,96 @@
                 "uri": "/{Bucket}?cors"
             },
             "input": {
+                "shape_name": "GetBucketCorsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketCorsOutput",
                 "type": "structure",
                 "members": {
                     "CORSRules": {
+                        "shape_name": "CORSRules",
                         "type": "list",
-                        "xmlname": "CORSRule",
                         "members": {
+                            "shape_name": "CORSRule",
                             "type": "structure",
                             "members": {
                                 "AllowedHeaders": {
+                                    "shape_name": "AllowedHeaders",
                                     "type": "list",
-                                    "xmlname": "AllowedHeader",
                                     "members": {
-                                        "type": "string"
+                                        "shape_name": "AllowedHeader",
+                                        "type": "string",
+                                        "documentation": null
                                     },
+                                    "flattened": true,
                                     "documentation": "Specifies which headers are allowed in a pre-flight OPTIONS request.",
-                                    "flattened": true
+                                    "xmlname": "AllowedHeader"
                                 },
                                 "AllowedMethods": {
+                                    "shape_name": "AllowedMethods",
                                     "type": "list",
-                                    "xmlname": "AllowedMethod",
                                     "members": {
-                                        "type": "string"
+                                        "shape_name": "AllowedMethod",
+                                        "type": "string",
+                                        "documentation": null
                                     },
+                                    "flattened": true,
                                     "documentation": "Identifies HTTP methods that the domain/origin specified in the rule is allowed to execute.",
-                                    "flattened": true
+                                    "xmlname": "AllowedMethod"
                                 },
                                 "AllowedOrigins": {
+                                    "shape_name": "AllowedOrigins",
                                     "type": "list",
-                                    "xmlname": "AllowedOrigin",
                                     "members": {
-                                        "type": "string"
+                                        "shape_name": "AllowedOrigin",
+                                        "type": "string",
+                                        "documentation": null
                                     },
+                                    "flattened": true,
                                     "documentation": "One or more origins you want customers to be able to access the bucket from.",
-                                    "flattened": true
+                                    "xmlname": "AllowedOrigin"
                                 },
                                 "ExposeHeaders": {
+                                    "shape_name": "ExposeHeaders",
                                     "type": "list",
-                                    "xmlname": "ExposeHeader",
                                     "members": {
-                                        "type": "string"
+                                        "shape_name": "ExposeHeader",
+                                        "type": "string",
+                                        "documentation": null
                                     },
+                                    "flattened": true,
                                     "documentation": "One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript XMLHttpRequest object).",
-                                    "flattened": true
+                                    "xmlname": "ExposeHeader"
                                 },
                                 "MaxAgeSeconds": {
+                                    "shape_name": "MaxAgeSeconds",
                                     "type": "integer",
                                     "documentation": "The time in seconds that your browser is to cache the preflight response for the specified resource."
                                 }
-                            }
+                            },
+                            "documentation": null
                         },
-                        "flattened": true
+                        "flattened": true,
+                        "documentation": null,
+                        "xmlname": "CORSRule"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETcors.html",
-            "documentation": "Returns the cors configuration for the bucket."
+            "documentation": "Returns the cors configuration for the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETcors.html"
         },
         "GetBucketLifecycle": {
             "name": "GetBucketLifecycle",
@@ -1105,68 +1338,86 @@
                 "uri": "/{Bucket}?lifecycle"
             },
             "input": {
+                "shape_name": "GetBucketLifecycleRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketLifecycleOutput",
                 "type": "structure",
                 "members": {
                     "Rules": {
+                        "shape_name": "Rules",
                         "type": "list",
-                        "xmlname": "Rule",
                         "members": {
+                            "shape_name": "Rule",
                             "type": "structure",
                             "members": {
                                 "Expiration": {
+                                    "shape_name": "LifecycleExpiration",
                                     "type": "structure",
                                     "members": {
                                         "Date": {
+                                            "shape_name": "Date",
                                             "type": "timestamp",
                                             "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                                             "timestamp_format": "iso8601"
                                         },
                                         "Days": {
+                                            "shape_name": "Days",
                                             "type": "integer",
                                             "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                                         }
-                                    }
+                                    },
+                                    "documentation": null
                                 },
                                 "ID": {
+                                    "shape_name": "ID",
                                     "type": "string",
                                     "documentation": "Unique identifier for the rule. The value cannot be longer than 255 characters."
                                 },
                                 "Prefix": {
+                                    "shape_name": "Prefix",
                                     "type": "string",
-                                    "documentation": "Prefix identifying one or more objects to which the rule applies."
+                                    "documentation": "Prefix identifying one or more objects to which the rule applies.",
+                                    "required": true
                                 },
                                 "Status": {
+                                    "shape_name": "ExpirationStatus",
                                     "type": "string",
                                     "enum": [
                                         "Enabled",
                                         "Disabled"
                                     ],
-                                    "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied."
+                                    "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied.",
+                                    "required": true
                                 },
                                 "Transition": {
+                                    "shape_name": "Transition",
                                     "type": "structure",
                                     "members": {
                                         "Date": {
+                                            "shape_name": "Date",
                                             "type": "timestamp",
                                             "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                                             "timestamp_format": "iso8601"
                                         },
                                         "Days": {
+                                            "shape_name": "Days",
                                             "type": "integer",
                                             "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                                         },
                                         "StorageClass": {
+                                            "shape_name": "StorageClass",
                                             "type": "string",
                                             "enum": [
                                                 "STANDARD",
@@ -1175,17 +1426,22 @@
                                             ],
                                             "documentation": "The class of storage used to store the object."
                                         }
-                                    }
+                                    },
+                                    "documentation": null
                                 }
-                            }
+                            },
+                            "documentation": null
                         },
-                        "flattened": true
+                        "flattened": true,
+                        "documentation": null,
+                        "xmlname": "Rule"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlifecycle.html",
-            "documentation": "Returns the lifecycle configuration information set on the bucket."
+            "documentation": "Returns the lifecycle configuration information set on the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlifecycle.html"
         },
         "GetBucketLocation": {
             "name": "GetBucketLocation",
@@ -1194,27 +1450,45 @@
                 "uri": "/{Bucket}?location"
             },
             "input": {
+                "shape_name": "GetBucketLocationRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketLocationOutput",
                 "type": "structure",
                 "members": {
                     "LocationConstraint": {
-                        "type": "string"
+                        "shape_name": "BucketLocationConstraint",
+                        "type": "string",
+                        "enum": [
+                            "EU",
+                            "eu-west-1",
+                            "us-west-1",
+                            "us-west-2",
+                            "ap-southeast-1",
+                            "ap-southeast-2",
+                            "ap-northeast-1",
+                            "sa-east-1",
+                            ""
+                        ],
+                        "documentation": null
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html",
-            "documentation": "Returns the region the bucket resides in."
+            "documentation": "Returns the region the bucket resides in.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html"
         },
         "GetBucketLogging": {
             "name": "GetBucketLogging",
@@ -1223,85 +1497,113 @@
                 "uri": "/{Bucket}?logging"
             },
             "input": {
+                "shape_name": "GetBucketLoggingRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketLoggingOutput",
                 "type": "structure",
                 "members": {
                     "LoggingEnabled": {
+                        "shape_name": "LoggingEnabled",
                         "type": "structure",
                         "members": {
                             "TargetBucket": {
+                                "shape_name": "TargetBucket",
                                 "type": "string",
                                 "documentation": "Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own, including the same bucket that is being logged. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case you should choose a different TargetPrefix for each source bucket so that the delivered log files can be distinguished by key."
                             },
                             "TargetGrants": {
+                                "shape_name": "TargetGrants",
                                 "type": "list",
                                 "members": {
+                                    "shape_name": "TargetGrant",
                                     "type": "structure",
-                                    "xmlname": "Grant",
                                     "members": {
                                         "Grantee": {
-                                            "xmlnamespace": {
-                                                "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                                                "prefix": "xsi"
-                                            },
+                                            "shape_name": "Grantee",
                                             "type": "structure",
                                             "members": {
                                                 "DisplayName": {
+                                                    "shape_name": "DisplayName",
                                                     "type": "string",
                                                     "documentation": "Screen name of the grantee."
                                                 },
                                                 "EmailAddress": {
+                                                    "shape_name": "EmailAddress",
                                                     "type": "string",
                                                     "documentation": "Email address of the grantee."
                                                 },
                                                 "ID": {
+                                                    "shape_name": "ID",
                                                     "type": "string",
                                                     "documentation": "The canonical user ID of the grantee."
                                                 },
                                                 "Type": {
+                                                    "shape_name": "Type",
                                                     "type": "string",
-                                                    "xmlname": "xsi:type",
-                                                    "xmlattribute": true,
                                                     "enum": [
                                                         "CanonicalUser",
                                                         "AmazonCustomerByEmail",
                                                         "Group"
                                                     ],
-                                                    "documentation": "Type of grantee"
+                                                    "documentation": "Type of grantee",
+                                                    "required": true,
+                                                    "xmlattribute": true,
+                                                    "xmlname": "xsi:type"
                                                 },
                                                 "URI": {
+                                                    "shape_name": "URI",
                                                     "type": "string",
                                                     "documentation": "URI of the grantee group."
                                                 }
+                                            },
+                                            "documentation": null,
+                                            "xmlnamespace": {
+                                                "prefix": "xsi",
+                                                "uri": "http://www.w3.org/2001/XMLSchema-instance"
                                             }
                                         },
                                         "Permission": {
-                                            "type": "string"
+                                            "shape_name": "BucketLogsPermission",
+                                            "type": "string",
+                                            "enum": [
+                                                "FULL_CONTROL",
+                                                "READ",
+                                                "WRITE"
+                                            ],
+                                            "documentation": "Logging permissions assigned to the Grantee for the bucket."
                                         }
-                                    }
-                                }
+                                    },
+                                    "documentation": null,
+                                    "xmlname": "Grant"
+                                },
+                                "documentation": null
                             },
                             "TargetPrefix": {
+                                "shape_name": "TargetPrefix",
                                 "type": "string",
                                 "documentation": "This element lets you specify a prefix for the keys that the log files will be stored under."
                             }
-                        }
+                        },
+                        "documentation": null
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlogging.html",
-            "documentation": "Returns the logging status of a bucket and the permissions users have to view and modify that status. To use GET, you must be the bucket owner."
+            "documentation": "Returns the logging status of a bucket and the permissions users have to view and modify that status. To use GET, you must be the bucket owner.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlogging.html"
         },
         "GetBucketNotification": {
             "name": "GetBucketNotification",
@@ -1310,23 +1612,29 @@
                 "uri": "/{Bucket}?notification"
             },
             "input": {
+                "shape_name": "GetBucketNotificationRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketNotificationOutput",
                 "type": "structure",
                 "members": {
                     "TopicConfiguration": {
+                        "shape_name": "TopicConfiguration",
                         "type": "structure",
                         "members": {
                             "Event": {
+                                "shape_name": "Event",
                                 "type": "string",
                                 "enum": [
                                     "s3:ReducedRedundancyLostObject"
@@ -1334,16 +1642,19 @@
                                 "documentation": "Bucket event for which to send notifications."
                             },
                             "Topic": {
+                                "shape_name": "Topic",
                                 "type": "string",
                                 "documentation": "Amazon SNS topic to which Amazon S3 will publish a message to report the specified events for the bucket."
                             }
-                        }
+                        },
+                        "documentation": null
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETnotification.html",
-            "documentation": "Return the notification configuration of a bucket."
+            "documentation": "Return the notification configuration of a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETnotification.html"
         },
         "GetBucketPolicy": {
             "name": "GetBucketPolicy",
@@ -1352,29 +1663,35 @@
                 "uri": "/{Bucket}?policy"
             },
             "input": {
+                "shape_name": "GetBucketPolicyRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketPolicyOutput",
                 "type": "structure",
                 "members": {
                     "Policy": {
+                        "shape_name": "Policy",
                         "type": "string",
-                        "payload": true,
-                        "documentation": "The bucket policy as a JSON document."
+                        "documentation": "The bucket policy as a JSON document.",
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETpolicy.html",
-            "documentation": "Returns the policy of a specified bucket."
+            "documentation": "Returns the policy of a specified bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETpolicy.html"
         },
         "GetBucketRequestPayment": {
             "name": "GetBucketRequestPayment",
@@ -1383,20 +1700,25 @@
                 "uri": "/{Bucket}?requestPayment"
             },
             "input": {
+                "shape_name": "GetBucketRequestPaymentRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketRequestPaymentOutput",
                 "type": "structure",
                 "members": {
                     "Payer": {
+                        "shape_name": "Payer",
                         "type": "string",
                         "enum": [
                             "Requester",
@@ -1404,11 +1726,12 @@
                         ],
                         "documentation": "Specifies who pays for the download and request fees."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentGET.html",
-            "documentation": "Returns the request payment configuration of a bucket."
+            "documentation": "Returns the request payment configuration of a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentGET.html"
         },
         "GetBucketTagging": {
             "name": "GetBucketTagging",
@@ -1417,41 +1740,55 @@
                 "uri": "/{Bucket}?tagging"
             },
             "input": {
+                "shape_name": "GetBucketTaggingRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketTaggingOutput",
                 "type": "structure",
                 "members": {
                     "TagSet": {
+                        "shape_name": "TagSet",
                         "type": "list",
                         "members": {
+                            "shape_name": "Tag",
                             "type": "structure",
-                            "xmlname": "Tag",
                             "members": {
                                 "Key": {
+                                    "shape_name": "ObjectKey",
                                     "type": "string",
-                                    "documentation": "Name of the tag."
+                                    "documentation": "Name of the tag.",
+                                    "required": true
                                 },
                                 "Value": {
+                                    "shape_name": "Value",
                                     "type": "string",
-                                    "documentation": "Value of the tag."
+                                    "documentation": "Value of the tag.",
+                                    "required": true
                                 }
-                            }
-                        }
+                            },
+                            "documentation": null,
+                            "xmlname": "Tag"
+                        },
+                        "documentation": null,
+                        "required": true
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETtagging.html",
-            "documentation": "Returns the tag set associated with the bucket."
+            "documentation": "Returns the tag set associated with the bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETtagging.html"
         },
         "GetBucketVersioning": {
             "name": "GetBucketVersioning",
@@ -1460,40 +1797,47 @@
                 "uri": "/{Bucket}?versioning"
             },
             "input": {
+                "shape_name": "GetBucketVersioningRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketVersioningOutput",
                 "type": "structure",
                 "members": {
-                    "MfaDelete": {
-                        "type": "string",
-                        "enum": [
-                            "Enabled",
-                            "Disabled"
-                        ],
-                        "documentation": "Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."
-                    },
                     "Status": {
+                        "shape_name": "BucketVersioningStatus",
                         "type": "string",
                         "enum": [
                             "Enabled",
                             "Suspended"
                         ],
                         "documentation": "The versioning state of the bucket."
+                    },
+                    "MfaDelete": {
+                        "shape_name": "MFADeleteStatus",
+                        "type": "string",
+                        "enum": [
+                            "Enabled",
+                            "Disabled"
+                        ],
+                        "documentation": "Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETversioningStatus.html",
-            "documentation": "Returns the versioning state of a bucket."
+            "documentation": "Returns the versioning state of a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETversioningStatus.html"
         },
         "GetBucketWebsite": {
             "name": "GetBucketWebsite",
@@ -1502,45 +1846,35 @@
                 "uri": "/{Bucket}?website"
             },
             "input": {
+                "shape_name": "GetBucketWebsiteRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetBucketWebsiteOutput",
                 "type": "structure",
                 "members": {
-                    "ErrorDocument": {
-                        "type": "structure",
-                        "members": {
-                            "Key": {
-                                "type": "string",
-                                "documentation": "The object key name to use when a 4XX class error occurs."
-                            }
-                        }
-                    },
-                    "IndexDocument": {
-                        "type": "structure",
-                        "members": {
-                            "Suffix": {
-                                "type": "string",
-                                "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character."
-                            }
-                        }
-                    },
                     "RedirectAllRequestsTo": {
+                        "shape_name": "RedirectAllRequestsTo",
                         "type": "structure",
                         "members": {
                             "HostName": {
+                                "shape_name": "HostName",
                                 "type": "string",
-                                "documentation": "Name of the host where requests will be redirected."
+                                "documentation": "Name of the host where requests will be redirected.",
+                                "required": true
                             },
                             "Protocol": {
+                                "shape_name": "Protocol",
                                 "type": "string",
                                 "enum": [
                                     "http",
@@ -1548,22 +1882,53 @@
                                 ],
                                 "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
                             }
-                        }
+                        },
+                        "documentation": null
+                    },
+                    "IndexDocument": {
+                        "shape_name": "IndexDocument",
+                        "type": "structure",
+                        "members": {
+                            "Suffix": {
+                                "shape_name": "Suffix",
+                                "type": "string",
+                                "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character.",
+                                "required": true
+                            }
+                        },
+                        "documentation": null
+                    },
+                    "ErrorDocument": {
+                        "shape_name": "ErrorDocument",
+                        "type": "structure",
+                        "members": {
+                            "Key": {
+                                "shape_name": "ObjectKey",
+                                "type": "string",
+                                "documentation": "The object key name to use when a 4XX class error occurs.",
+                                "required": true
+                            }
+                        },
+                        "documentation": null
                     },
                     "RoutingRules": {
+                        "shape_name": "RoutingRules",
                         "type": "list",
                         "members": {
+                            "shape_name": "RoutingRule",
                             "type": "structure",
-                            "xmlname": "RoutingRule",
                             "members": {
                                 "Condition": {
+                                    "shape_name": "Condition",
                                     "type": "structure",
                                     "members": {
                                         "HttpErrorCodeReturnedEquals": {
+                                            "shape_name": "HttpErrorCodeReturnedEquals",
                                             "type": "string",
                                             "documentation": "The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element Condition is specified and sibling KeyPrefixEquals is not specified. If both are specified, then both must be true for the redirect to be applied."
                                         },
                                         "KeyPrefixEquals": {
+                                            "shape_name": "KeyPrefixEquals",
                                             "type": "string",
                                             "documentation": "The object key name prefix when the redirect is applied. For example, to redirect requests for ExamplePage.html, the key prefix will be ExamplePage.html. To redirect request for all pages with the prefix docs/, the key prefix will be /docs, which identifies all objects in the docs/ folder. Required when the parent element Condition is specified and sibling HttpErrorCodeReturnedEquals is not specified. If both conditions are specified, both must be true for the redirect to be applied."
                                         }
@@ -1571,17 +1936,21 @@
                                     "documentation": "A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the /docs folder, redirect to the /documents folder. 2. If request results in HTTP error 4xx, redirect request to another host where you might process the error."
                                 },
                                 "Redirect": {
+                                    "shape_name": "Redirect",
                                     "type": "structure",
                                     "members": {
                                         "HostName": {
+                                            "shape_name": "HostName",
                                             "type": "string",
                                             "documentation": "The host name to use in the redirect request."
                                         },
                                         "HttpRedirectCode": {
+                                            "shape_name": "HttpRedirectCode",
                                             "type": "string",
                                             "documentation": "The HTTP redirect code to use on the response. Not required if one of the siblings is present."
                                         },
                                         "Protocol": {
+                                            "shape_name": "Protocol",
                                             "type": "string",
                                             "enum": [
                                                 "http",
@@ -1590,24 +1959,31 @@
                                             "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
                                         },
                                         "ReplaceKeyPrefixWith": {
+                                            "shape_name": "ReplaceKeyPrefixWith",
                                             "type": "string",
                                             "documentation": "The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix docs/ (objects in the docs/ folder) to documents/, you can set a condition block with KeyPrefixEquals set to docs/ and in the Redirect set ReplaceKeyPrefixWith to /documents. Not required if one of the siblings is present. Can be present only if ReplaceKeyWith is not provided."
                                         },
                                         "ReplaceKeyWith": {
+                                            "shape_name": "ReplaceKeyWith",
                                             "type": "string",
                                             "documentation": "The specific object key to use in the redirect request. For example, redirect request to error.html. Not required if one of the sibling is present. Can be present only if ReplaceKeyPrefixWith is not provided."
                                         }
                                     },
-                                    "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return."
+                                    "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return.",
+                                    "required": true
                                 }
-                            }
-                        }
+                            },
+                            "documentation": null,
+                            "xmlname": "RoutingRule"
+                        },
+                        "documentation": null
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETwebsite.html",
-            "documentation": "Returns the website configuration for a bucket."
+            "documentation": "Returns the website configuration for a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETwebsite.html"
         },
         "GetObject": {
             "name": "GetObject",
@@ -1616,224 +1992,263 @@
                 "uri": "/{Bucket}/{Key}?versionId={VersionId}&response-content-type={ResponseContentType}&response-content-language={ResponseContentLanguage}&response-expires={ResponseExpires}&response-cache-control={ResponseCacheControl}&response-content-disposition={ResponseContentDisposition}&response-content-encoding={ResponseContentEncoding}"
             },
             "input": {
+                "shape_name": "GetObjectRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "IfMatch": {
+                        "shape_name": "IfMatch",
                         "type": "string",
+                        "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).",
                         "location": "header",
-                        "location_name": "If-Match",
-                        "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."
+                        "location_name": "If-Match"
                     },
                     "IfModifiedSince": {
+                        "shape_name": "IfModifiedSince",
                         "type": "timestamp",
+                        "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified).",
                         "location": "header",
-                        "location_name": "If-Modified-Since",
-                        "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified)."
+                        "location_name": "If-Modified-Since"
                     },
                     "IfNoneMatch": {
+                        "shape_name": "IfNoneMatch",
                         "type": "string",
+                        "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified).",
                         "location": "header",
-                        "location_name": "If-None-Match",
-                        "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified)."
+                        "location_name": "If-None-Match"
                     },
                     "IfUnmodifiedSince": {
+                        "shape_name": "IfUnmodifiedSince",
                         "type": "timestamp",
+                        "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed).",
                         "location": "header",
-                        "location_name": "If-Unmodified-Since",
-                        "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed)."
+                        "location_name": "If-Unmodified-Since"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Range": {
+                        "shape_name": "Range",
                         "type": "string",
+                        "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.",
                         "location": "header",
-                        "location_name": "Range",
-                        "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35."
+                        "location_name": "Range"
                     },
                     "ResponseCacheControl": {
+                        "shape_name": "ResponseCacheControl",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Sets the Cache-Control header of the response."
+                        "documentation": "Sets the Cache-Control header of the response.",
+                        "location": "uri"
                     },
                     "ResponseContentDisposition": {
+                        "shape_name": "ResponseContentDisposition",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Sets the Content-Disposition header of the response"
+                        "documentation": "Sets the Content-Disposition header of the response",
+                        "location": "uri"
                     },
                     "ResponseContentEncoding": {
+                        "shape_name": "ResponseContentEncoding",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Sets the Content-Encoding header of the response."
+                        "documentation": "Sets the Content-Encoding header of the response.",
+                        "location": "uri"
                     },
                     "ResponseContentLanguage": {
+                        "shape_name": "ResponseContentLanguage",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Sets the Content-Language header of the response."
+                        "documentation": "Sets the Content-Language header of the response.",
+                        "location": "uri"
                     },
                     "ResponseContentType": {
+                        "shape_name": "ResponseContentType",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Sets the Content-Type header of the response."
+                        "documentation": "Sets the Content-Type header of the response.",
+                        "location": "uri"
                     },
                     "ResponseExpires": {
+                        "shape_name": "ResponseExpires",
                         "type": "timestamp",
-                        "location": "uri",
-                        "documentation": "Sets the Expires header of the response."
+                        "documentation": "Sets the Expires header of the response.",
+                        "location": "uri"
                     },
                     "VersionId": {
+                        "shape_name": "ObjectVersionId",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "VersionId used to reference a specific version of the object."
+                        "documentation": "VersionId used to reference a specific version of the object.",
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetObjectOutput",
                 "type": "structure",
                 "members": {
+                    "Body": {
+                        "shape_name": "Body",
+                        "type": "blob",
+                        "documentation": "Object data.",
+                        "payload": true,
+                        "streaming": true
+                    },
+                    "DeleteMarker": {
+                        "shape_name": "DeleteMarker",
+                        "type": "boolean",
+                        "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.",
+                        "location": "header",
+                        "location_name": "x-amz-delete-marker"
+                    },
                     "AcceptRanges": {
+                        "shape_name": "AcceptRanges",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "accept-ranges"
                     },
-                    "Body": {
-                        "type": "blob",
-                        "payload": true,
-                        "documentation": "Object data.",
-                        "streaming": true
-                    },
-                    "CacheControl": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Cache-Control",
-                        "documentation": "Specifies caching behavior along the request/reply chain."
-                    },
-                    "ContentDisposition": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Disposition",
-                        "documentation": "Specifies presentational information for the object."
-                    },
-                    "ContentEncoding": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Encoding",
-                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
-                    },
-                    "ContentLanguage": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Language",
-                        "documentation": "The language the content is in."
-                    },
-                    "ContentLength": {
-                        "type": "integer",
-                        "location": "header",
-                        "location_name": "Content-Length",
-                        "documentation": "Size of the body in bytes."
-                    },
-                    "ContentType": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Type",
-                        "documentation": "A standard MIME type describing the format of the object data."
-                    },
-                    "DeleteMarker": {
-                        "type": "boolean",
-                        "location": "header",
-                        "location_name": "x-amz-delete-marker",
-                        "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response."
-                    },
-                    "ETag": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "ETag",
-                        "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL"
-                    },
                     "Expiration": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-expiration",
-                        "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded."
-                    },
-                    "Expires": {
+                        "shape_name": "Expiration",
                         "type": "timestamp",
+                        "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded.",
                         "location": "header",
-                        "location_name": "Expires",
-                        "documentation": "The date and time at which the object is no longer cacheable."
+                        "location_name": "x-amz-expiration"
+                    },
+                    "Restore": {
+                        "shape_name": "Restore",
+                        "type": "string",
+                        "documentation": "Provides information about object restoration operation and expiration time of the restored object copy.",
+                        "location": "header",
+                        "location_name": "x-amz-restore"
                     },
                     "LastModified": {
+                        "shape_name": "LastModified",
                         "type": "timestamp",
+                        "documentation": "Last modified date of the object",
                         "location": "header",
-                        "location_name": "Last-Modified",
-                        "documentation": "Last modified date of the object"
+                        "location_name": "Last-Modified"
+                    },
+                    "ContentLength": {
+                        "shape_name": "ContentLength",
+                        "type": "integer",
+                        "documentation": "Size of the body in bytes.",
+                        "location": "header",
+                        "location_name": "Content-Length"
+                    },
+                    "ETag": {
+                        "shape_name": "ETag",
+                        "type": "string",
+                        "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL",
+                        "location": "header",
+                        "location_name": "ETag"
+                    },
+                    "MissingMeta": {
+                        "shape_name": "MissingMeta",
+                        "type": "integer",
+                        "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.",
+                        "location": "header",
+                        "location_name": "x-amz-missing-meta"
+                    },
+                    "VersionId": {
+                        "shape_name": "ObjectVersionId",
+                        "type": "string",
+                        "documentation": "Version of the object.",
+                        "location": "header",
+                        "location_name": "x-amz-version-id"
+                    },
+                    "CacheControl": {
+                        "shape_name": "CacheControl",
+                        "type": "string",
+                        "documentation": "Specifies caching behavior along the request/reply chain.",
+                        "location": "header",
+                        "location_name": "Cache-Control"
+                    },
+                    "ContentDisposition": {
+                        "shape_name": "ContentDisposition",
+                        "type": "string",
+                        "documentation": "Specifies presentational information for the object.",
+                        "location": "header",
+                        "location_name": "Content-Disposition"
+                    },
+                    "ContentEncoding": {
+                        "shape_name": "ContentEncoding",
+                        "type": "string",
+                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
+                        "location": "header",
+                        "location_name": "Content-Encoding"
+                    },
+                    "ContentLanguage": {
+                        "shape_name": "ContentLanguage",
+                        "type": "string",
+                        "documentation": "The language the content is in.",
+                        "location": "header",
+                        "location_name": "Content-Language"
+                    },
+                    "ContentType": {
+                        "shape_name": "ContentType",
+                        "type": "string",
+                        "documentation": "A standard MIME type describing the format of the object data.",
+                        "location": "header",
+                        "location_name": "Content-Type"
+                    },
+                    "Expires": {
+                        "shape_name": "Expires",
+                        "type": "timestamp",
+                        "documentation": "The date and time at which the object is no longer cacheable.",
+                        "location": "header",
+                        "location_name": "Expires"
+                    },
+                    "WebsiteRedirectLocation": {
+                        "shape_name": "WebsiteRedirectLocation",
+                        "type": "string",
+                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
+                        "location": "header",
+                        "location_name": "x-amz-website-redirect-location"
+                    },
+                    "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
+                        "type": "string",
+                        "enum": [
+                            "AES256"
+                        ],
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     },
                     "Metadata": {
                         "type": "map",
                         "location": "header",
                         "location_name": "x-amz-meta-",
+                        "keys": {
+                            "type": "string",
+                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+                        },
                         "members": {
                             "type": "string",
                             "documentation": "The metadata value."
                         },
-                        "documentation": "A map of metadata to store with the object in S3.",
-                        "keys": {
-                            "type": "string",
-                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-                        }
-                    },
-                    "MissingMeta": {
-                        "type": "integer",
-                        "location": "header",
-                        "location_name": "x-amz-missing-meta",
-                        "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers."
-                    },
-                    "Restore": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-restore",
-                        "documentation": "Provides information about object restoration operation and expiration time of the restored object copy."
-                    },
-                    "ServerSideEncryption": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
-                        "enum": [
-                            "AES256"
-                        ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
-                    },
-                    "VersionId": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-version-id",
-                        "documentation": "Version of the object."
-                    },
-                    "WebsiteRedirectLocation": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-website-redirect-location",
-                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."
+                        "documentation": "A map of metadata to store with the object in S3."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [
                 {
                     "shape_name": "NoSuchKey",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The specified key does not exist."
                 }
             ],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html",
-            "documentation": "Retrieves objects from Amazon S3."
+            "documentation": "Retrieves objects from Amazon S3.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html"
         },
         "GetObjectAcl": {
             "name": "GetObjectAcl",
@@ -1842,73 +2257,106 @@
                 "uri": "/{Bucket}/{Key}?acl&versionId={VersionId}"
             },
             "input": {
+                "shape_name": "GetObjectAclRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "VersionId": {
+                        "shape_name": "ObjectVersionId",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "VersionId used to reference a specific version of the object."
+                        "documentation": "VersionId used to reference a specific version of the object.",
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetObjectAclOutput",
                 "type": "structure",
                 "members": {
-                    "Grants": {
-                        "type": "list",
-                        "xmlname": "AccessControlList",
+                    "Owner": {
+                        "shape_name": "Owner",
+                        "type": "structure",
                         "members": {
+                            "DisplayName": {
+                                "shape_name": "DisplayName",
+                                "type": "string",
+                                "documentation": null
+                            },
+                            "ID": {
+                                "shape_name": "ID",
+                                "type": "string",
+                                "documentation": null
+                            }
+                        },
+                        "documentation": null
+                    },
+                    "Grants": {
+                        "shape_name": "Grants",
+                        "type": "list",
+                        "members": {
+                            "shape_name": "Grant",
                             "type": "structure",
-                            "xmlname": "Grant",
                             "members": {
                                 "Grantee": {
-                                    "xmlnamespace": {
-                                        "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                                        "prefix": "xsi"
-                                    },
+                                    "shape_name": "Grantee",
                                     "type": "structure",
                                     "members": {
                                         "DisplayName": {
+                                            "shape_name": "DisplayName",
                                             "type": "string",
                                             "documentation": "Screen name of the grantee."
                                         },
                                         "EmailAddress": {
+                                            "shape_name": "EmailAddress",
                                             "type": "string",
                                             "documentation": "Email address of the grantee."
                                         },
                                         "ID": {
+                                            "shape_name": "ID",
                                             "type": "string",
                                             "documentation": "The canonical user ID of the grantee."
                                         },
                                         "Type": {
+                                            "shape_name": "Type",
                                             "type": "string",
-                                            "xmlname": "xsi:type",
-                                            "xmlattribute": true,
                                             "enum": [
                                                 "CanonicalUser",
                                                 "AmazonCustomerByEmail",
                                                 "Group"
                                             ],
-                                            "documentation": "Type of grantee"
+                                            "documentation": "Type of grantee",
+                                            "required": true,
+                                            "xmlattribute": true,
+                                            "xmlname": "xsi:type"
                                         },
                                         "URI": {
+                                            "shape_name": "URI",
                                             "type": "string",
                                             "documentation": "URI of the grantee group."
                                         }
+                                    },
+                                    "documentation": null,
+                                    "xmlnamespace": {
+                                        "prefix": "xsi",
+                                        "uri": "http://www.w3.org/2001/XMLSchema-instance"
                                     }
                                 },
                                 "Permission": {
+                                    "shape_name": "Permission",
                                     "type": "string",
                                     "enum": [
                                         "FULL_CONTROL",
@@ -1919,32 +2367,26 @@
                                     ],
                                     "documentation": "Specifies the permission given to the grantee."
                                 }
-                            }
-                        },
-                        "documentation": "A list of grants."
-                    },
-                    "Owner": {
-                        "type": "structure",
-                        "members": {
-                            "DisplayName": {
-                                "type": "string"
                             },
-                            "ID": {
-                                "type": "string"
-                            }
-                        }
+                            "documentation": null,
+                            "xmlname": "Grant"
+                        },
+                        "documentation": "A list of grants.",
+                        "xmlname": "AccessControlList"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [
                 {
                     "shape_name": "NoSuchKey",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The specified key does not exist."
                 }
             ],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETacl.html",
-            "documentation": "Returns the access control list (ACL) of an object."
+            "documentation": "Returns the access control list (ACL) of an object.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETacl.html"
         },
         "GetObjectTorrent": {
             "name": "GetObjectTorrent",
@@ -1953,34 +2395,43 @@
                 "uri": "/{Bucket}/{Key}?torrent"
             },
             "input": {
+                "shape_name": "GetObjectTorrentRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "GetObjectTorrentOutput",
                 "type": "structure",
                 "members": {
                     "Body": {
+                        "shape_name": "Body",
                         "type": "blob",
+                        "documentation": null,
                         "payload": true,
                         "streaming": true
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtorrent.html",
-            "documentation": "Return torrent files from a bucket."
+            "documentation": "Return torrent files from a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtorrent.html"
         },
         "HeadBucket": {
             "name": "HeadBucket",
@@ -1989,25 +2440,30 @@
                 "uri": "/{Bucket}"
             },
             "input": {
+                "shape_name": "HeadBucketRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [
                 {
                     "shape_name": "NoSuchBucket",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The specified bucket does not exist."
                 }
             ],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html",
-            "documentation": "This operation is useful to determine if a bucket exists and you have permission to access it."
+            "documentation": "This operation is useful to determine if a bucket exists and you have permission to access it.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html"
         },
         "HeadObject": {
             "name": "HeadObject",
@@ -2016,192 +2472,223 @@
                 "uri": "/{Bucket}/{Key}?versionId={VersionId}"
             },
             "input": {
+                "shape_name": "HeadObjectRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "IfMatch": {
+                        "shape_name": "IfMatch",
                         "type": "string",
+                        "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).",
                         "location": "header",
-                        "location_name": "If-Match",
-                        "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."
+                        "location_name": "If-Match"
                     },
                     "IfModifiedSince": {
+                        "shape_name": "IfModifiedSince",
                         "type": "timestamp",
+                        "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified).",
                         "location": "header",
-                        "location_name": "If-Modified-Since",
-                        "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified)."
+                        "location_name": "If-Modified-Since"
                     },
                     "IfNoneMatch": {
+                        "shape_name": "IfNoneMatch",
                         "type": "string",
+                        "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified).",
                         "location": "header",
-                        "location_name": "If-None-Match",
-                        "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified)."
+                        "location_name": "If-None-Match"
                     },
                     "IfUnmodifiedSince": {
+                        "shape_name": "IfUnmodifiedSince",
                         "type": "timestamp",
+                        "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed).",
                         "location": "header",
-                        "location_name": "If-Unmodified-Since",
-                        "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed)."
+                        "location_name": "If-Unmodified-Since"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Range": {
+                        "shape_name": "Range",
                         "type": "string",
+                        "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.",
                         "location": "header",
-                        "location_name": "Range",
-                        "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35."
+                        "location_name": "Range"
                     },
                     "VersionId": {
+                        "shape_name": "ObjectVersionId",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "VersionId used to reference a specific version of the object."
+                        "documentation": "VersionId used to reference a specific version of the object.",
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "HeadObjectOutput",
                 "type": "structure",
                 "members": {
+                    "DeleteMarker": {
+                        "shape_name": "DeleteMarker",
+                        "type": "boolean",
+                        "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.",
+                        "location": "header",
+                        "location_name": "x-amz-delete-marker"
+                    },
                     "AcceptRanges": {
+                        "shape_name": "AcceptRanges",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "accept-ranges"
                     },
-                    "CacheControl": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Cache-Control",
-                        "documentation": "Specifies caching behavior along the request/reply chain."
-                    },
-                    "ContentDisposition": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Disposition",
-                        "documentation": "Specifies presentational information for the object."
-                    },
-                    "ContentEncoding": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Encoding",
-                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
-                    },
-                    "ContentLanguage": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Language",
-                        "documentation": "The language the content is in."
-                    },
-                    "ContentLength": {
-                        "type": "integer",
-                        "location": "header",
-                        "location_name": "Content-Length",
-                        "documentation": "Size of the body in bytes."
-                    },
-                    "ContentType": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Content-Type",
-                        "documentation": "A standard MIME type describing the format of the object data."
-                    },
-                    "DeleteMarker": {
-                        "type": "boolean",
-                        "location": "header",
-                        "location_name": "x-amz-delete-marker",
-                        "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response."
-                    },
-                    "ETag": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "ETag",
-                        "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL"
-                    },
                     "Expiration": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-expiration",
-                        "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded."
-                    },
-                    "Expires": {
+                        "shape_name": "Expiration",
                         "type": "timestamp",
+                        "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded.",
                         "location": "header",
-                        "location_name": "Expires",
-                        "documentation": "The date and time at which the object is no longer cacheable."
+                        "location_name": "x-amz-expiration"
+                    },
+                    "Restore": {
+                        "shape_name": "Restore",
+                        "type": "string",
+                        "documentation": "Provides information about object restoration operation and expiration time of the restored object copy.",
+                        "location": "header",
+                        "location_name": "x-amz-restore"
                     },
                     "LastModified": {
+                        "shape_name": "LastModified",
                         "type": "timestamp",
+                        "documentation": "Last modified date of the object",
                         "location": "header",
-                        "location_name": "Last-Modified",
-                        "documentation": "Last modified date of the object"
+                        "location_name": "Last-Modified"
+                    },
+                    "ContentLength": {
+                        "shape_name": "ContentLength",
+                        "type": "integer",
+                        "documentation": "Size of the body in bytes.",
+                        "location": "header",
+                        "location_name": "Content-Length"
+                    },
+                    "ETag": {
+                        "shape_name": "ETag",
+                        "type": "string",
+                        "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL",
+                        "location": "header",
+                        "location_name": "ETag"
+                    },
+                    "MissingMeta": {
+                        "shape_name": "MissingMeta",
+                        "type": "integer",
+                        "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.",
+                        "location": "header",
+                        "location_name": "x-amz-missing-meta"
+                    },
+                    "VersionId": {
+                        "shape_name": "ObjectVersionId",
+                        "type": "string",
+                        "documentation": "Version of the object.",
+                        "location": "header",
+                        "location_name": "x-amz-version-id"
+                    },
+                    "CacheControl": {
+                        "shape_name": "CacheControl",
+                        "type": "string",
+                        "documentation": "Specifies caching behavior along the request/reply chain.",
+                        "location": "header",
+                        "location_name": "Cache-Control"
+                    },
+                    "ContentDisposition": {
+                        "shape_name": "ContentDisposition",
+                        "type": "string",
+                        "documentation": "Specifies presentational information for the object.",
+                        "location": "header",
+                        "location_name": "Content-Disposition"
+                    },
+                    "ContentEncoding": {
+                        "shape_name": "ContentEncoding",
+                        "type": "string",
+                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
+                        "location": "header",
+                        "location_name": "Content-Encoding"
+                    },
+                    "ContentLanguage": {
+                        "shape_name": "ContentLanguage",
+                        "type": "string",
+                        "documentation": "The language the content is in.",
+                        "location": "header",
+                        "location_name": "Content-Language"
+                    },
+                    "ContentType": {
+                        "shape_name": "ContentType",
+                        "type": "string",
+                        "documentation": "A standard MIME type describing the format of the object data.",
+                        "location": "header",
+                        "location_name": "Content-Type"
+                    },
+                    "Expires": {
+                        "shape_name": "Expires",
+                        "type": "timestamp",
+                        "documentation": "The date and time at which the object is no longer cacheable.",
+                        "location": "header",
+                        "location_name": "Expires"
+                    },
+                    "WebsiteRedirectLocation": {
+                        "shape_name": "WebsiteRedirectLocation",
+                        "type": "string",
+                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
+                        "location": "header",
+                        "location_name": "x-amz-website-redirect-location"
+                    },
+                    "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
+                        "type": "string",
+                        "enum": [
+                            "AES256"
+                        ],
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     },
                     "Metadata": {
                         "type": "map",
                         "location": "header",
                         "location_name": "x-amz-meta-",
+                        "keys": {
+                            "type": "string",
+                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+                        },
                         "members": {
                             "type": "string",
                             "documentation": "The metadata value."
                         },
-                        "documentation": "A map of metadata to store with the object in S3.",
-                        "keys": {
-                            "type": "string",
-                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-                        }
-                    },
-                    "MissingMeta": {
-                        "type": "integer",
-                        "location": "header",
-                        "location_name": "x-amz-missing-meta",
-                        "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers."
-                    },
-                    "Restore": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-restore",
-                        "documentation": "Provides information about object restoration operation and expiration time of the restored object copy."
-                    },
-                    "ServerSideEncryption": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
-                        "enum": [
-                            "AES256"
-                        ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
-                    },
-                    "VersionId": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-version-id",
-                        "documentation": "Version of the object."
-                    },
-                    "WebsiteRedirectLocation": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-website-redirect-location",
-                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."
+                        "documentation": "A map of metadata to store with the object in S3."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [
                 {
                     "shape_name": "NoSuchKey",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The specified key does not exist."
                 }
             ],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html",
-            "documentation": "The HEAD operation retrieves metadata from an object without returning the object itself. This operation is useful if you're only interested in an object's metadata. To use HEAD, you must have READ access to the object."
+            "documentation": "The HEAD operation retrieves metadata from an object without returning the object itself. This operation is useful if you're only interested in an object's metadata. To use HEAD, you must have READ access to the object.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html"
         },
         "ListBuckets": {
             "name": "ListBuckets",
-            "alias": "GetService",
             "http": {
                 "method": "GET",
                 "uri": "/"
@@ -2212,38 +2699,52 @@
                 "type": "structure",
                 "members": {
                     "Buckets": {
+                        "shape_name": "Buckets",
                         "type": "list",
                         "members": {
+                            "shape_name": "Bucket",
                             "type": "structure",
-                            "xmlname": "Bucket",
                             "members": {
-                                "CreationDate": {
-                                    "type": "timestamp",
-                                    "documentation": "Date the bucket was created."
-                                },
                                 "Name": {
+                                    "shape_name": "BucketName",
                                     "type": "string",
                                     "documentation": "The name of the bucket."
+                                },
+                                "CreationDate": {
+                                    "shape_name": "CreationDate",
+                                    "type": "timestamp",
+                                    "documentation": "Date the bucket was created."
                                 }
-                            }
-                        }
+                            },
+                            "documentation": null,
+                            "xmlname": "Bucket"
+                        },
+                        "documentation": null
                     },
                     "Owner": {
+                        "shape_name": "Owner",
                         "type": "structure",
                         "members": {
                             "DisplayName": {
-                                "type": "string"
+                                "shape_name": "DisplayName",
+                                "type": "string",
+                                "documentation": null
                             },
                             "ID": {
-                                "type": "string"
+                                "shape_name": "ID",
+                                "type": "string",
+                                "documentation": null
                             }
-                        }
+                        },
+                        "documentation": null
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
+            "documentation": "Returns a list of all buckets owned by the authenticated sender of the request.",
             "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html",
-            "documentation": "Returns a list of all buckets owned by the authenticated sender of the request."
+            "alias": "GetService"
         },
         "ListMultipartUploads": {
             "name": "ListMultipartUploads",
@@ -2252,142 +2753,126 @@
                 "uri": "/{Bucket}?uploads&prefix={Prefix}&delimiter={Delimiter}&max-uploads={MaxUploads}&key-marker={KeyMarker}&upload-id-marker={UploadIdMarker}&encoding-type={EncodingType}"
             },
             "input": {
+                "shape_name": "ListMultipartUploadsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Delimiter": {
+                        "shape_name": "Delimiter",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Character you use to group keys."
+                        "documentation": "Character you use to group keys.",
+                        "location": "uri"
                     },
                     "EncodingType": {
+                        "shape_name": "EncodingType",
                         "type": "string",
-                        "location": "uri",
                         "enum": [
                             "url"
                         ],
-                        "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."
+                        "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.",
+                        "location": "uri"
                     },
                     "KeyMarker": {
+                        "shape_name": "KeyMarker",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Together with upload-id-marker, this parameter specifies the multipart upload after which listing should begin."
+                        "documentation": "Together with upload-id-marker, this parameter specifies the multipart upload after which listing should begin.",
+                        "location": "uri"
                     },
                     "MaxUploads": {
+                        "shape_name": "MaxUploads",
                         "type": "integer",
-                        "location": "uri",
-                        "documentation": "Sets the maximum number of multipart uploads, from 1 to 1,000, to return in the response body. 1,000 is the maximum number of uploads that can be returned in a response."
+                        "documentation": "Sets the maximum number of multipart uploads, from 1 to 1,000, to return in the response body. 1,000 is the maximum number of uploads that can be returned in a response.",
+                        "location": "uri"
                     },
                     "Prefix": {
+                        "shape_name": "Prefix",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Lists in-progress uploads only for those keys that begin with the specified prefix."
+                        "documentation": "Lists in-progress uploads only for those keys that begin with the specified prefix.",
+                        "location": "uri"
                     },
                     "UploadIdMarker": {
+                        "shape_name": "UploadIdMarker",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Together with key-marker, specifies the multipart upload after which listing should begin. If key-marker is not specified, the upload-id-marker parameter is ignored."
+                        "documentation": "Together with key-marker, specifies the multipart upload after which listing should begin. If key-marker is not specified, the upload-id-marker parameter is ignored.",
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "ListMultipartUploadsOutput",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
                         "documentation": "Name of the bucket to which the multipart upload was initiated."
                     },
-                    "CommonPrefixes": {
-                        "type": "list",
-                        "members": {
-                            "type": "structure",
-                            "members": {
-                                "Prefix": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "flattened": true
-                    },
-                    "EncodingType": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Encoding-Type",
-                        "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
-                    },
-                    "IsTruncated": {
-                        "type": "boolean",
-                        "documentation": "Indicates whether the returned list of multipart uploads is truncated. A value of true indicates that the list was truncated. The list can be truncated if the number of multipart uploads exceeds the limit allowed or specified by max uploads."
-                    },
                     "KeyMarker": {
+                        "shape_name": "KeyMarker",
                         "type": "string",
                         "documentation": "The key at or after which the listing began."
                     },
-                    "MaxUploads": {
-                        "type": "integer",
-                        "documentation": "Maximum number of multipart uploads that could have been included in the response."
-                    },
-                    "NextKeyMarker": {
-                        "type": "string",
-                        "documentation": "When a list is truncated, this element specifies the value that should be used for the key-marker request parameter in a subsequent request."
-                    },
-                    "NextUploadIdMarker": {
-                        "type": "string",
-                        "documentation": "When a list is truncated, this element specifies the value that should be used for the upload-id-marker request parameter in a subsequent request."
-                    },
-                    "Prefix": {
-                        "type": "string",
-                        "documentation": "When a prefix is provided in the request, this field contains the specified prefix. The result contains only keys starting with the specified prefix."
-                    },
                     "UploadIdMarker": {
+                        "shape_name": "UploadIdMarker",
                         "type": "string",
                         "documentation": "Upload ID after which listing began."
                     },
+                    "NextKeyMarker": {
+                        "shape_name": "NextKeyMarker",
+                        "type": "string",
+                        "documentation": "When a list is truncated, this element specifies the value that should be used for the key-marker request parameter in a subsequent request."
+                    },
+                    "Prefix": {
+                        "shape_name": "Prefix",
+                        "type": "string",
+                        "documentation": "When a prefix is provided in the request, this field contains the specified prefix. The result contains only keys starting with the specified prefix."
+                    },
+                    "NextUploadIdMarker": {
+                        "shape_name": "NextUploadIdMarker",
+                        "type": "string",
+                        "documentation": "When a list is truncated, this element specifies the value that should be used for the upload-id-marker request parameter in a subsequent request."
+                    },
+                    "MaxUploads": {
+                        "shape_name": "MaxUploads",
+                        "type": "integer",
+                        "documentation": "Maximum number of multipart uploads that could have been included in the response."
+                    },
+                    "IsTruncated": {
+                        "shape_name": "IsTruncated",
+                        "type": "boolean",
+                        "documentation": "Indicates whether the returned list of multipart uploads is truncated. A value of true indicates that the list was truncated. The list can be truncated if the number of multipart uploads exceeds the limit allowed or specified by max uploads."
+                    },
                     "Uploads": {
+                        "shape_name": "MultipartUploadList",
                         "type": "list",
-                        "xmlname": "Upload",
                         "members": {
+                            "shape_name": "MultipartUpload",
                             "type": "structure",
                             "members": {
-                                "Initiated": {
-                                    "type": "timestamp",
-                                    "documentation": "Date and time at which the multipart upload was initiated."
-                                },
-                                "Initiator": {
-                                    "type": "structure",
-                                    "members": {
-                                        "DisplayName": {
-                                            "type": "string",
-                                            "documentation": "Name of the Principal."
-                                        },
-                                        "ID": {
-                                            "type": "string",
-                                            "documentation": "If the principal is an AWS account, it provides the Canonical User ID. If the principal is an IAM User, it provides a user ARN value."
-                                        }
-                                    },
-                                    "documentation": "Identifies who initiated the multipart upload."
+                                "UploadId": {
+                                    "shape_name": "MultipartUploadId",
+                                    "type": "string",
+                                    "documentation": "Upload ID that identifies the multipart upload."
                                 },
                                 "Key": {
+                                    "shape_name": "ObjectKey",
                                     "type": "string",
                                     "documentation": "Key of the object for which the multipart upload was initiated."
                                 },
-                                "Owner": {
-                                    "type": "structure",
-                                    "members": {
-                                        "DisplayName": {
-                                            "type": "string"
-                                        },
-                                        "ID": {
-                                            "type": "string"
-                                        }
-                                    }
+                                "Initiated": {
+                                    "shape_name": "Initiated",
+                                    "type": "timestamp",
+                                    "documentation": "Date and time at which the multipart upload was initiated."
                                 },
                                 "StorageClass": {
+                                    "shape_name": "StorageClass",
                                     "type": "string",
                                     "enum": [
                                         "STANDARD",
@@ -2396,19 +2881,79 @@
                                     ],
                                     "documentation": "The class of storage used to store the object."
                                 },
-                                "UploadId": {
-                                    "type": "string",
-                                    "documentation": "Upload ID that identifies the multipart upload."
+                                "Owner": {
+                                    "shape_name": "Owner",
+                                    "type": "structure",
+                                    "members": {
+                                        "DisplayName": {
+                                            "shape_name": "DisplayName",
+                                            "type": "string",
+                                            "documentation": null
+                                        },
+                                        "ID": {
+                                            "shape_name": "ID",
+                                            "type": "string",
+                                            "documentation": null
+                                        }
+                                    },
+                                    "documentation": null
+                                },
+                                "Initiator": {
+                                    "shape_name": "Initiator",
+                                    "type": "structure",
+                                    "members": {
+                                        "ID": {
+                                            "shape_name": "ID",
+                                            "type": "string",
+                                            "documentation": "If the principal is an AWS account, it provides the Canonical User ID. If the principal is an IAM User, it provides a user ARN value."
+                                        },
+                                        "DisplayName": {
+                                            "shape_name": "DisplayName",
+                                            "type": "string",
+                                            "documentation": "Name of the Principal."
+                                        }
+                                    },
+                                    "documentation": "Identifies who initiated the multipart upload."
                                 }
-                            }
+                            },
+                            "documentation": null
                         },
-                        "flattened": true
+                        "flattened": true,
+                        "documentation": null,
+                        "xmlname": "Upload"
+                    },
+                    "CommonPrefixes": {
+                        "shape_name": "CommonPrefixList",
+                        "type": "list",
+                        "members": {
+                            "shape_name": "CommonPrefix",
+                            "type": "structure",
+                            "members": {
+                                "Prefix": {
+                                    "shape_name": "Prefix",
+                                    "type": "string",
+                                    "documentation": null
+                                }
+                            },
+                            "documentation": null
+                        },
+                        "flattened": true,
+                        "documentation": null
+                    },
+                    "EncodingType": {
+                        "shape_name": "EncodingType",
+                        "type": "string",
+                        "enum": [
+                            "url"
+                        ],
+                        "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html",
             "documentation": "This operation lists in-progress multipart uploads.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html",
             "pagination": {
                 "limit_key": "MaxUploads",
                 "more_results": "IsTruncated",
@@ -2432,178 +2977,111 @@
         },
         "ListObjectVersions": {
             "name": "ListObjectVersions",
-            "alias": "GetBucketObjectVersions",
             "http": {
                 "method": "GET",
                 "uri": "/{Bucket}?versions&delimiter={Delimiter}&key-marker={KeyMarker}&max-keys={MaxKeys}&prefix={Prefix}&version-id-marker={VersionIdMarker}&encoding-type={EncodingType}"
             },
             "input": {
+                "shape_name": "ListObjectVersionsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Delimiter": {
+                        "shape_name": "Delimiter",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "A delimiter is a character you use to group keys."
+                        "documentation": "A delimiter is a character you use to group keys.",
+                        "location": "uri"
                     },
                     "EncodingType": {
+                        "shape_name": "EncodingType",
                         "type": "string",
-                        "location": "uri",
                         "enum": [
                             "url"
                         ],
-                        "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."
+                        "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.",
+                        "location": "uri"
                     },
                     "KeyMarker": {
+                        "shape_name": "KeyMarker",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Specifies the key to start with when listing objects in a bucket."
+                        "documentation": "Specifies the key to start with when listing objects in a bucket.",
+                        "location": "uri"
                     },
                     "MaxKeys": {
+                        "shape_name": "MaxKeys",
                         "type": "integer",
-                        "location": "uri",
-                        "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."
+                        "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more.",
+                        "location": "uri"
                     },
                     "Prefix": {
+                        "shape_name": "Prefix",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Limits the response to keys that begin with the specified prefix."
+                        "documentation": "Limits the response to keys that begin with the specified prefix.",
+                        "location": "uri"
                     },
                     "VersionIdMarker": {
+                        "shape_name": "VersionIdMarker",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Specifies the object version you want to start listing from."
+                        "documentation": "Specifies the object version you want to start listing from.",
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "ListObjectVersionsOutput",
                 "type": "structure",
                 "members": {
-                    "CommonPrefixes": {
-                        "type": "list",
-                        "members": {
-                            "type": "structure",
-                            "members": {
-                                "Prefix": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "flattened": true
-                    },
-                    "DeleteMarkers": {
-                        "type": "list",
-                        "xmlname": "DeleteMarker",
-                        "members": {
-                            "type": "structure",
-                            "members": {
-                                "IsLatest": {
-                                    "type": "boolean",
-                                    "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
-                                },
-                                "Key": {
-                                    "type": "string",
-                                    "documentation": "The object key."
-                                },
-                                "LastModified": {
-                                    "type": "timestamp",
-                                    "documentation": "Date and time the object was last modified."
-                                },
-                                "Owner": {
-                                    "type": "structure",
-                                    "members": {
-                                        "DisplayName": {
-                                            "type": "string"
-                                        },
-                                        "ID": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "VersionId": {
-                                    "type": "string",
-                                    "documentation": "Version ID of an object."
-                                }
-                            }
-                        },
-                        "flattened": true
-                    },
-                    "EncodingType": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Encoding-Type",
-                        "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
-                    },
                     "IsTruncated": {
+                        "shape_name": "IsTruncated",
                         "type": "boolean",
                         "documentation": "A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria. If your results were truncated, you can make a follow-up paginated request using the NextKeyMarker and NextVersionIdMarker response parameters as a starting place in another request to return the rest of the results."
                     },
                     "KeyMarker": {
+                        "shape_name": "KeyMarker",
                         "type": "string",
                         "documentation": "Marks the last Key returned in a truncated response."
                     },
-                    "MaxKeys": {
-                        "type": "integer"
-                    },
-                    "Name": {
-                        "type": "string"
+                    "VersionIdMarker": {
+                        "shape_name": "VersionIdMarker",
+                        "type": "string",
+                        "documentation": null
                     },
                     "NextKeyMarker": {
+                        "shape_name": "NextKeyMarker",
                         "type": "string",
                         "documentation": "Use this value for the key marker request parameter in a subsequent request."
                     },
                     "NextVersionIdMarker": {
+                        "shape_name": "NextVersionIdMarker",
                         "type": "string",
                         "documentation": "Use this value for the next version id marker parameter in a subsequent request."
                     },
-                    "Prefix": {
-                        "type": "string"
-                    },
-                    "VersionIdMarker": {
-                        "type": "string"
-                    },
                     "Versions": {
+                        "shape_name": "ObjectVersionList",
                         "type": "list",
-                        "xmlname": "Version",
                         "members": {
+                            "shape_name": "ObjectVersion",
                             "type": "structure",
                             "members": {
                                 "ETag": {
-                                    "type": "string"
-                                },
-                                "IsLatest": {
-                                    "type": "boolean",
-                                    "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
-                                },
-                                "Key": {
+                                    "shape_name": "ETag",
                                     "type": "string",
-                                    "documentation": "The object key."
-                                },
-                                "LastModified": {
-                                    "type": "timestamp",
-                                    "documentation": "Date and time the object was last modified."
-                                },
-                                "Owner": {
-                                    "type": "structure",
-                                    "members": {
-                                        "DisplayName": {
-                                            "type": "string"
-                                        },
-                                        "ID": {
-                                            "type": "string"
-                                        }
-                                    }
+                                    "documentation": null
                                 },
                                 "Size": {
-                                    "type": "string",
+                                    "shape_name": "Size",
+                                    "type": "integer",
                                     "documentation": "Size in bytes of the object."
                                 },
                                 "StorageClass": {
+                                    "shape_name": "StorageClass",
                                     "type": "string",
                                     "enum": [
                                         "STANDARD",
@@ -2612,19 +3090,149 @@
                                     ],
                                     "documentation": "The class of storage used to store the object."
                                 },
+                                "Key": {
+                                    "shape_name": "ObjectKey",
+                                    "type": "string",
+                                    "documentation": "The object key."
+                                },
                                 "VersionId": {
+                                    "shape_name": "ObjectVersionId",
                                     "type": "string",
                                     "documentation": "Version ID of an object."
+                                },
+                                "IsLatest": {
+                                    "shape_name": "IsLatest",
+                                    "type": "boolean",
+                                    "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
+                                },
+                                "LastModified": {
+                                    "shape_name": "LastModified",
+                                    "type": "timestamp",
+                                    "documentation": "Date and time the object was last modified."
+                                },
+                                "Owner": {
+                                    "shape_name": "Owner",
+                                    "type": "structure",
+                                    "members": {
+                                        "DisplayName": {
+                                            "shape_name": "DisplayName",
+                                            "type": "string",
+                                            "documentation": null
+                                        },
+                                        "ID": {
+                                            "shape_name": "ID",
+                                            "type": "string",
+                                            "documentation": null
+                                        }
+                                    },
+                                    "documentation": null
                                 }
-                            }
+                            },
+                            "documentation": null
                         },
-                        "flattened": true
+                        "flattened": true,
+                        "documentation": null,
+                        "xmlname": "Version"
+                    },
+                    "DeleteMarkers": {
+                        "shape_name": "DeleteMarkers",
+                        "type": "list",
+                        "members": {
+                            "shape_name": "DeleteMarkerEntry",
+                            "type": "structure",
+                            "members": {
+                                "Owner": {
+                                    "shape_name": "Owner",
+                                    "type": "structure",
+                                    "members": {
+                                        "DisplayName": {
+                                            "shape_name": "DisplayName",
+                                            "type": "string",
+                                            "documentation": null
+                                        },
+                                        "ID": {
+                                            "shape_name": "ID",
+                                            "type": "string",
+                                            "documentation": null
+                                        }
+                                    },
+                                    "documentation": null
+                                },
+                                "Key": {
+                                    "shape_name": "ObjectKey",
+                                    "type": "string",
+                                    "documentation": "The object key."
+                                },
+                                "VersionId": {
+                                    "shape_name": "ObjectVersionId",
+                                    "type": "string",
+                                    "documentation": "Version ID of an object."
+                                },
+                                "IsLatest": {
+                                    "shape_name": "IsLatest",
+                                    "type": "boolean",
+                                    "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
+                                },
+                                "LastModified": {
+                                    "shape_name": "LastModified",
+                                    "type": "timestamp",
+                                    "documentation": "Date and time the object was last modified."
+                                }
+                            },
+                            "documentation": null
+                        },
+                        "flattened": true,
+                        "documentation": null,
+                        "xmlname": "DeleteMarker"
+                    },
+                    "Name": {
+                        "shape_name": "BucketName",
+                        "type": "string",
+                        "documentation": null
+                    },
+                    "Prefix": {
+                        "shape_name": "Prefix",
+                        "type": "string",
+                        "documentation": null
+                    },
+                    "MaxKeys": {
+                        "shape_name": "MaxKeys",
+                        "type": "integer",
+                        "documentation": null
+                    },
+                    "CommonPrefixes": {
+                        "shape_name": "CommonPrefixList",
+                        "type": "list",
+                        "members": {
+                            "shape_name": "CommonPrefix",
+                            "type": "structure",
+                            "members": {
+                                "Prefix": {
+                                    "shape_name": "Prefix",
+                                    "type": "string",
+                                    "documentation": null
+                                }
+                            },
+                            "documentation": null
+                        },
+                        "flattened": true,
+                        "documentation": null
+                    },
+                    "EncodingType": {
+                        "shape_name": "EncodingType",
+                        "type": "string",
+                        "enum": [
+                            "url"
+                        ],
+                        "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETVersion.html",
             "documentation": "Returns metadata about all of the versions of objects in a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETVersion.html",
+            "alias": "GetBucketObjectVersions",
             "pagination": {
                 "more_results": "IsTruncated",
                 "limit_key": "MaxKeys",
@@ -2649,94 +3257,105 @@
         },
         "ListObjects": {
             "name": "ListObjects",
-            "alias": "GetBucket",
             "http": {
                 "method": "GET",
                 "uri": "/{Bucket}?delimiter={Delimiter}&marker={Marker}&max-keys={MaxKeys}&prefix={Prefix}&encoding-type={EncodingType}"
             },
             "input": {
+                "shape_name": "ListObjectsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Delimiter": {
+                        "shape_name": "Delimiter",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "A delimiter is a character you use to group keys."
+                        "documentation": "A delimiter is a character you use to group keys.",
+                        "location": "uri"
                     },
                     "EncodingType": {
+                        "shape_name": "EncodingType",
                         "type": "string",
-                        "location": "uri",
                         "enum": [
                             "url"
                         ],
-                        "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."
+                        "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.",
+                        "location": "uri"
                     },
                     "Marker": {
+                        "shape_name": "Marker",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Specifies the key to start with when listing objects in a bucket."
+                        "documentation": "Specifies the key to start with when listing objects in a bucket.",
+                        "location": "uri"
                     },
                     "MaxKeys": {
+                        "shape_name": "MaxKeys",
                         "type": "integer",
-                        "location": "uri",
-                        "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."
+                        "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more.",
+                        "location": "uri"
                     },
                     "Prefix": {
+                        "shape_name": "Prefix",
                         "type": "string",
-                        "location": "uri",
-                        "documentation": "Limits the response to keys that begin with the specified prefix."
+                        "documentation": "Limits the response to keys that begin with the specified prefix.",
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "ListObjectsOutput",
                 "type": "structure",
                 "members": {
-                    "CommonPrefixes": {
-                        "type": "list",
-                        "members": {
-                            "type": "structure",
-                            "members": {
-                                "Prefix": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "flattened": true
+                    "IsTruncated": {
+                        "shape_name": "IsTruncated",
+                        "type": "boolean",
+                        "documentation": "A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria."
+                    },
+                    "Marker": {
+                        "shape_name": "Marker",
+                        "type": "string",
+                        "documentation": null
+                    },
+                    "NextMarker": {
+                        "shape_name": "NextMarker",
+                        "type": "string",
+                        "documentation": "When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMaker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys."
                     },
                     "Contents": {
+                        "shape_name": "ObjectList",
                         "type": "list",
                         "members": {
+                            "shape_name": "Object",
                             "type": "structure",
                             "members": {
-                                "ETag": {
-                                    "type": "string"
-                                },
                                 "Key": {
-                                    "type": "string"
+                                    "shape_name": "ObjectKey",
+                                    "type": "string",
+                                    "documentation": null
                                 },
                                 "LastModified": {
-                                    "type": "timestamp"
+                                    "shape_name": "LastModified",
+                                    "type": "timestamp",
+                                    "documentation": null
                                 },
-                                "Owner": {
-                                    "type": "structure",
-                                    "members": {
-                                        "DisplayName": {
-                                            "type": "string"
-                                        },
-                                        "ID": {
-                                            "type": "string"
-                                        }
-                                    }
+                                "ETag": {
+                                    "shape_name": "ETag",
+                                    "type": "string",
+                                    "documentation": null
                                 },
                                 "Size": {
-                                    "type": "integer"
+                                    "shape_name": "Size",
+                                    "type": "integer",
+                                    "documentation": null
                                 },
                                 "StorageClass": {
+                                    "shape_name": "StorageClass",
                                     "type": "string",
                                     "enum": [
                                         "STANDARD",
@@ -2744,48 +3363,85 @@
                                         "GLACIER"
                                     ],
                                     "documentation": "The class of storage used to store the object."
+                                },
+                                "Owner": {
+                                    "shape_name": "Owner",
+                                    "type": "structure",
+                                    "members": {
+                                        "DisplayName": {
+                                            "shape_name": "DisplayName",
+                                            "type": "string",
+                                            "documentation": null
+                                        },
+                                        "ID": {
+                                            "shape_name": "ID",
+                                            "type": "string",
+                                            "documentation": null
+                                        }
+                                    },
+                                    "documentation": null
                                 }
-                            }
+                            },
+                            "documentation": null
                         },
-                        "flattened": true
-                    },
-                    "EncodingType": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "Encoding-Type",
-                        "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
-                    },
-                    "IsTruncated": {
-                        "type": "boolean",
-                        "documentation": "A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria."
-                    },
-                    "Marker": {
-                        "type": "string"
-                    },
-                    "MaxKeys": {
-                        "type": "integer"
+                        "flattened": true,
+                        "documentation": null
                     },
                     "Name": {
-                        "type": "string"
-                    },
-                    "NextMarker": {
+                        "shape_name": "BucketName",
                         "type": "string",
-                        "documentation": "When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMaker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys."
+                        "documentation": null
                     },
                     "Prefix": {
-                        "type": "string"
+                        "shape_name": "Prefix",
+                        "type": "string",
+                        "documentation": null
+                    },
+                    "MaxKeys": {
+                        "shape_name": "MaxKeys",
+                        "type": "integer",
+                        "documentation": null
+                    },
+                    "CommonPrefixes": {
+                        "shape_name": "CommonPrefixList",
+                        "type": "list",
+                        "members": {
+                            "shape_name": "CommonPrefix",
+                            "type": "structure",
+                            "members": {
+                                "Prefix": {
+                                    "shape_name": "Prefix",
+                                    "type": "string",
+                                    "documentation": null
+                                }
+                            },
+                            "documentation": null
+                        },
+                        "flattened": true,
+                        "documentation": null
+                    },
+                    "EncodingType": {
+                        "shape_name": "EncodingType",
+                        "type": "string",
+                        "enum": [
+                            "url"
+                        ],
+                        "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [
                 {
                     "shape_name": "NoSuchBucket",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The specified bucket does not exist."
                 }
             ],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html",
             "documentation": "Returns some or all (up to 1000) of the objects in a bucket. You can use the request parameters as selection criteria to return a subset of the objects in a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html",
+            "alias": "GetBucket",
             "pagination": {
                 "more_results": "IsTruncated",
                 "limit_key": "MaxKeys",
@@ -2805,116 +3461,154 @@
                 "uri": "/{Bucket}/{Key}?uploadId={UploadId}&max-parts={MaxParts}&part-number-marker={PartNumberMarker}"
             },
             "input": {
+                "shape_name": "ListPartsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "MaxParts": {
+                        "shape_name": "MaxParts",
                         "type": "integer",
-                        "location": "uri",
-                        "documentation": "Sets the maximum number of parts to return."
+                        "documentation": "Sets the maximum number of parts to return.",
+                        "location": "uri"
                     },
                     "PartNumberMarker": {
+                        "shape_name": "PartNumberMarker",
                         "type": "integer",
-                        "location": "uri",
-                        "documentation": "Specifies the part after which listing should begin. Only parts with higher part numbers will be listed."
+                        "documentation": "Specifies the part after which listing should begin. Only parts with higher part numbers will be listed.",
+                        "location": "uri"
                     },
                     "UploadId": {
+                        "shape_name": "MultipartUploadId",
                         "type": "string",
+                        "documentation": "Upload ID identifying the multipart upload whose parts are being listed.",
                         "required": true,
-                        "location": "uri",
-                        "documentation": "Upload ID identifying the multipart upload whose parts are being listed."
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "ListPartsOutput",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
                         "documentation": "Name of the bucket to which the multipart upload was initiated."
                     },
+                    "Key": {
+                        "shape_name": "ObjectKey",
+                        "type": "string",
+                        "documentation": "Object key for which the multipart upload was initiated."
+                    },
+                    "UploadId": {
+                        "shape_name": "MultipartUploadId",
+                        "type": "string",
+                        "documentation": "Upload ID identifying the multipart upload whose parts are being listed."
+                    },
+                    "PartNumberMarker": {
+                        "shape_name": "PartNumberMarker",
+                        "type": "integer",
+                        "documentation": "Part number after which listing begins."
+                    },
+                    "NextPartNumberMarker": {
+                        "shape_name": "NextPartNumberMarker",
+                        "type": "integer",
+                        "documentation": "When a list is truncated, this element specifies the last part in the list, as well as the value to use for the part-number-marker request parameter in a subsequent request."
+                    },
+                    "MaxParts": {
+                        "shape_name": "MaxParts",
+                        "type": "integer",
+                        "documentation": "Maximum number of parts that were allowed in the response."
+                    },
+                    "IsTruncated": {
+                        "shape_name": "IsTruncated",
+                        "type": "boolean",
+                        "documentation": "Indicates whether the returned list of parts is truncated."
+                    },
+                    "Parts": {
+                        "shape_name": "Parts",
+                        "type": "list",
+                        "members": {
+                            "shape_name": "Part",
+                            "type": "structure",
+                            "members": {
+                                "PartNumber": {
+                                    "shape_name": "PartNumber",
+                                    "type": "integer",
+                                    "documentation": "Part number identifying the part."
+                                },
+                                "LastModified": {
+                                    "shape_name": "LastModified",
+                                    "type": "timestamp",
+                                    "documentation": "Date and time at which the part was uploaded."
+                                },
+                                "ETag": {
+                                    "shape_name": "ETag",
+                                    "type": "string",
+                                    "documentation": "Entity tag returned when the part was uploaded."
+                                },
+                                "Size": {
+                                    "shape_name": "Size",
+                                    "type": "integer",
+                                    "documentation": "Size of the uploaded part data."
+                                }
+                            },
+                            "documentation": null
+                        },
+                        "flattened": true,
+                        "documentation": null,
+                        "xmlname": "Part"
+                    },
                     "Initiator": {
+                        "shape_name": "Initiator",
                         "type": "structure",
                         "members": {
-                            "DisplayName": {
-                                "type": "string",
-                                "documentation": "Name of the Principal."
-                            },
                             "ID": {
+                                "shape_name": "ID",
                                 "type": "string",
                                 "documentation": "If the principal is an AWS account, it provides the Canonical User ID. If the principal is an IAM User, it provides a user ARN value."
+                            },
+                            "DisplayName": {
+                                "shape_name": "DisplayName",
+                                "type": "string",
+                                "documentation": "Name of the Principal."
                             }
                         },
                         "documentation": "Identifies who initiated the multipart upload."
                     },
-                    "IsTruncated": {
-                        "type": "boolean",
-                        "documentation": "Indicates whether the returned list of parts is truncated."
-                    },
-                    "Key": {
-                        "type": "string",
-                        "documentation": "Object key for which the multipart upload was initiated."
-                    },
-                    "MaxParts": {
-                        "type": "integer",
-                        "documentation": "Maximum number of parts that were allowed in the response."
-                    },
-                    "NextPartNumberMarker": {
-                        "type": "integer",
-                        "documentation": "When a list is truncated, this element specifies the last part in the list, as well as the value to use for the part-number-marker request parameter in a subsequent request."
-                    },
                     "Owner": {
+                        "shape_name": "Owner",
                         "type": "structure",
                         "members": {
                             "DisplayName": {
-                                "type": "string"
+                                "shape_name": "DisplayName",
+                                "type": "string",
+                                "documentation": null
                             },
                             "ID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "PartNumberMarker": {
-                        "type": "integer",
-                        "documentation": "Part number after which listing begins."
-                    },
-                    "Parts": {
-                        "type": "list",
-                        "xmlname": "Part",
-                        "members": {
-                            "type": "structure",
-                            "members": {
-                                "ETag": {
-                                    "type": "string",
-                                    "documentation": "Entity tag returned when the part was uploaded."
-                                },
-                                "LastModified": {
-                                    "type": "timestamp",
-                                    "documentation": "Date and time at which the part was uploaded."
-                                },
-                                "PartNumber": {
-                                    "type": "integer",
-                                    "documentation": "Part number identifying the part."
-                                },
-                                "Size": {
-                                    "type": "integer",
-                                    "documentation": "Size of the uploaded part data."
-                                }
+                                "shape_name": "ID",
+                                "type": "string",
+                                "documentation": null
                             }
                         },
-                        "flattened": true
+                        "documentation": null
                     },
                     "StorageClass": {
+                        "shape_name": "StorageClass",
                         "type": "string",
                         "enum": [
                             "STANDARD",
@@ -2922,16 +3616,13 @@
                             "GLACIER"
                         ],
                         "documentation": "The class of storage used to store the object."
-                    },
-                    "UploadId": {
-                        "type": "string",
-                        "documentation": "Upload ID identifying the multipart upload whose parts are being listed."
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html",
             "documentation": "Lists the parts that have been uploaded for a specific multipart upload.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html",
             "pagination": {
                 "more_results": "IsTruncated",
                 "limit_key": "MaxParts",
@@ -2948,71 +3639,79 @@
                 "uri": "/{Bucket}?acl"
             },
             "input": {
+                "shape_name": "PutBucketAclRequest",
                 "type": "structure",
                 "members": {
                     "ACL": {
+                        "shape_name": "BucketCannedACL",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-acl",
                         "enum": [
                             "private",
                             "public-read",
                             "public-read-write",
-                            "authenticated-read",
-                            "bucket-owner-read",
-                            "bucket-owner-full-control"
+                            "authenticated-read"
                         ],
-                        "documentation": "The canned ACL to apply to the bucket."
+                        "documentation": "The canned ACL to apply to the bucket.",
+                        "location": "header",
+                        "location_name": "x-amz-acl"
                     },
                     "AccessControlPolicy": {
+                        "shape_name": "AccessControlPolicy",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "Grants": {
+                                "shape_name": "Grants",
                                 "type": "list",
-                                "xmlname": "AccessControlList",
                                 "members": {
+                                    "shape_name": "Grant",
                                     "type": "structure",
-                                    "xmlname": "Grant",
                                     "members": {
                                         "Grantee": {
-                                            "xmlnamespace": {
-                                                "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                                                "prefix": "xsi"
-                                            },
+                                            "shape_name": "Grantee",
                                             "type": "structure",
                                             "members": {
                                                 "DisplayName": {
+                                                    "shape_name": "DisplayName",
                                                     "type": "string",
                                                     "documentation": "Screen name of the grantee."
                                                 },
                                                 "EmailAddress": {
+                                                    "shape_name": "EmailAddress",
                                                     "type": "string",
                                                     "documentation": "Email address of the grantee."
                                                 },
                                                 "ID": {
+                                                    "shape_name": "ID",
                                                     "type": "string",
                                                     "documentation": "The canonical user ID of the grantee."
                                                 },
                                                 "Type": {
+                                                    "shape_name": "Type",
                                                     "type": "string",
-                                                    "required": true,
-                                                    "xmlname": "xsi:type",
-                                                    "xmlattribute": true,
                                                     "enum": [
                                                         "CanonicalUser",
                                                         "AmazonCustomerByEmail",
                                                         "Group"
                                                     ],
-                                                    "documentation": "Type of grantee"
+                                                    "documentation": "Type of grantee",
+                                                    "required": true,
+                                                    "xmlattribute": true,
+                                                    "xmlname": "xsi:type"
                                                 },
                                                 "URI": {
+                                                    "shape_name": "URI",
                                                     "type": "string",
                                                     "documentation": "URI of the grantee group."
                                                 }
+                                            },
+                                            "documentation": null,
+                                            "xmlnamespace": {
+                                                "prefix": "xsi",
+                                                "uri": "http://www.w3.org/2001/XMLSchema-instance"
                                             }
                                         },
                                         "Permission": {
+                                            "shape_name": "Permission",
                                             "type": "string",
                                             "enum": [
                                                 "FULL_CONTROL",
@@ -3023,69 +3722,90 @@
                                             ],
                                             "documentation": "Specifies the permission given to the grantee."
                                         }
-                                    }
+                                    },
+                                    "documentation": null,
+                                    "xmlname": "Grant"
                                 },
-                                "documentation": "A list of grants."
+                                "documentation": "A list of grants.",
+                                "xmlname": "AccessControlList"
                             },
                             "Owner": {
+                                "shape_name": "Owner",
                                 "type": "structure",
                                 "members": {
                                     "DisplayName": {
-                                        "type": "string"
+                                        "shape_name": "DisplayName",
+                                        "type": "string",
+                                        "documentation": null
                                     },
                                     "ID": {
-                                        "type": "string"
+                                        "shape_name": "ID",
+                                        "type": "string",
+                                        "documentation": null
                                     }
-                                }
+                                },
+                                "documentation": null
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "payload": true
                     },
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "GrantFullControl": {
+                        "shape_name": "GrantFullControl",
                         "type": "string",
+                        "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-full-control",
-                        "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."
+                        "location_name": "x-amz-grant-full-control"
                     },
                     "GrantRead": {
+                        "shape_name": "GrantRead",
                         "type": "string",
+                        "documentation": "Allows grantee to list the objects in the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read",
-                        "documentation": "Allows grantee to list the objects in the bucket."
+                        "location_name": "x-amz-grant-read"
                     },
                     "GrantReadACP": {
+                        "shape_name": "GrantReadACP",
                         "type": "string",
+                        "documentation": "Allows grantee to read the bucket ACL.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read-acp",
-                        "documentation": "Allows grantee to read the bucket ACL."
+                        "location_name": "x-amz-grant-read-acp"
                     },
                     "GrantWrite": {
+                        "shape_name": "GrantWrite",
                         "type": "string",
+                        "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write",
-                        "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket."
+                        "location_name": "x-amz-grant-write"
                     },
                     "GrantWriteACP": {
+                        "shape_name": "GrantWriteACP",
                         "type": "string",
+                        "documentation": "Allows grantee to write the ACL for the applicable bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write-acp",
-                        "documentation": "Allows grantee to write the ACL for the applicable bucket."
+                        "location_name": "x-amz-grant-write-acp"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTacl.html",
-            "documentation": "Sets the permissions on a bucket using access control lists (ACL)."
+            "documentation": "Sets the permissions on a bucket using access control lists (ACL).",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTacl.html"
         },
         "PutBucketCors": {
             "name": "PutBucketCors",
@@ -3094,80 +3814,105 @@
                 "uri": "/{Bucket}?cors"
             },
             "input": {
+                "shape_name": "PutBucketCorsRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "CORSConfiguration": {
+                        "shape_name": "CORSConfiguration",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "CORSRules": {
+                                "shape_name": "CORSRules",
                                 "type": "list",
-                                "xmlname": "CORSRule",
                                 "members": {
+                                    "shape_name": "CORSRule",
                                     "type": "structure",
                                     "members": {
                                         "AllowedHeaders": {
+                                            "shape_name": "AllowedHeaders",
                                             "type": "list",
-                                            "xmlname": "AllowedHeader",
                                             "members": {
-                                                "type": "string"
+                                                "shape_name": "AllowedHeader",
+                                                "type": "string",
+                                                "documentation": null
                                             },
+                                            "flattened": true,
                                             "documentation": "Specifies which headers are allowed in a pre-flight OPTIONS request.",
-                                            "flattened": true
+                                            "xmlname": "AllowedHeader"
                                         },
                                         "AllowedMethods": {
+                                            "shape_name": "AllowedMethods",
                                             "type": "list",
-                                            "xmlname": "AllowedMethod",
                                             "members": {
-                                                "type": "string"
+                                                "shape_name": "AllowedMethod",
+                                                "type": "string",
+                                                "documentation": null
                                             },
+                                            "flattened": true,
                                             "documentation": "Identifies HTTP methods that the domain/origin specified in the rule is allowed to execute.",
-                                            "flattened": true
+                                            "xmlname": "AllowedMethod"
                                         },
                                         "AllowedOrigins": {
+                                            "shape_name": "AllowedOrigins",
                                             "type": "list",
-                                            "xmlname": "AllowedOrigin",
                                             "members": {
-                                                "type": "string"
+                                                "shape_name": "AllowedOrigin",
+                                                "type": "string",
+                                                "documentation": null
                                             },
+                                            "flattened": true,
                                             "documentation": "One or more origins you want customers to be able to access the bucket from.",
-                                            "flattened": true
+                                            "xmlname": "AllowedOrigin"
                                         },
                                         "ExposeHeaders": {
+                                            "shape_name": "ExposeHeaders",
                                             "type": "list",
-                                            "xmlname": "ExposeHeader",
                                             "members": {
-                                                "type": "string"
+                                                "shape_name": "ExposeHeader",
+                                                "type": "string",
+                                                "documentation": null
                                             },
+                                            "flattened": true,
                                             "documentation": "One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript XMLHttpRequest object).",
-                                            "flattened": true
+                                            "xmlname": "ExposeHeader"
                                         },
                                         "MaxAgeSeconds": {
+                                            "shape_name": "MaxAgeSeconds",
                                             "type": "integer",
                                             "documentation": "The time in seconds that your browser is to cache the preflight response for the specified resource."
                                         }
-                                    }
+                                    },
+                                    "documentation": null
                                 },
-                                "flattened": true
+                                "flattened": true,
+                                "documentation": null,
+                                "xmlname": "CORSRule"
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "payload": true
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTcors.html",
-            "documentation": "Sets the cors configuration for a bucket."
+            "documentation": "Sets the cors configuration for a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTcors.html"
         },
         "PutBucketLifecycle": {
             "name": "PutBucketLifecycle",
@@ -3176,74 +3921,90 @@
                 "uri": "/{Bucket}?lifecycle"
             },
             "input": {
+                "shape_name": "PutBucketLifecycleRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "LifecycleConfiguration": {
+                        "shape_name": "LifecycleConfiguration",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "Rules": {
+                                "shape_name": "Rules",
                                 "type": "list",
-                                "required": true,
-                                "xmlname": "Rule",
                                 "members": {
+                                    "shape_name": "Rule",
                                     "type": "structure",
                                     "members": {
                                         "Expiration": {
+                                            "shape_name": "LifecycleExpiration",
                                             "type": "structure",
                                             "members": {
                                                 "Date": {
+                                                    "shape_name": "Date",
                                                     "type": "timestamp",
                                                     "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                                                     "timestamp_format": "iso8601"
                                                 },
                                                 "Days": {
+                                                    "shape_name": "Days",
                                                     "type": "integer",
                                                     "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                                                 }
-                                            }
+                                            },
+                                            "documentation": null
                                         },
                                         "ID": {
+                                            "shape_name": "ID",
                                             "type": "string",
                                             "documentation": "Unique identifier for the rule. The value cannot be longer than 255 characters."
                                         },
                                         "Prefix": {
+                                            "shape_name": "Prefix",
                                             "type": "string",
-                                            "required": true,
-                                            "documentation": "Prefix identifying one or more objects to which the rule applies."
+                                            "documentation": "Prefix identifying one or more objects to which the rule applies.",
+                                            "required": true
                                         },
                                         "Status": {
+                                            "shape_name": "ExpirationStatus",
                                             "type": "string",
-                                            "required": true,
                                             "enum": [
                                                 "Enabled",
                                                 "Disabled"
                                             ],
-                                            "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied."
+                                            "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied.",
+                                            "required": true
                                         },
                                         "Transition": {
+                                            "shape_name": "Transition",
                                             "type": "structure",
                                             "members": {
                                                 "Date": {
+                                                    "shape_name": "Date",
                                                     "type": "timestamp",
                                                     "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                                                     "timestamp_format": "iso8601"
                                                 },
                                                 "Days": {
+                                                    "shape_name": "Days",
                                                     "type": "integer",
                                                     "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                                                 },
                                                 "StorageClass": {
+                                                    "shape_name": "StorageClass",
                                                     "type": "string",
                                                     "enum": [
                                                         "STANDARD",
@@ -3252,20 +4013,28 @@
                                                     ],
                                                     "documentation": "The class of storage used to store the object."
                                                 }
-                                            }
+                                            },
+                                            "documentation": null
                                         }
-                                    }
+                                    },
+                                    "documentation": null
                                 },
-                                "flattened": true
+                                "flattened": true,
+                                "documentation": null,
+                                "required": true,
+                                "xmlname": "Rule"
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html",
-            "documentation": "Sets lifecycle configuration for your bucket. If a lifecycle configuration exists, it replaces it."
+            "documentation": "Sets lifecycle configuration for your bucket. If a lifecycle configuration exists, it replaces it.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html"
         },
         "PutBucketLogging": {
             "name": "PutBucketLogging",
@@ -3274,93 +4043,123 @@
                 "uri": "/{Bucket}?logging"
             },
             "input": {
+                "shape_name": "PutBucketLoggingRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "BucketLoggingStatus": {
+                        "shape_name": "BucketLoggingStatus",
                         "type": "structure",
-                        "payload": true,
-                        "required": true,
                         "members": {
                             "LoggingEnabled": {
+                                "shape_name": "LoggingEnabled",
                                 "type": "structure",
                                 "members": {
                                     "TargetBucket": {
+                                        "shape_name": "TargetBucket",
                                         "type": "string",
                                         "documentation": "Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own, including the same bucket that is being logged. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case you should choose a different TargetPrefix for each source bucket so that the delivered log files can be distinguished by key."
                                     },
                                     "TargetGrants": {
+                                        "shape_name": "TargetGrants",
                                         "type": "list",
                                         "members": {
+                                            "shape_name": "TargetGrant",
                                             "type": "structure",
-                                            "xmlname": "Grant",
                                             "members": {
                                                 "Grantee": {
-                                                    "xmlnamespace": {
-                                                        "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                                                        "prefix": "xsi"
-                                                    },
+                                                    "shape_name": "Grantee",
                                                     "type": "structure",
                                                     "members": {
                                                         "DisplayName": {
+                                                            "shape_name": "DisplayName",
                                                             "type": "string",
                                                             "documentation": "Screen name of the grantee."
                                                         },
                                                         "EmailAddress": {
+                                                            "shape_name": "EmailAddress",
                                                             "type": "string",
                                                             "documentation": "Email address of the grantee."
                                                         },
                                                         "ID": {
+                                                            "shape_name": "ID",
                                                             "type": "string",
                                                             "documentation": "The canonical user ID of the grantee."
                                                         },
                                                         "Type": {
+                                                            "shape_name": "Type",
                                                             "type": "string",
-                                                            "required": true,
-                                                            "xmlname": "xsi:type",
-                                                            "xmlattribute": true,
                                                             "enum": [
                                                                 "CanonicalUser",
                                                                 "AmazonCustomerByEmail",
                                                                 "Group"
                                                             ],
-                                                            "documentation": "Type of grantee"
+                                                            "documentation": "Type of grantee",
+                                                            "required": true,
+                                                            "xmlattribute": true,
+                                                            "xmlname": "xsi:type"
                                                         },
                                                         "URI": {
+                                                            "shape_name": "URI",
                                                             "type": "string",
                                                             "documentation": "URI of the grantee group."
                                                         }
+                                                    },
+                                                    "documentation": null,
+                                                    "xmlnamespace": {
+                                                        "prefix": "xsi",
+                                                        "uri": "http://www.w3.org/2001/XMLSchema-instance"
                                                     }
                                                 },
                                                 "Permission": {
-                                                    "type": "string"
+                                                    "shape_name": "BucketLogsPermission",
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "FULL_CONTROL",
+                                                        "READ",
+                                                        "WRITE"
+                                                    ],
+                                                    "documentation": "Logging permissions assigned to the Grantee for the bucket."
                                                 }
-                                            }
-                                        }
+                                            },
+                                            "documentation": null,
+                                            "xmlname": "Grant"
+                                        },
+                                        "documentation": null
                                     },
                                     "TargetPrefix": {
+                                        "shape_name": "TargetPrefix",
                                         "type": "string",
                                         "documentation": "This element lets you specify a prefix for the keys that the log files will be stored under."
                                     }
-                                }
+                                },
+                                "documentation": null
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "required": true,
+                        "payload": true
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html",
-            "documentation": "Set the logging parameters for a bucket and to specify permissions for who can view and modify the logging parameters. To set the logging status of a bucket, you must be the bucket owner."
+            "documentation": "Set the logging parameters for a bucket and to specify permissions for who can view and modify the logging parameters. To set the logging status of a bucket, you must be the bucket owner.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html"
         },
         "PutBucketNotification": {
             "name": "PutBucketNotification",
@@ -3369,28 +4168,33 @@
                 "uri": "/{Bucket}?notification"
             },
             "input": {
+                "shape_name": "PutBucketNotificationRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "NotificationConfiguration": {
+                        "shape_name": "NotificationConfiguration",
                         "type": "structure",
-                        "payload": true,
-                        "required": true,
                         "members": {
                             "TopicConfiguration": {
+                                "shape_name": "TopicConfiguration",
                                 "type": "structure",
-                                "required": true,
                                 "members": {
                                     "Event": {
+                                        "shape_name": "Event",
                                         "type": "string",
                                         "enum": [
                                             "s3:ReducedRedundancyLostObject"
@@ -3398,19 +4202,26 @@
                                         "documentation": "Bucket event for which to send notifications."
                                     },
                                     "Topic": {
+                                        "shape_name": "Topic",
                                         "type": "string",
                                         "documentation": "Amazon SNS topic to which Amazon S3 will publish a message to report the specified events for the bucket."
                                     }
-                                }
+                                },
+                                "documentation": null,
+                                "required": true
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "required": true,
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html",
-            "documentation": "Enables notifications of specified events for a bucket."
+            "documentation": "Enables notifications of specified events for a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html"
         },
         "PutBucketPolicy": {
             "name": "PutBucketPolicy",
@@ -3419,30 +4230,37 @@
                 "uri": "/{Bucket}?policy"
             },
             "input": {
+                "shape_name": "PutBucketPolicyRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "Policy": {
+                        "shape_name": "Policy",
                         "type": "string",
-                        "payload": true,
+                        "documentation": "The bucket policy as a JSON document.",
                         "required": true,
-                        "documentation": "The bucket policy as a JSON document."
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTpolicy.html",
-            "documentation": "Replaces a policy on a bucket. If the bucket already has a policy, the one in this request completely replaces it."
+            "documentation": "Replaces a policy on a bucket. If the bucket already has a policy, the one in this request completely replaces it.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTpolicy.html"
         },
         "PutBucketRequestPayment": {
             "name": "PutBucketRequestPayment",
@@ -3451,40 +4269,49 @@
                 "uri": "/{Bucket}?requestPayment"
             },
             "input": {
+                "shape_name": "PutBucketRequestPaymentRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "RequestPaymentConfiguration": {
+                        "shape_name": "RequestPaymentConfiguration",
                         "type": "structure",
-                        "payload": true,
-                        "required": true,
                         "members": {
                             "Payer": {
+                                "shape_name": "Payer",
                                 "type": "string",
-                                "required": true,
                                 "enum": [
                                     "Requester",
                                     "BucketOwner"
                                 ],
-                                "documentation": "Specifies who pays for the download and request fees."
+                                "documentation": "Specifies who pays for the download and request fees.",
+                                "required": true
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "required": true,
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentPUT.html",
-            "documentation": "Sets the request payment configuration for a bucket. By default, the bucket owner pays for downloads from the bucket. This configuration parameter enables the bucket owner (only) to specify that the person requesting the download will be charged for the download."
+            "documentation": "Sets the request payment configuration for a bucket. By default, the bucket owner pays for downloads from the bucket. This configuration parameter enables the bucket owner (only) to specify that the person requesting the download will be charged for the download.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentPUT.html"
         },
         "PutBucketTagging": {
             "name": "PutBucketTagging",
@@ -3493,52 +4320,65 @@
                 "uri": "/{Bucket}?tagging"
             },
             "input": {
+                "shape_name": "PutBucketTaggingRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "Tagging": {
+                        "shape_name": "Tagging",
                         "type": "structure",
-                        "payload": true,
-                        "required": true,
                         "members": {
                             "TagSet": {
+                                "shape_name": "TagSet",
                                 "type": "list",
-                                "required": true,
                                 "members": {
+                                    "shape_name": "Tag",
                                     "type": "structure",
-                                    "required": true,
-                                    "xmlname": "Tag",
                                     "members": {
                                         "Key": {
+                                            "shape_name": "ObjectKey",
                                             "type": "string",
-                                            "required": true,
-                                            "documentation": "Name of the tag."
+                                            "documentation": "Name of the tag.",
+                                            "required": true
                                         },
                                         "Value": {
+                                            "shape_name": "Value",
                                             "type": "string",
-                                            "required": true,
-                                            "documentation": "Value of the tag."
+                                            "documentation": "Value of the tag.",
+                                            "required": true
                                         }
-                                    }
-                                }
+                                    },
+                                    "documentation": null,
+                                    "xmlname": "Tag"
+                                },
+                                "documentation": null,
+                                "required": true
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "required": true,
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTtagging.html",
-            "documentation": "Sets the tags for a bucket."
+            "documentation": "Sets the tags for a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTtagging.html"
         },
         "PutBucketVersioning": {
             "name": "PutBucketVersioning",
@@ -3547,53 +4387,64 @@
                 "uri": "/{Bucket}?versioning"
             },
             "input": {
+                "shape_name": "PutBucketVersioningRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "MFA": {
+                        "shape_name": "MFA",
                         "type": "string",
+                        "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device.",
                         "location": "header",
-                        "location_name": "x-amz-mfa",
-                        "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."
+                        "location_name": "x-amz-mfa"
                     },
                     "VersioningConfiguration": {
+                        "shape_name": "VersioningConfiguration",
                         "type": "structure",
-                        "payload": true,
-                        "required": true,
                         "members": {
-                            "MfaDelete": {
-                                "type": "string",
-                                "enum": [
-                                    "Enabled",
-                                    "Disabled"
-                                ],
-                                "documentation": "Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."
-                            },
                             "Status": {
+                                "shape_name": "BucketVersioningStatus",
                                 "type": "string",
                                 "enum": [
                                     "Enabled",
                                     "Suspended"
                                 ],
                                 "documentation": "The versioning state of the bucket."
+                            },
+                            "MfaDelete": {
+                                "shape_name": "MFADelete",
+                                "type": "string",
+                                "enum": [
+                                    "Enabled",
+                                    "Disabled"
+                                ],
+                                "documentation": "Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "required": true,
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTVersioningStatus.html",
-            "documentation": "Sets the versioning state of an existing bucket. To set the versioning state, you must be the bucket owner."
+            "documentation": "Sets the versioning state of an existing bucket. To set the versioning state, you must be the bucket owner.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTVersioningStatus.html"
         },
         "PutBucketWebsite": {
             "name": "PutBucketWebsite",
@@ -3602,52 +4453,65 @@
                 "uri": "/{Bucket}?website"
             },
             "input": {
+                "shape_name": "PutBucketWebsiteRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "WebsiteConfiguration": {
+                        "shape_name": "WebsiteConfiguration",
                         "type": "structure",
-                        "payload": true,
-                        "required": true,
                         "members": {
                             "ErrorDocument": {
+                                "shape_name": "ErrorDocument",
                                 "type": "structure",
                                 "members": {
                                     "Key": {
+                                        "shape_name": "ObjectKey",
                                         "type": "string",
-                                        "required": true,
-                                        "documentation": "The object key name to use when a 4XX class error occurs."
+                                        "documentation": "The object key name to use when a 4XX class error occurs.",
+                                        "required": true
                                     }
-                                }
+                                },
+                                "documentation": null
                             },
                             "IndexDocument": {
+                                "shape_name": "IndexDocument",
                                 "type": "structure",
                                 "members": {
                                     "Suffix": {
+                                        "shape_name": "Suffix",
                                         "type": "string",
-                                        "required": true,
-                                        "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character."
+                                        "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character.",
+                                        "required": true
                                     }
-                                }
+                                },
+                                "documentation": null
                             },
                             "RedirectAllRequestsTo": {
+                                "shape_name": "RedirectAllRequestsTo",
                                 "type": "structure",
                                 "members": {
                                     "HostName": {
+                                        "shape_name": "HostName",
                                         "type": "string",
-                                        "required": true,
-                                        "documentation": "Name of the host where requests will be redirected."
+                                        "documentation": "Name of the host where requests will be redirected.",
+                                        "required": true
                                     },
                                     "Protocol": {
+                                        "shape_name": "Protocol",
                                         "type": "string",
                                         "enum": [
                                             "http",
@@ -3655,22 +4519,27 @@
                                         ],
                                         "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
                                     }
-                                }
+                                },
+                                "documentation": null
                             },
                             "RoutingRules": {
+                                "shape_name": "RoutingRules",
                                 "type": "list",
                                 "members": {
+                                    "shape_name": "RoutingRule",
                                     "type": "structure",
-                                    "xmlname": "RoutingRule",
                                     "members": {
                                         "Condition": {
+                                            "shape_name": "Condition",
                                             "type": "structure",
                                             "members": {
                                                 "HttpErrorCodeReturnedEquals": {
+                                                    "shape_name": "HttpErrorCodeReturnedEquals",
                                                     "type": "string",
                                                     "documentation": "The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element Condition is specified and sibling KeyPrefixEquals is not specified. If both are specified, then both must be true for the redirect to be applied."
                                                 },
                                                 "KeyPrefixEquals": {
+                                                    "shape_name": "KeyPrefixEquals",
                                                     "type": "string",
                                                     "documentation": "The object key name prefix when the redirect is applied. For example, to redirect requests for ExamplePage.html, the key prefix will be ExamplePage.html. To redirect request for all pages with the prefix docs/, the key prefix will be /docs, which identifies all objects in the docs/ folder. Required when the parent element Condition is specified and sibling HttpErrorCodeReturnedEquals is not specified. If both conditions are specified, both must be true for the redirect to be applied."
                                                 }
@@ -3678,18 +4547,21 @@
                                             "documentation": "A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the /docs folder, redirect to the /documents folder. 2. If request results in HTTP error 4xx, redirect request to another host where you might process the error."
                                         },
                                         "Redirect": {
+                                            "shape_name": "Redirect",
                                             "type": "structure",
-                                            "required": true,
                                             "members": {
                                                 "HostName": {
+                                                    "shape_name": "HostName",
                                                     "type": "string",
                                                     "documentation": "The host name to use in the redirect request."
                                                 },
                                                 "HttpRedirectCode": {
+                                                    "shape_name": "HttpRedirectCode",
                                                     "type": "string",
                                                     "documentation": "The HTTP redirect code to use on the response. Not required if one of the siblings is present."
                                                 },
                                                 "Protocol": {
+                                                    "shape_name": "Protocol",
                                                     "type": "string",
                                                     "enum": [
                                                         "http",
@@ -3698,27 +4570,37 @@
                                                     "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
                                                 },
                                                 "ReplaceKeyPrefixWith": {
+                                                    "shape_name": "ReplaceKeyPrefixWith",
                                                     "type": "string",
                                                     "documentation": "The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix docs/ (objects in the docs/ folder) to documents/, you can set a condition block with KeyPrefixEquals set to docs/ and in the Redirect set ReplaceKeyPrefixWith to /documents. Not required if one of the siblings is present. Can be present only if ReplaceKeyWith is not provided."
                                                 },
                                                 "ReplaceKeyWith": {
+                                                    "shape_name": "ReplaceKeyWith",
                                                     "type": "string",
                                                     "documentation": "The specific object key to use in the redirect request. For example, redirect request to error.html. Not required if one of the sibling is present. Can be present only if ReplaceKeyPrefixWith is not provided."
                                                 }
                                             },
-                                            "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return."
+                                            "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return.",
+                                            "required": true
                                         }
-                                    }
-                                }
+                                    },
+                                    "documentation": null,
+                                    "xmlname": "RoutingRule"
+                                },
+                                "documentation": null
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "required": true,
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html",
-            "documentation": "Set the website configuration for a bucket."
+            "documentation": "Set the website configuration for a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html"
         },
         "PutObject": {
             "name": "PutObject",
@@ -3727,12 +4609,12 @@
                 "uri": "/{Bucket}/{Key}"
             },
             "input": {
+                "shape_name": "PutObjectRequest",
                 "type": "structure",
                 "members": {
                     "ACL": {
+                        "shape_name": "ObjectCannedACL",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-acl",
                         "enum": [
                             "private",
                             "public-read",
@@ -3741,91 +4623,112 @@
                             "bucket-owner-read",
                             "bucket-owner-full-control"
                         ],
-                        "documentation": "The canned ACL to apply to the object."
+                        "documentation": "The canned ACL to apply to the object.",
+                        "location": "header",
+                        "location_name": "x-amz-acl"
                     },
                     "Body": {
+                        "shape_name": "Body",
                         "type": "blob",
+                        "documentation": null,
                         "payload": true,
                         "streaming": true
                     },
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "CacheControl": {
+                        "shape_name": "CacheControl",
                         "type": "string",
+                        "documentation": "Specifies caching behavior along the request/reply chain.",
                         "location": "header",
-                        "location_name": "Cache-Control",
-                        "documentation": "Specifies caching behavior along the request/reply chain."
+                        "location_name": "Cache-Control"
                     },
                     "ContentDisposition": {
+                        "shape_name": "ContentDisposition",
                         "type": "string",
+                        "documentation": "Specifies presentational information for the object.",
                         "location": "header",
-                        "location_name": "Content-Disposition",
-                        "documentation": "Specifies presentational information for the object."
+                        "location_name": "Content-Disposition"
                     },
                     "ContentEncoding": {
+                        "shape_name": "ContentEncoding",
                         "type": "string",
+                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
                         "location": "header",
-                        "location_name": "Content-Encoding",
-                        "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
+                        "location_name": "Content-Encoding"
                     },
                     "ContentLanguage": {
+                        "shape_name": "ContentLanguage",
                         "type": "string",
+                        "documentation": "The language the content is in.",
                         "location": "header",
-                        "location_name": "Content-Language",
-                        "documentation": "The language the content is in."
+                        "location_name": "Content-Language"
                     },
                     "ContentLength": {
+                        "shape_name": "ContentLength",
                         "type": "integer",
+                        "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.",
                         "location": "header",
-                        "location_name": "Content-Length",
-                        "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically."
+                        "location_name": "Content-Length"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "ContentType": {
+                        "shape_name": "ContentType",
                         "type": "string",
+                        "documentation": "A standard MIME type describing the format of the object data.",
                         "location": "header",
-                        "location_name": "Content-Type",
-                        "documentation": "A standard MIME type describing the format of the object data."
+                        "location_name": "Content-Type"
                     },
                     "Expires": {
+                        "shape_name": "Expires",
                         "type": "timestamp",
+                        "documentation": "The date and time at which the object is no longer cacheable.",
                         "location": "header",
-                        "location_name": "Expires",
-                        "documentation": "The date and time at which the object is no longer cacheable."
+                        "location_name": "Expires"
                     },
                     "GrantFullControl": {
+                        "shape_name": "GrantFullControl",
                         "type": "string",
+                        "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.",
                         "location": "header",
-                        "location_name": "x-amz-grant-full-control",
-                        "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."
+                        "location_name": "x-amz-grant-full-control"
                     },
                     "GrantRead": {
+                        "shape_name": "GrantRead",
                         "type": "string",
+                        "documentation": "Allows grantee to read the object data and its metadata.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read",
-                        "documentation": "Allows grantee to read the object data and its metadata."
+                        "location_name": "x-amz-grant-read"
                     },
                     "GrantReadACP": {
+                        "shape_name": "GrantReadACP",
                         "type": "string",
+                        "documentation": "Allows grantee to read the object ACL.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read-acp",
-                        "documentation": "Allows grantee to read the object ACL."
+                        "location_name": "x-amz-grant-read-acp"
                     },
                     "GrantWriteACP": {
+                        "shape_name": "GrantWriteACP",
                         "type": "string",
+                        "documentation": "Allows grantee to write the ACL for the applicable object.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write-acp",
-                        "documentation": "Allows grantee to write the ACL for the applicable object."
+                        "location_name": "x-amz-grant-write-acp"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
@@ -3833,80 +4736,89 @@
                         "type": "map",
                         "location": "header",
                         "location_name": "x-amz-meta-",
+                        "keys": {
+                            "type": "string",
+                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+                        },
                         "members": {
                             "type": "string",
                             "documentation": "The metadata value."
                         },
-                        "documentation": "A map of metadata to store with the object in S3.",
-                        "keys": {
-                            "type": "string",
-                            "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-                        }
+                        "documentation": "A map of metadata to store with the object in S3."
                     },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     },
                     "StorageClass": {
+                        "shape_name": "StorageClassOptions",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-storage-class",
                         "enum": [
                             "STANDARD",
                             "REDUCED_REDUNDANCY"
                         ],
-                        "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'."
+                        "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'.",
+                        "location": "header",
+                        "location_name": "x-amz-storage-class"
                     },
                     "WebsiteRedirectLocation": {
+                        "shape_name": "WebsiteRedirectLocation",
                         "type": "string",
+                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
                         "location": "header",
                         "location_name": "x-amz-website-redirect-location",
-                        "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
                         "no_paramfile": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "PutObjectOutput",
                 "type": "structure",
                 "members": {
-                    "ETag": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "ETag",
-                        "documentation": "Entity tag for the uploaded object."
-                    },
                     "Expiration": {
+                        "shape_name": "Expiration",
                         "type": "timestamp",
+                        "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded.",
                         "location": "header",
-                        "location_name": "x-amz-expiration",
-                        "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded."
+                        "location_name": "x-amz-expiration"
+                    },
+                    "ETag": {
+                        "shape_name": "ETag",
+                        "type": "string",
+                        "documentation": "Entity tag for the uploaded object.",
+                        "location": "header",
+                        "location_name": "ETag"
                     },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     },
                     "VersionId": {
+                        "shape_name": "ObjectVersionId",
                         "type": "string",
+                        "documentation": "Version of the object.",
                         "location": "header",
-                        "location_name": "x-amz-version-id",
-                        "documentation": "Version of the object."
+                        "location_name": "x-amz-version-id"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html",
-            "documentation": "Adds an object to a bucket."
+            "documentation": "Adds an object to a bucket.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html"
         },
         "PutObjectAcl": {
             "name": "PutObjectAcl",
@@ -3915,12 +4827,12 @@
                 "uri": "/{Bucket}/{Key}?acl"
             },
             "input": {
+                "shape_name": "PutObjectAclRequest",
                 "type": "structure",
                 "members": {
                     "ACL": {
+                        "shape_name": "ObjectCannedACL",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-acl",
                         "enum": [
                             "private",
                             "public-read",
@@ -3929,57 +4841,67 @@
                             "bucket-owner-read",
                             "bucket-owner-full-control"
                         ],
-                        "documentation": "The canned ACL to apply to the bucket."
+                        "documentation": "The canned ACL to apply to the object.",
+                        "location": "header",
+                        "location_name": "x-amz-acl"
                     },
                     "AccessControlPolicy": {
+                        "shape_name": "AccessControlPolicy",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "Grants": {
+                                "shape_name": "Grants",
                                 "type": "list",
-                                "xmlname": "AccessControlList",
                                 "members": {
+                                    "shape_name": "Grant",
                                     "type": "structure",
-                                    "xmlname": "Grant",
                                     "members": {
                                         "Grantee": {
-                                            "xmlnamespace": {
-                                                "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                                                "prefix": "xsi"
-                                            },
+                                            "shape_name": "Grantee",
                                             "type": "structure",
                                             "members": {
                                                 "DisplayName": {
+                                                    "shape_name": "DisplayName",
                                                     "type": "string",
                                                     "documentation": "Screen name of the grantee."
                                                 },
                                                 "EmailAddress": {
+                                                    "shape_name": "EmailAddress",
                                                     "type": "string",
                                                     "documentation": "Email address of the grantee."
                                                 },
                                                 "ID": {
+                                                    "shape_name": "ID",
                                                     "type": "string",
                                                     "documentation": "The canonical user ID of the grantee."
                                                 },
                                                 "Type": {
+                                                    "shape_name": "Type",
                                                     "type": "string",
-                                                    "required": true,
-                                                    "xmlname": "xsi:type",
-                                                    "xmlattribute": true,
                                                     "enum": [
                                                         "CanonicalUser",
                                                         "AmazonCustomerByEmail",
                                                         "Group"
                                                     ],
-                                                    "documentation": "Type of grantee"
+                                                    "documentation": "Type of grantee",
+                                                    "required": true,
+                                                    "xmlattribute": true,
+                                                    "xmlname": "xsi:type"
                                                 },
                                                 "URI": {
+                                                    "shape_name": "URI",
                                                     "type": "string",
                                                     "documentation": "URI of the grantee group."
                                                 }
+                                            },
+                                            "documentation": null,
+                                            "xmlnamespace": {
+                                                "prefix": "xsi",
+                                                "uri": "http://www.w3.org/2001/XMLSchema-instance"
                                             }
                                         },
                                         "Permission": {
+                                            "shape_name": "Permission",
                                             "type": "string",
                                             "enum": [
                                                 "FULL_CONTROL",
@@ -3990,124 +4912,158 @@
                                             ],
                                             "documentation": "Specifies the permission given to the grantee."
                                         }
-                                    }
+                                    },
+                                    "documentation": null,
+                                    "xmlname": "Grant"
                                 },
-                                "documentation": "A list of grants."
+                                "documentation": "A list of grants.",
+                                "xmlname": "AccessControlList"
                             },
                             "Owner": {
+                                "shape_name": "Owner",
                                 "type": "structure",
                                 "members": {
                                     "DisplayName": {
-                                        "type": "string"
+                                        "shape_name": "DisplayName",
+                                        "type": "string",
+                                        "documentation": null
                                     },
                                     "ID": {
-                                        "type": "string"
+                                        "shape_name": "ID",
+                                        "type": "string",
+                                        "documentation": null
                                     }
-                                }
+                                },
+                                "documentation": null
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "payload": true
                     },
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "GrantFullControl": {
+                        "shape_name": "GrantFullControl",
                         "type": "string",
+                        "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-full-control",
-                        "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."
+                        "location_name": "x-amz-grant-full-control"
                     },
                     "GrantRead": {
+                        "shape_name": "GrantRead",
                         "type": "string",
+                        "documentation": "Allows grantee to list the objects in the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read",
-                        "documentation": "Allows grantee to list the objects in the bucket."
+                        "location_name": "x-amz-grant-read"
                     },
                     "GrantReadACP": {
+                        "shape_name": "GrantReadACP",
                         "type": "string",
+                        "documentation": "Allows grantee to read the bucket ACL.",
                         "location": "header",
-                        "location_name": "x-amz-grant-read-acp",
-                        "documentation": "Allows grantee to read the bucket ACL."
+                        "location_name": "x-amz-grant-read-acp"
                     },
                     "GrantWrite": {
+                        "shape_name": "GrantWrite",
                         "type": "string",
+                        "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write",
-                        "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket."
+                        "location_name": "x-amz-grant-write"
                     },
                     "GrantWriteACP": {
+                        "shape_name": "GrantWriteACP",
                         "type": "string",
+                        "documentation": "Allows grantee to write the ACL for the applicable bucket.",
                         "location": "header",
-                        "location_name": "x-amz-grant-write-acp",
-                        "documentation": "Allows grantee to write the ACL for the applicable bucket."
+                        "location_name": "x-amz-grant-write-acp"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [
                 {
                     "shape_name": "NoSuchKey",
                     "type": "structure",
+                    "members": {},
                     "documentation": "The specified key does not exist."
                 }
             ],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html",
-            "documentation": "uses the acl subresource to set the access control list (ACL) permissions for an object that already exists in a bucket"
+            "documentation": "uses the acl subresource to set the access control list (ACL) permissions for an object that already exists in a bucket",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html"
         },
         "RestoreObject": {
             "name": "RestoreObject",
-            "alias": "PostObjectRestore",
             "http": {
                 "method": "POST",
                 "uri": "/{Bucket}/{Key}?restore"
             },
             "input": {
+                "shape_name": "RestoreObjectRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "RestoreRequest": {
+                        "shape_name": "RestoreRequest",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "Days": {
+                                "shape_name": "Days",
                                 "type": "integer",
-                                "required": true,
-                                "documentation": "Lifetime of the active copy in days"
+                                "documentation": "Lifetime of the active copy in days",
+                                "required": true
                             }
-                        }
+                        },
+                        "documentation": null,
+                        "payload": true
                     }
-                }
+                },
+                "documentation": null
             },
             "output": null,
             "errors": [
                 {
                     "shape_name": "ObjectAlreadyInActiveTierError",
                     "type": "structure",
+                    "members": {},
                     "documentation": "This operation is not allowed against this storage tier"
                 }
             ],
+            "documentation": "Restores an archived copy of an object back into Amazon S3",
             "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectRestore.html",
-            "documentation": "Restores an archived copy of an object back into Amazon S3"
+            "alias": "PostObjectRestore"
         },
         "UploadPart": {
             "name": "UploadPart",
@@ -4116,72 +5072,88 @@
                 "uri": "/{Bucket}/{Key}?partNumber={PartNumber}&uploadId={UploadId}"
             },
             "input": {
+                "shape_name": "UploadPartRequest",
                 "type": "structure",
                 "members": {
                     "Body": {
+                        "shape_name": "Body",
                         "type": "blob",
+                        "documentation": null,
                         "payload": true,
                         "streaming": true
                     },
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "ContentLength": {
+                        "shape_name": "ContentLength",
                         "type": "integer",
+                        "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.",
                         "location": "header",
-                        "location_name": "Content-Length",
-                        "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically."
+                        "location_name": "Content-Length"
                     },
                     "ContentMD5": {
+                        "shape_name": "ContentMD5",
                         "type": "string",
+                        "documentation": null,
                         "location": "header",
                         "location_name": "Content-MD5"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "PartNumber": {
+                        "shape_name": "PartNumber",
                         "type": "integer",
+                        "documentation": "Part number of part being uploaded.",
                         "required": true,
-                        "location": "uri",
-                        "documentation": "Part number of part being uploaded."
+                        "location": "uri"
                     },
                     "UploadId": {
+                        "shape_name": "MultipartUploadId",
                         "type": "string",
+                        "documentation": "Upload ID identifying the multipart upload whose part is being uploaded.",
                         "required": true,
-                        "location": "uri",
-                        "documentation": "Upload ID identifying the multipart upload whose part is being uploaded."
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "UploadPartOutput",
                 "type": "structure",
                 "members": {
-                    "ETag": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "ETag",
-                        "documentation": "Entity tag for the uploaded object."
-                    },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
+                    },
+                    "ETag": {
+                        "shape_name": "ETag",
+                        "type": "string",
+                        "documentation": "Entity tag for the uploaded object.",
+                        "location": "header",
+                        "location_name": "ETag"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html",
-            "documentation": "<p>Uploads a part in a multipart upload.</p><p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>"
+            "documentation": "<p>Uploads a part in a multipart upload.</p>\n<p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html"
         },
         "UploadPartCopy": {
             "name": "UploadPartCopy",
@@ -4190,108 +5162,129 @@
                 "uri": "/{Bucket}/{Key}?partNumber={PartNumber}&uploadId={UploadId}"
             },
             "input": {
+                "shape_name": "UploadPartCopyRequest",
                 "type": "structure",
                 "members": {
                     "Bucket": {
+                        "shape_name": "BucketName",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "CopySource": {
+                        "shape_name": "CopySource",
                         "type": "string",
+                        "pattern": "\\/.+\\/.+",
+                        "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
                         "required": true,
                         "location": "header",
-                        "location_name": "x-amz-copy-source",
-                        "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
-                        "pattern": "\\/.+\\/.+"
+                        "location_name": "x-amz-copy-source"
                     },
                     "CopySourceIfMatch": {
+                        "shape_name": "CopySourceIfMatch",
                         "type": "timestamp",
+                        "documentation": "Copies the object if its entity tag (ETag) matches the specified tag.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-match",
-                        "documentation": "Copies the object if its entity tag (ETag) matches the specified tag."
+                        "location_name": "x-amz-copy-source-if-match"
                     },
                     "CopySourceIfModifiedSince": {
+                        "shape_name": "CopySourceIfModifiedSince",
                         "type": "timestamp",
+                        "documentation": "Copies the object if it has been modified since the specified time.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-modified-since",
-                        "documentation": "Copies the object if it has been modified since the specified time."
+                        "location_name": "x-amz-copy-source-if-modified-since"
                     },
                     "CopySourceIfNoneMatch": {
+                        "shape_name": "CopySourceIfNoneMatch",
                         "type": "timestamp",
+                        "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-none-match",
-                        "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag."
+                        "location_name": "x-amz-copy-source-if-none-match"
                     },
                     "CopySourceIfUnmodifiedSince": {
+                        "shape_name": "CopySourceIfUnmodifiedSince",
                         "type": "timestamp",
+                        "documentation": "Copies the object if it hasn't been modified since the specified time.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-if-unmodified-since",
-                        "documentation": "Copies the object if it hasn't been modified since the specified time."
+                        "location_name": "x-amz-copy-source-if-unmodified-since"
                     },
                     "CopySourceRange": {
+                        "shape_name": "CopySourceRange",
                         "type": "string",
+                        "documentation": "The range of bytes to copy from the source object. The range value must use the form bytes=first-last, where the first and last are the zero-based byte offsets to copy. For example, bytes=0-9 indicates that you want to copy the first ten bytes of the source. You can copy a range only if the source object is greater than 5 GB.",
                         "location": "header",
-                        "location_name": "x-amz-copy-source-range",
-                        "documentation": "The range of bytes to copy from the source object. The range value must use the form bytes=first-last, where the first and last are the zero-based byte offsets to copy. For example, bytes=0-9 indicates that you want to copy the first ten bytes of the source. You can copy a range only if the source object is greater than 5 GB."
+                        "location_name": "x-amz-copy-source-range"
                     },
                     "Key": {
+                        "shape_name": "ObjectKey",
                         "type": "string",
+                        "documentation": null,
                         "required": true,
                         "location": "uri"
                     },
                     "PartNumber": {
+                        "shape_name": "PartNumber",
                         "type": "integer",
+                        "documentation": "Part number of part being copied.",
                         "required": true,
-                        "location": "uri",
-                        "documentation": "Part number of part being copied."
+                        "location": "uri"
                     },
                     "UploadId": {
+                        "shape_name": "MultipartUploadId",
                         "type": "string",
+                        "documentation": "Upload ID identifying the multipart upload whose part is being copied.",
                         "required": true,
-                        "location": "uri",
-                        "documentation": "Upload ID identifying the multipart upload whose part is being copied."
+                        "location": "uri"
                     }
-                }
+                },
+                "documentation": null
             },
             "output": {
                 "shape_name": "UploadPartCopyOutput",
                 "type": "structure",
                 "members": {
+                    "CopySourceVersionId": {
+                        "shape_name": "CopySourceVersionId",
+                        "type": "string",
+                        "documentation": "The version of the source object that was copied, if you have enabled versioning on the source bucket.",
+                        "location": "header",
+                        "location_name": "x-amz-copy-source-version-id"
+                    },
                     "CopyPartResult": {
+                        "shape_name": "CopyPartResult",
                         "type": "structure",
-                        "payload": true,
                         "members": {
                             "ETag": {
+                                "shape_name": "ETag",
                                 "type": "string",
                                 "documentation": "Entity tag of the object."
                             },
                             "LastModified": {
+                                "shape_name": "LastModified",
                                 "type": "timestamp",
                                 "documentation": "Date and time at which the object was uploaded."
                             }
-                        }
-                    },
-                    "CopySourceVersionId": {
-                        "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-copy-source-version-id",
-                        "documentation": "The version of the source object that was copied, if you have enabled versioning on the source bucket."
+                        },
+                        "documentation": null,
+                        "payload": true
                     },
                     "ServerSideEncryption": {
+                        "shape_name": "ServerSideEncryption",
                         "type": "string",
-                        "location": "header",
-                        "location_name": "x-amz-server-side-encryption",
                         "enum": [
                             "AES256"
                         ],
-                        "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+                        "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+                        "location": "header",
+                        "location_name": "x-amz-server-side-encryption"
                     }
-                }
+                },
+                "documentation": null
             },
             "errors": [],
-            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html",
-            "documentation": "Uploads a part by copying data from an existing object as data source."
+            "documentation": "Uploads a part by copying data from an existing object as data source.",
+            "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html"
         }
     },
     "metadata": {

--- a/services/s3.extra.json
+++ b/services/s3.extra.json
@@ -146,5 +146,11 @@
       ],
       "success_type": "output"
     }
+  },
+  "transformations": {
+    "renames": {
+        "PutBucketVersioning.input.members.VersioningConfiguration.members.MFADelete": "MfaDelete",
+        "GetBucketVersioning.output.members.MFADelete": "MfaDelete"
+    }
   }
 }

--- a/services/s3.json
+++ b/services/s3.json
@@ -9,7 +9,7 @@
   "global_endpoint": "s3.amazonaws.com",
   "endpoint_prefix": "s3",
   "xmlnamespace": "http://s3.amazonaws.com/doc/2006-03-01/",
-  "documentation": "",
+  "documentation": null,
   "operations": {
     "AbortMultipartUpload": {
       "name": "AbortMultipartUpload",
@@ -18,35 +18,45 @@
         "uri": "/{Bucket}/{Key}?uploadId={UploadId}"
       },
       "input": {
+        "shape_name": "AbortMultipartUploadRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "UploadId": {
+            "shape_name": "MultipartUploadId",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
         {
           "shape_name": "NoSuchUpload",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The specified multipart upload does not exist."
         }
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html",
-      "documentation": "<p>Aborts a multipart upload.</p><p>To verify that all parts have been removed, so you don't get charged for the part storage, you should call the List Parts operation and ensure the parts list is empty.</p>"
+      "documentation": "<p>Aborts a multipart upload.</p>\n<p>To verify that all parts have been removed, so you don't get charged for the part storage, you should call the List Parts operation and ensure the parts list is empty.</p>",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html"
     },
     "CompleteMultipartUpload": {
       "name": "CompleteMultipartUpload",
@@ -55,110 +65,136 @@
         "uri": "/{Bucket}/{Key}?uploadId={UploadId}"
       },
       "input": {
+        "shape_name": "CompleteMultipartUploadRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "MultipartUpload": {
+            "shape_name": "CompletedMultipartUpload",
             "type": "structure",
-            "payload": true,
-            "xmlname": "CompleteMultipartUpload",
             "members": {
               "Parts": {
+                "shape_name": "CompletedPartList",
                 "type": "list",
-                "xmlname": "Part",
                 "members": {
+                  "shape_name": "CompletedPart",
                   "type": "structure",
                   "members": {
                     "ETag": {
+                      "shape_name": "ETag",
                       "type": "string",
                       "documentation": "Entity tag returned when the part was uploaded."
                     },
                     "PartNumber": {
+                      "shape_name": "PartNumber",
                       "type": "integer",
                       "documentation": "Part number that identifies the part."
                     }
-                  }
+                  },
+                  "documentation": null
                 },
-                "flattened": true
+                "flattened": true,
+                "documentation": null,
+                "xmlname": "Part"
               }
-            }
+            },
+            "documentation": null,
+            "xmlname": "CompleteMultipartUpload",
+            "payload": true
           },
           "UploadId": {
+            "shape_name": "MultipartUploadId",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "CompleteMultipartUploadOutput",
         "type": "structure",
         "members": {
+          "Location": {
+            "shape_name": "Location",
+            "type": "string",
+            "documentation": null
+          },
           "Bucket": {
-            "type": "string"
+            "shape_name": "BucketName",
+            "type": "string",
+            "documentation": null
+          },
+          "Key": {
+            "shape_name": "ObjectKey",
+            "type": "string",
+            "documentation": null
+          },
+          "Expiration": {
+            "shape_name": "Expiration",
+            "type": "timestamp",
+            "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded.",
+            "location": "header",
+            "location_name": "x-amz-expiration"
           },
           "ETag": {
+            "shape_name": "ETag",
             "type": "string",
             "documentation": "Entity tag of the object."
           },
-          "Expiration": {
-            "type": "timestamp",
-            "location": "header",
-            "location_name": "x-amz-expiration",
-            "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded."
-          },
-          "Key": {
-            "type": "string"
-          },
-          "Location": {
-            "type": "string"
-          },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           },
           "VersionId": {
+            "shape_name": "ObjectVersionId",
             "type": "string",
+            "documentation": "Version of the object.",
             "location": "header",
-            "location_name": "x-amz-version-id",
-            "documentation": "Version of the object."
+            "location_name": "x-amz-version-id"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html",
-      "documentation": "Completes a multipart upload by assembling previously uploaded parts."
+      "documentation": "Completes a multipart upload by assembling previously uploaded parts.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html"
     },
     "CopyObject": {
       "name": "CopyObject",
-      "alias": "PutObjectCopy",
       "http": {
         "method": "PUT",
         "uri": "/{Bucket}/{Key}"
       },
       "input": {
+        "shape_name": "CopyObjectRequest",
         "type": "structure",
         "members": {
           "ACL": {
+            "shape_name": "ObjectCannedACL",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-acl",
             "enum": [
               "private",
               "public-read",
@@ -167,107 +203,128 @@
               "bucket-owner-read",
               "bucket-owner-full-control"
             ],
-            "documentation": "The canned ACL to apply to the object."
+            "documentation": "The canned ACL to apply to the object.",
+            "location": "header",
+            "location_name": "x-amz-acl"
           },
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "CacheControl": {
+            "shape_name": "CacheControl",
             "type": "string",
+            "documentation": "Specifies caching behavior along the request/reply chain.",
             "location": "header",
-            "location_name": "Cache-Control",
-            "documentation": "Specifies caching behavior along the request/reply chain."
+            "location_name": "Cache-Control"
           },
           "ContentDisposition": {
+            "shape_name": "ContentDisposition",
             "type": "string",
+            "documentation": "Specifies presentational information for the object.",
             "location": "header",
-            "location_name": "Content-Disposition",
-            "documentation": "Specifies presentational information for the object."
+            "location_name": "Content-Disposition"
           },
           "ContentEncoding": {
+            "shape_name": "ContentEncoding",
             "type": "string",
+            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
             "location": "header",
-            "location_name": "Content-Encoding",
-            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
+            "location_name": "Content-Encoding"
           },
           "ContentLanguage": {
+            "shape_name": "ContentLanguage",
             "type": "string",
+            "documentation": "The language the content is in.",
             "location": "header",
-            "location_name": "Content-Language",
-            "documentation": "The language the content is in."
+            "location_name": "Content-Language"
           },
           "ContentType": {
+            "shape_name": "ContentType",
             "type": "string",
+            "documentation": "A standard MIME type describing the format of the object data.",
             "location": "header",
-            "location_name": "Content-Type",
-            "documentation": "A standard MIME type describing the format of the object data."
+            "location_name": "Content-Type"
           },
           "CopySource": {
+            "shape_name": "CopySource",
             "type": "string",
+            "pattern": "\\/.+\\/.+",
+            "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
             "required": true,
             "location": "header",
-            "location_name": "x-amz-copy-source",
-            "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
-            "pattern": "\\/.+\\/.+"
+            "location_name": "x-amz-copy-source"
           },
           "CopySourceIfMatch": {
+            "shape_name": "CopySourceIfMatch",
             "type": "timestamp",
+            "documentation": "Copies the object if its entity tag (ETag) matches the specified tag.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-match",
-            "documentation": "Copies the object if its entity tag (ETag) matches the specified tag."
+            "location_name": "x-amz-copy-source-if-match"
           },
           "CopySourceIfModifiedSince": {
+            "shape_name": "CopySourceIfModifiedSince",
             "type": "timestamp",
+            "documentation": "Copies the object if it has been modified since the specified time.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-modified-since",
-            "documentation": "Copies the object if it has been modified since the specified time."
+            "location_name": "x-amz-copy-source-if-modified-since"
           },
           "CopySourceIfNoneMatch": {
+            "shape_name": "CopySourceIfNoneMatch",
             "type": "timestamp",
+            "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-none-match",
-            "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag."
+            "location_name": "x-amz-copy-source-if-none-match"
           },
           "CopySourceIfUnmodifiedSince": {
+            "shape_name": "CopySourceIfUnmodifiedSince",
             "type": "timestamp",
+            "documentation": "Copies the object if it hasn't been modified since the specified time.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-unmodified-since",
-            "documentation": "Copies the object if it hasn't been modified since the specified time."
+            "location_name": "x-amz-copy-source-if-unmodified-since"
           },
           "Expires": {
+            "shape_name": "Expires",
             "type": "timestamp",
+            "documentation": "The date and time at which the object is no longer cacheable.",
             "location": "header",
-            "location_name": "Expires",
-            "documentation": "The date and time at which the object is no longer cacheable."
+            "location_name": "Expires"
           },
           "GrantFullControl": {
+            "shape_name": "GrantFullControl",
             "type": "string",
+            "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.",
             "location": "header",
-            "location_name": "x-amz-grant-full-control",
-            "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."
+            "location_name": "x-amz-grant-full-control"
           },
           "GrantRead": {
+            "shape_name": "GrantRead",
             "type": "string",
+            "documentation": "Allows grantee to read the object data and its metadata.",
             "location": "header",
-            "location_name": "x-amz-grant-read",
-            "documentation": "Allows grantee to read the object data and its metadata."
+            "location_name": "x-amz-grant-read"
           },
           "GrantReadACP": {
+            "shape_name": "GrantReadACP",
             "type": "string",
+            "documentation": "Allows grantee to read the object ACL.",
             "location": "header",
-            "location_name": "x-amz-grant-read-acp",
-            "documentation": "Allows grantee to read the object ACL."
+            "location_name": "x-amz-grant-read-acp"
           },
           "GrantWriteACP": {
+            "shape_name": "GrantWriteACP",
             "type": "string",
+            "documentation": "Allows grantee to write the ACL for the applicable object.",
             "location": "header",
-            "location_name": "x-amz-grant-write-acp",
-            "documentation": "Allows grantee to write the ACL for the applicable object."
+            "location_name": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
@@ -275,135 +332,156 @@
             "type": "map",
             "location": "header",
             "location_name": "x-amz-meta-",
+            "keys": {
+              "type": "string",
+              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+            },
             "members": {
               "type": "string",
               "documentation": "The metadata value."
             },
-            "documentation": "A map of metadata to store with the object in S3.",
-            "keys": {
-              "type": "string",
-              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-            }
+            "documentation": "A map of metadata to store with the object in S3."
           },
           "MetadataDirective": {
+            "shape_name": "MetadataDirective",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-metadata-directive",
             "enum": [
               "COPY",
               "REPLACE"
             ],
-            "documentation": "Specifies whether the metadata is copied from the source object or replaced with metadata provided in the request."
+            "documentation": "Specifies whether the metadata is copied from the source object or replaced with metadata provided in the request.",
+            "location": "header",
+            "location_name": "x-amz-metadata-directive"
           },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           },
           "StorageClass": {
+            "shape_name": "StorageClassOptions",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-storage-class",
             "enum": [
               "STANDARD",
               "REDUCED_REDUNDANCY"
             ],
-            "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'."
+            "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'.",
+            "location": "header",
+            "location_name": "x-amz-storage-class"
           },
           "WebsiteRedirectLocation": {
+            "shape_name": "WebsiteRedirectLocation",
             "type": "string",
+            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
             "location": "header",
-            "location_name": "x-amz-website-redirect-location",
-            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."
+            "location_name": "x-amz-website-redirect-location"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "CopyObjectOutput",
         "type": "structure",
         "members": {
           "CopyObjectResult": {
+            "shape_name": "CopyObjectResult",
             "type": "structure",
-            "payload": true,
             "members": {
               "ETag": {
-                "type": "string"
+                "shape_name": "ETag",
+                "type": "string",
+                "documentation": null
               },
               "LastModified": {
-                "type": "string"
+                "shape_name": "LastModified",
+                "type": "timestamp",
+                "documentation": null
               }
-            }
+            },
+            "documentation": null,
+            "payload": true
+          },
+          "Expiration": {
+            "shape_name": "Expiration",
+            "type": "timestamp",
+            "documentation": "If the object expiration is configured, the response includes this header.",
+            "location": "header",
+            "location_name": "x-amz-expiration"
           },
           "CopySourceVersionId": {
+            "shape_name": "CopySourceVersionId",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "x-amz-copy-source-version-id"
           },
-          "Expiration": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-expiration",
-            "documentation": "If the object expiration is configured, the response includes this header."
-          },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
         {
           "shape_name": "ObjectNotInActiveTierError",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The source object of the COPY operation is not in the active tier and is only stored in Amazon Glacier."
         }
       ],
+      "documentation": "Creates a copy of an object that is already stored in Amazon S3.",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html",
-      "documentation": "Creates a copy of an object that is already stored in Amazon S3."
+      "alias": "PutObjectCopy"
     },
     "CreateBucket": {
       "name": "CreateBucket",
-      "alias": "PutBucket",
       "http": {
         "method": "PUT",
         "uri": "/{Bucket}"
       },
       "input": {
+        "shape_name": "CreateBucketRequest",
         "type": "structure",
         "members": {
           "ACL": {
+            "shape_name": "BucketCannedACL",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-acl",
             "enum": [
               "private",
               "public-read",
               "public-read-write",
-              "authenticated-read",
-              "bucket-owner-read",
-              "bucket-owner-full-control"
+              "authenticated-read"
             ],
-            "documentation": "The canned ACL to apply to the bucket."
+            "documentation": "The canned ACL to apply to the bucket.",
+            "location": "header",
+            "location_name": "x-amz-acl"
           },
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "CreateBucketConfiguration": {
+            "shape_name": "CreateBucketConfiguration",
             "type": "structure",
-            "payload": true,
             "members": {
               "LocationConstraint": {
+                "shape_name": "BucketLocationConstraint",
                 "type": "string",
                 "enum": [
                   "EU",
@@ -418,75 +496,88 @@
                 ],
                 "documentation": "Specifies the region where the bucket will be created."
               }
-            }
+            },
+            "documentation": null,
+            "payload": true
           },
           "GrantFullControl": {
+            "shape_name": "GrantFullControl",
             "type": "string",
+            "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-full-control",
-            "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."
+            "location_name": "x-amz-grant-full-control"
           },
           "GrantRead": {
+            "shape_name": "GrantRead",
             "type": "string",
+            "documentation": "Allows grantee to list the objects in the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-read",
-            "documentation": "Allows grantee to list the objects in the bucket."
+            "location_name": "x-amz-grant-read"
           },
           "GrantReadACP": {
+            "shape_name": "GrantReadACP",
             "type": "string",
+            "documentation": "Allows grantee to read the bucket ACL.",
             "location": "header",
-            "location_name": "x-amz-grant-read-acp",
-            "documentation": "Allows grantee to read the bucket ACL."
+            "location_name": "x-amz-grant-read-acp"
           },
           "GrantWrite": {
+            "shape_name": "GrantWrite",
             "type": "string",
+            "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-write",
-            "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket."
+            "location_name": "x-amz-grant-write"
           },
           "GrantWriteACP": {
+            "shape_name": "GrantWriteACP",
             "type": "string",
+            "documentation": "Allows grantee to write the ACL for the applicable bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-write-acp",
-            "documentation": "Allows grantee to write the ACL for the applicable bucket."
+            "location_name": "x-amz-grant-write-acp"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "CreateBucketOutput",
         "type": "structure",
         "members": {
           "Location": {
+            "shape_name": "Location",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Location"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
         {
           "shape_name": "BucketAlreadyExists",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again."
         }
       ],
+      "documentation": "Creates a new bucket.",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html",
-      "documentation": "Creates a new bucket."
+      "alias": "PutBucket"
     },
     "CreateMultipartUpload": {
       "name": "CreateMultipartUpload",
-      "alias": "InitiateMultipartUpload",
       "http": {
         "method": "POST",
         "uri": "/{Bucket}/{Key}?uploads"
       },
       "input": {
+        "shape_name": "CreateMultipartUploadRequest",
         "type": "structure",
         "members": {
           "ACL": {
+            "shape_name": "ObjectCannedACL",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-acl",
             "enum": [
               "private",
               "public-read",
@@ -495,75 +586,91 @@
               "bucket-owner-read",
               "bucket-owner-full-control"
             ],
-            "documentation": "The canned ACL to apply to the object."
+            "documentation": "The canned ACL to apply to the object.",
+            "location": "header",
+            "location_name": "x-amz-acl"
           },
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "CacheControl": {
+            "shape_name": "CacheControl",
             "type": "string",
+            "documentation": "Specifies caching behavior along the request/reply chain.",
             "location": "header",
-            "location_name": "Cache-Control",
-            "documentation": "Specifies caching behavior along the request/reply chain."
+            "location_name": "Cache-Control"
           },
           "ContentDisposition": {
+            "shape_name": "ContentDisposition",
             "type": "string",
+            "documentation": "Specifies presentational information for the object.",
             "location": "header",
-            "location_name": "Content-Disposition",
-            "documentation": "Specifies presentational information for the object."
+            "location_name": "Content-Disposition"
           },
           "ContentEncoding": {
+            "shape_name": "ContentEncoding",
             "type": "string",
+            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
             "location": "header",
-            "location_name": "Content-Encoding",
-            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
+            "location_name": "Content-Encoding"
           },
           "ContentLanguage": {
+            "shape_name": "ContentLanguage",
             "type": "string",
+            "documentation": "The language the content is in.",
             "location": "header",
-            "location_name": "Content-Language",
-            "documentation": "The language the content is in."
+            "location_name": "Content-Language"
           },
           "ContentType": {
+            "shape_name": "ContentType",
             "type": "string",
+            "documentation": "A standard MIME type describing the format of the object data.",
             "location": "header",
-            "location_name": "Content-Type",
-            "documentation": "A standard MIME type describing the format of the object data."
+            "location_name": "Content-Type"
           },
           "Expires": {
+            "shape_name": "Expires",
             "type": "timestamp",
+            "documentation": "The date and time at which the object is no longer cacheable.",
             "location": "header",
-            "location_name": "Expires",
-            "documentation": "The date and time at which the object is no longer cacheable."
+            "location_name": "Expires"
           },
           "GrantFullControl": {
+            "shape_name": "GrantFullControl",
             "type": "string",
+            "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.",
             "location": "header",
-            "location_name": "x-amz-grant-full-control",
-            "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."
+            "location_name": "x-amz-grant-full-control"
           },
           "GrantRead": {
+            "shape_name": "GrantRead",
             "type": "string",
+            "documentation": "Allows grantee to read the object data and its metadata.",
             "location": "header",
-            "location_name": "x-amz-grant-read",
-            "documentation": "Allows grantee to read the object data and its metadata."
+            "location_name": "x-amz-grant-read"
           },
           "GrantReadACP": {
+            "shape_name": "GrantReadACP",
             "type": "string",
+            "documentation": "Allows grantee to read the object ACL.",
             "location": "header",
-            "location_name": "x-amz-grant-read-acp",
-            "documentation": "Allows grantee to read the object ACL."
+            "location_name": "x-amz-grant-read-acp"
           },
           "GrantWriteACP": {
+            "shape_name": "GrantWriteACP",
             "type": "string",
+            "documentation": "Allows grantee to write the ACL for the applicable object.",
             "location": "header",
-            "location_name": "x-amz-grant-write-acp",
-            "documentation": "Allows grantee to write the ACL for the applicable object."
+            "location_name": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
@@ -571,76 +678,86 @@
             "type": "map",
             "location": "header",
             "location_name": "x-amz-meta-",
+            "keys": {
+              "type": "string",
+              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+            },
             "members": {
               "type": "string",
               "documentation": "The metadata value."
             },
-            "documentation": "A map of metadata to store with the object in S3.",
-            "keys": {
-              "type": "string",
-              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-            }
+            "documentation": "A map of metadata to store with the object in S3."
           },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           },
           "StorageClass": {
+            "shape_name": "StorageClassOptions",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-storage-class",
             "enum": [
               "STANDARD",
               "REDUCED_REDUNDANCY"
             ],
-            "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'."
+            "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'.",
+            "location": "header",
+            "location_name": "x-amz-storage-class"
           },
           "WebsiteRedirectLocation": {
+            "shape_name": "WebsiteRedirectLocation",
             "type": "string",
+            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
             "location": "header",
-            "location_name": "x-amz-website-redirect-location",
-            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."
+            "location_name": "x-amz-website-redirect-location"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "CreateMultipartUploadOutput",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
-            "xmlname": "Bucket",
-            "documentation": "Name of the bucket to which the multipart upload was initiated."
+            "documentation": "Name of the bucket to which the multipart upload was initiated.",
+            "xmlname": "Bucket"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
             "documentation": "Object key for which the multipart upload was initiated."
           },
-          "ServerSideEncryption": {
+          "UploadId": {
+            "shape_name": "MultipartUploadId",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
+            "documentation": "ID for the initiated multipart upload."
+          },
+          "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
+            "type": "string",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
-          },
-          "UploadId": {
-            "type": "string",
-            "documentation": "ID for the initiated multipart upload."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
+      "documentation": "<p>Initiates a multipart upload and returns an upload ID.</p>\n<p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html",
-      "documentation": "<p>Initiates a multipart upload and returns an upload ID.</p><p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>"
+      "alias": "InitiateMultipartUpload"
     },
     "DeleteBucket": {
       "name": "DeleteBucket",
@@ -649,21 +766,25 @@
         "uri": "/{Bucket}"
       },
       "input": {
+        "shape_name": "DeleteBucketRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETE.html",
-      "documentation": "Deletes the bucket. All objects (including all object versions and Delete Markers) in the bucket must be deleted before the bucket itself can be deleted."
+      "documentation": "Deletes the bucket. All objects (including all object versions and Delete Markers) in the bucket must be deleted before the bucket itself can be deleted.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETE.html"
     },
     "DeleteBucketCors": {
       "name": "DeleteBucketCors",
@@ -672,21 +793,25 @@
         "uri": "/{Bucket}?cors"
       },
       "input": {
+        "shape_name": "DeleteBucketCorsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEcors.html",
-      "documentation": "Deletes the cors configuration information set for the bucket."
+      "documentation": "Deletes the cors configuration information set for the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEcors.html"
     },
     "DeleteBucketLifecycle": {
       "name": "DeleteBucketLifecycle",
@@ -695,21 +820,25 @@
         "uri": "/{Bucket}?lifecycle"
       },
       "input": {
+        "shape_name": "DeleteBucketLifecycleRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETElifecycle.html",
-      "documentation": "Deletes the lifecycle configuration from the bucket."
+      "documentation": "Deletes the lifecycle configuration from the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETElifecycle.html"
     },
     "DeleteBucketPolicy": {
       "name": "DeleteBucketPolicy",
@@ -718,21 +847,25 @@
         "uri": "/{Bucket}?policy"
       },
       "input": {
+        "shape_name": "DeleteBucketPolicyRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEpolicy.html",
-      "documentation": "Deletes the policy from the bucket."
+      "documentation": "Deletes the policy from the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEpolicy.html"
     },
     "DeleteBucketTagging": {
       "name": "DeleteBucketTagging",
@@ -741,21 +874,25 @@
         "uri": "/{Bucket}?tagging"
       },
       "input": {
+        "shape_name": "DeleteBucketTaggingRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEtagging.html",
-      "documentation": "Deletes the tags from the bucket."
+      "documentation": "Deletes the tags from the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEtagging.html"
     },
     "DeleteBucketWebsite": {
       "name": "DeleteBucketWebsite",
@@ -764,21 +901,25 @@
         "uri": "/{Bucket}?website"
       },
       "input": {
+        "shape_name": "DeleteBucketWebsiteRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEwebsite.html",
-      "documentation": "This operation removes the website configuration from the bucket."
+      "documentation": "This operation removes the website configuration from the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEwebsite.html"
     },
     "DeleteObject": {
       "name": "DeleteObject",
@@ -787,163 +928,213 @@
         "uri": "/{Bucket}/{Key}?versionId={VersionId}"
       },
       "input": {
+        "shape_name": "DeleteObjectRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "MFA": {
+            "shape_name": "MFA",
             "type": "string",
+            "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device.",
             "location": "header",
-            "location_name": "x-amz-mfa",
-            "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."
+            "location_name": "x-amz-mfa"
           },
           "VersionId": {
+            "shape_name": "ObjectVersionId",
             "type": "string",
-            "location": "uri",
-            "documentation": "VersionId used to reference a specific version of the object."
+            "documentation": "VersionId used to reference a specific version of the object.",
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "DeleteObjectOutput",
         "type": "structure",
         "members": {
           "DeleteMarker": {
+            "shape_name": "DeleteMarker",
             "type": "boolean",
+            "documentation": "Specifies whether the versioned object that was permanently deleted was (true) or was not (false) a delete marker.",
             "location": "header",
-            "location_name": "x-amz-delete-marker",
-            "documentation": "Specifies whether the versioned object that was permanently deleted was (true) or was not (false) a delete marker."
+            "location_name": "x-amz-delete-marker"
           },
           "VersionId": {
+            "shape_name": "ObjectVersionId",
             "type": "string",
+            "documentation": "Returns the version ID of the delete marker created as a result of the DELETE operation.",
             "location": "header",
-            "location_name": "x-amz-version-id",
-            "documentation": "Returns the version ID of the delete marker created as a result of the DELETE operation."
+            "location_name": "x-amz-version-id"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html",
-      "documentation": "Removes the null version (if there is one) of an object and inserts a delete marker, which becomes the latest version of the object. If there isn't a null version, Amazon S3 does not remove any objects."
+      "documentation": "Removes the null version (if there is one) of an object and inserts a delete marker, which becomes the latest version of the object. If there isn't a null version, Amazon S3 does not remove any objects.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html"
     },
     "DeleteObjects": {
       "name": "DeleteObjects",
-      "alias": "DeleteMultipleObjects",
       "http": {
         "method": "POST",
         "uri": "/{Bucket}?delete"
       },
       "input": {
+        "shape_name": "DeleteObjectsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Delete": {
+            "shape_name": "Delete",
             "type": "structure",
-            "payload": true,
-            "required": true,
             "members": {
               "Objects": {
+                "shape_name": "ObjectIdentifierList",
                 "type": "list",
-                "required": true,
-                "xmlname": "Object",
                 "members": {
+                  "shape_name": "ObjectIdentifier",
                   "type": "structure",
                   "members": {
                     "Key": {
+                      "shape_name": "ObjectKey",
                       "type": "string",
-                      "required": true,
-                      "documentation": "Key name of the object to delete."
+                      "documentation": "Key name of the object to delete.",
+                      "required": true
                     },
                     "VersionId": {
+                      "shape_name": "ObjectVersionId",
                       "type": "string",
                       "documentation": "VersionId for the specific version of the object to delete."
                     }
-                  }
+                  },
+                  "documentation": null
                 },
-                "flattened": true
+                "flattened": true,
+                "documentation": null,
+                "required": true,
+                "xmlname": "Object"
               },
               "Quiet": {
+                "shape_name": "Quiet",
                 "type": "boolean",
                 "documentation": "Element to enable quiet mode for the request. When you add this element, you must set its value to true."
               }
-            }
+            },
+            "documentation": null,
+            "required": true,
+            "payload": true
           },
           "MFA": {
+            "shape_name": "MFA",
             "type": "string",
+            "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device.",
             "location": "header",
-            "location_name": "x-amz-mfa",
-            "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."
+            "location_name": "x-amz-mfa"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "DeleteObjectsOutput",
         "type": "structure",
         "members": {
           "Deleted": {
+            "shape_name": "DeletedObjects",
             "type": "list",
             "members": {
+              "shape_name": "DeletedObject",
               "type": "structure",
               "members": {
+                "Key": {
+                  "shape_name": "ObjectKey",
+                  "type": "string",
+                  "documentation": null
+                },
+                "VersionId": {
+                  "shape_name": "ObjectVersionId",
+                  "type": "string",
+                  "documentation": null
+                },
                 "DeleteMarker": {
-                  "type": "boolean"
+                  "shape_name": "DeleteMarker",
+                  "type": "boolean",
+                  "documentation": null
                 },
                 "DeleteMarkerVersionId": {
-                  "type": "string"
-                },
-                "Key": {
-                  "type": "string"
-                },
-                "VersionId": {
-                  "type": "string"
+                  "shape_name": "DeleteMarkerVersionId",
+                  "type": "string",
+                  "documentation": null
                 }
-              }
+              },
+              "documentation": null
             },
-            "flattened": true
+            "flattened": true,
+            "documentation": null
           },
           "Errors": {
+            "shape_name": "Errors",
             "type": "list",
-            "xmlname": "Error",
             "members": {
+              "shape_name": "Error",
               "type": "structure",
               "members": {
-                "Code": {
-                  "type": "string"
-                },
                 "Key": {
-                  "type": "string"
-                },
-                "Message": {
-                  "type": "string"
+                  "shape_name": "ObjectKey",
+                  "type": "string",
+                  "documentation": null
                 },
                 "VersionId": {
-                  "type": "string"
+                  "shape_name": "ObjectVersionId",
+                  "type": "string",
+                  "documentation": null
+                },
+                "Code": {
+                  "shape_name": "Code",
+                  "type": "string",
+                  "documentation": null
+                },
+                "Message": {
+                  "shape_name": "Message",
+                  "type": "string",
+                  "documentation": null
                 }
-              }
+              },
+              "documentation": null
             },
-            "flattened": true
+            "flattened": true,
+            "documentation": null,
+            "xmlname": "Error"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
+      "documentation": "This operation enables you to delete multiple objects from a bucket using a single HTTP request. You may specify up to 1000 keys.",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html",
-      "documentation": "This operation enables you to delete multiple objects from a bucket using a single HTTP request. You may specify up to 1000 keys."
+      "alias": "DeleteMultipleObjects"
     },
     "GetBucketAcl": {
       "name": "GetBucketAcl",
@@ -952,63 +1143,93 @@
         "uri": "/{Bucket}?acl"
       },
       "input": {
+        "shape_name": "GetBucketAclRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketAclOutput",
         "type": "structure",
         "members": {
-          "Grants": {
-            "type": "list",
-            "xmlname": "AccessControlList",
+          "Owner": {
+            "shape_name": "Owner",
+            "type": "structure",
             "members": {
+              "DisplayName": {
+                "shape_name": "DisplayName",
+                "type": "string",
+                "documentation": null
+              },
+              "ID": {
+                "shape_name": "ID",
+                "type": "string",
+                "documentation": null
+              }
+            },
+            "documentation": null
+          },
+          "Grants": {
+            "shape_name": "Grants",
+            "type": "list",
+            "members": {
+              "shape_name": "Grant",
               "type": "structure",
-              "xmlname": "Grant",
               "members": {
                 "Grantee": {
-                  "xmlnamespace": {
-                    "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                    "prefix": "xsi"
-                  },
+                  "shape_name": "Grantee",
                   "type": "structure",
                   "members": {
                     "DisplayName": {
+                      "shape_name": "DisplayName",
                       "type": "string",
                       "documentation": "Screen name of the grantee."
                     },
                     "EmailAddress": {
+                      "shape_name": "EmailAddress",
                       "type": "string",
                       "documentation": "Email address of the grantee."
                     },
                     "ID": {
+                      "shape_name": "ID",
                       "type": "string",
                       "documentation": "The canonical user ID of the grantee."
                     },
                     "Type": {
+                      "shape_name": "Type",
                       "type": "string",
-                      "xmlname": "xsi:type",
-                      "xmlattribute": true,
                       "enum": [
                         "CanonicalUser",
                         "AmazonCustomerByEmail",
                         "Group"
                       ],
-                      "documentation": "Type of grantee"
+                      "documentation": "Type of grantee",
+                      "required": true,
+                      "xmlattribute": true,
+                      "xmlname": "xsi:type"
                     },
                     "URI": {
+                      "shape_name": "URI",
                       "type": "string",
                       "documentation": "URI of the grantee group."
                     }
+                  },
+                  "documentation": null,
+                  "xmlnamespace": {
+                    "prefix": "xsi",
+                    "uri": "http://www.w3.org/2001/XMLSchema-instance"
                   }
                 },
                 "Permission": {
+                  "shape_name": "Permission",
                   "type": "string",
                   "enum": [
                     "FULL_CONTROL",
@@ -1019,28 +1240,21 @@
                   ],
                   "documentation": "Specifies the permission given to the grantee."
                 }
-              }
-            },
-            "documentation": "A list of grants."
-          },
-          "Owner": {
-            "type": "structure",
-            "members": {
-              "DisplayName": {
-                "type": "string"
               },
-              "ID": {
-                "type": "string"
-              }
-            }
+              "documentation": null,
+              "xmlname": "Grant"
+            },
+            "documentation": "A list of grants.",
+            "xmlname": "AccessControlList"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETacl.html",
-      "documentation": "Gets the access control policy for the bucket."
+      "documentation": "Gets the access control policy for the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETacl.html"
     },
     "GetBucketCors": {
       "name": "GetBucketCors",
@@ -1049,76 +1263,98 @@
         "uri": "/{Bucket}?cors"
       },
       "input": {
+        "shape_name": "GetBucketCorsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketCorsOutput",
         "type": "structure",
         "members": {
           "CORSRules": {
+            "shape_name": "CORSRules",
             "type": "list",
-            "xmlname": "CORSRule",
             "members": {
+              "shape_name": "CORSRule",
               "type": "structure",
               "members": {
                 "AllowedHeaders": {
+                  "shape_name": "AllowedHeaders",
                   "type": "list",
-                  "xmlname": "AllowedHeader",
                   "members": {
-                    "type": "string"
+                    "shape_name": "AllowedHeader",
+                    "type": "string",
+                    "documentation": null
                   },
+                  "flattened": true,
                   "documentation": "Specifies which headers are allowed in a pre-flight OPTIONS request.",
-                  "flattened": true
+                  "xmlname": "AllowedHeader"
                 },
                 "AllowedMethods": {
+                  "shape_name": "AllowedMethods",
                   "type": "list",
-                  "xmlname": "AllowedMethod",
                   "members": {
-                    "type": "string"
+                    "shape_name": "AllowedMethod",
+                    "type": "string",
+                    "documentation": null
                   },
+                  "flattened": true,
                   "documentation": "Identifies HTTP methods that the domain/origin specified in the rule is allowed to execute.",
-                  "flattened": true
+                  "xmlname": "AllowedMethod"
                 },
                 "AllowedOrigins": {
+                  "shape_name": "AllowedOrigins",
                   "type": "list",
-                  "xmlname": "AllowedOrigin",
                   "members": {
-                    "type": "string"
+                    "shape_name": "AllowedOrigin",
+                    "type": "string",
+                    "documentation": null
                   },
+                  "flattened": true,
                   "documentation": "One or more origins you want customers to be able to access the bucket from.",
-                  "flattened": true
+                  "xmlname": "AllowedOrigin"
                 },
                 "ExposeHeaders": {
+                  "shape_name": "ExposeHeaders",
                   "type": "list",
-                  "xmlname": "ExposeHeader",
                   "members": {
-                    "type": "string"
+                    "shape_name": "ExposeHeader",
+                    "type": "string",
+                    "documentation": null
                   },
+                  "flattened": true,
                   "documentation": "One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript XMLHttpRequest object).",
-                  "flattened": true
+                  "xmlname": "ExposeHeader"
                 },
                 "MaxAgeSeconds": {
+                  "shape_name": "MaxAgeSeconds",
                   "type": "integer",
                   "documentation": "The time in seconds that your browser is to cache the preflight response for the specified resource."
                 }
-              }
+              },
+              "documentation": null
             },
-            "flattened": true
+            "flattened": true,
+            "documentation": null,
+            "xmlname": "CORSRule"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETcors.html",
-      "documentation": "Returns the cors configuration for the bucket."
+      "documentation": "Returns the cors configuration for the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETcors.html"
     },
     "GetBucketLifecycle": {
       "name": "GetBucketLifecycle",
@@ -1127,68 +1363,86 @@
         "uri": "/{Bucket}?lifecycle"
       },
       "input": {
+        "shape_name": "GetBucketLifecycleRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketLifecycleOutput",
         "type": "structure",
         "members": {
           "Rules": {
+            "shape_name": "Rules",
             "type": "list",
-            "xmlname": "Rule",
             "members": {
+              "shape_name": "Rule",
               "type": "structure",
               "members": {
                 "Expiration": {
+                  "shape_name": "LifecycleExpiration",
                   "type": "structure",
                   "members": {
                     "Date": {
+                      "shape_name": "Date",
                       "type": "timestamp",
                       "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                       "timestamp_format": "iso8601"
                     },
                     "Days": {
+                      "shape_name": "Days",
                       "type": "integer",
                       "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                     }
-                  }
+                  },
+                  "documentation": null
                 },
                 "ID": {
+                  "shape_name": "ID",
                   "type": "string",
                   "documentation": "Unique identifier for the rule. The value cannot be longer than 255 characters."
                 },
                 "Prefix": {
+                  "shape_name": "Prefix",
                   "type": "string",
-                  "documentation": "Prefix identifying one or more objects to which the rule applies."
+                  "documentation": "Prefix identifying one or more objects to which the rule applies.",
+                  "required": true
                 },
                 "Status": {
+                  "shape_name": "ExpirationStatus",
                   "type": "string",
                   "enum": [
                     "Enabled",
                     "Disabled"
                   ],
-                  "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied."
+                  "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied.",
+                  "required": true
                 },
                 "Transition": {
+                  "shape_name": "Transition",
                   "type": "structure",
                   "members": {
                     "Date": {
+                      "shape_name": "Date",
                       "type": "timestamp",
                       "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                       "timestamp_format": "iso8601"
                     },
                     "Days": {
+                      "shape_name": "Days",
                       "type": "integer",
                       "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                     },
                     "StorageClass": {
+                      "shape_name": "StorageClass",
                       "type": "string",
                       "enum": [
                         "STANDARD",
@@ -1197,19 +1451,24 @@
                       ],
                       "documentation": "The class of storage used to store the object."
                     }
-                  }
+                  },
+                  "documentation": null
                 }
-              }
+              },
+              "documentation": null
             },
-            "flattened": true
+            "flattened": true,
+            "documentation": null,
+            "xmlname": "Rule"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlifecycle.html",
-      "documentation": "Returns the lifecycle configuration information set on the bucket."
+      "documentation": "Returns the lifecycle configuration information set on the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlifecycle.html"
     },
     "GetBucketLocation": {
       "name": "GetBucketLocation",
@@ -1218,29 +1477,47 @@
         "uri": "/{Bucket}?location"
       },
       "input": {
+        "shape_name": "GetBucketLocationRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketLocationOutput",
         "type": "structure",
         "members": {
           "LocationConstraint": {
-            "type": "string"
+            "shape_name": "BucketLocationConstraint",
+            "type": "string",
+            "enum": [
+              "EU",
+              "eu-west-1",
+              "us-west-1",
+              "us-west-2",
+              "ap-southeast-1",
+              "ap-southeast-2",
+              "ap-northeast-1",
+              "sa-east-1",
+              ""
+            ],
+            "documentation": null
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html",
-      "documentation": "Returns the region the bucket resides in."
+      "documentation": "Returns the region the bucket resides in.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html"
     },
     "GetBucketLogging": {
       "name": "GetBucketLogging",
@@ -1249,87 +1526,115 @@
         "uri": "/{Bucket}?logging"
       },
       "input": {
+        "shape_name": "GetBucketLoggingRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketLoggingOutput",
         "type": "structure",
         "members": {
           "LoggingEnabled": {
+            "shape_name": "LoggingEnabled",
             "type": "structure",
             "members": {
               "TargetBucket": {
+                "shape_name": "TargetBucket",
                 "type": "string",
                 "documentation": "Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own, including the same bucket that is being logged. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case you should choose a different TargetPrefix for each source bucket so that the delivered log files can be distinguished by key."
               },
               "TargetGrants": {
+                "shape_name": "TargetGrants",
                 "type": "list",
                 "members": {
+                  "shape_name": "TargetGrant",
                   "type": "structure",
-                  "xmlname": "Grant",
                   "members": {
                     "Grantee": {
-                      "xmlnamespace": {
-                        "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                        "prefix": "xsi"
-                      },
+                      "shape_name": "Grantee",
                       "type": "structure",
                       "members": {
                         "DisplayName": {
+                          "shape_name": "DisplayName",
                           "type": "string",
                           "documentation": "Screen name of the grantee."
                         },
                         "EmailAddress": {
+                          "shape_name": "EmailAddress",
                           "type": "string",
                           "documentation": "Email address of the grantee."
                         },
                         "ID": {
+                          "shape_name": "ID",
                           "type": "string",
                           "documentation": "The canonical user ID of the grantee."
                         },
                         "Type": {
+                          "shape_name": "Type",
                           "type": "string",
-                          "xmlname": "xsi:type",
-                          "xmlattribute": true,
                           "enum": [
                             "CanonicalUser",
                             "AmazonCustomerByEmail",
                             "Group"
                           ],
-                          "documentation": "Type of grantee"
+                          "documentation": "Type of grantee",
+                          "required": true,
+                          "xmlattribute": true,
+                          "xmlname": "xsi:type"
                         },
                         "URI": {
+                          "shape_name": "URI",
                           "type": "string",
                           "documentation": "URI of the grantee group."
                         }
+                      },
+                      "documentation": null,
+                      "xmlnamespace": {
+                        "prefix": "xsi",
+                        "uri": "http://www.w3.org/2001/XMLSchema-instance"
                       }
                     },
                     "Permission": {
-                      "type": "string"
+                      "shape_name": "BucketLogsPermission",
+                      "type": "string",
+                      "enum": [
+                        "FULL_CONTROL",
+                        "READ",
+                        "WRITE"
+                      ],
+                      "documentation": "Logging permissions assigned to the Grantee for the bucket."
                     }
-                  }
-                }
+                  },
+                  "documentation": null,
+                  "xmlname": "Grant"
+                },
+                "documentation": null
               },
               "TargetPrefix": {
+                "shape_name": "TargetPrefix",
                 "type": "string",
                 "documentation": "This element lets you specify a prefix for the keys that the log files will be stored under."
               }
-            }
+            },
+            "documentation": null
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlogging.html",
-      "documentation": "Returns the logging status of a bucket and the permissions users have to view and modify that status. To use GET, you must be the bucket owner."
+      "documentation": "Returns the logging status of a bucket and the permissions users have to view and modify that status. To use GET, you must be the bucket owner.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlogging.html"
     },
     "GetBucketNotification": {
       "name": "GetBucketNotification",
@@ -1338,23 +1643,29 @@
         "uri": "/{Bucket}?notification"
       },
       "input": {
+        "shape_name": "GetBucketNotificationRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketNotificationOutput",
         "type": "structure",
         "members": {
           "TopicConfiguration": {
+            "shape_name": "TopicConfiguration",
             "type": "structure",
             "members": {
               "Event": {
+                "shape_name": "Event",
                 "type": "string",
                 "enum": [
                   "s3:ReducedRedundancyLostObject"
@@ -1362,18 +1673,21 @@
                 "documentation": "Bucket event for which to send notifications."
               },
               "Topic": {
+                "shape_name": "Topic",
                 "type": "string",
                 "documentation": "Amazon SNS topic to which Amazon S3 will publish a message to report the specified events for the bucket."
               }
-            }
+            },
+            "documentation": null
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETnotification.html",
-      "documentation": "Return the notification configuration of a bucket."
+      "documentation": "Return the notification configuration of a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETnotification.html"
     },
     "GetBucketPolicy": {
       "name": "GetBucketPolicy",
@@ -1382,31 +1696,37 @@
         "uri": "/{Bucket}?policy"
       },
       "input": {
+        "shape_name": "GetBucketPolicyRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketPolicyOutput",
         "type": "structure",
         "members": {
           "Policy": {
+            "shape_name": "Policy",
             "type": "string",
-            "payload": true,
-            "documentation": "The bucket policy as a JSON document."
+            "documentation": "The bucket policy as a JSON document.",
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETpolicy.html",
-      "documentation": "Returns the policy of a specified bucket."
+      "documentation": "Returns the policy of a specified bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETpolicy.html"
     },
     "GetBucketRequestPayment": {
       "name": "GetBucketRequestPayment",
@@ -1415,20 +1735,25 @@
         "uri": "/{Bucket}?requestPayment"
       },
       "input": {
+        "shape_name": "GetBucketRequestPaymentRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketRequestPaymentOutput",
         "type": "structure",
         "members": {
           "Payer": {
+            "shape_name": "Payer",
             "type": "string",
             "enum": [
               "Requester",
@@ -1436,13 +1761,14 @@
             ],
             "documentation": "Specifies who pays for the download and request fees."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentGET.html",
-      "documentation": "Returns the request payment configuration of a bucket."
+      "documentation": "Returns the request payment configuration of a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentGET.html"
     },
     "GetBucketTagging": {
       "name": "GetBucketTagging",
@@ -1451,43 +1777,57 @@
         "uri": "/{Bucket}?tagging"
       },
       "input": {
+        "shape_name": "GetBucketTaggingRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketTaggingOutput",
         "type": "structure",
         "members": {
           "TagSet": {
+            "shape_name": "TagSet",
             "type": "list",
             "members": {
+              "shape_name": "Tag",
               "type": "structure",
-              "xmlname": "Tag",
               "members": {
                 "Key": {
+                  "shape_name": "ObjectKey",
                   "type": "string",
-                  "documentation": "Name of the tag."
+                  "documentation": "Name of the tag.",
+                  "required": true
                 },
                 "Value": {
+                  "shape_name": "Value",
                   "type": "string",
-                  "documentation": "Value of the tag."
+                  "documentation": "Value of the tag.",
+                  "required": true
                 }
-              }
-            }
+              },
+              "documentation": null,
+              "xmlname": "Tag"
+            },
+            "documentation": null,
+            "required": true
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETtagging.html",
-      "documentation": "Returns the tag set associated with the bucket."
+      "documentation": "Returns the tag set associated with the bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETtagging.html"
     },
     "GetBucketVersioning": {
       "name": "GetBucketVersioning",
@@ -1496,42 +1836,49 @@
         "uri": "/{Bucket}?versioning"
       },
       "input": {
+        "shape_name": "GetBucketVersioningRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketVersioningOutput",
         "type": "structure",
         "members": {
-          "MfaDelete": {
-            "type": "string",
-            "enum": [
-              "Enabled",
-              "Disabled"
-            ],
-            "documentation": "Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."
-          },
           "Status": {
+            "shape_name": "BucketVersioningStatus",
             "type": "string",
             "enum": [
               "Enabled",
               "Suspended"
             ],
             "documentation": "The versioning state of the bucket."
+          },
+          "MFADelete": {
+            "shape_name": "MFADeleteStatus",
+            "type": "string",
+            "enum": [
+              "Enabled",
+              "Disabled"
+            ],
+            "documentation": "Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETversioningStatus.html",
-      "documentation": "Returns the versioning state of a bucket."
+      "documentation": "Returns the versioning state of a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETversioningStatus.html"
     },
     "GetBucketWebsite": {
       "name": "GetBucketWebsite",
@@ -1540,45 +1887,35 @@
         "uri": "/{Bucket}?website"
       },
       "input": {
+        "shape_name": "GetBucketWebsiteRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetBucketWebsiteOutput",
         "type": "structure",
         "members": {
-          "ErrorDocument": {
-            "type": "structure",
-            "members": {
-              "Key": {
-                "type": "string",
-                "documentation": "The object key name to use when a 4XX class error occurs."
-              }
-            }
-          },
-          "IndexDocument": {
-            "type": "structure",
-            "members": {
-              "Suffix": {
-                "type": "string",
-                "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character."
-              }
-            }
-          },
           "RedirectAllRequestsTo": {
+            "shape_name": "RedirectAllRequestsTo",
             "type": "structure",
             "members": {
               "HostName": {
+                "shape_name": "HostName",
                 "type": "string",
-                "documentation": "Name of the host where requests will be redirected."
+                "documentation": "Name of the host where requests will be redirected.",
+                "required": true
               },
               "Protocol": {
+                "shape_name": "Protocol",
                 "type": "string",
                 "enum": [
                   "http",
@@ -1586,22 +1923,53 @@
                 ],
                 "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
               }
-            }
+            },
+            "documentation": null
+          },
+          "IndexDocument": {
+            "shape_name": "IndexDocument",
+            "type": "structure",
+            "members": {
+              "Suffix": {
+                "shape_name": "Suffix",
+                "type": "string",
+                "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character.",
+                "required": true
+              }
+            },
+            "documentation": null
+          },
+          "ErrorDocument": {
+            "shape_name": "ErrorDocument",
+            "type": "structure",
+            "members": {
+              "Key": {
+                "shape_name": "ObjectKey",
+                "type": "string",
+                "documentation": "The object key name to use when a 4XX class error occurs.",
+                "required": true
+              }
+            },
+            "documentation": null
           },
           "RoutingRules": {
+            "shape_name": "RoutingRules",
             "type": "list",
             "members": {
+              "shape_name": "RoutingRule",
               "type": "structure",
-              "xmlname": "RoutingRule",
               "members": {
                 "Condition": {
+                  "shape_name": "Condition",
                   "type": "structure",
                   "members": {
                     "HttpErrorCodeReturnedEquals": {
+                      "shape_name": "HttpErrorCodeReturnedEquals",
                       "type": "string",
                       "documentation": "The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element Condition is specified and sibling KeyPrefixEquals is not specified. If both are specified, then both must be true for the redirect to be applied."
                     },
                     "KeyPrefixEquals": {
+                      "shape_name": "KeyPrefixEquals",
                       "type": "string",
                       "documentation": "The object key name prefix when the redirect is applied. For example, to redirect requests for ExamplePage.html, the key prefix will be ExamplePage.html. To redirect request for all pages with the prefix docs/, the key prefix will be /docs, which identifies all objects in the docs/ folder. Required when the parent element Condition is specified and sibling HttpErrorCodeReturnedEquals is not specified. If both conditions are specified, both must be true for the redirect to be applied."
                     }
@@ -1609,17 +1977,21 @@
                   "documentation": "A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the /docs folder, redirect to the /documents folder. 2. If request results in HTTP error 4xx, redirect request to another host where you might process the error."
                 },
                 "Redirect": {
+                  "shape_name": "Redirect",
                   "type": "structure",
                   "members": {
                     "HostName": {
+                      "shape_name": "HostName",
                       "type": "string",
                       "documentation": "The host name to use in the redirect request."
                     },
                     "HttpRedirectCode": {
+                      "shape_name": "HttpRedirectCode",
                       "type": "string",
                       "documentation": "The HTTP redirect code to use on the response. Not required if one of the siblings is present."
                     },
                     "Protocol": {
+                      "shape_name": "Protocol",
                       "type": "string",
                       "enum": [
                         "http",
@@ -1628,26 +2000,33 @@
                       "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
                     },
                     "ReplaceKeyPrefixWith": {
+                      "shape_name": "ReplaceKeyPrefixWith",
                       "type": "string",
                       "documentation": "The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix docs/ (objects in the docs/ folder) to documents/, you can set a condition block with KeyPrefixEquals set to docs/ and in the Redirect set ReplaceKeyPrefixWith to /documents. Not required if one of the siblings is present. Can be present only if ReplaceKeyWith is not provided."
                     },
                     "ReplaceKeyWith": {
+                      "shape_name": "ReplaceKeyWith",
                       "type": "string",
                       "documentation": "The specific object key to use in the redirect request. For example, redirect request to error.html. Not required if one of the sibling is present. Can be present only if ReplaceKeyPrefixWith is not provided."
                     }
                   },
-                  "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return."
+                  "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return.",
+                  "required": true
                 }
-              }
-            }
+              },
+              "documentation": null,
+              "xmlname": "RoutingRule"
+            },
+            "documentation": null
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETwebsite.html",
-      "documentation": "Returns the website configuration for a bucket."
+      "documentation": "Returns the website configuration for a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETwebsite.html"
     },
     "GetObject": {
       "name": "GetObject",
@@ -1656,224 +2035,264 @@
         "uri": "/{Bucket}/{Key}?versionId={VersionId}&response-content-type={ResponseContentType}&response-content-language={ResponseContentLanguage}&response-expires={ResponseExpires}&response-cache-control={ResponseCacheControl}&response-content-disposition={ResponseContentDisposition}&response-content-encoding={ResponseContentEncoding}"
       },
       "input": {
+        "shape_name": "GetObjectRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "IfMatch": {
+            "shape_name": "IfMatch",
             "type": "string",
+            "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).",
             "location": "header",
-            "location_name": "If-Match",
-            "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."
+            "location_name": "If-Match"
           },
           "IfModifiedSince": {
+            "shape_name": "IfModifiedSince",
             "type": "timestamp",
+            "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified).",
             "location": "header",
-            "location_name": "If-Modified-Since",
-            "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified)."
+            "location_name": "If-Modified-Since"
           },
           "IfNoneMatch": {
+            "shape_name": "IfNoneMatch",
             "type": "string",
+            "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified).",
             "location": "header",
-            "location_name": "If-None-Match",
-            "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified)."
+            "location_name": "If-None-Match"
           },
           "IfUnmodifiedSince": {
+            "shape_name": "IfUnmodifiedSince",
             "type": "timestamp",
+            "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed).",
             "location": "header",
-            "location_name": "If-Unmodified-Since",
-            "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed)."
+            "location_name": "If-Unmodified-Since"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Range": {
+            "shape_name": "Range",
             "type": "string",
+            "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.",
             "location": "header",
-            "location_name": "Range",
-            "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35."
+            "location_name": "Range"
           },
           "ResponseCacheControl": {
+            "shape_name": "ResponseCacheControl",
             "type": "string",
-            "location": "uri",
-            "documentation": "Sets the Cache-Control header of the response."
+            "documentation": "Sets the Cache-Control header of the response.",
+            "location": "uri"
           },
           "ResponseContentDisposition": {
+            "shape_name": "ResponseContentDisposition",
             "type": "string",
-            "location": "uri",
-            "documentation": "Sets the Content-Disposition header of the response"
+            "documentation": "Sets the Content-Disposition header of the response",
+            "location": "uri"
           },
           "ResponseContentEncoding": {
+            "shape_name": "ResponseContentEncoding",
             "type": "string",
-            "location": "uri",
-            "documentation": "Sets the Content-Encoding header of the response."
+            "documentation": "Sets the Content-Encoding header of the response.",
+            "location": "uri"
           },
           "ResponseContentLanguage": {
+            "shape_name": "ResponseContentLanguage",
             "type": "string",
-            "location": "uri",
-            "documentation": "Sets the Content-Language header of the response."
+            "documentation": "Sets the Content-Language header of the response.",
+            "location": "uri"
           },
           "ResponseContentType": {
+            "shape_name": "ResponseContentType",
             "type": "string",
-            "location": "uri",
-            "documentation": "Sets the Content-Type header of the response."
+            "documentation": "Sets the Content-Type header of the response.",
+            "location": "uri"
           },
           "ResponseExpires": {
+            "shape_name": "ResponseExpires",
             "type": "timestamp",
-            "location": "uri",
-            "documentation": "Sets the Expires header of the response."
+            "documentation": "Sets the Expires header of the response.",
+            "location": "uri"
           },
           "VersionId": {
+            "shape_name": "ObjectVersionId",
             "type": "string",
-            "location": "uri",
-            "documentation": "VersionId used to reference a specific version of the object."
+            "documentation": "VersionId used to reference a specific version of the object.",
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetObjectOutput",
         "type": "structure",
         "members": {
+          "Body": {
+            "shape_name": "Body",
+            "type": "blob",
+            "documentation": "Object data.",
+            "payload": true,
+            "streaming": true
+          },
+          "DeleteMarker": {
+            "shape_name": "DeleteMarker",
+            "type": "boolean",
+            "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.",
+            "location": "header",
+            "location_name": "x-amz-delete-marker"
+          },
           "AcceptRanges": {
+            "shape_name": "AcceptRanges",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "accept-ranges"
           },
-          "Body": {
-            "type": "blob",
-            "payload": true,
-            "documentation": "Object data.",
-            "streaming": true
-          },
-          "CacheControl": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Cache-Control",
-            "documentation": "Specifies caching behavior along the request/reply chain."
-          },
-          "ContentDisposition": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Disposition",
-            "documentation": "Specifies presentational information for the object."
-          },
-          "ContentEncoding": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Encoding",
-            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
-          },
-          "ContentLanguage": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Language",
-            "documentation": "The language the content is in."
-          },
-          "ContentLength": {
-            "type": "integer",
-            "location": "header",
-            "location_name": "Content-Length",
-            "documentation": "Size of the body in bytes."
-          },
-          "ContentType": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Type",
-            "documentation": "A standard MIME type describing the format of the object data."
-          },
-          "DeleteMarker": {
-            "type": "boolean",
-            "location": "header",
-            "location_name": "x-amz-delete-marker",
-            "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response."
-          },
-          "ETag": {
-            "type": "string",
-            "location": "header",
-            "location_name": "ETag",
-            "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL"
-          },
           "Expiration": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-expiration",
-            "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded."
-          },
-          "Expires": {
+            "shape_name": "Expiration",
             "type": "timestamp",
+            "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded.",
             "location": "header",
-            "location_name": "Expires",
-            "documentation": "The date and time at which the object is no longer cacheable."
+            "location_name": "x-amz-expiration"
+          },
+          "Restore": {
+            "shape_name": "Restore",
+            "type": "string",
+            "documentation": "Provides information about object restoration operation and expiration time of the restored object copy.",
+            "location": "header",
+            "location_name": "x-amz-restore"
           },
           "LastModified": {
+            "shape_name": "LastModified",
             "type": "timestamp",
+            "documentation": "Last modified date of the object",
             "location": "header",
-            "location_name": "Last-Modified",
-            "documentation": "Last modified date of the object"
+            "location_name": "Last-Modified"
+          },
+          "ContentLength": {
+            "shape_name": "ContentLength",
+            "type": "integer",
+            "documentation": "Size of the body in bytes.",
+            "location": "header",
+            "location_name": "Content-Length"
+          },
+          "ETag": {
+            "shape_name": "ETag",
+            "type": "string",
+            "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL",
+            "location": "header",
+            "location_name": "ETag"
+          },
+          "MissingMeta": {
+            "shape_name": "MissingMeta",
+            "type": "integer",
+            "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.",
+            "location": "header",
+            "location_name": "x-amz-missing-meta"
+          },
+          "VersionId": {
+            "shape_name": "ObjectVersionId",
+            "type": "string",
+            "documentation": "Version of the object.",
+            "location": "header",
+            "location_name": "x-amz-version-id"
+          },
+          "CacheControl": {
+            "shape_name": "CacheControl",
+            "type": "string",
+            "documentation": "Specifies caching behavior along the request/reply chain.",
+            "location": "header",
+            "location_name": "Cache-Control"
+          },
+          "ContentDisposition": {
+            "shape_name": "ContentDisposition",
+            "type": "string",
+            "documentation": "Specifies presentational information for the object.",
+            "location": "header",
+            "location_name": "Content-Disposition"
+          },
+          "ContentEncoding": {
+            "shape_name": "ContentEncoding",
+            "type": "string",
+            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
+            "location": "header",
+            "location_name": "Content-Encoding"
+          },
+          "ContentLanguage": {
+            "shape_name": "ContentLanguage",
+            "type": "string",
+            "documentation": "The language the content is in.",
+            "location": "header",
+            "location_name": "Content-Language"
+          },
+          "ContentType": {
+            "shape_name": "ContentType",
+            "type": "string",
+            "documentation": "A standard MIME type describing the format of the object data.",
+            "location": "header",
+            "location_name": "Content-Type"
+          },
+          "Expires": {
+            "shape_name": "Expires",
+            "type": "timestamp",
+            "documentation": "The date and time at which the object is no longer cacheable.",
+            "location": "header",
+            "location_name": "Expires"
+          },
+          "WebsiteRedirectLocation": {
+            "shape_name": "WebsiteRedirectLocation",
+            "type": "string",
+            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
+            "location": "header",
+            "location_name": "x-amz-website-redirect-location"
+          },
+          "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
+            "type": "string",
+            "enum": [
+              "AES256"
+            ],
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           },
           "Metadata": {
             "type": "map",
             "location": "header",
             "location_name": "x-amz-meta-",
+            "keys": {
+              "type": "string",
+              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+            },
             "members": {
               "type": "string",
               "documentation": "The metadata value."
             },
-            "documentation": "A map of metadata to store with the object in S3.",
-            "keys": {
-              "type": "string",
-              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-            }
-          },
-          "MissingMeta": {
-            "type": "integer",
-            "location": "header",
-            "location_name": "x-amz-missing-meta",
-            "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers."
-          },
-          "Restore": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-restore",
-            "documentation": "Provides information about object restoration operation and expiration time of the restored object copy."
-          },
-          "ServerSideEncryption": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
-            "enum": [
-              "AES256"
-            ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
-          },
-          "VersionId": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-version-id",
-            "documentation": "Version of the object."
-          },
-          "WebsiteRedirectLocation": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-website-redirect-location",
-            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."
+            "documentation": "A map of metadata to store with the object in S3."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
         {
           "shape_name": "NoSuchKey",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The specified key does not exist."
         }
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html",
-      "documentation": "Retrieves objects from Amazon S3."
+      "documentation": "Retrieves objects from Amazon S3.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html"
     },
     "GetObjectAcl": {
       "name": "GetObjectAcl",
@@ -1882,73 +2301,106 @@
         "uri": "/{Bucket}/{Key}?acl&versionId={VersionId}"
       },
       "input": {
+        "shape_name": "GetObjectAclRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "VersionId": {
+            "shape_name": "ObjectVersionId",
             "type": "string",
-            "location": "uri",
-            "documentation": "VersionId used to reference a specific version of the object."
+            "documentation": "VersionId used to reference a specific version of the object.",
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetObjectAclOutput",
         "type": "structure",
         "members": {
-          "Grants": {
-            "type": "list",
-            "xmlname": "AccessControlList",
+          "Owner": {
+            "shape_name": "Owner",
+            "type": "structure",
             "members": {
+              "DisplayName": {
+                "shape_name": "DisplayName",
+                "type": "string",
+                "documentation": null
+              },
+              "ID": {
+                "shape_name": "ID",
+                "type": "string",
+                "documentation": null
+              }
+            },
+            "documentation": null
+          },
+          "Grants": {
+            "shape_name": "Grants",
+            "type": "list",
+            "members": {
+              "shape_name": "Grant",
               "type": "structure",
-              "xmlname": "Grant",
               "members": {
                 "Grantee": {
-                  "xmlnamespace": {
-                    "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                    "prefix": "xsi"
-                  },
+                  "shape_name": "Grantee",
                   "type": "structure",
                   "members": {
                     "DisplayName": {
+                      "shape_name": "DisplayName",
                       "type": "string",
                       "documentation": "Screen name of the grantee."
                     },
                     "EmailAddress": {
+                      "shape_name": "EmailAddress",
                       "type": "string",
                       "documentation": "Email address of the grantee."
                     },
                     "ID": {
+                      "shape_name": "ID",
                       "type": "string",
                       "documentation": "The canonical user ID of the grantee."
                     },
                     "Type": {
+                      "shape_name": "Type",
                       "type": "string",
-                      "xmlname": "xsi:type",
-                      "xmlattribute": true,
                       "enum": [
                         "CanonicalUser",
                         "AmazonCustomerByEmail",
                         "Group"
                       ],
-                      "documentation": "Type of grantee"
+                      "documentation": "Type of grantee",
+                      "required": true,
+                      "xmlattribute": true,
+                      "xmlname": "xsi:type"
                     },
                     "URI": {
+                      "shape_name": "URI",
                       "type": "string",
                       "documentation": "URI of the grantee group."
                     }
+                  },
+                  "documentation": null,
+                  "xmlnamespace": {
+                    "prefix": "xsi",
+                    "uri": "http://www.w3.org/2001/XMLSchema-instance"
                   }
                 },
                 "Permission": {
+                  "shape_name": "Permission",
                   "type": "string",
                   "enum": [
                     "FULL_CONTROL",
@@ -1959,32 +2411,27 @@
                   ],
                   "documentation": "Specifies the permission given to the grantee."
                 }
-              }
-            },
-            "documentation": "A list of grants."
-          },
-          "Owner": {
-            "type": "structure",
-            "members": {
-              "DisplayName": {
-                "type": "string"
               },
-              "ID": {
-                "type": "string"
-              }
-            }
+              "documentation": null,
+              "xmlname": "Grant"
+            },
+            "documentation": "A list of grants.",
+            "xmlname": "AccessControlList"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
         {
           "shape_name": "NoSuchKey",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The specified key does not exist."
         }
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETacl.html",
-      "documentation": "Returns the access control list (ACL) of an object."
+      "documentation": "Returns the access control list (ACL) of an object.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETacl.html"
     },
     "GetObjectTorrent": {
       "name": "GetObjectTorrent",
@@ -1993,36 +2440,45 @@
         "uri": "/{Bucket}/{Key}?torrent"
       },
       "input": {
+        "shape_name": "GetObjectTorrentRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "GetObjectTorrentOutput",
         "type": "structure",
         "members": {
           "Body": {
+            "shape_name": "Body",
             "type": "blob",
+            "documentation": null,
             "payload": true,
             "streaming": true
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtorrent.html",
-      "documentation": "Return torrent files from a bucket."
+      "documentation": "Return torrent files from a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtorrent.html"
     },
     "HeadBucket": {
       "name": "HeadBucket",
@@ -2031,25 +2487,31 @@
         "uri": "/{Bucket}"
       },
       "input": {
+        "shape_name": "HeadBucketRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
         {
           "shape_name": "NoSuchBucket",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The specified bucket does not exist."
         }
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html",
-      "documentation": "This operation is useful to determine if a bucket exists and you have permission to access it."
+      "documentation": "This operation is useful to determine if a bucket exists and you have permission to access it.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html"
     },
     "HeadObject": {
       "name": "HeadObject",
@@ -2058,192 +2520,224 @@
         "uri": "/{Bucket}/{Key}?versionId={VersionId}"
       },
       "input": {
+        "shape_name": "HeadObjectRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "IfMatch": {
+            "shape_name": "IfMatch",
             "type": "string",
+            "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).",
             "location": "header",
-            "location_name": "If-Match",
-            "documentation": "Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."
+            "location_name": "If-Match"
           },
           "IfModifiedSince": {
+            "shape_name": "IfModifiedSince",
             "type": "timestamp",
+            "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified).",
             "location": "header",
-            "location_name": "If-Modified-Since",
-            "documentation": "Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified)."
+            "location_name": "If-Modified-Since"
           },
           "IfNoneMatch": {
+            "shape_name": "IfNoneMatch",
             "type": "string",
+            "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified).",
             "location": "header",
-            "location_name": "If-None-Match",
-            "documentation": "Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified)."
+            "location_name": "If-None-Match"
           },
           "IfUnmodifiedSince": {
+            "shape_name": "IfUnmodifiedSince",
             "type": "timestamp",
+            "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed).",
             "location": "header",
-            "location_name": "If-Unmodified-Since",
-            "documentation": "Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed)."
+            "location_name": "If-Unmodified-Since"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Range": {
+            "shape_name": "Range",
             "type": "string",
+            "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.",
             "location": "header",
-            "location_name": "Range",
-            "documentation": "Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35."
+            "location_name": "Range"
           },
           "VersionId": {
+            "shape_name": "ObjectVersionId",
             "type": "string",
-            "location": "uri",
-            "documentation": "VersionId used to reference a specific version of the object."
+            "documentation": "VersionId used to reference a specific version of the object.",
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "HeadObjectOutput",
         "type": "structure",
         "members": {
+          "DeleteMarker": {
+            "shape_name": "DeleteMarker",
+            "type": "boolean",
+            "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.",
+            "location": "header",
+            "location_name": "x-amz-delete-marker"
+          },
           "AcceptRanges": {
+            "shape_name": "AcceptRanges",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "accept-ranges"
           },
-          "CacheControl": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Cache-Control",
-            "documentation": "Specifies caching behavior along the request/reply chain."
-          },
-          "ContentDisposition": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Disposition",
-            "documentation": "Specifies presentational information for the object."
-          },
-          "ContentEncoding": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Encoding",
-            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
-          },
-          "ContentLanguage": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Language",
-            "documentation": "The language the content is in."
-          },
-          "ContentLength": {
-            "type": "integer",
-            "location": "header",
-            "location_name": "Content-Length",
-            "documentation": "Size of the body in bytes."
-          },
-          "ContentType": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Content-Type",
-            "documentation": "A standard MIME type describing the format of the object data."
-          },
-          "DeleteMarker": {
-            "type": "boolean",
-            "location": "header",
-            "location_name": "x-amz-delete-marker",
-            "documentation": "Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response."
-          },
-          "ETag": {
-            "type": "string",
-            "location": "header",
-            "location_name": "ETag",
-            "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL"
-          },
           "Expiration": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-expiration",
-            "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded."
-          },
-          "Expires": {
+            "shape_name": "Expiration",
             "type": "timestamp",
+            "documentation": "If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded.",
             "location": "header",
-            "location_name": "Expires",
-            "documentation": "The date and time at which the object is no longer cacheable."
+            "location_name": "x-amz-expiration"
+          },
+          "Restore": {
+            "shape_name": "Restore",
+            "type": "string",
+            "documentation": "Provides information about object restoration operation and expiration time of the restored object copy.",
+            "location": "header",
+            "location_name": "x-amz-restore"
           },
           "LastModified": {
+            "shape_name": "LastModified",
             "type": "timestamp",
+            "documentation": "Last modified date of the object",
             "location": "header",
-            "location_name": "Last-Modified",
-            "documentation": "Last modified date of the object"
+            "location_name": "Last-Modified"
+          },
+          "ContentLength": {
+            "shape_name": "ContentLength",
+            "type": "integer",
+            "documentation": "Size of the body in bytes.",
+            "location": "header",
+            "location_name": "Content-Length"
+          },
+          "ETag": {
+            "shape_name": "ETag",
+            "type": "string",
+            "documentation": "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL",
+            "location": "header",
+            "location_name": "ETag"
+          },
+          "MissingMeta": {
+            "shape_name": "MissingMeta",
+            "type": "integer",
+            "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.",
+            "location": "header",
+            "location_name": "x-amz-missing-meta"
+          },
+          "VersionId": {
+            "shape_name": "ObjectVersionId",
+            "type": "string",
+            "documentation": "Version of the object.",
+            "location": "header",
+            "location_name": "x-amz-version-id"
+          },
+          "CacheControl": {
+            "shape_name": "CacheControl",
+            "type": "string",
+            "documentation": "Specifies caching behavior along the request/reply chain.",
+            "location": "header",
+            "location_name": "Cache-Control"
+          },
+          "ContentDisposition": {
+            "shape_name": "ContentDisposition",
+            "type": "string",
+            "documentation": "Specifies presentational information for the object.",
+            "location": "header",
+            "location_name": "Content-Disposition"
+          },
+          "ContentEncoding": {
+            "shape_name": "ContentEncoding",
+            "type": "string",
+            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
+            "location": "header",
+            "location_name": "Content-Encoding"
+          },
+          "ContentLanguage": {
+            "shape_name": "ContentLanguage",
+            "type": "string",
+            "documentation": "The language the content is in.",
+            "location": "header",
+            "location_name": "Content-Language"
+          },
+          "ContentType": {
+            "shape_name": "ContentType",
+            "type": "string",
+            "documentation": "A standard MIME type describing the format of the object data.",
+            "location": "header",
+            "location_name": "Content-Type"
+          },
+          "Expires": {
+            "shape_name": "Expires",
+            "type": "timestamp",
+            "documentation": "The date and time at which the object is no longer cacheable.",
+            "location": "header",
+            "location_name": "Expires"
+          },
+          "WebsiteRedirectLocation": {
+            "shape_name": "WebsiteRedirectLocation",
+            "type": "string",
+            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
+            "location": "header",
+            "location_name": "x-amz-website-redirect-location"
+          },
+          "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
+            "type": "string",
+            "enum": [
+              "AES256"
+            ],
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           },
           "Metadata": {
             "type": "map",
             "location": "header",
             "location_name": "x-amz-meta-",
+            "keys": {
+              "type": "string",
+              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+            },
             "members": {
               "type": "string",
               "documentation": "The metadata value."
             },
-            "documentation": "A map of metadata to store with the object in S3.",
-            "keys": {
-              "type": "string",
-              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-            }
-          },
-          "MissingMeta": {
-            "type": "integer",
-            "location": "header",
-            "location_name": "x-amz-missing-meta",
-            "documentation": "This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers."
-          },
-          "Restore": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-restore",
-            "documentation": "Provides information about object restoration operation and expiration time of the restored object copy."
-          },
-          "ServerSideEncryption": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
-            "enum": [
-              "AES256"
-            ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
-          },
-          "VersionId": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-version-id",
-            "documentation": "Version of the object."
-          },
-          "WebsiteRedirectLocation": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-website-redirect-location",
-            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."
+            "documentation": "A map of metadata to store with the object in S3."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
         {
           "shape_name": "NoSuchKey",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The specified key does not exist."
         }
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html",
-      "documentation": "The HEAD operation retrieves metadata from an object without returning the object itself. This operation is useful if you're only interested in an object's metadata. To use HEAD, you must have READ access to the object."
+      "documentation": "The HEAD operation retrieves metadata from an object without returning the object itself. This operation is useful if you're only interested in an object's metadata. To use HEAD, you must have READ access to the object.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html"
     },
     "ListBuckets": {
       "name": "ListBuckets",
-      "alias": "GetService",
       "http": {
         "method": "GET",
         "uri": "/"
@@ -2254,40 +2748,54 @@
         "type": "structure",
         "members": {
           "Buckets": {
+            "shape_name": "Buckets",
             "type": "list",
             "members": {
+              "shape_name": "Bucket",
               "type": "structure",
-              "xmlname": "Bucket",
               "members": {
-                "CreationDate": {
-                  "type": "timestamp",
-                  "documentation": "Date the bucket was created."
-                },
                 "Name": {
+                  "shape_name": "BucketName",
                   "type": "string",
                   "documentation": "The name of the bucket."
+                },
+                "CreationDate": {
+                  "shape_name": "CreationDate",
+                  "type": "timestamp",
+                  "documentation": "Date the bucket was created."
                 }
-              }
-            }
+              },
+              "documentation": null,
+              "xmlname": "Bucket"
+            },
+            "documentation": null
           },
           "Owner": {
+            "shape_name": "Owner",
             "type": "structure",
             "members": {
               "DisplayName": {
-                "type": "string"
+                "shape_name": "DisplayName",
+                "type": "string",
+                "documentation": null
               },
               "ID": {
-                "type": "string"
+                "shape_name": "ID",
+                "type": "string",
+                "documentation": null
               }
-            }
+            },
+            "documentation": null
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
+      "documentation": "Returns a list of all buckets owned by the authenticated sender of the request.",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html",
-      "documentation": "Returns a list of all buckets owned by the authenticated sender of the request."
+      "alias": "GetService"
     },
     "ListMultipartUploads": {
       "name": "ListMultipartUploads",
@@ -2296,142 +2804,126 @@
         "uri": "/{Bucket}?uploads&prefix={Prefix}&delimiter={Delimiter}&max-uploads={MaxUploads}&key-marker={KeyMarker}&upload-id-marker={UploadIdMarker}&encoding-type={EncodingType}"
       },
       "input": {
+        "shape_name": "ListMultipartUploadsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Delimiter": {
+            "shape_name": "Delimiter",
             "type": "string",
-            "location": "uri",
-            "documentation": "Character you use to group keys."
+            "documentation": "Character you use to group keys.",
+            "location": "uri"
           },
           "EncodingType": {
+            "shape_name": "EncodingType",
             "type": "string",
-            "location": "uri",
             "enum": [
               "url"
             ],
-            "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."
+            "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.",
+            "location": "uri"
           },
           "KeyMarker": {
+            "shape_name": "KeyMarker",
             "type": "string",
-            "location": "uri",
-            "documentation": "Together with upload-id-marker, this parameter specifies the multipart upload after which listing should begin."
+            "documentation": "Together with upload-id-marker, this parameter specifies the multipart upload after which listing should begin.",
+            "location": "uri"
           },
           "MaxUploads": {
+            "shape_name": "MaxUploads",
             "type": "integer",
-            "location": "uri",
-            "documentation": "Sets the maximum number of multipart uploads, from 1 to 1,000, to return in the response body. 1,000 is the maximum number of uploads that can be returned in a response."
+            "documentation": "Sets the maximum number of multipart uploads, from 1 to 1,000, to return in the response body. 1,000 is the maximum number of uploads that can be returned in a response.",
+            "location": "uri"
           },
           "Prefix": {
+            "shape_name": "Prefix",
             "type": "string",
-            "location": "uri",
-            "documentation": "Lists in-progress uploads only for those keys that begin with the specified prefix."
+            "documentation": "Lists in-progress uploads only for those keys that begin with the specified prefix.",
+            "location": "uri"
           },
           "UploadIdMarker": {
+            "shape_name": "UploadIdMarker",
             "type": "string",
-            "location": "uri",
-            "documentation": "Together with key-marker, specifies the multipart upload after which listing should begin. If key-marker is not specified, the upload-id-marker parameter is ignored."
+            "documentation": "Together with key-marker, specifies the multipart upload after which listing should begin. If key-marker is not specified, the upload-id-marker parameter is ignored.",
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "ListMultipartUploadsOutput",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
             "documentation": "Name of the bucket to which the multipart upload was initiated."
           },
-          "CommonPrefixes": {
-            "type": "list",
-            "members": {
-              "type": "structure",
-              "members": {
-                "Prefix": {
-                  "type": "string"
-                }
-              }
-            },
-            "flattened": true
-          },
-          "EncodingType": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Encoding-Type",
-            "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
-          },
-          "IsTruncated": {
-            "type": "boolean",
-            "documentation": "Indicates whether the returned list of multipart uploads is truncated. A value of true indicates that the list was truncated. The list can be truncated if the number of multipart uploads exceeds the limit allowed or specified by max uploads."
-          },
           "KeyMarker": {
+            "shape_name": "KeyMarker",
             "type": "string",
             "documentation": "The key at or after which the listing began."
           },
-          "MaxUploads": {
-            "type": "integer",
-            "documentation": "Maximum number of multipart uploads that could have been included in the response."
-          },
-          "NextKeyMarker": {
-            "type": "string",
-            "documentation": "When a list is truncated, this element specifies the value that should be used for the key-marker request parameter in a subsequent request."
-          },
-          "NextUploadIdMarker": {
-            "type": "string",
-            "documentation": "When a list is truncated, this element specifies the value that should be used for the upload-id-marker request parameter in a subsequent request."
-          },
-          "Prefix": {
-            "type": "string",
-            "documentation": "When a prefix is provided in the request, this field contains the specified prefix. The result contains only keys starting with the specified prefix."
-          },
           "UploadIdMarker": {
+            "shape_name": "UploadIdMarker",
             "type": "string",
             "documentation": "Upload ID after which listing began."
           },
+          "NextKeyMarker": {
+            "shape_name": "NextKeyMarker",
+            "type": "string",
+            "documentation": "When a list is truncated, this element specifies the value that should be used for the key-marker request parameter in a subsequent request."
+          },
+          "Prefix": {
+            "shape_name": "Prefix",
+            "type": "string",
+            "documentation": "When a prefix is provided in the request, this field contains the specified prefix. The result contains only keys starting with the specified prefix."
+          },
+          "NextUploadIdMarker": {
+            "shape_name": "NextUploadIdMarker",
+            "type": "string",
+            "documentation": "When a list is truncated, this element specifies the value that should be used for the upload-id-marker request parameter in a subsequent request."
+          },
+          "MaxUploads": {
+            "shape_name": "MaxUploads",
+            "type": "integer",
+            "documentation": "Maximum number of multipart uploads that could have been included in the response."
+          },
+          "IsTruncated": {
+            "shape_name": "IsTruncated",
+            "type": "boolean",
+            "documentation": "Indicates whether the returned list of multipart uploads is truncated. A value of true indicates that the list was truncated. The list can be truncated if the number of multipart uploads exceeds the limit allowed or specified by max uploads."
+          },
           "Uploads": {
+            "shape_name": "MultipartUploadList",
             "type": "list",
-            "xmlname": "Upload",
             "members": {
+              "shape_name": "MultipartUpload",
               "type": "structure",
               "members": {
-                "Initiated": {
-                  "type": "timestamp",
-                  "documentation": "Date and time at which the multipart upload was initiated."
-                },
-                "Initiator": {
-                  "type": "structure",
-                  "members": {
-                    "DisplayName": {
-                      "type": "string",
-                      "documentation": "Name of the Principal."
-                    },
-                    "ID": {
-                      "type": "string",
-                      "documentation": "If the principal is an AWS account, it provides the Canonical User ID. If the principal is an IAM User, it provides a user ARN value."
-                    }
-                  },
-                  "documentation": "Identifies who initiated the multipart upload."
+                "UploadId": {
+                  "shape_name": "MultipartUploadId",
+                  "type": "string",
+                  "documentation": "Upload ID that identifies the multipart upload."
                 },
                 "Key": {
+                  "shape_name": "ObjectKey",
                   "type": "string",
                   "documentation": "Key of the object for which the multipart upload was initiated."
                 },
-                "Owner": {
-                  "type": "structure",
-                  "members": {
-                    "DisplayName": {
-                      "type": "string"
-                    },
-                    "ID": {
-                      "type": "string"
-                    }
-                  }
+                "Initiated": {
+                  "shape_name": "Initiated",
+                  "type": "timestamp",
+                  "documentation": "Date and time at which the multipart upload was initiated."
                 },
                 "StorageClass": {
+                  "shape_name": "StorageClass",
                   "type": "string",
                   "enum": [
                     "STANDARD",
@@ -2440,196 +2932,189 @@
                   ],
                   "documentation": "The class of storage used to store the object."
                 },
-                "UploadId": {
-                  "type": "string",
-                  "documentation": "Upload ID that identifies the multipart upload."
+                "Owner": {
+                  "shape_name": "Owner",
+                  "type": "structure",
+                  "members": {
+                    "DisplayName": {
+                      "shape_name": "DisplayName",
+                      "type": "string",
+                      "documentation": null
+                    },
+                    "ID": {
+                      "shape_name": "ID",
+                      "type": "string",
+                      "documentation": null
+                    }
+                  },
+                  "documentation": null
+                },
+                "Initiator": {
+                  "shape_name": "Initiator",
+                  "type": "structure",
+                  "members": {
+                    "ID": {
+                      "shape_name": "ID",
+                      "type": "string",
+                      "documentation": "If the principal is an AWS account, it provides the Canonical User ID. If the principal is an IAM User, it provides a user ARN value."
+                    },
+                    "DisplayName": {
+                      "shape_name": "DisplayName",
+                      "type": "string",
+                      "documentation": "Name of the Principal."
+                    }
+                  },
+                  "documentation": "Identifies who initiated the multipart upload."
                 }
-              }
+              },
+              "documentation": null
             },
-            "flattened": true
+            "flattened": true,
+            "documentation": null,
+            "xmlname": "Upload"
+          },
+          "CommonPrefixes": {
+            "shape_name": "CommonPrefixList",
+            "type": "list",
+            "members": {
+              "shape_name": "CommonPrefix",
+              "type": "structure",
+              "members": {
+                "Prefix": {
+                  "shape_name": "Prefix",
+                  "type": "string",
+                  "documentation": null
+                }
+              },
+              "documentation": null
+            },
+            "flattened": true,
+            "documentation": null
+          },
+          "EncodingType": {
+            "shape_name": "EncodingType",
+            "type": "string",
+            "enum": [
+              "url"
+            ],
+            "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html",
-      "documentation": "This operation lists in-progress multipart uploads."
+      "documentation": "This operation lists in-progress multipart uploads.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html"
     },
     "ListObjectVersions": {
       "name": "ListObjectVersions",
-      "alias": "GetBucketObjectVersions",
       "http": {
         "method": "GET",
         "uri": "/{Bucket}?versions&delimiter={Delimiter}&key-marker={KeyMarker}&max-keys={MaxKeys}&prefix={Prefix}&version-id-marker={VersionIdMarker}&encoding-type={EncodingType}"
       },
       "input": {
+        "shape_name": "ListObjectVersionsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Delimiter": {
+            "shape_name": "Delimiter",
             "type": "string",
-            "location": "uri",
-            "documentation": "A delimiter is a character you use to group keys."
+            "documentation": "A delimiter is a character you use to group keys.",
+            "location": "uri"
           },
           "EncodingType": {
+            "shape_name": "EncodingType",
             "type": "string",
-            "location": "uri",
             "enum": [
               "url"
             ],
-            "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."
+            "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.",
+            "location": "uri"
           },
           "KeyMarker": {
+            "shape_name": "KeyMarker",
             "type": "string",
-            "location": "uri",
-            "documentation": "Specifies the key to start with when listing objects in a bucket."
+            "documentation": "Specifies the key to start with when listing objects in a bucket.",
+            "location": "uri"
           },
           "MaxKeys": {
+            "shape_name": "MaxKeys",
             "type": "integer",
-            "location": "uri",
-            "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."
+            "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more.",
+            "location": "uri"
           },
           "Prefix": {
+            "shape_name": "Prefix",
             "type": "string",
-            "location": "uri",
-            "documentation": "Limits the response to keys that begin with the specified prefix."
+            "documentation": "Limits the response to keys that begin with the specified prefix.",
+            "location": "uri"
           },
           "VersionIdMarker": {
+            "shape_name": "VersionIdMarker",
             "type": "string",
-            "location": "uri",
-            "documentation": "Specifies the object version you want to start listing from."
+            "documentation": "Specifies the object version you want to start listing from.",
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "ListObjectVersionsOutput",
         "type": "structure",
         "members": {
-          "CommonPrefixes": {
-            "type": "list",
-            "members": {
-              "type": "structure",
-              "members": {
-                "Prefix": {
-                  "type": "string"
-                }
-              }
-            },
-            "flattened": true
-          },
-          "DeleteMarkers": {
-            "type": "list",
-            "xmlname": "DeleteMarker",
-            "members": {
-              "type": "structure",
-              "members": {
-                "IsLatest": {
-                  "type": "boolean",
-                  "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
-                },
-                "Key": {
-                  "type": "string",
-                  "documentation": "The object key."
-                },
-                "LastModified": {
-                  "type": "timestamp",
-                  "documentation": "Date and time the object was last modified."
-                },
-                "Owner": {
-                  "type": "structure",
-                  "members": {
-                    "DisplayName": {
-                      "type": "string"
-                    },
-                    "ID": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "VersionId": {
-                  "type": "string",
-                  "documentation": "Version ID of an object."
-                }
-              }
-            },
-            "flattened": true
-          },
-          "EncodingType": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Encoding-Type",
-            "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
-          },
           "IsTruncated": {
+            "shape_name": "IsTruncated",
             "type": "boolean",
             "documentation": "A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria. If your results were truncated, you can make a follow-up paginated request using the NextKeyMarker and NextVersionIdMarker response parameters as a starting place in another request to return the rest of the results."
           },
           "KeyMarker": {
+            "shape_name": "KeyMarker",
             "type": "string",
             "documentation": "Marks the last Key returned in a truncated response."
           },
-          "MaxKeys": {
-            "type": "integer"
-          },
-          "Name": {
-            "type": "string"
+          "VersionIdMarker": {
+            "shape_name": "VersionIdMarker",
+            "type": "string",
+            "documentation": null
           },
           "NextKeyMarker": {
+            "shape_name": "NextKeyMarker",
             "type": "string",
             "documentation": "Use this value for the key marker request parameter in a subsequent request."
           },
           "NextVersionIdMarker": {
+            "shape_name": "NextVersionIdMarker",
             "type": "string",
             "documentation": "Use this value for the next version id marker parameter in a subsequent request."
           },
-          "Prefix": {
-            "type": "string"
-          },
-          "VersionIdMarker": {
-            "type": "string"
-          },
           "Versions": {
+            "shape_name": "ObjectVersionList",
             "type": "list",
-            "xmlname": "Version",
             "members": {
+              "shape_name": "ObjectVersion",
               "type": "structure",
               "members": {
                 "ETag": {
-                  "type": "string"
-                },
-                "IsLatest": {
-                  "type": "boolean",
-                  "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
-                },
-                "Key": {
+                  "shape_name": "ETag",
                   "type": "string",
-                  "documentation": "The object key."
-                },
-                "LastModified": {
-                  "type": "timestamp",
-                  "documentation": "Date and time the object was last modified."
-                },
-                "Owner": {
-                  "type": "structure",
-                  "members": {
-                    "DisplayName": {
-                      "type": "string"
-                    },
-                    "ID": {
-                      "type": "string"
-                    }
-                  }
+                  "documentation": null
                 },
                 "Size": {
-                  "type": "string",
+                  "shape_name": "Size",
+                  "type": "integer",
                   "documentation": "Size in bytes of the object."
                 },
                 "StorageClass": {
+                  "shape_name": "StorageClass",
                   "type": "string",
                   "enum": [
                     "STANDARD",
@@ -2638,112 +3123,253 @@
                   ],
                   "documentation": "The class of storage used to store the object."
                 },
+                "Key": {
+                  "shape_name": "ObjectKey",
+                  "type": "string",
+                  "documentation": "The object key."
+                },
                 "VersionId": {
+                  "shape_name": "ObjectVersionId",
                   "type": "string",
                   "documentation": "Version ID of an object."
+                },
+                "IsLatest": {
+                  "shape_name": "IsLatest",
+                  "type": "boolean",
+                  "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
+                },
+                "LastModified": {
+                  "shape_name": "LastModified",
+                  "type": "timestamp",
+                  "documentation": "Date and time the object was last modified."
+                },
+                "Owner": {
+                  "shape_name": "Owner",
+                  "type": "structure",
+                  "members": {
+                    "DisplayName": {
+                      "shape_name": "DisplayName",
+                      "type": "string",
+                      "documentation": null
+                    },
+                    "ID": {
+                      "shape_name": "ID",
+                      "type": "string",
+                      "documentation": null
+                    }
+                  },
+                  "documentation": null
                 }
-              }
+              },
+              "documentation": null
             },
-            "flattened": true
+            "flattened": true,
+            "documentation": null,
+            "xmlname": "Version"
+          },
+          "DeleteMarkers": {
+            "shape_name": "DeleteMarkers",
+            "type": "list",
+            "members": {
+              "shape_name": "DeleteMarkerEntry",
+              "type": "structure",
+              "members": {
+                "Owner": {
+                  "shape_name": "Owner",
+                  "type": "structure",
+                  "members": {
+                    "DisplayName": {
+                      "shape_name": "DisplayName",
+                      "type": "string",
+                      "documentation": null
+                    },
+                    "ID": {
+                      "shape_name": "ID",
+                      "type": "string",
+                      "documentation": null
+                    }
+                  },
+                  "documentation": null
+                },
+                "Key": {
+                  "shape_name": "ObjectKey",
+                  "type": "string",
+                  "documentation": "The object key."
+                },
+                "VersionId": {
+                  "shape_name": "ObjectVersionId",
+                  "type": "string",
+                  "documentation": "Version ID of an object."
+                },
+                "IsLatest": {
+                  "shape_name": "IsLatest",
+                  "type": "boolean",
+                  "documentation": "Specifies whether the object is (true) or is not (false) the latest version of an object."
+                },
+                "LastModified": {
+                  "shape_name": "LastModified",
+                  "type": "timestamp",
+                  "documentation": "Date and time the object was last modified."
+                }
+              },
+              "documentation": null
+            },
+            "flattened": true,
+            "documentation": null,
+            "xmlname": "DeleteMarker"
+          },
+          "Name": {
+            "shape_name": "BucketName",
+            "type": "string",
+            "documentation": null
+          },
+          "Prefix": {
+            "shape_name": "Prefix",
+            "type": "string",
+            "documentation": null
+          },
+          "MaxKeys": {
+            "shape_name": "MaxKeys",
+            "type": "integer",
+            "documentation": null
+          },
+          "CommonPrefixes": {
+            "shape_name": "CommonPrefixList",
+            "type": "list",
+            "members": {
+              "shape_name": "CommonPrefix",
+              "type": "structure",
+              "members": {
+                "Prefix": {
+                  "shape_name": "Prefix",
+                  "type": "string",
+                  "documentation": null
+                }
+              },
+              "documentation": null
+            },
+            "flattened": true,
+            "documentation": null
+          },
+          "EncodingType": {
+            "shape_name": "EncodingType",
+            "type": "string",
+            "enum": [
+              "url"
+            ],
+            "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
+      "documentation": "Returns metadata about all of the versions of objects in a bucket.",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETVersion.html",
-      "documentation": "Returns metadata about all of the versions of objects in a bucket."
+      "alias": "GetBucketObjectVersions"
     },
     "ListObjects": {
       "name": "ListObjects",
-      "alias": "GetBucket",
       "http": {
         "method": "GET",
         "uri": "/{Bucket}?delimiter={Delimiter}&marker={Marker}&max-keys={MaxKeys}&prefix={Prefix}&encoding-type={EncodingType}"
       },
       "input": {
+        "shape_name": "ListObjectsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Delimiter": {
+            "shape_name": "Delimiter",
             "type": "string",
-            "location": "uri",
-            "documentation": "A delimiter is a character you use to group keys."
+            "documentation": "A delimiter is a character you use to group keys.",
+            "location": "uri"
           },
           "EncodingType": {
+            "shape_name": "EncodingType",
             "type": "string",
-            "location": "uri",
             "enum": [
               "url"
             ],
-            "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."
+            "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.",
+            "location": "uri"
           },
           "Marker": {
+            "shape_name": "Marker",
             "type": "string",
-            "location": "uri",
-            "documentation": "Specifies the key to start with when listing objects in a bucket."
+            "documentation": "Specifies the key to start with when listing objects in a bucket.",
+            "location": "uri"
           },
           "MaxKeys": {
+            "shape_name": "MaxKeys",
             "type": "integer",
-            "location": "uri",
-            "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."
+            "documentation": "Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more.",
+            "location": "uri"
           },
           "Prefix": {
+            "shape_name": "Prefix",
             "type": "string",
-            "location": "uri",
-            "documentation": "Limits the response to keys that begin with the specified prefix."
+            "documentation": "Limits the response to keys that begin with the specified prefix.",
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "ListObjectsOutput",
         "type": "structure",
         "members": {
-          "CommonPrefixes": {
-            "type": "list",
-            "members": {
-              "type": "structure",
-              "members": {
-                "Prefix": {
-                  "type": "string"
-                }
-              }
-            },
-            "flattened": true
+          "IsTruncated": {
+            "shape_name": "IsTruncated",
+            "type": "boolean",
+            "documentation": "A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria."
+          },
+          "Marker": {
+            "shape_name": "Marker",
+            "type": "string",
+            "documentation": null
+          },
+          "NextMarker": {
+            "shape_name": "NextMarker",
+            "type": "string",
+            "documentation": "When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMaker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys."
           },
           "Contents": {
+            "shape_name": "ObjectList",
             "type": "list",
             "members": {
+              "shape_name": "Object",
               "type": "structure",
               "members": {
-                "ETag": {
-                  "type": "string"
-                },
                 "Key": {
-                  "type": "string"
+                  "shape_name": "ObjectKey",
+                  "type": "string",
+                  "documentation": null
                 },
                 "LastModified": {
-                  "type": "timestamp"
+                  "shape_name": "LastModified",
+                  "type": "timestamp",
+                  "documentation": null
                 },
-                "Owner": {
-                  "type": "structure",
-                  "members": {
-                    "DisplayName": {
-                      "type": "string"
-                    },
-                    "ID": {
-                      "type": "string"
-                    }
-                  }
+                "ETag": {
+                  "shape_name": "ETag",
+                  "type": "string",
+                  "documentation": null
                 },
                 "Size": {
-                  "type": "integer"
+                  "shape_name": "Size",
+                  "type": "integer",
+                  "documentation": null
                 },
                 "StorageClass": {
+                  "shape_name": "StorageClass",
                   "type": "string",
                   "enum": [
                     "STANDARD",
@@ -2751,48 +3377,86 @@
                     "GLACIER"
                   ],
                   "documentation": "The class of storage used to store the object."
+                },
+                "Owner": {
+                  "shape_name": "Owner",
+                  "type": "structure",
+                  "members": {
+                    "DisplayName": {
+                      "shape_name": "DisplayName",
+                      "type": "string",
+                      "documentation": null
+                    },
+                    "ID": {
+                      "shape_name": "ID",
+                      "type": "string",
+                      "documentation": null
+                    }
+                  },
+                  "documentation": null
                 }
-              }
+              },
+              "documentation": null
             },
-            "flattened": true
-          },
-          "EncodingType": {
-            "type": "string",
-            "location": "header",
-            "location_name": "Encoding-Type",
-            "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
-          },
-          "IsTruncated": {
-            "type": "boolean",
-            "documentation": "A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria."
-          },
-          "Marker": {
-            "type": "string"
-          },
-          "MaxKeys": {
-            "type": "integer"
+            "flattened": true,
+            "documentation": null
           },
           "Name": {
-            "type": "string"
-          },
-          "NextMarker": {
+            "shape_name": "BucketName",
             "type": "string",
-            "documentation": "When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMaker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys."
+            "documentation": null
           },
           "Prefix": {
-            "type": "string"
+            "shape_name": "Prefix",
+            "type": "string",
+            "documentation": null
+          },
+          "MaxKeys": {
+            "shape_name": "MaxKeys",
+            "type": "integer",
+            "documentation": null
+          },
+          "CommonPrefixes": {
+            "shape_name": "CommonPrefixList",
+            "type": "list",
+            "members": {
+              "shape_name": "CommonPrefix",
+              "type": "structure",
+              "members": {
+                "Prefix": {
+                  "shape_name": "Prefix",
+                  "type": "string",
+                  "documentation": null
+                }
+              },
+              "documentation": null
+            },
+            "flattened": true,
+            "documentation": null
+          },
+          "EncodingType": {
+            "shape_name": "EncodingType",
+            "type": "string",
+            "enum": [
+              "url"
+            ],
+            "documentation": "Encoding type used by Amazon S3 to encode object keys in the response."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
         {
           "shape_name": "NoSuchBucket",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The specified bucket does not exist."
         }
       ],
+      "documentation": "Returns some or all (up to 1000) of the objects in a bucket. You can use the request parameters as selection criteria to return a subset of the objects in a bucket.",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html",
-      "documentation": "Returns some or all (up to 1000) of the objects in a bucket. You can use the request parameters as selection criteria to return a subset of the objects in a bucket."
+      "alias": "GetBucket"
     },
     "ListParts": {
       "name": "ListParts",
@@ -2801,116 +3465,154 @@
         "uri": "/{Bucket}/{Key}?uploadId={UploadId}&max-parts={MaxParts}&part-number-marker={PartNumberMarker}"
       },
       "input": {
+        "shape_name": "ListPartsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "MaxParts": {
+            "shape_name": "MaxParts",
             "type": "integer",
-            "location": "uri",
-            "documentation": "Sets the maximum number of parts to return."
+            "documentation": "Sets the maximum number of parts to return.",
+            "location": "uri"
           },
           "PartNumberMarker": {
+            "shape_name": "PartNumberMarker",
             "type": "integer",
-            "location": "uri",
-            "documentation": "Specifies the part after which listing should begin. Only parts with higher part numbers will be listed."
+            "documentation": "Specifies the part after which listing should begin. Only parts with higher part numbers will be listed.",
+            "location": "uri"
           },
           "UploadId": {
+            "shape_name": "MultipartUploadId",
             "type": "string",
+            "documentation": "Upload ID identifying the multipart upload whose parts are being listed.",
             "required": true,
-            "location": "uri",
-            "documentation": "Upload ID identifying the multipart upload whose parts are being listed."
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "ListPartsOutput",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
             "documentation": "Name of the bucket to which the multipart upload was initiated."
           },
+          "Key": {
+            "shape_name": "ObjectKey",
+            "type": "string",
+            "documentation": "Object key for which the multipart upload was initiated."
+          },
+          "UploadId": {
+            "shape_name": "MultipartUploadId",
+            "type": "string",
+            "documentation": "Upload ID identifying the multipart upload whose parts are being listed."
+          },
+          "PartNumberMarker": {
+            "shape_name": "PartNumberMarker",
+            "type": "integer",
+            "documentation": "Part number after which listing begins."
+          },
+          "NextPartNumberMarker": {
+            "shape_name": "NextPartNumberMarker",
+            "type": "integer",
+            "documentation": "When a list is truncated, this element specifies the last part in the list, as well as the value to use for the part-number-marker request parameter in a subsequent request."
+          },
+          "MaxParts": {
+            "shape_name": "MaxParts",
+            "type": "integer",
+            "documentation": "Maximum number of parts that were allowed in the response."
+          },
+          "IsTruncated": {
+            "shape_name": "IsTruncated",
+            "type": "boolean",
+            "documentation": "Indicates whether the returned list of parts is truncated."
+          },
+          "Parts": {
+            "shape_name": "Parts",
+            "type": "list",
+            "members": {
+              "shape_name": "Part",
+              "type": "structure",
+              "members": {
+                "PartNumber": {
+                  "shape_name": "PartNumber",
+                  "type": "integer",
+                  "documentation": "Part number identifying the part."
+                },
+                "LastModified": {
+                  "shape_name": "LastModified",
+                  "type": "timestamp",
+                  "documentation": "Date and time at which the part was uploaded."
+                },
+                "ETag": {
+                  "shape_name": "ETag",
+                  "type": "string",
+                  "documentation": "Entity tag returned when the part was uploaded."
+                },
+                "Size": {
+                  "shape_name": "Size",
+                  "type": "integer",
+                  "documentation": "Size of the uploaded part data."
+                }
+              },
+              "documentation": null
+            },
+            "flattened": true,
+            "documentation": null,
+            "xmlname": "Part"
+          },
           "Initiator": {
+            "shape_name": "Initiator",
             "type": "structure",
             "members": {
-              "DisplayName": {
-                "type": "string",
-                "documentation": "Name of the Principal."
-              },
               "ID": {
+                "shape_name": "ID",
                 "type": "string",
                 "documentation": "If the principal is an AWS account, it provides the Canonical User ID. If the principal is an IAM User, it provides a user ARN value."
+              },
+              "DisplayName": {
+                "shape_name": "DisplayName",
+                "type": "string",
+                "documentation": "Name of the Principal."
               }
             },
             "documentation": "Identifies who initiated the multipart upload."
           },
-          "IsTruncated": {
-            "type": "boolean",
-            "documentation": "Indicates whether the returned list of parts is truncated."
-          },
-          "Key": {
-            "type": "string",
-            "documentation": "Object key for which the multipart upload was initiated."
-          },
-          "MaxParts": {
-            "type": "integer",
-            "documentation": "Maximum number of parts that were allowed in the response."
-          },
-          "NextPartNumberMarker": {
-            "type": "integer",
-            "documentation": "When a list is truncated, this element specifies the last part in the list, as well as the value to use for the part-number-marker request parameter in a subsequent request."
-          },
           "Owner": {
+            "shape_name": "Owner",
             "type": "structure",
             "members": {
               "DisplayName": {
-                "type": "string"
+                "shape_name": "DisplayName",
+                "type": "string",
+                "documentation": null
               },
               "ID": {
-                "type": "string"
-              }
-            }
-          },
-          "PartNumberMarker": {
-            "type": "integer",
-            "documentation": "Part number after which listing begins."
-          },
-          "Parts": {
-            "type": "list",
-            "xmlname": "Part",
-            "members": {
-              "type": "structure",
-              "members": {
-                "ETag": {
-                  "type": "string",
-                  "documentation": "Entity tag returned when the part was uploaded."
-                },
-                "LastModified": {
-                  "type": "timestamp",
-                  "documentation": "Date and time at which the part was uploaded."
-                },
-                "PartNumber": {
-                  "type": "integer",
-                  "documentation": "Part number identifying the part."
-                },
-                "Size": {
-                  "type": "integer",
-                  "documentation": "Size of the uploaded part data."
-                }
+                "shape_name": "ID",
+                "type": "string",
+                "documentation": null
               }
             },
-            "flattened": true
+            "documentation": null
           },
           "StorageClass": {
+            "shape_name": "StorageClass",
             "type": "string",
             "enum": [
               "STANDARD",
@@ -2918,18 +3620,15 @@
               "GLACIER"
             ],
             "documentation": "The class of storage used to store the object."
-          },
-          "UploadId": {
-            "type": "string",
-            "documentation": "Upload ID identifying the multipart upload whose parts are being listed."
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html",
-      "documentation": "Lists the parts that have been uploaded for a specific multipart upload."
+      "documentation": "Lists the parts that have been uploaded for a specific multipart upload.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html"
     },
     "PutBucketAcl": {
       "name": "PutBucketAcl",
@@ -2938,71 +3637,79 @@
         "uri": "/{Bucket}?acl"
       },
       "input": {
+        "shape_name": "PutBucketAclRequest",
         "type": "structure",
         "members": {
           "ACL": {
+            "shape_name": "BucketCannedACL",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-acl",
             "enum": [
               "private",
               "public-read",
               "public-read-write",
-              "authenticated-read",
-              "bucket-owner-read",
-              "bucket-owner-full-control"
+              "authenticated-read"
             ],
-            "documentation": "The canned ACL to apply to the bucket."
+            "documentation": "The canned ACL to apply to the bucket.",
+            "location": "header",
+            "location_name": "x-amz-acl"
           },
           "AccessControlPolicy": {
+            "shape_name": "AccessControlPolicy",
             "type": "structure",
-            "payload": true,
             "members": {
               "Grants": {
+                "shape_name": "Grants",
                 "type": "list",
-                "xmlname": "AccessControlList",
                 "members": {
+                  "shape_name": "Grant",
                   "type": "structure",
-                  "xmlname": "Grant",
                   "members": {
                     "Grantee": {
-                      "xmlnamespace": {
-                        "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                        "prefix": "xsi"
-                      },
+                      "shape_name": "Grantee",
                       "type": "structure",
                       "members": {
                         "DisplayName": {
+                          "shape_name": "DisplayName",
                           "type": "string",
                           "documentation": "Screen name of the grantee."
                         },
                         "EmailAddress": {
+                          "shape_name": "EmailAddress",
                           "type": "string",
                           "documentation": "Email address of the grantee."
                         },
                         "ID": {
+                          "shape_name": "ID",
                           "type": "string",
                           "documentation": "The canonical user ID of the grantee."
                         },
                         "Type": {
+                          "shape_name": "Type",
                           "type": "string",
-                          "required": true,
-                          "xmlname": "xsi:type",
-                          "xmlattribute": true,
                           "enum": [
                             "CanonicalUser",
                             "AmazonCustomerByEmail",
                             "Group"
                           ],
-                          "documentation": "Type of grantee"
+                          "documentation": "Type of grantee",
+                          "required": true,
+                          "xmlattribute": true,
+                          "xmlname": "xsi:type"
                         },
                         "URI": {
+                          "shape_name": "URI",
                           "type": "string",
                           "documentation": "URI of the grantee group."
                         }
+                      },
+                      "documentation": null,
+                      "xmlnamespace": {
+                        "prefix": "xsi",
+                        "uri": "http://www.w3.org/2001/XMLSchema-instance"
                       }
                     },
                     "Permission": {
+                      "shape_name": "Permission",
                       "type": "string",
                       "enum": [
                         "FULL_CONTROL",
@@ -3013,71 +3720,92 @@
                       ],
                       "documentation": "Specifies the permission given to the grantee."
                     }
-                  }
+                  },
+                  "documentation": null,
+                  "xmlname": "Grant"
                 },
-                "documentation": "A list of grants."
+                "documentation": "A list of grants.",
+                "xmlname": "AccessControlList"
               },
               "Owner": {
+                "shape_name": "Owner",
                 "type": "structure",
                 "members": {
                   "DisplayName": {
-                    "type": "string"
+                    "shape_name": "DisplayName",
+                    "type": "string",
+                    "documentation": null
                   },
                   "ID": {
-                    "type": "string"
+                    "shape_name": "ID",
+                    "type": "string",
+                    "documentation": null
                   }
-                }
+                },
+                "documentation": null
               }
-            }
+            },
+            "documentation": null,
+            "payload": true
           },
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "GrantFullControl": {
+            "shape_name": "GrantFullControl",
             "type": "string",
+            "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-full-control",
-            "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."
+            "location_name": "x-amz-grant-full-control"
           },
           "GrantRead": {
+            "shape_name": "GrantRead",
             "type": "string",
+            "documentation": "Allows grantee to list the objects in the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-read",
-            "documentation": "Allows grantee to list the objects in the bucket."
+            "location_name": "x-amz-grant-read"
           },
           "GrantReadACP": {
+            "shape_name": "GrantReadACP",
             "type": "string",
+            "documentation": "Allows grantee to read the bucket ACL.",
             "location": "header",
-            "location_name": "x-amz-grant-read-acp",
-            "documentation": "Allows grantee to read the bucket ACL."
+            "location_name": "x-amz-grant-read-acp"
           },
           "GrantWrite": {
+            "shape_name": "GrantWrite",
             "type": "string",
+            "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-write",
-            "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket."
+            "location_name": "x-amz-grant-write"
           },
           "GrantWriteACP": {
+            "shape_name": "GrantWriteACP",
             "type": "string",
+            "documentation": "Allows grantee to write the ACL for the applicable bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-write-acp",
-            "documentation": "Allows grantee to write the ACL for the applicable bucket."
+            "location_name": "x-amz-grant-write-acp"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTacl.html",
-      "documentation": "Sets the permissions on a bucket using access control lists (ACL)."
+      "documentation": "Sets the permissions on a bucket using access control lists (ACL).",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTacl.html"
     },
     "PutBucketCors": {
       "name": "PutBucketCors",
@@ -3086,82 +3814,107 @@
         "uri": "/{Bucket}?cors"
       },
       "input": {
+        "shape_name": "PutBucketCorsRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "CORSConfiguration": {
+            "shape_name": "CORSConfiguration",
             "type": "structure",
-            "payload": true,
             "members": {
               "CORSRules": {
+                "shape_name": "CORSRules",
                 "type": "list",
-                "xmlname": "CORSRule",
                 "members": {
+                  "shape_name": "CORSRule",
                   "type": "structure",
                   "members": {
                     "AllowedHeaders": {
+                      "shape_name": "AllowedHeaders",
                       "type": "list",
-                      "xmlname": "AllowedHeader",
                       "members": {
-                        "type": "string"
+                        "shape_name": "AllowedHeader",
+                        "type": "string",
+                        "documentation": null
                       },
+                      "flattened": true,
                       "documentation": "Specifies which headers are allowed in a pre-flight OPTIONS request.",
-                      "flattened": true
+                      "xmlname": "AllowedHeader"
                     },
                     "AllowedMethods": {
+                      "shape_name": "AllowedMethods",
                       "type": "list",
-                      "xmlname": "AllowedMethod",
                       "members": {
-                        "type": "string"
+                        "shape_name": "AllowedMethod",
+                        "type": "string",
+                        "documentation": null
                       },
+                      "flattened": true,
                       "documentation": "Identifies HTTP methods that the domain/origin specified in the rule is allowed to execute.",
-                      "flattened": true
+                      "xmlname": "AllowedMethod"
                     },
                     "AllowedOrigins": {
+                      "shape_name": "AllowedOrigins",
                       "type": "list",
-                      "xmlname": "AllowedOrigin",
                       "members": {
-                        "type": "string"
+                        "shape_name": "AllowedOrigin",
+                        "type": "string",
+                        "documentation": null
                       },
+                      "flattened": true,
                       "documentation": "One or more origins you want customers to be able to access the bucket from.",
-                      "flattened": true
+                      "xmlname": "AllowedOrigin"
                     },
                     "ExposeHeaders": {
+                      "shape_name": "ExposeHeaders",
                       "type": "list",
-                      "xmlname": "ExposeHeader",
                       "members": {
-                        "type": "string"
+                        "shape_name": "ExposeHeader",
+                        "type": "string",
+                        "documentation": null
                       },
+                      "flattened": true,
                       "documentation": "One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript XMLHttpRequest object).",
-                      "flattened": true
+                      "xmlname": "ExposeHeader"
                     },
                     "MaxAgeSeconds": {
+                      "shape_name": "MaxAgeSeconds",
                       "type": "integer",
                       "documentation": "The time in seconds that your browser is to cache the preflight response for the specified resource."
                     }
-                  }
+                  },
+                  "documentation": null
                 },
-                "flattened": true
+                "flattened": true,
+                "documentation": null,
+                "xmlname": "CORSRule"
               }
-            }
+            },
+            "documentation": null,
+            "payload": true
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTcors.html",
-      "documentation": "Sets the cors configuration for a bucket."
+      "documentation": "Sets the cors configuration for a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTcors.html"
     },
     "PutBucketLifecycle": {
       "name": "PutBucketLifecycle",
@@ -3170,74 +3923,90 @@
         "uri": "/{Bucket}?lifecycle"
       },
       "input": {
+        "shape_name": "PutBucketLifecycleRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "LifecycleConfiguration": {
+            "shape_name": "LifecycleConfiguration",
             "type": "structure",
-            "payload": true,
             "members": {
               "Rules": {
+                "shape_name": "Rules",
                 "type": "list",
-                "required": true,
-                "xmlname": "Rule",
                 "members": {
+                  "shape_name": "Rule",
                   "type": "structure",
                   "members": {
                     "Expiration": {
+                      "shape_name": "LifecycleExpiration",
                       "type": "structure",
                       "members": {
                         "Date": {
+                          "shape_name": "Date",
                           "type": "timestamp",
                           "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                           "timestamp_format": "iso8601"
                         },
                         "Days": {
+                          "shape_name": "Days",
                           "type": "integer",
                           "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                         }
-                      }
+                      },
+                      "documentation": null
                     },
                     "ID": {
+                      "shape_name": "ID",
                       "type": "string",
                       "documentation": "Unique identifier for the rule. The value cannot be longer than 255 characters."
                     },
                     "Prefix": {
+                      "shape_name": "Prefix",
                       "type": "string",
-                      "required": true,
-                      "documentation": "Prefix identifying one or more objects to which the rule applies."
+                      "documentation": "Prefix identifying one or more objects to which the rule applies.",
+                      "required": true
                     },
                     "Status": {
+                      "shape_name": "ExpirationStatus",
                       "type": "string",
-                      "required": true,
                       "enum": [
                         "Enabled",
                         "Disabled"
                       ],
-                      "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied."
+                      "documentation": "If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied.",
+                      "required": true
                     },
                     "Transition": {
+                      "shape_name": "Transition",
                       "type": "structure",
                       "members": {
                         "Date": {
+                          "shape_name": "Date",
                           "type": "timestamp",
                           "documentation": "Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.",
                           "timestamp_format": "iso8601"
                         },
                         "Days": {
+                          "shape_name": "Days",
                           "type": "integer",
                           "documentation": "Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."
                         },
                         "StorageClass": {
+                          "shape_name": "StorageClass",
                           "type": "string",
                           "enum": [
                             "STANDARD",
@@ -3246,22 +4015,30 @@
                           ],
                           "documentation": "The class of storage used to store the object."
                         }
-                      }
+                      },
+                      "documentation": null
                     }
-                  }
+                  },
+                  "documentation": null
                 },
-                "flattened": true
+                "flattened": true,
+                "documentation": null,
+                "required": true,
+                "xmlname": "Rule"
               }
-            }
+            },
+            "documentation": null,
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html",
-      "documentation": "Sets lifecycle configuration for your bucket. If a lifecycle configuration exists, it replaces it."
+      "documentation": "Sets lifecycle configuration for your bucket. If a lifecycle configuration exists, it replaces it.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html"
     },
     "PutBucketLogging": {
       "name": "PutBucketLogging",
@@ -3270,95 +4047,125 @@
         "uri": "/{Bucket}?logging"
       },
       "input": {
+        "shape_name": "PutBucketLoggingRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "BucketLoggingStatus": {
+            "shape_name": "BucketLoggingStatus",
             "type": "structure",
-            "payload": true,
-            "required": true,
             "members": {
               "LoggingEnabled": {
+                "shape_name": "LoggingEnabled",
                 "type": "structure",
                 "members": {
                   "TargetBucket": {
+                    "shape_name": "TargetBucket",
                     "type": "string",
                     "documentation": "Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own, including the same bucket that is being logged. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case you should choose a different TargetPrefix for each source bucket so that the delivered log files can be distinguished by key."
                   },
                   "TargetGrants": {
+                    "shape_name": "TargetGrants",
                     "type": "list",
                     "members": {
+                      "shape_name": "TargetGrant",
                       "type": "structure",
-                      "xmlname": "Grant",
                       "members": {
                         "Grantee": {
-                          "xmlnamespace": {
-                            "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                            "prefix": "xsi"
-                          },
+                          "shape_name": "Grantee",
                           "type": "structure",
                           "members": {
                             "DisplayName": {
+                              "shape_name": "DisplayName",
                               "type": "string",
                               "documentation": "Screen name of the grantee."
                             },
                             "EmailAddress": {
+                              "shape_name": "EmailAddress",
                               "type": "string",
                               "documentation": "Email address of the grantee."
                             },
                             "ID": {
+                              "shape_name": "ID",
                               "type": "string",
                               "documentation": "The canonical user ID of the grantee."
                             },
                             "Type": {
+                              "shape_name": "Type",
                               "type": "string",
-                              "required": true,
-                              "xmlname": "xsi:type",
-                              "xmlattribute": true,
                               "enum": [
                                 "CanonicalUser",
                                 "AmazonCustomerByEmail",
                                 "Group"
                               ],
-                              "documentation": "Type of grantee"
+                              "documentation": "Type of grantee",
+                              "required": true,
+                              "xmlattribute": true,
+                              "xmlname": "xsi:type"
                             },
                             "URI": {
+                              "shape_name": "URI",
                               "type": "string",
                               "documentation": "URI of the grantee group."
                             }
+                          },
+                          "documentation": null,
+                          "xmlnamespace": {
+                            "prefix": "xsi",
+                            "uri": "http://www.w3.org/2001/XMLSchema-instance"
                           }
                         },
                         "Permission": {
-                          "type": "string"
+                          "shape_name": "BucketLogsPermission",
+                          "type": "string",
+                          "enum": [
+                            "FULL_CONTROL",
+                            "READ",
+                            "WRITE"
+                          ],
+                          "documentation": "Logging permissions assigned to the Grantee for the bucket."
                         }
-                      }
-                    }
+                      },
+                      "documentation": null,
+                      "xmlname": "Grant"
+                    },
+                    "documentation": null
                   },
                   "TargetPrefix": {
+                    "shape_name": "TargetPrefix",
                     "type": "string",
                     "documentation": "This element lets you specify a prefix for the keys that the log files will be stored under."
                   }
-                }
+                },
+                "documentation": null
               }
-            }
+            },
+            "documentation": null,
+            "required": true,
+            "payload": true
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html",
-      "documentation": "Set the logging parameters for a bucket and to specify permissions for who can view and modify the logging parameters. To set the logging status of a bucket, you must be the bucket owner."
+      "documentation": "Set the logging parameters for a bucket and to specify permissions for who can view and modify the logging parameters. To set the logging status of a bucket, you must be the bucket owner.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html"
     },
     "PutBucketNotification": {
       "name": "PutBucketNotification",
@@ -3367,28 +4174,33 @@
         "uri": "/{Bucket}?notification"
       },
       "input": {
+        "shape_name": "PutBucketNotificationRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "NotificationConfiguration": {
+            "shape_name": "NotificationConfiguration",
             "type": "structure",
-            "payload": true,
-            "required": true,
             "members": {
               "TopicConfiguration": {
+                "shape_name": "TopicConfiguration",
                 "type": "structure",
-                "required": true,
                 "members": {
                   "Event": {
+                    "shape_name": "Event",
                     "type": "string",
                     "enum": [
                       "s3:ReducedRedundancyLostObject"
@@ -3396,21 +4208,28 @@
                     "documentation": "Bucket event for which to send notifications."
                   },
                   "Topic": {
+                    "shape_name": "Topic",
                     "type": "string",
                     "documentation": "Amazon SNS topic to which Amazon S3 will publish a message to report the specified events for the bucket."
                   }
-                }
+                },
+                "documentation": null,
+                "required": true
               }
-            }
+            },
+            "documentation": null,
+            "required": true,
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html",
-      "documentation": "Enables notifications of specified events for a bucket."
+      "documentation": "Enables notifications of specified events for a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html"
     },
     "PutBucketPolicy": {
       "name": "PutBucketPolicy",
@@ -3419,32 +4238,39 @@
         "uri": "/{Bucket}?policy"
       },
       "input": {
+        "shape_name": "PutBucketPolicyRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "Policy": {
+            "shape_name": "Policy",
             "type": "string",
-            "payload": true,
+            "documentation": "The bucket policy as a JSON document.",
             "required": true,
-            "documentation": "The bucket policy as a JSON document."
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTpolicy.html",
-      "documentation": "Replaces a policy on a bucket. If the bucket already has a policy, the one in this request completely replaces it."
+      "documentation": "Replaces a policy on a bucket. If the bucket already has a policy, the one in this request completely replaces it.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTpolicy.html"
     },
     "PutBucketRequestPayment": {
       "name": "PutBucketRequestPayment",
@@ -3453,42 +4279,51 @@
         "uri": "/{Bucket}?requestPayment"
       },
       "input": {
+        "shape_name": "PutBucketRequestPaymentRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "RequestPaymentConfiguration": {
+            "shape_name": "RequestPaymentConfiguration",
             "type": "structure",
-            "payload": true,
-            "required": true,
             "members": {
               "Payer": {
+                "shape_name": "Payer",
                 "type": "string",
-                "required": true,
                 "enum": [
                   "Requester",
                   "BucketOwner"
                 ],
-                "documentation": "Specifies who pays for the download and request fees."
+                "documentation": "Specifies who pays for the download and request fees.",
+                "required": true
               }
-            }
+            },
+            "documentation": null,
+            "required": true,
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentPUT.html",
-      "documentation": "Sets the request payment configuration for a bucket. By default, the bucket owner pays for downloads from the bucket. This configuration parameter enables the bucket owner (only) to specify that the person requesting the download will be charged for the download."
+      "documentation": "Sets the request payment configuration for a bucket. By default, the bucket owner pays for downloads from the bucket. This configuration parameter enables the bucket owner (only) to specify that the person requesting the download will be charged for the download.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTrequestPaymentPUT.html"
     },
     "PutBucketTagging": {
       "name": "PutBucketTagging",
@@ -3497,54 +4332,67 @@
         "uri": "/{Bucket}?tagging"
       },
       "input": {
+        "shape_name": "PutBucketTaggingRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "Tagging": {
+            "shape_name": "Tagging",
             "type": "structure",
-            "payload": true,
-            "required": true,
             "members": {
               "TagSet": {
+                "shape_name": "TagSet",
                 "type": "list",
-                "required": true,
                 "members": {
+                  "shape_name": "Tag",
                   "type": "structure",
-                  "required": true,
-                  "xmlname": "Tag",
                   "members": {
                     "Key": {
+                      "shape_name": "ObjectKey",
                       "type": "string",
-                      "required": true,
-                      "documentation": "Name of the tag."
+                      "documentation": "Name of the tag.",
+                      "required": true
                     },
                     "Value": {
+                      "shape_name": "Value",
                       "type": "string",
-                      "required": true,
-                      "documentation": "Value of the tag."
+                      "documentation": "Value of the tag.",
+                      "required": true
                     }
-                  }
-                }
+                  },
+                  "documentation": null,
+                  "xmlname": "Tag"
+                },
+                "documentation": null,
+                "required": true
               }
-            }
+            },
+            "documentation": null,
+            "required": true,
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTtagging.html",
-      "documentation": "Sets the tags for a bucket."
+      "documentation": "Sets the tags for a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTtagging.html"
     },
     "PutBucketVersioning": {
       "name": "PutBucketVersioning",
@@ -3553,30 +4401,36 @@
         "uri": "/{Bucket}?versioning"
       },
       "input": {
+        "shape_name": "PutBucketVersioningRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "MFA": {
+            "shape_name": "MFA",
             "type": "string",
+            "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device.",
             "location": "header",
-            "location_name": "x-amz-mfa",
-            "documentation": "The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."
+            "location_name": "x-amz-mfa"
           },
           "VersioningConfiguration": {
+            "shape_name": "VersioningConfiguration",
             "type": "structure",
-            "payload": true,
-            "required": true,
             "members": {
-              "MfaDelete": {
+              "MFADelete": {
+                "shape_name": "MFADelete",
                 "type": "string",
                 "enum": [
                   "Enabled",
@@ -3585,6 +4439,7 @@
                 "documentation": "Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."
               },
               "Status": {
+                "shape_name": "BucketVersioningStatus",
                 "type": "string",
                 "enum": [
                   "Enabled",
@@ -3592,16 +4447,20 @@
                 ],
                 "documentation": "The versioning state of the bucket."
               }
-            }
+            },
+            "documentation": null,
+            "required": true,
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTVersioningStatus.html",
-      "documentation": "Sets the versioning state of an existing bucket. To set the versioning state, you must be the bucket owner."
+      "documentation": "Sets the versioning state of an existing bucket. To set the versioning state, you must be the bucket owner.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTVersioningStatus.html"
     },
     "PutBucketWebsite": {
       "name": "PutBucketWebsite",
@@ -3610,52 +4469,65 @@
         "uri": "/{Bucket}?website"
       },
       "input": {
+        "shape_name": "PutBucketWebsiteRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "WebsiteConfiguration": {
+            "shape_name": "WebsiteConfiguration",
             "type": "structure",
-            "payload": true,
-            "required": true,
             "members": {
               "ErrorDocument": {
+                "shape_name": "ErrorDocument",
                 "type": "structure",
                 "members": {
                   "Key": {
+                    "shape_name": "ObjectKey",
                     "type": "string",
-                    "required": true,
-                    "documentation": "The object key name to use when a 4XX class error occurs."
+                    "documentation": "The object key name to use when a 4XX class error occurs.",
+                    "required": true
                   }
-                }
+                },
+                "documentation": null
               },
               "IndexDocument": {
+                "shape_name": "IndexDocument",
                 "type": "structure",
                 "members": {
                   "Suffix": {
+                    "shape_name": "Suffix",
                     "type": "string",
-                    "required": true,
-                    "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character."
+                    "documentation": "A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character.",
+                    "required": true
                   }
-                }
+                },
+                "documentation": null
               },
               "RedirectAllRequestsTo": {
+                "shape_name": "RedirectAllRequestsTo",
                 "type": "structure",
                 "members": {
                   "HostName": {
+                    "shape_name": "HostName",
                     "type": "string",
-                    "required": true,
-                    "documentation": "Name of the host where requests will be redirected."
+                    "documentation": "Name of the host where requests will be redirected.",
+                    "required": true
                   },
                   "Protocol": {
+                    "shape_name": "Protocol",
                     "type": "string",
                     "enum": [
                       "http",
@@ -3663,22 +4535,27 @@
                     ],
                     "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
                   }
-                }
+                },
+                "documentation": null
               },
               "RoutingRules": {
+                "shape_name": "RoutingRules",
                 "type": "list",
                 "members": {
+                  "shape_name": "RoutingRule",
                   "type": "structure",
-                  "xmlname": "RoutingRule",
                   "members": {
                     "Condition": {
+                      "shape_name": "Condition",
                       "type": "structure",
                       "members": {
                         "HttpErrorCodeReturnedEquals": {
+                          "shape_name": "HttpErrorCodeReturnedEquals",
                           "type": "string",
                           "documentation": "The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element Condition is specified and sibling KeyPrefixEquals is not specified. If both are specified, then both must be true for the redirect to be applied."
                         },
                         "KeyPrefixEquals": {
+                          "shape_name": "KeyPrefixEquals",
                           "type": "string",
                           "documentation": "The object key name prefix when the redirect is applied. For example, to redirect requests for ExamplePage.html, the key prefix will be ExamplePage.html. To redirect request for all pages with the prefix docs/, the key prefix will be /docs, which identifies all objects in the docs/ folder. Required when the parent element Condition is specified and sibling HttpErrorCodeReturnedEquals is not specified. If both conditions are specified, both must be true for the redirect to be applied."
                         }
@@ -3686,18 +4563,21 @@
                       "documentation": "A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the /docs folder, redirect to the /documents folder. 2. If request results in HTTP error 4xx, redirect request to another host where you might process the error."
                     },
                     "Redirect": {
+                      "shape_name": "Redirect",
                       "type": "structure",
-                      "required": true,
                       "members": {
                         "HostName": {
+                          "shape_name": "HostName",
                           "type": "string",
                           "documentation": "The host name to use in the redirect request."
                         },
                         "HttpRedirectCode": {
+                          "shape_name": "HttpRedirectCode",
                           "type": "string",
                           "documentation": "The HTTP redirect code to use on the response. Not required if one of the siblings is present."
                         },
                         "Protocol": {
+                          "shape_name": "Protocol",
                           "type": "string",
                           "enum": [
                             "http",
@@ -3706,29 +4586,39 @@
                           "documentation": "Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."
                         },
                         "ReplaceKeyPrefixWith": {
+                          "shape_name": "ReplaceKeyPrefixWith",
                           "type": "string",
                           "documentation": "The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix docs/ (objects in the docs/ folder) to documents/, you can set a condition block with KeyPrefixEquals set to docs/ and in the Redirect set ReplaceKeyPrefixWith to /documents. Not required if one of the siblings is present. Can be present only if ReplaceKeyWith is not provided."
                         },
                         "ReplaceKeyWith": {
+                          "shape_name": "ReplaceKeyWith",
                           "type": "string",
                           "documentation": "The specific object key to use in the redirect request. For example, redirect request to error.html. Not required if one of the sibling is present. Can be present only if ReplaceKeyPrefixWith is not provided."
                         }
                       },
-                      "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return."
+                      "documentation": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return.",
+                      "required": true
                     }
-                  }
-                }
+                  },
+                  "documentation": null,
+                  "xmlname": "RoutingRule"
+                },
+                "documentation": null
               }
-            }
+            },
+            "documentation": null,
+            "required": true,
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html",
-      "documentation": "Set the website configuration for a bucket."
+      "documentation": "Set the website configuration for a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html"
     },
     "PutObject": {
       "name": "PutObject",
@@ -3737,12 +4627,12 @@
         "uri": "/{Bucket}/{Key}"
       },
       "input": {
+        "shape_name": "PutObjectRequest",
         "type": "structure",
         "members": {
           "ACL": {
+            "shape_name": "ObjectCannedACL",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-acl",
             "enum": [
               "private",
               "public-read",
@@ -3751,91 +4641,112 @@
               "bucket-owner-read",
               "bucket-owner-full-control"
             ],
-            "documentation": "The canned ACL to apply to the object."
+            "documentation": "The canned ACL to apply to the object.",
+            "location": "header",
+            "location_name": "x-amz-acl"
           },
           "Body": {
+            "shape_name": "Body",
             "type": "blob",
+            "documentation": null,
             "payload": true,
             "streaming": true
           },
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "CacheControl": {
+            "shape_name": "CacheControl",
             "type": "string",
+            "documentation": "Specifies caching behavior along the request/reply chain.",
             "location": "header",
-            "location_name": "Cache-Control",
-            "documentation": "Specifies caching behavior along the request/reply chain."
+            "location_name": "Cache-Control"
           },
           "ContentDisposition": {
+            "shape_name": "ContentDisposition",
             "type": "string",
+            "documentation": "Specifies presentational information for the object.",
             "location": "header",
-            "location_name": "Content-Disposition",
-            "documentation": "Specifies presentational information for the object."
+            "location_name": "Content-Disposition"
           },
           "ContentEncoding": {
+            "shape_name": "ContentEncoding",
             "type": "string",
+            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.",
             "location": "header",
-            "location_name": "Content-Encoding",
-            "documentation": "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."
+            "location_name": "Content-Encoding"
           },
           "ContentLanguage": {
+            "shape_name": "ContentLanguage",
             "type": "string",
+            "documentation": "The language the content is in.",
             "location": "header",
-            "location_name": "Content-Language",
-            "documentation": "The language the content is in."
+            "location_name": "Content-Language"
           },
           "ContentLength": {
+            "shape_name": "ContentLength",
             "type": "integer",
+            "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.",
             "location": "header",
-            "location_name": "Content-Length",
-            "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically."
+            "location_name": "Content-Length"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "ContentType": {
+            "shape_name": "ContentType",
             "type": "string",
+            "documentation": "A standard MIME type describing the format of the object data.",
             "location": "header",
-            "location_name": "Content-Type",
-            "documentation": "A standard MIME type describing the format of the object data."
+            "location_name": "Content-Type"
           },
           "Expires": {
+            "shape_name": "Expires",
             "type": "timestamp",
+            "documentation": "The date and time at which the object is no longer cacheable.",
             "location": "header",
-            "location_name": "Expires",
-            "documentation": "The date and time at which the object is no longer cacheable."
+            "location_name": "Expires"
           },
           "GrantFullControl": {
+            "shape_name": "GrantFullControl",
             "type": "string",
+            "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.",
             "location": "header",
-            "location_name": "x-amz-grant-full-control",
-            "documentation": "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."
+            "location_name": "x-amz-grant-full-control"
           },
           "GrantRead": {
+            "shape_name": "GrantRead",
             "type": "string",
+            "documentation": "Allows grantee to read the object data and its metadata.",
             "location": "header",
-            "location_name": "x-amz-grant-read",
-            "documentation": "Allows grantee to read the object data and its metadata."
+            "location_name": "x-amz-grant-read"
           },
           "GrantReadACP": {
+            "shape_name": "GrantReadACP",
             "type": "string",
+            "documentation": "Allows grantee to read the object ACL.",
             "location": "header",
-            "location_name": "x-amz-grant-read-acp",
-            "documentation": "Allows grantee to read the object ACL."
+            "location_name": "x-amz-grant-read-acp"
           },
           "GrantWriteACP": {
+            "shape_name": "GrantWriteACP",
             "type": "string",
+            "documentation": "Allows grantee to write the ACL for the applicable object.",
             "location": "header",
-            "location_name": "x-amz-grant-write-acp",
-            "documentation": "Allows grantee to write the ACL for the applicable object."
+            "location_name": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
@@ -3843,81 +4754,90 @@
             "type": "map",
             "location": "header",
             "location_name": "x-amz-meta-",
+            "keys": {
+              "type": "string",
+              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
+            },
             "members": {
               "type": "string",
               "documentation": "The metadata value."
             },
-            "documentation": "A map of metadata to store with the object in S3.",
-            "keys": {
-              "type": "string",
-              "documentation": "The metadata key. This will be prefixed with x-amz-meta- before sending to S3 as a header. The x-amz-meta- header will be stripped from the key when retrieving headers."
-            }
+            "documentation": "A map of metadata to store with the object in S3."
           },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           },
           "StorageClass": {
+            "shape_name": "StorageClassOptions",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-storage-class",
             "enum": [
               "STANDARD",
               "REDUCED_REDUNDANCY"
             ],
-            "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'."
+            "documentation": "The type of storage to use for the object. Defaults to 'STANDARD'.",
+            "location": "header",
+            "location_name": "x-amz-storage-class"
           },
           "WebsiteRedirectLocation": {
+            "shape_name": "WebsiteRedirectLocation",
             "type": "string",
+            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.",
             "location": "header",
-            "location_name": "x-amz-website-redirect-location",
-            "documentation": "If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."
+            "location_name": "x-amz-website-redirect-location"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "PutObjectOutput",
         "type": "structure",
         "members": {
-          "ETag": {
-            "type": "string",
-            "location": "header",
-            "location_name": "ETag",
-            "documentation": "Entity tag for the uploaded object."
-          },
           "Expiration": {
+            "shape_name": "Expiration",
             "type": "timestamp",
+            "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded.",
             "location": "header",
-            "location_name": "x-amz-expiration",
-            "documentation": "If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded."
+            "location_name": "x-amz-expiration"
+          },
+          "ETag": {
+            "shape_name": "ETag",
+            "type": "string",
+            "documentation": "Entity tag for the uploaded object.",
+            "location": "header",
+            "location_name": "ETag"
           },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           },
           "VersionId": {
+            "shape_name": "ObjectVersionId",
             "type": "string",
+            "documentation": "Version of the object.",
             "location": "header",
-            "location_name": "x-amz-version-id",
-            "documentation": "Version of the object."
+            "location_name": "x-amz-version-id"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html",
-      "documentation": "Adds an object to a bucket."
+      "documentation": "Adds an object to a bucket.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html"
     },
     "PutObjectAcl": {
       "name": "PutObjectAcl",
@@ -3926,12 +4846,12 @@
         "uri": "/{Bucket}/{Key}?acl"
       },
       "input": {
+        "shape_name": "PutObjectAclRequest",
         "type": "structure",
         "members": {
           "ACL": {
+            "shape_name": "ObjectCannedACL",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-acl",
             "enum": [
               "private",
               "public-read",
@@ -3940,57 +4860,67 @@
               "bucket-owner-read",
               "bucket-owner-full-control"
             ],
-            "documentation": "The canned ACL to apply to the bucket."
+            "documentation": "The canned ACL to apply to the object.",
+            "location": "header",
+            "location_name": "x-amz-acl"
           },
           "AccessControlPolicy": {
+            "shape_name": "AccessControlPolicy",
             "type": "structure",
-            "payload": true,
             "members": {
               "Grants": {
+                "shape_name": "Grants",
                 "type": "list",
-                "xmlname": "AccessControlList",
                 "members": {
+                  "shape_name": "Grant",
                   "type": "structure",
-                  "xmlname": "Grant",
                   "members": {
                     "Grantee": {
-                      "xmlnamespace": {
-                        "uri": "http://www.w3.org/2001/XMLSchema-instance",
-                        "prefix": "xsi"
-                      },
+                      "shape_name": "Grantee",
                       "type": "structure",
                       "members": {
                         "DisplayName": {
+                          "shape_name": "DisplayName",
                           "type": "string",
                           "documentation": "Screen name of the grantee."
                         },
                         "EmailAddress": {
+                          "shape_name": "EmailAddress",
                           "type": "string",
                           "documentation": "Email address of the grantee."
                         },
                         "ID": {
+                          "shape_name": "ID",
                           "type": "string",
                           "documentation": "The canonical user ID of the grantee."
                         },
                         "Type": {
+                          "shape_name": "Type",
                           "type": "string",
-                          "required": true,
-                          "xmlname": "xsi:type",
-                          "xmlattribute": true,
                           "enum": [
                             "CanonicalUser",
                             "AmazonCustomerByEmail",
                             "Group"
                           ],
-                          "documentation": "Type of grantee"
+                          "documentation": "Type of grantee",
+                          "required": true,
+                          "xmlattribute": true,
+                          "xmlname": "xsi:type"
                         },
                         "URI": {
+                          "shape_name": "URI",
                           "type": "string",
                           "documentation": "URI of the grantee group."
                         }
+                      },
+                      "documentation": null,
+                      "xmlnamespace": {
+                        "prefix": "xsi",
+                        "uri": "http://www.w3.org/2001/XMLSchema-instance"
                       }
                     },
                     "Permission": {
+                      "shape_name": "Permission",
                       "type": "string",
                       "enum": [
                         "FULL_CONTROL",
@@ -4001,124 +4931,160 @@
                       ],
                       "documentation": "Specifies the permission given to the grantee."
                     }
-                  }
+                  },
+                  "documentation": null,
+                  "xmlname": "Grant"
                 },
-                "documentation": "A list of grants."
+                "documentation": "A list of grants.",
+                "xmlname": "AccessControlList"
               },
               "Owner": {
+                "shape_name": "Owner",
                 "type": "structure",
                 "members": {
                   "DisplayName": {
-                    "type": "string"
+                    "shape_name": "DisplayName",
+                    "type": "string",
+                    "documentation": null
                   },
                   "ID": {
-                    "type": "string"
+                    "shape_name": "ID",
+                    "type": "string",
+                    "documentation": null
                   }
-                }
+                },
+                "documentation": null
               }
-            }
+            },
+            "documentation": null,
+            "payload": true
           },
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "GrantFullControl": {
+            "shape_name": "GrantFullControl",
             "type": "string",
+            "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-full-control",
-            "documentation": "Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."
+            "location_name": "x-amz-grant-full-control"
           },
           "GrantRead": {
+            "shape_name": "GrantRead",
             "type": "string",
+            "documentation": "Allows grantee to list the objects in the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-read",
-            "documentation": "Allows grantee to list the objects in the bucket."
+            "location_name": "x-amz-grant-read"
           },
           "GrantReadACP": {
+            "shape_name": "GrantReadACP",
             "type": "string",
+            "documentation": "Allows grantee to read the bucket ACL.",
             "location": "header",
-            "location_name": "x-amz-grant-read-acp",
-            "documentation": "Allows grantee to read the bucket ACL."
+            "location_name": "x-amz-grant-read-acp"
           },
           "GrantWrite": {
+            "shape_name": "GrantWrite",
             "type": "string",
+            "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-write",
-            "documentation": "Allows grantee to create, overwrite, and delete any object in the bucket."
+            "location_name": "x-amz-grant-write"
           },
           "GrantWriteACP": {
+            "shape_name": "GrantWriteACP",
             "type": "string",
+            "documentation": "Allows grantee to write the ACL for the applicable bucket.",
             "location": "header",
-            "location_name": "x-amz-grant-write-acp",
-            "documentation": "Allows grantee to write the ACL for the applicable bucket."
+            "location_name": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
         {
           "shape_name": "NoSuchKey",
           "type": "structure",
+          "members": {
+          },
           "documentation": "The specified key does not exist."
         }
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html",
-      "documentation": "uses the acl subresource to set the access control list (ACL) permissions for an object that already exists in a bucket"
+      "documentation": "uses the acl subresource to set the access control list (ACL) permissions for an object that already exists in a bucket",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html"
     },
     "RestoreObject": {
       "name": "RestoreObject",
-      "alias": "PostObjectRestore",
       "http": {
         "method": "POST",
         "uri": "/{Bucket}/{Key}?restore"
       },
       "input": {
+        "shape_name": "RestoreObjectRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "RestoreRequest": {
+            "shape_name": "RestoreRequest",
             "type": "structure",
-            "payload": true,
             "members": {
               "Days": {
+                "shape_name": "Days",
                 "type": "integer",
-                "required": true,
-                "documentation": "Lifetime of the active copy in days"
+                "documentation": "Lifetime of the active copy in days",
+                "required": true
               }
-            }
+            },
+            "documentation": null,
+            "payload": true
           }
-        }
+        },
+        "documentation": null
       },
       "output": null,
       "errors": [
         {
           "shape_name": "ObjectAlreadyInActiveTierError",
           "type": "structure",
+          "members": {
+          },
           "documentation": "This operation is not allowed against this storage tier"
         }
       ],
+      "documentation": "Restores an archived copy of an object back into Amazon S3",
       "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectRestore.html",
-      "documentation": "Restores an archived copy of an object back into Amazon S3"
+      "alias": "PostObjectRestore"
     },
     "UploadPart": {
       "name": "UploadPart",
@@ -4127,74 +5093,90 @@
         "uri": "/{Bucket}/{Key}?partNumber={PartNumber}&uploadId={UploadId}"
       },
       "input": {
+        "shape_name": "UploadPartRequest",
         "type": "structure",
         "members": {
           "Body": {
+            "shape_name": "Body",
             "type": "blob",
+            "documentation": null,
             "payload": true,
             "streaming": true
           },
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "ContentLength": {
+            "shape_name": "ContentLength",
             "type": "integer",
+            "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.",
             "location": "header",
-            "location_name": "Content-Length",
-            "documentation": "Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically."
+            "location_name": "Content-Length"
           },
           "ContentMD5": {
+            "shape_name": "ContentMD5",
             "type": "string",
+            "documentation": null,
             "location": "header",
             "location_name": "Content-MD5"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "PartNumber": {
+            "shape_name": "PartNumber",
             "type": "integer",
+            "documentation": "Part number of part being uploaded.",
             "required": true,
-            "location": "uri",
-            "documentation": "Part number of part being uploaded."
+            "location": "uri"
           },
           "UploadId": {
+            "shape_name": "MultipartUploadId",
             "type": "string",
+            "documentation": "Upload ID identifying the multipart upload whose part is being uploaded.",
             "required": true,
-            "location": "uri",
-            "documentation": "Upload ID identifying the multipart upload whose part is being uploaded."
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "UploadPartOutput",
         "type": "structure",
         "members": {
-          "ETag": {
-            "type": "string",
-            "location": "header",
-            "location_name": "ETag",
-            "documentation": "Entity tag for the uploaded object."
-          },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
+          },
+          "ETag": {
+            "shape_name": "ETag",
+            "type": "string",
+            "documentation": "Entity tag for the uploaded object.",
+            "location": "header",
+            "location_name": "ETag"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html",
-      "documentation": "<p>Uploads a part in a multipart upload.</p><p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>"
+      "documentation": "<p>Uploads a part in a multipart upload.</p>\n<p><b>Note:</b> After you initiate multipart upload and upload one or more parts, you must either complete or abort multipart upload in order to stop getting charged for storage of the uploaded parts. Only after you either complete or abort multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts storage.</p>",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html"
     },
     "UploadPartCopy": {
       "name": "UploadPartCopy",
@@ -4203,110 +5185,131 @@
         "uri": "/{Bucket}/{Key}?partNumber={PartNumber}&uploadId={UploadId}"
       },
       "input": {
+        "shape_name": "UploadPartCopyRequest",
         "type": "structure",
         "members": {
           "Bucket": {
+            "shape_name": "BucketName",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "CopySource": {
+            "shape_name": "CopySource",
             "type": "string",
+            "pattern": "\\/.+\\/.+",
+            "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
             "required": true,
             "location": "header",
-            "location_name": "x-amz-copy-source",
-            "documentation": "The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.",
-            "pattern": "\\/.+\\/.+"
+            "location_name": "x-amz-copy-source"
           },
           "CopySourceIfMatch": {
+            "shape_name": "CopySourceIfMatch",
             "type": "timestamp",
+            "documentation": "Copies the object if its entity tag (ETag) matches the specified tag.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-match",
-            "documentation": "Copies the object if its entity tag (ETag) matches the specified tag."
+            "location_name": "x-amz-copy-source-if-match"
           },
           "CopySourceIfModifiedSince": {
+            "shape_name": "CopySourceIfModifiedSince",
             "type": "timestamp",
+            "documentation": "Copies the object if it has been modified since the specified time.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-modified-since",
-            "documentation": "Copies the object if it has been modified since the specified time."
+            "location_name": "x-amz-copy-source-if-modified-since"
           },
           "CopySourceIfNoneMatch": {
+            "shape_name": "CopySourceIfNoneMatch",
             "type": "timestamp",
+            "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-none-match",
-            "documentation": "Copies the object if its entity tag (ETag) is different than the specified ETag."
+            "location_name": "x-amz-copy-source-if-none-match"
           },
           "CopySourceIfUnmodifiedSince": {
+            "shape_name": "CopySourceIfUnmodifiedSince",
             "type": "timestamp",
+            "documentation": "Copies the object if it hasn't been modified since the specified time.",
             "location": "header",
-            "location_name": "x-amz-copy-source-if-unmodified-since",
-            "documentation": "Copies the object if it hasn't been modified since the specified time."
+            "location_name": "x-amz-copy-source-if-unmodified-since"
           },
           "CopySourceRange": {
+            "shape_name": "CopySourceRange",
             "type": "string",
+            "documentation": "The range of bytes to copy from the source object. The range value must use the form bytes=first-last, where the first and last are the zero-based byte offsets to copy. For example, bytes=0-9 indicates that you want to copy the first ten bytes of the source. You can copy a range only if the source object is greater than 5 GB.",
             "location": "header",
-            "location_name": "x-amz-copy-source-range",
-            "documentation": "The range of bytes to copy from the source object. The range value must use the form bytes=first-last, where the first and last are the zero-based byte offsets to copy. For example, bytes=0-9 indicates that you want to copy the first ten bytes of the source. You can copy a range only if the source object is greater than 5 GB."
+            "location_name": "x-amz-copy-source-range"
           },
           "Key": {
+            "shape_name": "ObjectKey",
             "type": "string",
+            "documentation": null,
             "required": true,
             "location": "uri"
           },
           "PartNumber": {
+            "shape_name": "PartNumber",
             "type": "integer",
+            "documentation": "Part number of part being copied.",
             "required": true,
-            "location": "uri",
-            "documentation": "Part number of part being copied."
+            "location": "uri"
           },
           "UploadId": {
+            "shape_name": "MultipartUploadId",
             "type": "string",
+            "documentation": "Upload ID identifying the multipart upload whose part is being copied.",
             "required": true,
-            "location": "uri",
-            "documentation": "Upload ID identifying the multipart upload whose part is being copied."
+            "location": "uri"
           }
-        }
+        },
+        "documentation": null
       },
       "output": {
         "shape_name": "UploadPartCopyOutput",
         "type": "structure",
         "members": {
+          "CopySourceVersionId": {
+            "shape_name": "CopySourceVersionId",
+            "type": "string",
+            "documentation": "The version of the source object that was copied, if you have enabled versioning on the source bucket.",
+            "location": "header",
+            "location_name": "x-amz-copy-source-version-id"
+          },
           "CopyPartResult": {
+            "shape_name": "CopyPartResult",
             "type": "structure",
-            "payload": true,
             "members": {
               "ETag": {
+                "shape_name": "ETag",
                 "type": "string",
                 "documentation": "Entity tag of the object."
               },
               "LastModified": {
+                "shape_name": "LastModified",
                 "type": "timestamp",
                 "documentation": "Date and time at which the object was uploaded."
               }
-            }
-          },
-          "CopySourceVersionId": {
-            "type": "string",
-            "location": "header",
-            "location_name": "x-amz-copy-source-version-id",
-            "documentation": "The version of the source object that was copied, if you have enabled versioning on the source bucket."
+            },
+            "documentation": null,
+            "payload": true
           },
           "ServerSideEncryption": {
+            "shape_name": "ServerSideEncryption",
             "type": "string",
-            "location": "header",
-            "location_name": "x-amz-server-side-encryption",
             "enum": [
               "AES256"
             ],
-            "documentation": "The Server-side encryption algorithm used when storing this object in S3."
+            "documentation": "The Server-side encryption algorithm used when storing this object in S3.",
+            "location": "header",
+            "location_name": "x-amz-server-side-encryption"
           }
-        }
+        },
+        "documentation": null
       },
       "errors": [
 
       ],
-      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html",
-      "documentation": "Uploads a part by copying data from an existing object as data source."
+      "documentation": "Uploads a part by copying data from an existing object as data source.",
+      "documentation_url": "http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html"
     }
   }
 }

--- a/tests/unit/response_parsing/xml/responses/s3-list-object-versions.json
+++ b/tests/unit/response_parsing/xml/responses/s3-list-object-versions.json
@@ -13,7 +13,7 @@
                 "ID": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
             }, 
             "IsLatest": true, 
-            "Size": "434234"
+            "Size": 434234
         }, 
         {
             "LastModified": "2009-10-10T17:50:30.000Z", 
@@ -26,7 +26,7 @@
                 "ID": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
             }, 
             "IsLatest": false, 
-            "Size": "166434"
+            "Size": 166434
         }, 
         {
             "LastModified": "2009-10-11T12:50:30.000Z", 
@@ -39,7 +39,7 @@
                 "ID": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
             }, 
             "IsLatest": false, 
-            "Size": "64"
+            "Size": 64
         }
     ], 
     "MaxKeys": 5, 

--- a/tests/unit/test_s3_operations.py
+++ b/tests/unit/test_s3_operations.py
@@ -42,8 +42,8 @@ XMLBODY5 = ('<BucketLoggingStatus><LoggingEnabled><TargetBucket>mybucketlogs'
             '</TargetGrants><TargetPrefix>mybucket-access_log-/</TargetPrefix>'
             '</LoggingEnabled></BucketLoggingStatus>')
 XMLBODY6 = ('<VersioningConfiguration>'
-            '<MfaDelete>Enabled</MfaDelete>'
             '<Status>Enabled</Status>'
+            '<MfaDelete>Enabled</MfaDelete>'
             '</VersioningConfiguration>')
 XMLBODY7 = ('<Delete><Object><Key>foobar</Key>'
            '</Object><Object><Key>fiebaz</Key></Object>'

--- a/tests/unit/test_translate.py
+++ b/tests/unit/test_translate.py
@@ -261,7 +261,26 @@ SERVICES = {
         }
       },
       "documentation": "This operation has been deprecated."
-    }
+    },
+    "RenameOperation": {
+      "input": {
+        "shape_name": "RenameOperation",
+        "type": "structure",
+        "members": {
+          "RenameMe": {
+            "shape_name": "RenameMe",
+            "type": "string",
+            "documentation": "blah blah blah blah",
+          },
+          "FieBaz": {
+            "shape_name": "fiebazType",
+            "type": "string",
+            "documentation": ""
+          }
+        }
+      },
+      "documentation": "This operation has been deprecated."
+    },
   }
 }
 
@@ -749,7 +768,7 @@ class TestReplacePartOfOperation(unittest.TestCase):
         self.assertEqual(list(sorted(new_model['operations'].keys())),
                          ['AssumeRole', 'DeprecatedOperation',
                           'DeprecatedOperation2', 'NoOutputOperation',
-                          'RealOperation'])
+                          'RealOperation', 'RenameOperation'])
         # But the name key attribute is left unchanged.
         self.assertEqual(new_model['operations']['RealOperation']['name'],
                          'RealOperation2013_02_04')
@@ -830,6 +849,23 @@ class TestFilteringOfDocumentation(unittest.TestCase):
         self.assertEqual(operation['documentation'], 'This is my  stuff')
         param = operation['input']['members']['FooBar']
         self.assertEqual(param['documentation'], 'blah blah blah blah')
+
+
+class TestRenameParams(unittest.TestCase):
+    def test_rename_param(self):
+        enhancements = {
+            'transformations': {
+                'renames': {
+                    'RenameOperation.input.members.RenameMe': 'BeenRenamed',
+                }
+            }
+        }
+        model = ModelFiles(SERVICES, regions={}, retry={},
+                           enhancements=enhancements)
+        new_model = translate(model)
+        arguments = new_model['operations']['RenameOperation']['input']['members']
+        self.assertNotIn('RenameMe', arguments)
+        self.assertIn('BeenRenamed', arguments)
 
 
 class TestWaiterDenormalization(unittest.TestCase):


### PR DESCRIPTION
This allows us to add handlers to response parsing.

Part of syncing with the upstream S3 model was handling the fact that `MfaDelete` was renamed locally.  To handle this, I added a new transformation that allows us to rename keys.  This should allow us to pull in updates from now on.
