### PR TITLE
Support python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; pip install --use-mirrors -r requirements26.txt; fi
   - pip install --use-mirrors -r requirements.txt

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -15,6 +15,7 @@ import copy
 import datetime
 import six
 import sys
+import inspect
 
 
 if six.PY3:
@@ -46,6 +47,12 @@ if six.PY3:
 
         """
         http_response._fp.fp.raw._sock.settimeout(timeout)
+
+    def accepts_kwargs(func):
+        # In python3.4.1, there's backwards incompatible
+        # changes when using getargspec with functools.partials.
+        return inspect.getfullargspec(func)[2]
+
 
 else:
     from urllib import quote
@@ -86,6 +93,9 @@ else:
 
         """
         http_response._fp.fp._sock.settimeout(timeout)
+
+    def accepts_kwargs(func):
+        return inspect.getargspec(func)[2]
 
 try:
     from collections import OrderedDict

--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import inspect
 import six
-from collections import defaultdict, deque
 import logging
+from collections import defaultdict, deque
+from botocore.compat import accepts_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -73,13 +73,11 @@ class BaseEventHooks(object):
 
         """
         try:
-            argspec = inspect.getargspec(func)
-        except TypeError:
-            return False
-        else:
-            if argspec[2] is None:
+            if not accepts_kwargs(func):
                 raise ValueError("Event handler %s must accept keyword "
                                  "arguments (**kwargs)" % func)
+        except TypeError:
+            return False
 
 
 class EventHooks(BaseEventHooks):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33
+envlist = py26,py27,py33,py34
 
 [testenv]
 commands = nosetests tests/unit


### PR DESCRIPTION
There was a fix needed for python3.4.1,
as shown in https://github.com/boto/botocore/pull/297

This also updates travis/tox to run tests against py3.4

Also verified the CLI tests pass.

Fixes: https://github.com/aws/aws-cli/issues/800

cc @danielgtaylor
