### PR TITLE
Fix kinesis pagination issue

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -30,6 +30,7 @@ if six.PY3:
     from urllib.parse import parse_qsl
     from io import IOBase as _IOBase
     file_type = _IOBase
+    zip = zip
 
     # In python3, unquote takes a str() object, url decodes it,
     # then takes the bytestring and decodes it to utf-8.
@@ -54,6 +55,8 @@ else:
     from urlparse import parse_qsl
     from email.message import Message
     file_type = file
+    from itertools import izip as zip
+
     class HTTPHeaders(Message):
 
         # The __iter__ method is not available in python2.x, so we have

--- a/botocore/data/aws/kinesis/2013-12-02.json
+++ b/botocore/data/aws/kinesis/2013-12-02.json
@@ -318,6 +318,11 @@
                 "more_results": "StreamDescription.HasMoreShards",
                 "output_token": "StreamDescription.Shards[-1].ShardId",
                 "result_key": "StreamDescription.Shards",
+                "non_aggregate_keys": [
+                    "StreamDescription.StreamARN",
+                    "StreamDescription.StreamName",
+                    "StreamDescription.StreamStatus"
+                ],
                 "py_input_token": "exclusive_start_shard_id"
             }
         },
@@ -929,6 +934,11 @@
             "more_results": "StreamDescription.HasMoreShards",
             "output_token": "StreamDescription.Shards[-1].ShardId",
             "result_key": "StreamDescription.Shards",
+            "non_aggregate_keys": [
+                "StreamDescription.StreamARN",
+                "StreamDescription.StreamName",
+                "StreamDescription.StreamStatus"
+            ],
             "py_input_token": "exclusive_start_shard_id"
         },
         "GetRecords": {

--- a/botocore/translate.py
+++ b/botocore/translate.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 import jmespath
 
 from botocore.compat import OrderedDict, json
-from botocore.utils import set_value_from_jmespath
+from botocore.utils import set_value_from_jmespath, merge_dicts
 from botocore import xform_name
 
 
@@ -404,7 +404,8 @@ def _transform_waiter(new_waiter):
 def _check_known_pagination_keys(config):
     # Verify that the pagination config only has keys we expect to see.
     expected = set(['input_token', 'py_input_token', 'output_token',
-                    'result_key', 'limit_key', 'more_results'])
+                    'result_key', 'limit_key', 'more_results',
+                    'non_aggregate_keys'])
     for key in config:
         if key not in expected:
             raise ValueError("Unknown key in pagination config: %s" % key)
@@ -465,25 +466,3 @@ def resolve_references(config, definitions):
                 config[key] = definitions[list(value.values())[0]]
             else:
                 resolve_references(value, definitions)
-
-
-def merge_dicts(dict1, dict2):
-    """Given two dict, merge the second dict into the first.
-
-    The dicts can have arbitrary nesting.
-
-    """
-    for key in dict2:
-        if is_sequence(dict2[key]):
-            if key in dict1 and key in dict2:
-                merge_dicts(dict1[key], dict2[key])
-            else:
-                dict1[key] = dict2[key]
-        else:
-            # At scalar types, we iterate and merge the
-            # current dict that we're on.
-            dict1[key] = dict2[key]
-
-
-def is_sequence(x):
-    return isinstance(x, (list, dict))

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -176,3 +176,22 @@ class InstanceMetadataFetcher(object):
                 'expiry_time': data[role_name]['Expiration'],
             }
         return final_data
+
+
+
+def merge_dicts(dict1, dict2):
+    """Given two dict, merge the second dict into the first.
+
+    The dicts can have arbitrary nesting.
+
+    """
+    for key in dict2:
+        if isinstance(dict2[key], dict):
+            if key in dict1 and key in dict2:
+                merge_dicts(dict1[key], dict2[key])
+            else:
+                dict1[key] = dict2[key]
+        else:
+            # At scalar types, we iterate and merge the
+            # current dict that we're on.
+            dict1[key] = dict2[key]

--- a/services/kinesis.extra.json
+++ b/services/kinesis.extra.json
@@ -15,7 +15,9 @@
       "limit_key": "Limit",
       "more_results": "StreamDescription.HasMoreShards",
       "output_token": "StreamDescription.Shards[-1].ShardId",
-      "result_key": "StreamDescription.Shards"
+      "result_key": "StreamDescription.Shards",
+      "non_aggregate_keys": ["StreamDescription.StreamARN", "StreamDescription.StreamName",
+                             "StreamDescription.StreamStatus"]
     },
     "GetRecords": {
       "input_token": "ShardIterator",

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -17,7 +17,7 @@ import itertools
 import botocore.session
 
 
-class TestKinesis(unittest.TestCase):
+class TestKinesisListStreams(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
         self.service = self.session.get_service('kinesis')

--- a/tests/unit/test_translate.py
+++ b/tests/unit/test_translate.py
@@ -418,6 +418,7 @@ class TestTranslateModel(unittest.TestCase):
                     'py_input_token': 'other_value',
                     'limit_key': 'MaxResults',
                     'result_key': 'Credentials',
+                    'non_aggregate_keys': ['foo'],
                 }
             }
         }
@@ -433,6 +434,7 @@ class TestTranslateModel(unittest.TestCase):
                 'output_token': 'NextToken',
                 'limit_key': 'MaxResults',
                 'result_key': 'Credentials',
+                    'non_aggregate_keys': ['foo'],
             })
 
     def test_paginators_are_validated(self):


### PR DESCRIPTION
Add support for non_aggregate_keys in the pagination
configs.

Also went through the other kinesis paginated operations
and verified that DescribeStream is the only thing that
needs non_aggregate_keys.

Fixes #270.

cc @danielgtaylor
