### PR TITLE
Fix ec2 ModifyVolumeAttribute model

### DIFF
--- a/botocore/data/aws/ec2/2014-05-01.json
+++ b/botocore/data/aws/ec2/2014-05-01.json
@@ -16753,9 +16753,15 @@
                         "required": true
                     },
                     "AutoEnableIO": {
-                        "shape_name": "Boolean",
-                        "type": "boolean",
-                        "documentation": "\n    <p>Indicates whether the volume should be auto-enabled for I/O operations.</p>\n  "
+                        "shape_name": "AttributeBooleanValue",
+                        "type": "structure",
+                        "documentation": "\n    <p>Indicates whether the volume should be auto-enabled for I/O operations.</p>\n  ",
+                        "members": {
+                            "Value": {
+                                "shape_name": "Boolean",
+                                "type": "boolean"
+                            }
+                        }
                     }
                 },
                 "documentation": "\n   "

--- a/services/ec2.json
+++ b/services/ec2.json
@@ -16958,9 +16958,15 @@
             "required": true
           },
           "AutoEnableIO": {
-            "shape_name": "Boolean",
-            "type": "boolean",
-            "documentation": "\n    <p>Indicates whether the volume should be auto-enabled for I/O operations.</p>\n  "
+            "shape_name": "AttributeBooleanValue",
+            "type": "structure",
+            "documentation": "\n    <p>Indicates whether the volume should be auto-enabled for I/O operations.</p>\n  ",
+            "members": {
+                "Value": {
+                    "shape_name": "Boolean",
+                    "type": "boolean"
+              }
+            }
           }
         },
         "documentation": "\n   "

--- a/tests/unit/test_ec2_operations.py
+++ b/tests/unit/test_ec2_operations.py
@@ -125,3 +125,14 @@ class TestEC2Operations(BaseSessionTest):
                   'IpPermissions.1.IpProtocol': 'tcp',
                   'IpPermissions.1.IpRanges.1.CidrIp': '0.0.0.0/0',}
         self.assertEqual(params, result)
+
+    def test_modify_volume_attribute(self):
+        op = self.ec2.get_operation('ModifyVolumeAttribute')
+        params = op.build_parameters(
+            volume_id='vol-12345678',
+            auto_enable_io={'Value': True})
+
+        result = {'VolumeId': 'vol-12345678',
+                  'AutoEnableIO.Value': 'true'}
+
+        self.assertEqual(params, result)


### PR DESCRIPTION
`AutoEnableIO` is AttributeBooleanValue type, not Boolean type.

Fixes aws/aws-cli#803
