### PR TITLE
Coerce max items to an integer

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -91,8 +91,11 @@ class Paginator(object):
                             endpoint, kwargs)
 
     def _extract_paging_params(self, kwargs):
+        max_items = kwargs.pop('max_items', None)
+        if max_items is not None:
+            max_items = int(max_items)
         return {
-            'max_items': kwargs.pop('max_items', None),
+            'max_items': max_items,
             'starting_token': kwargs.pop('starting_token', None),
         }
 

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -1,0 +1,35 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import unittest
+import itertools
+
+import botocore.session
+
+
+class TestRDSPagination(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.service = self.session.get_service('route53')
+        self.endpoint = self.service.get_endpoint('us-west-2')
+
+    def test_paginate_with_max_items(self):
+        # Route53 has a string type for MaxItems.  We need to ensure that this
+        # still works without any issues.
+        operation = self.service.get_operation('ListHostedZones')
+        results = list(operation.paginate(self.endpoint, max_items='1'))
+        self.assertTrue(len(results) >= 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -295,6 +295,21 @@ class TestKeyIterators(unittest.TestCase):
             paginator.paginate(None, max_items=1).build_full_result(),
             {'Users': ['User1'], 'NextToken': 'm1'})
 
+    def test_max_items_as_strings(self):
+        # Some services (route53) model MaxItems as a string type.
+        # We need to be able to handle this case.
+        paginator = Paginator(self.operation)
+        responses = [
+            (None, {"Users": ["User1"], "Marker": "m1"}),
+            (None, {"Users": ["User2"], "Marker": "m2"}),
+            (None, {"Users": ["User3"]}),
+        ]
+        self.operation.call.side_effect = responses
+        self.assertEqual(
+            # Note max_items is a string here.
+            paginator.paginate(None, max_items='1').build_full_result(),
+            {'Users': ['User1'], 'NextToken': 'm1'})
+
     def test_next_token_on_page_boundary(self):
         paginator = Paginator(self.operation)
         responses = [


### PR DESCRIPTION
Fixes a bug where services that model max items as a string
will fail.  Now we always convert this value to an int().
