### PR TITLE
Remove cli_name from .extra files

### DIFF
--- a/botocore/data/aws/elastictranscoder/2012-09-25.json
+++ b/botocore/data/aws/elastictranscoder/2012-09-25.json
@@ -293,8 +293,7 @@
                                 "documentation": "\n       <p>You can create an output file that contains an excerpt from the input file. This excerpt, called a clip, can come from the beginning, middle, or end of the file. The Composition object contains settings for the clips that make up an output file. For the current release, you can only specify settings for a single clip per output file. The Composition object cannot be null.</p>\n   "
                             }
                         },
-                        "documentation": "\n        <p>The <code>CreateJobOutput</code> structure.</p>\n    ",
-                        "cli_name": "job-output"
+                        "documentation": "\n        <p>The <code>CreateJobOutput</code> structure.</p>\n    "
                     },
                     "Outputs": {
                         "shape_name": "CreateJobOutputs",

--- a/botocore/data/aws/opsworks/2013-02-18.json
+++ b/botocore/data/aws/opsworks/2013-02-18.json
@@ -177,8 +177,7 @@
                     "Region": {
                         "shape_name": "String",
                         "type": "string",
-                        "documentation": "\n  <p>The cloned stack AWS region, such as \"us-east-1\". For more information about AWS regions, see\n  <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html\">Regions and Endpoints</a>.</p>\n  ",
-                        "cli_name": "stack-region"
+                        "documentation": "\n  <p>The cloned stack AWS region, such as \"us-east-1\". For more information about AWS regions, see\n  <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html\">Regions and Endpoints</a>.</p>\n  "
                     },
                     "VpcId": {
                         "shape_name": "String",
@@ -1158,8 +1157,7 @@
                         "shape_name": "String",
                         "type": "string",
                         "documentation": "\n  <p>The stack AWS region, such as \"us-east-1\". For more information about Amazon regions, see\n  <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html\">Regions and Endpoints</a>.</p>\n  ",
-                        "required": true,
-                        "cli_name": "stack-region"
+                        "required": true
                     },
                     "VpcId": {
                         "shape_name": "String",

--- a/botocore/data/aws/swf/2012-01-25.json
+++ b/botocore/data/aws/swf/2012-01-25.json
@@ -7373,8 +7373,7 @@
                         "min_length": 1,
                         "max_length": 64,
                         "documentation": "\n    <p>\n      The version of the activity type.\n    </p>\n    <note>\n      The activity type consists of the name and version, the combination of which must be unique within the domain.\n    </note>\n    <p>The specified string must not start or end with whitespace. It must not contain a <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any control characters (\\u0000-\\u001f | \\u007f - \\u009f). Also, it must not contain the literal string &quot;arn&quot;.</p>\n  ",
-                        "required": true,
-                        "cli_name": "activity-version"
+                        "required": true
                     },
                     "description": {
                         "shape_name": "Description",
@@ -7577,8 +7576,7 @@
                         "min_length": 1,
                         "max_length": 64,
                         "documentation": "\n      <p>\n         The version of the workflow type.\n      </p>\n      <note>\n         The workflow type consists of the name and version, the combination of which must be unique within the domain. To get a list of all currently registered\n         workflow types, use the <a>ListWorkflowTypes</a> action.\n      </note>\n      <p>The specified string must not start or end with whitespace. It must not contain a <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any control characters (\\u0000-\\u001f | \\u007f - \\u009f). Also, it must not contain the literal string &quot;arn&quot;.</p>\n   ",
-                        "required": true,
-                        "cli_name": "workflow-version"
+                        "required": true
                     },
                     "description": {
                         "shape_name": "Description",

--- a/services/elastictranscoder.extra.json
+++ b/services/elastictranscoder.extra.json
@@ -24,15 +24,6 @@
         }
       }
     },
-    "CreateJob": {
-      "input": {
-        "members": {
-          "Output": {
-            "cli_name": "job-output"
-          }
-        }
-      }
-    },
     "DeletePipeline": {
       "input": {
         "members": {

--- a/services/opsworks.extra.json
+++ b/services/opsworks.extra.json
@@ -9,25 +9,5 @@
       ]
     }
   },
-  "operations": {
-    "CloneStack": {
-      "input": {
-        "members": {
-          "Region": {
-            "cli_name": "stack-region"
-          }
-        }
-      }
-    },
-    "CreateStack": {
-      "input": {
-        "members": {
-          "Region": {
-            "cli_name": "stack-region"
-          }
-        }
-      }
-    }
-  },
   "pagination": {}
 }

--- a/services/swf.extra.json
+++ b/services/swf.extra.json
@@ -18,26 +18,6 @@
       ]
     }
   },
-  "operations": {
-    "RegisterActivityType": {
-      "input": {
-        "members": {
-          "version": {
-            "cli_name": "activity-version"
-          }
-        }
-      }
-    },
-    "RegisterWorkflowType": {
-      "input": {
-        "members": {
-          "version": {
-            "cli_name": "workflow-version"
-          }
-        }
-      }
-    }
-  },
   "pagination": {
     "GetWorkflowExecutionHistory": {
       "limit_key": "maximumPageSize",


### PR DESCRIPTION
This logic can live in the argrename CLI customization.

The only one I didn't pull out was the sns one for endpoint,
because that also has a py_name attribute as well.

I think we might be able to move that out, but I'll have to double
check, and if so, it will be in a separate commit/PR.
