### PR TITLE
Fix bug in xform_name for already transformed names

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -51,9 +51,16 @@ BOTOCORE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 def xform_name(name, sep='_', _xform_cache=_xform_cache):
+    """Convert camel case to a "pythonic" name.
+
+    If the name contains the ``sep`` character, then it is
+    returned unchanged.
+
     """
-    Convert camel case to a "pythonic" name.
-    """
+    if sep in name:
+        # If the sep is in the name, assume that it's already
+        # transformed and return the string unchanged.
+        return name
     key = (name, sep)
     if key not in _xform_cache:
         s1 = _first_cap_regex.sub(r'\1' + sep + r'\2', name)

--- a/tests/unit/test_cloudtrail.py
+++ b/tests/unit/test_cloudtrail.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from tests import BaseSessionTest
+import botocore.session
+
+
+class TestCloudTrailOperations(BaseSessionTest):
+
+    def setUp(self):
+        super(TestCloudTrailOperations, self).setUp()
+        self.cloudtrail = self.session.get_service('cloudtrail')
+
+    def test_cloudtrail_create_subscription(self):
+        op = self.cloudtrail.get_operation('CreateTrail')
+        kwargs = {
+            "name": "name",
+            "s3_bucket_name": "s3bucketname",
+            "s3_key_prefix": "s3keyprefix",
+            "sns_topic_name": "snstopicname",
+            "include_global_service_events": True
+        }
+        params = op.build_parameters(**kwargs)
+        result = {
+            'Name': 'name',
+            'S3BucketName': 's3bucketname',
+            'S3KeyPrefix': 's3keyprefix',
+            'SnsTopicName': 'snstopicname',
+            'IncludeGlobalServiceEvents': True,
+        }
+        self.assertEqual(params, result)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -59,8 +59,13 @@ class TestTransformName(unittest.TestCase):
         self.assertEqual(xform_name('MainHTTPHeaders'), 'main_http_headers')
         self.assertEqual(xform_name('MainHTTPHeaders', '-'), 'main-http-headers')
 
+    def test_s3_prefix(self):
+        self.assertEqual(xform_name('S3BucketName'), 's3_bucket_name')
+
     def test_already_snake_cased(self):
         self.assertEqual(xform_name('leave_alone'), 'leave_alone')
+        self.assertEqual(xform_name('s3_bucket_name'), 's3_bucket_name')
+        self.assertEqual(xform_name('bucket_s3_name'), 'bucket_s3_name')
 
     def test_special_cases(self):
         # Some patterns don't actually match the rules we expect.


### PR DESCRIPTION
This is a regression introduced from https://github.com/boto/botocore/pull/240

When you try to create a trail you'll get an error:

```
Unknown parameter 's_3_bucket_name' for operation Operation:CreateTrail.  Must b
e one of: name, s3_bucket_name, s3_key_prefix, sns_topic_name, include_global_se
rvice_events, trail
```

The issue is that we xform `s3_bucket_name` again and get `s_3_bucket_name`.  The fix here is to not translate names if they already appear to be translated.
