### PR TITLE
Fix py2.6 for expect 100 continue

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -25,6 +25,164 @@ from botocore.exceptions import UnseekableStreamError
 logger = logging.getLogger(__name__)
 
 
+class AWSHTTPResponse(HTTPResponse):
+    # The *args, **kwargs is used because the args are slightly
+    # different in py2.6 than in py2.7/py3.
+    def __init__(self, *args, **kwargs):
+        self._status_tuple = kwargs.pop('status_tuple')
+        HTTPResponse.__init__(self, *args, **kwargs)
+
+    def _read_status(self):
+        if self._status_tuple is not None:
+            status_tuple = self._status_tuple
+            self._status_tuple = None
+            return status_tuple
+        else:
+            return HTTPResponse._read_status(self)
+
+
+class AWSHTTPConnection(HTTPConnection):
+    """HTTPConnection that supports Expect 100-continue.
+
+    This is conceptually a subclass of httplib.HTTPConnection (though
+    technically we subclass from urllib3, which subclasses
+    httplib.HTTPConnection) and we only override this class to support Expect
+    100-continue, which we need for S3.  As far as I can tell, this is
+    general purpose enough to not be specific to S3, but I'm being
+    tentative and keeping it in botocore because I've only tested
+    this against AWS services.
+
+    """
+    def __init__(self, *args, **kwargs):
+        HTTPConnection.__init__(self, *args, **kwargs)
+        self._original_response_cls = self.response_class
+        # We'd ideally hook into httplib's states, but they're all
+        # __mangled_vars so we use our own state var.  This variable is set
+        # when we receive an early response from the server.  If this value is
+        # set to True, any calls to send() are noops.  This value is reset to
+        # false every time _send_request is called.  This is to workaround the
+        # fact that py2.6 (and only py2.6) has a separate send() call for the
+        # body in _send_request, as opposed to endheaders(), which is where the
+        # body is sent in all versions > 2.6.
+        self._response_received = False
+
+    def _send_request(self, method, url, body, headers):
+        self._response_received = False
+        if headers.get('Expect', '') == '100-continue':
+            self._expect_header_set = True
+        else:
+            self._expect_header_set = False
+            self.response_class = self._original_response_cls
+        rval = HTTPConnection._send_request(
+            self, method, url, body, headers)
+        self._expect_header_set = False
+        return rval
+
+    def _send_output(self, message_body=None):
+        self._buffer.extend((b"", b""))
+        msg = b"\r\n".join(self._buffer)
+        del self._buffer[:]
+        # If msg and message_body are sent in a single send() call,
+        # it will avoid performance problems caused by the interaction
+        # between delayed ack and the Nagle algorithm.
+        if isinstance(message_body, bytes):
+            msg += message_body
+            message_body = None
+        self.send(msg)
+        if self._expect_header_set:
+            # This is our custom behavior.  If the Expect header was
+            # set, it will trigger this custom behavior.
+            logger.debug("Waiting for 100 Continue response.")
+            # Wait for 1 second for the server to send a response.
+            read, write, exc = select.select([self.sock], [], [self.sock], 1)
+            if read:
+                self._handle_expect_response(message_body)
+                return
+            else:
+                # From the RFC:
+                # Because of the presence of older implementations, the
+                # protocol allows ambiguous situations in which a client may
+                # send "Expect: 100-continue" without receiving either a 417
+                # (Expectation Failed) status or a 100 (Continue) status.
+                # Therefore, when a client sends this header field to an origin
+                # server (possibly via a proxy) from which it has never seen a
+                # 100 (Continue) status, the client SHOULD NOT wait for an
+                # indefinite period before sending the request body.
+                logger.debug("No response seen from server, continuing to "
+                             "send the response body.")
+        if message_body is not None:
+            # message_body was not a string (i.e. it is a file), and
+            # we must run the risk of Nagle.
+            self.send(message_body)
+
+    def _handle_expect_response(self, message_body):
+        # This is called when we sent the request headers containing
+        # an Expect: 100-continue header and received a response.
+        # We now need to figure out what to do.
+        fp = self.sock.makefile('rb', 0)
+        try:
+            maybe_status_line = fp.readline()
+            parts = maybe_status_line.split(None, 2)
+            if self._is_100_continue_status(maybe_status_line):
+                # Read an empty line as per the RFC.
+                fp.readline()
+                logger.debug("100 Continue response seen, now sending request body.")
+                self._send_message_body(message_body)
+            elif len(parts) == 3 and parts[0].startswith(b'HTTP/'):
+                # From the RFC:
+                # Requirements for HTTP/1.1 origin servers:
+                #
+                # - Upon receiving a request which includes an Expect
+                #   request-header field with the "100-continue"
+                #   expectation, an origin server MUST either respond with
+                #   100 (Continue) status and continue to read from the
+                #   input stream, or respond with a final status code.
+                #
+                # So if we don't get a 100 Continue response, then
+                # whatever the server has sent back is the final response
+                # and don't send the message_body.
+                logger.debug("Received a non 100 Continue response "
+                            "from the server, NOT sending request body.")
+                status_tuple = (parts[0].decode('ascii'),
+                                int(parts[1]), parts[2].decode('ascii'))
+                response_class = functools.partial(
+                    AWSHTTPResponse, status_tuple=status_tuple)
+                self.response_class = response_class
+                self._response_received = True
+        finally:
+            fp.close()
+
+    def _send_message_body(self, message_body):
+        if message_body is not None:
+            self.send(message_body)
+
+    def send(self, str):
+        if self._response_received:
+            logger.debug("send() called, but reseponse already received. "
+                         "Not sending data.")
+            return
+        return HTTPConnection.send(self, str)
+
+    def _is_100_continue_status(self, maybe_status_line):
+        parts = maybe_status_line.split(None, 2)
+        # Check for HTTP/<version> 100 Continue\r\n
+        return (
+            len(parts) == 3 and parts[0].startswith(b'HTTP/') and
+            parts[1] == b'100' and parts[2].startswith(b'Continue'))
+
+
+class AWSHTTPSConnection(VerifiedHTTPSConnection):
+    pass
+
+
+# Now we need to set the methods we overrode from AWSHTTPConnection
+# onto AWSHTTPSConnection.  This is just a shortcut to avoid
+# copy/pasting the same code into AWSHTTPSConnection.
+for name, function in AWSHTTPConnection.__dict__.items():
+    if inspect.isfunction(function):
+        setattr(AWSHTTPSConnection, name, function)
+
+
 class AWSRequest(models.RequestEncodingMixin, models.Request):
     def __init__(self, *args, **kwargs):
         self.auth_path = None


### PR DESCRIPTION
This PR is https://github.com/boto/botocore/pull/303 (which was reverted because it didn't work in py2.6 + the fix for py2.6.

The issue is that py2.6's _send_request is different
than the other supported python versions.  Because of this,
we have to add a check such that we don't send the body if
this response_received flag has been set.

Verified this works on py2.6, py2.7, py3.3, py3.4.  Integration tests passing on all versions.

cc @danielgtaylor
