### PR TITLE
Use get_config_variable instead of profile attr

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -38,7 +38,7 @@ def create_credential_resolver(session):
     credentials.
 
     """
-    profile_name = session.profile or 'default'
+    profile_name = session.get_config_variable('profile') or 'default'
     credential_file = session.get_config_variable('credentials_file')
     config_file = session.get_config_variable('config_file')
     metadata_timeout = session.get_config_variable('metadata_service_timeout')

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -527,6 +527,7 @@ class TestCreateCredentialResolver(BaseEnvVar):
             'config_file': 'c',
             'metadata_service_timeout': 'd',
             'metadata_service_num_attempts': 'e',
+            'profile': 'profilename',
         }
         fake_session.get_config_variable = lambda x: config[x]
         resolver = credentials.create_credential_resolver(fake_session)


### PR DESCRIPTION
session.get_config_variable('profile') != session.profile.

In the case of "--profile", we set the session.profile attr,
but in the case of the env var, we look it up when we create
the scoped config or when we call get_config_variable('profile').

I think this can probably be fixed such that we always set
session.profile, but this fixes the immediate issue of
aws/aws-cli#805.

Fixes aws/aws-cli#805

cc @danielgtaylor
