### PR TITLE
Fix py26 issue when serializing empty lists

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -374,14 +374,11 @@ class ListParameter(Parameter):
             # insert a parameter into the dictionary with the base name
             # of the parameter and a value of the empty string. See
             # ELB SetLoadBalancerPoliciesForBackendServer for example.
-            parts = label.split('.')
-            for pos in range(len(parts) - 1, -1, -1):
-                item = parts[pos]
-                if item != 'member' and not item.isnumeric():
-                    break
-            new_label = '.'.join(parts[:pos + 1])
-
-            built_params[new_label] = ''
+            if not self.flattened and label.endswith('.member'):
+                # Strip off the last '.member' part of the string
+                # if we're serializing an empty non flattened list.
+                label = '.'.join(label.split('.')[:-1])
+            built_params[label] = ''
         else:
             for i, v in enumerate(value, 1):
                 member_type.build_parameter_query(v, built_params,


### PR DESCRIPTION
In python2.6 the json.load from the model does not give unicode,
and isnumeric is not defined on string types.

This causes an AttributeError to propogate on python2.6 if you hit
this condition.

On further review, this code can be simplified. If we're serializing
an empty list in the query protocol, we either strip off the '.member'
at the end of it's a non flattened list, otherwise we do nothing.
