### PR TITLE
Fixed deprecated getargspec() function for Python 3.x

### DIFF
--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -15,6 +15,7 @@ import inspect
 import six
 from collections import defaultdict, deque
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +74,12 @@ class BaseEventHooks(object):
 
         """
         try:
-            argspec = inspect.getargspec(func)
+            # Check Python version to determine functions to execute
+            # getfullargspec() not present in Python 2.x
+            if sys.version_info < (3, 0):
+                argspec = inspect.getargspec(func)
+            else:
+                argspec = inspect.getfullargspec(func)
         except TypeError:
             return False
         else:


### PR DESCRIPTION
A fix for Python 3.x when trying to run aws-cli tool "ValueError: Function has keyword-only arguments or annotations, use getfullargspec() API which can support them" error
