### PR TITLE
Update ec2 docs for user data and base64 encoding

### DIFF
--- a/botocore/data/aws/ec2.json
+++ b/botocore/data/aws/ec2.json
@@ -18109,7 +18109,7 @@
                     "UserData": {
                         "shape_name": "String",
                         "type": "blob",
-                        "documentation": "\n    <p>The Base64-encoded MIME user data for the instances.</p>\n   "
+                        "documentation": "\n    <p>The user data for the instances.  You can specify the user data as a string, or if the user data contents are in a file, you can use file://filename.</p>\n   "
                     },
                     "InstanceType": {
                         "shape_name": "InstanceType",

--- a/services/ec2.extra.json
+++ b/services/ec2.extra.json
@@ -75,7 +75,8 @@
       "input": {
         "members": {
           "UserData": {
-            "type": "blob"
+            "type": "blob",
+            "documentation": "\n    <p>The user data for the instances.  You can specify the user data as a string, or if the user data contents are in a file, you can use file://filename.</p>\n   "
           },
           "NetworkInterfaces": {
             "members": {


### PR DESCRIPTION
Looks like we customize our model to be a blob type, but we
never updated the docs.  This has led to customer confusion.

Fixes aws/aws-cli#366
