### PR TITLE
Handle capitalized message key in errors

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -350,9 +350,10 @@ class JSONResponse(Response):
             error_type = self.value['__type']
             error = {'Type': error_type}
             del self.value['__type']
-            if 'message' in self.value:
-                error['Message'] = self.value['message']
-                del self.value['message']
+            for key in ['message', 'Message']:
+                if key in self.value:
+                    error['Message'] = self.value[key]
+                    del self.value[key]
             code = self._parse_code_from_type(error_type)
             error['Code'] = code
         elif 'message' in self.value and len(self.value.keys()) == 1:

--- a/tests/unit/response_parsing/json/inputs/datapipeline-create-pipeline.json
+++ b/tests/unit/response_parsing/json/inputs/datapipeline-create-pipeline.json
@@ -1,0 +1,1 @@
+{"__type":"AccessDeniedException","Message":"Operation createPipeline is not allowed to be performed with role identity"}

--- a/tests/unit/response_parsing/json/outputs/datapipeline-create-pipeline.json
+++ b/tests/unit/response_parsing/json/outputs/datapipeline-create-pipeline.json
@@ -1,0 +1,9 @@
+{
+    "Errors": [
+        {
+            "Message": "Operation createPipeline is not allowed to be performed with role identity",
+            "Type": "AccessDeniedException",
+            "Code": "AccessDeniedException"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #256 by looking for both `message` and `Message` in returned errors.
Adds a test to ensure this works as expected.

@jamesls, please review.
