### PR TITLE
Update fix_s3_host to check for sigv4 subclasses

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -102,7 +102,7 @@ class Endpoint(object):
                 event = self.session.create_event(
                     'before-auth', self.service.endpoint_prefix)
                 self.session.emit(event, endpoint=self,
-                                request=request, auth=self.auth)
+                                  request=request, auth=signer)
                 signer.add_auth(request=request)
         prepared_request = request.prepare()
         return prepared_request

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -108,7 +108,7 @@ def fix_s3_host(event_name, endpoint, request, auth, **kwargs):
     parts = urlsplit(request.url)
     auth.auth_path = parts.path
     path_parts = parts.path.split('/')
-    if isinstance(auth, botocore.auth.S3SigV4Auth):
+    if isinstance(auth, botocore.auth.SigV4Auth):
         return
     if len(path_parts) > 1:
         bucket_name = path_parts[1]


### PR DESCRIPTION
We shouldn't be messing with the host when we use the
s3v4 presigned auth either.

cc @danielgtaylor
