### PR TITLE
Add proper retry config for emr

### DIFF
--- a/botocore/data/aws/_retry.json
+++ b/botocore/data/aws/_retry.json
@@ -65,10 +65,10 @@
         }
       }
     },
-    "emr": {
+    "elasticmapreduce": {
       "__default__": {
         "policies": {
-          "throttling": {"$ref": "throttling"}
+          "throttling": {"$ref": "throttling_exception"}
         }
       }
     },

--- a/botocore/data/aws/emr/2009-03-31.json
+++ b/botocore/data/aws/emr/2009-03-31.json
@@ -3078,6 +3078,14 @@
                             "http_status_code": 509
                         }
                     }
+                },
+                "throttling": {
+                    "applies_when": {
+                        "response": {
+                            "service_error_code": "ThrottlingException",
+                            "http_status_code": 400
+                        }
+                    }
                 }
             }
         }

--- a/services/_retry.json
+++ b/services/_retry.json
@@ -65,10 +65,10 @@
         }
       }
     },
-    "emr": {
+    "elasticmapreduce": {
       "__default__": {
         "policies": {
-          "throttling": {"$ref": "throttling"}
+          "throttling": {"$ref": "throttling_exception"}
         }
       }
     },


### PR DESCRIPTION
Two issues:
- We need to use the proper endpoint prefix of "elasticmapreduce",
  not "emr".
- We need to use throttling_exception instead of the throttling
  rule for retry.

cc @danielgtaylor
