### PR TITLE
Allow loader *instance* to be passed in

### DIFF
--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -93,7 +93,7 @@ class Loader(object):
     file_loader_class = JSONFileLoader
     extension = '.json'
 
-    def __init__(self, data_path, file_loader_class=None, extension=None,
+    def __init__(self, data_path='', file_loader_class=None, extension=None,
                  cache=None):
         """
         Sets up the Loader.
@@ -112,7 +112,7 @@ class Loader(object):
         Default is ``None`` (creates its own ``Cache()`` instance).
         """
         super(Loader, self).__init__()
-        self.data_path = data_path
+        self._data_path = data_path
         self._cache = {}
 
         if file_loader_class is not None:
@@ -125,6 +125,14 @@ class Loader(object):
             self._cache = cache
 
         self.file_loader = self.file_loader_class()
+
+    @property
+    def data_path(self):
+        return self._data_path
+
+    @data_path.setter
+    def data_path(self, value):
+        self._data_path = value
 
     def get_search_paths(self):
         """

--- a/tests/unit/response_parsing/test_response_parsing.py
+++ b/tests/unit/response_parsing/test_response_parsing.py
@@ -17,7 +17,7 @@ import json
 import pprint
 import logging
 import difflib
-from tests import unittest, patch_session
+from tests import unittest, create_session
 
 from mock import Mock
 from botocore.vendored.requests.structures import CaseInsensitiveDict
@@ -66,8 +66,7 @@ def test_xml_parsing():
     for dp in ['responses', 'errors']:
         data_path = os.path.join(os.path.dirname(__file__), 'xml')
         data_path = os.path.join(data_path, dp)
-        session = botocore.session.get_session()
-        patch_session(session)
+        session = create_session()
         xml_files = glob.glob('%s/*.xml' % data_path)
         service_names = set()
         for fn in xml_files:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -13,7 +13,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, BaseEnvVar, patch_session
+from tests import unittest, BaseSessionTest
 import os
 
 import mock
@@ -22,14 +22,12 @@ import botocore.session
 import botocore.exceptions
 
 
-class TestConfig(BaseEnvVar):
+class TestConfig(BaseSessionTest):
 
     def setUp(self):
         super(TestConfig, self).setUp()
         data_path = os.path.join(os.path.dirname(__file__), 'data')
         self.environ['BOTO_DATA_PATH'] = data_path
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
 
     def test_data_not_found(self):
         self.assertRaises(botocore.exceptions.DataNotFoundError,

--- a/tests/unit/test_cloudformation_operations.py
+++ b/tests/unit/test_cloudformation_operations.py
@@ -13,15 +13,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import BaseSessionTest
 import botocore.session
 
 
-class TestCloudformationOperations(unittest.TestCase):
+class TestCloudformationOperations(BaseSessionTest):
 
     def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
+        super(TestCloudformationOperations, self).setUp()
         self.cf = self.session.get_service('cloudformation')
 
     def test_create_stack(self):

--- a/tests/unit/test_cloudfront_operations.py
+++ b/tests/unit/test_cloudfront_operations.py
@@ -13,7 +13,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, BaseEnvVar, patch_session
+from tests import unittest, BaseSessionTest
 import botocore.session
 
 CREATE_DISTRIBUTION_INPUT = {
@@ -240,14 +240,10 @@ CREATE_INVALIDATION_PAYLOAD = """
 </InvalidationBatch>"""
 
 
-class TestCloudFrontOperations(BaseEnvVar):
+class TestCloudFrontOperations(BaseSessionTest):
 
     def setUp(self):
         super(TestCloudFrontOperations, self).setUp()
-        self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
-        self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
         self.cloudfront = self.session.get_service('cloudfront')
         self.endpoint = self.cloudfront.get_endpoint('us-east-1')
 
@@ -292,7 +288,3 @@ class TestCloudFrontOperations(BaseEnvVar):
         self.assertEqual(params['payload'].getvalue(), payload)
         self.assertEqual(params['uri_params'],
                          {'DistributionId': 'IDFDVBD632BHDS5'})
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -23,7 +23,7 @@ import botocore.exceptions
 import botocore.session
 from botocore.vendored.requests import ConnectionError
 
-from tests import unittest, BaseEnvVar, patch_session
+from tests import unittest, BaseEnvVar, create_session
 
 
 # Passed to session to keep it from finding default config file
@@ -112,8 +112,7 @@ class EnvVarTest(BaseEnvVar):
         self.environ['BOTO_CONFIG'] = ''
         self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
         self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        self.session = botocore.session.get_session(env_vars=TESTENVVARS)
-        patch_session(self.session)
+        self.session = create_session(session_vars=TESTENVVARS)
 
     def test_envvar(self):
         credentials = self.session.get_credentials()
@@ -127,8 +126,7 @@ class CredentialsFileTest(BaseEnvVar):
     def setUp(self):
         super(CredentialsFileTest, self).setUp()
         self.environ['BOTO_CONFIG'] = ''
-        self.session = botocore.session.get_session(env_vars=TESTENVVARS)
-        patch_session(self.session)
+        self.session = create_session(session_vars=TESTENVVARS)
 
     def test_credentials_file(self):
         self.environ['AWS_CREDENTIAL_FILE'] = path('aws_credentials')
@@ -150,8 +148,7 @@ class ConfigTest(BaseEnvVar):
         super(ConfigTest, self).setUp()
         self.environ['AWS_CONFIG_FILE'] = path('aws_config')
         self.environ['BOTO_CONFIG'] = ''
-        self.session = botocore.session.get_session(env_vars=TESTENVVARS)
-        patch_session(self.session)
+        self.session = create_session(session_vars=TESTENVVARS)
 
     def test_config(self):
         credentials = self.session.get_credentials()
@@ -164,8 +161,7 @@ class ConfigTest(BaseEnvVar):
 
     def test_default_profile_is_obeyed(self):
         self.environ['BOTO_DEFAULT_PROFILE'] = 'personal'
-        session = botocore.session.get_session()
-        patch_session(session)
+        session = create_session()
         credentials = session.get_credentials()
         self.assertEqual(credentials.access_key, 'fie')
         self.assertEqual(credentials.secret_key, 'baz')
@@ -181,8 +177,7 @@ class BotoConfigTest(BaseEnvVar):
     def setUp(self):
         super(BotoConfigTest, self).setUp()
         self.environ['BOTO_CONFIG'] = path('boto_config')
-        self.session = botocore.session.get_session(env_vars=TESTENVVARS)
-        patch_session(self.session)
+        self.session = create_session(session_vars=TESTENVVARS)
 
     def test_boto_config(self):
         credentials = self.session.get_credentials()
@@ -194,8 +189,7 @@ class BotoConfigTest(BaseEnvVar):
 class IamRoleTest(BaseEnvVar):
     def setUp(self):
         super(IamRoleTest, self).setUp()
-        self.session = botocore.session.get_session(env_vars=TESTENVVARS)
-        patch_session(self.session)
+        self.session = create_session(session_vars=TESTENVVARS)
         self.environ['BOTO_CONFIG'] = ''
 
     @mock.patch('botocore.utils.InstanceMetadataFetcher.retrieve_iam_role_credentials')
@@ -306,8 +300,7 @@ class CredentialResolverTest(BaseEnvVar):
         self.environ['BOTO_CONFIG'] = ''
         self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
         self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        self.session = botocore.session.get_session(env_vars=TESTENVVARS)
-        patch_session(self.session)
+        self.session = create_session(session_vars=TESTENVVARS)
         self.default_resolver = credentials.CredentialResolver(
             session=self.session
         )
@@ -441,8 +434,7 @@ class AlternateCredentialResolverTest(BaseEnvVar):
         super(AlternateCredentialResolverTest, self).setUp()
         self.environ['AWS_CONFIG_FILE'] = path('aws_config')
         self.environ['BOTO_CONFIG'] = ''
-        self.session = botocore.session.get_session(env_vars=TESTENVVARS)
-        patch_session(self.session)
+        self.session = create_session(session_vars=TESTENVVARS)
         self.small_resolver = credentials.CredentialResolver(
             session=self.session,
             methods=[

--- a/tests/unit/test_directconnect_operations.py
+++ b/tests/unit/test_directconnect_operations.py
@@ -13,15 +13,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import BaseSessionTest
 import botocore.session
 
 
-class TestDirectconnectOperations(unittest.TestCase):
+class TestDirectconnectOperations(BaseSessionTest):
 
     def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
+        super(TestDirectconnectOperations, self).setUp()
         self.dc = self.session.get_service('directconnect')
 
     def test_create_connection(self):
@@ -56,8 +55,3 @@ class TestDirectconnectOperations(unittest.TestCase):
                                               {'cidr': '6.7.8.9/10'}]}}
         self.maxDiff = None
         self.assertEqual(params, result)
-
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_ec2_operations.py
+++ b/tests/unit/test_ec2_operations.py
@@ -13,17 +13,16 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import BaseSessionTest
 import base64
 import six
 import botocore.session
 
 
-class TestEC2Operations(unittest.TestCase):
+class TestEC2Operations(BaseSessionTest):
 
     def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
+        super(TestEC2Operations, self).setUp()
         self.ec2 = self.session.get_service('ec2')
 
     def test_describe_instances_no_params(self):
@@ -126,7 +125,3 @@ class TestEC2Operations(unittest.TestCase):
                   'IpPermissions.1.IpProtocol': 'tcp',
                   'IpPermissions.1.IpRanges.1.CidrIp': '0.0.0.0/0',}
         self.assertEqual(params, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_elastictranscoder_operations.py
+++ b/tests/unit/test_elastictranscoder_operations.py
@@ -13,18 +13,17 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import BaseSessionTest
 import botocore.session
 from botocore.compat import json
 
 
-class TestElasticTranscoderOperations(unittest.TestCase):
+class TestElasticTranscoderOperations(BaseSessionTest):
 
     maxDiff = None
 
     def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
+        super(TestElasticTranscoderOperations, self).setUp()
         self.dc = self.session.get_service('elastictranscoder')
 
     def test_create_connection(self):
@@ -47,7 +46,3 @@ class TestElasticTranscoderOperations(unittest.TestCase):
                   "InputBucket": "etc-input"}
         json_body = json.loads(params['payload'].getvalue())
         self.assertEqual(json_body, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_elb_operations.py
+++ b/tests/unit/test_elb_operations.py
@@ -13,15 +13,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import BaseSessionTest
 import botocore.session
 
 
-class TestELBOperations(unittest.TestCase):
+class TestELBOperations(BaseSessionTest):
 
     def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
+        super(TestELBOperations, self).setUp()
         self.elb = self.session.get_service('elb')
 
     def test_describe_load_balancers_no_params(self):

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, BaseSessionTest, patch_session
+from tests import unittest, BaseSessionTest, create_session
 
 from mock import Mock, patch, sentinel
 from botocore.vendored.requests import ConnectionError
@@ -281,8 +281,7 @@ class TestRetryInterface(BaseSessionTest):
         super(TestRetryInterface, self).setUp()
         self.total_calls = 0
         self.auth = Mock()
-        self.session = Session(include_builtin_handlers=False)
-        patch_session(self.session)
+        self.session = create_session(include_builtin_handlers=False)
         self.service = Mock()
         self.service.endpoint_prefix = 'ec2'
         self.service.session = self.session
@@ -353,8 +352,7 @@ class TestResetStreamOnRetry(unittest.TestCase):
         super(TestResetStreamOnRetry, self).setUp()
         self.total_calls = 0
         self.auth = Mock()
-        self.session = Session(include_builtin_handlers=False)
-        patch_session(self.session)
+        self.session = create_session(include_builtin_handlers=False)
         self.service = Mock()
         self.service.endpoint_prefix = 's3'
         self.service.session = self.session

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import BaseSessionTest
 import botocore.session
 from botocore.hooks import first_non_none_response
 from botocore.compat import quote
@@ -21,14 +21,7 @@ import six
 import mock
 
 
-class TestHandlers(unittest.TestCase):
-
-    def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
-
-    def tearDown(self):
-        pass
+class TestHandlers(BaseSessionTest):
 
     def test_get_console_output(self):
         event = self.session.create_event('after-parsed', 'ec2',

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#1 Copyright (c) 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the
@@ -56,6 +56,12 @@ class LoaderTestCase(BaseEnvVar):
 
         # Make sure the cache is clear.
         self.loader._cache.clear()
+
+    def test_data_path_not_required(self):
+        loader = Loader()
+        self.assertEqual(loader.data_path, '')
+        loader.data_path = 'foo:bar'
+        self.assertEqual(loader.data_path, 'foo:bar')
 
     def test_get_search_paths(self):
         paths = self.loader.get_search_paths()

--- a/tests/unit/test_opsworks_operations.py
+++ b/tests/unit/test_opsworks_operations.py
@@ -12,9 +12,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from tests import BaseSessionTest
 
-from tests import BaseEnvVar, patch_session
-import botocore.session
 
 attributes = {
     "MysqlRootPasswordUbiquitous": None,
@@ -38,13 +37,11 @@ attributes = {
     "HaproxyStatsUser": None
 }
 
-class TestOpsworksOperations(BaseEnvVar):
+class TestOpsworksOperations(BaseSessionTest):
 
     def setUp(self):
         super(TestOpsworksOperations, self).setUp()
         self.environ['BOTO_DATA_PATH'] = '~/.aws_data'
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
         self.opsworks = self.session.get_service('opsworks')
         self.stack_id = '35959772-cd1e-4082-8346-79096d4179f2'
 
@@ -72,7 +69,3 @@ class TestOpsworksOperations(BaseEnvVar):
                   'Shortname': 'a'}
         self.maxDiff = None
         self.assertEqual(params, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_route53_operations.py
+++ b/tests/unit/test_route53_operations.py
@@ -13,8 +13,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import BaseEnvVar, patch_session
-import botocore.session
+from tests import BaseSessionTest
 
 
 CREATE_HOSTED_ZONE_PAYLOAD="""<CreateHostedZoneRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><Name>foobar.com</Name><CallerReference>foobar</CallerReference><HostedZoneConfig><Comment>blahblahblah</Comment></HostedZoneConfig></CreateHostedZoneRequest>"""
@@ -23,14 +22,12 @@ DELETE_RRSET_PAYLOAD="""<ChangeResourceRecordSetsRequest xmlns="https://route53.
 CREATE_HEALTH_CHECK_PAYLOAD="""<CreateHealthCheckRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><CallerReference>foobar</CallerReference><HealthCheckConfig><IPAddress>192.168.10.0</IPAddress><Port>8888</Port><Type>HTTP</Type><ResourcePath>foo/bar</ResourcePath><FullyQualifiedDomainName>foobar.com</FullyQualifiedDomainName></HealthCheckConfig></CreateHealthCheckRequest>"""
 
 
-class TestRoute53Operations(BaseEnvVar):
+class TestRoute53Operations(BaseSessionTest):
 
     def setUp(self):
         super(TestRoute53Operations, self).setUp()
         self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
         self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
         self.route53 = self.session.get_service('route53')
         self.endpoint = self.route53.get_endpoint('us-east-1')
         self.hosted_zone_name = 'foobar.com'
@@ -89,7 +86,3 @@ class TestRoute53Operations(BaseEnvVar):
         self.maxDiff = None
         self.assertEqual(params['payload'].getvalue(),
                          CREATE_HEALTH_CHECK_PAYLOAD)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -15,20 +15,16 @@
 
 import os
 
-from tests import BaseEnvVar, patch_session
+from tests import BaseSessionTest
 from mock import patch, Mock
 
 import botocore.session
 
 
-class TestS3Addressing(BaseEnvVar):
+class TestS3Addressing(BaseSessionTest):
 
     def setUp(self):
         super(TestS3Addressing, self).setUp()
-        self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
-        self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
         self.s3 = self.session.get_service('s3')
 
     @patch('botocore.response.get_response', Mock())
@@ -167,7 +163,3 @@ class TestS3Addressing(BaseEnvVar):
         prepared_request = self.get_prepared_request(op, params)
         self.assertEqual(prepared_request.url,
                          'https://s3.amazonaws.com/192.168.5.256/mykeyname')
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_s3_operations.py
+++ b/tests/unit/test_s3_operations.py
@@ -14,7 +14,7 @@
 # language governing permissions and limitations under the License.
 
 import os
-from tests import unittest, BaseEnvVar, patch_session
+from tests import BaseSessionTest
 import botocore.session
 
 XMLBODY1 = ('<CreateBucketConfiguration><LocationConstraint>sa-east-1'
@@ -63,16 +63,13 @@ POLICY = ('{"Version": "2008-10-17","Statement": [{"Sid": "AddPerm",'
           '"Action": "s3:GetObject", "Resource": "arn:aws:s3:::BUCKET_NAME/*"'
           '}]}')
 
-class TestS3Operations(BaseEnvVar):
+
+class TestS3Operations(BaseSessionTest):
 
     maxDiff = None
 
     def setUp(self):
         super(TestS3Operations, self).setUp()
-        self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
-        self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
         self.s3 = self.session.get_service('s3')
         self.endpoint = self.s3.get_endpoint('us-east-1')
         self.bucket_name = 'foo'
@@ -301,7 +298,3 @@ class TestS3Operations(BaseEnvVar):
         # Explicitly check that <Parts> is not in the payload anywhere.
         self.assertNotIn('<Parts>', xml_payload)
         self.assertNotIn('</Parts>', xml_payload)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_ses_operations.py
+++ b/tests/unit/test_ses_operations.py
@@ -12,7 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import BaseEnvVar, patch_session
+from tests import BaseSessionTest
 
 from mock import Mock, sentinel
 
@@ -22,14 +22,10 @@ from botocore.exceptions import UnknownParameterError
 from botocore.exceptions import UnknownKeyError
 
 
-class TestSESOperations(BaseEnvVar):
+class TestSESOperations(BaseSessionTest):
 
     def setUp(self):
         super(TestSESOperations, self).setUp()
-        self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
-        self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
         self.ses = self.session.get_service('ses')
         self.op = self.ses.get_operation('SendEmail')
 
@@ -78,7 +74,3 @@ class TestSESOperations(BaseEnvVar):
                 destination={'ToAddresses': ['bar@examplecom']},
                 message={'Subject': {'Data': 'foo'},
                          'Body': {'Text': {'BADKEY': 'foo'}}})
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_sns_operations.py
+++ b/tests/unit/test_sns_operations.py
@@ -12,19 +12,17 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import BaseSessionTest
 
 from mock import Mock
 
 from botocore.compat import OrderedDict
-import botocore.session
 
 
-class TestSNSOperations(unittest.TestCase):
+class TestSNSOperations(BaseSessionTest):
 
     def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
+        super(TestSNSOperations, self).setUp()
         self.sns = self.session.get_service('sns')
         self.http_response = Mock()
         self.http_response.status_code = 200
@@ -82,7 +80,3 @@ class TestSNSOperations(unittest.TestCase):
                   'Attributes.entry.2.key': 'PlatformPrincipal',
                   'Attributes.entry.2.value': 'bar'}
         self.assertEqual(params, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_sqs_operations.py
+++ b/tests/unit/test_sqs_operations.py
@@ -13,15 +13,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, patch_session
+from tests import unittest, BaseSessionTest
 import botocore.session
 
 
-class TestSQSOperations(unittest.TestCase):
+class TestSQSOperations(BaseSessionTest):
 
     def setUp(self):
-        self.session = botocore.session.get_session()
-        patch_session(self.session)
+        super(TestSQSOperations, self).setUp()
         self.sqs = self.session.get_service('sqs')
         self.queue_url = 'https://queue.amazonaws.com/123456789012/testcli'
         self.receipt_handle = """MbZj6wDWli%2BJvwwJaBV%2B3dcjk2YW2vA3%2BSTFFljT
@@ -92,6 +91,3 @@ SbkJ0="""
         for param in op.params:
             if param.name == 'QueueUrl':
                 self.assertEqual(getattr(param, 'no_paramfile', None), True)
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
A loader instance (instead of a loader class) should be passed
to the session.  By requiring a loader class, this ties the `__init__`
to the interface of the loader, which should not be the case.  This
also makes it harder to share loader instances (which is where any
kind of caching would live) across sessions.

As a result of this I updated the unit tests to remove all the
patch_session code, and use the _public_ API to set the loaders.

Additionally, many of these tests were written before BaseSessionTest
was around, so in many cases, the tests could just be updated to use
BaseSessionTest and use the pre-created session instance created
in the base class's setUp.
