### PR TITLE
Convert to bytes only if we get a text_type for blobs

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -321,7 +321,11 @@ class BlobParameter(Parameter):
                                       param=self)
             if not hasattr(self, 'payload') or self.payload is False:
                 # Blobs that are not in the payload should be base64-encoded
-                value = base64.b64encode(six.b(value)).decode('utf-8')
+                if isinstance(value, six.text_type):
+                    v = value.encode('utf-8')
+                else:
+                    v = value
+                value = base64.b64encode(v).decode('utf-8')
         return value
 
 


### PR DESCRIPTION
This allows unicode to be passed in for the blob parameter.

cc @danielgtaylor
