### PR TITLE
Fix region endpoint for cn-north-1

### DIFF
--- a/botocore/data/aws/_endpoints.json
+++ b/botocore/data/aws/_endpoints.json
@@ -78,7 +78,7 @@
       }
     },
     {
-      "uri":"{scheme}://{service}-{region}.amazonaws.com.cn",
+      "uri":"{scheme}://{service}.{region}.amazonaws.com.cn",
       "constraints":[
         ["region", "startsWith", "cn-"]
       ]
@@ -163,7 +163,7 @@
   ],
   "dynamodb": [
     {
-      "uri": "http://localhost:8080",
+      "uri": "http://localhost:8000",
       "constraints": [
         ["region", "equals", "local"]
       ],

--- a/services/_endpoints.json
+++ b/services/_endpoints.json
@@ -78,7 +78,7 @@
       }
     },
     {
-      "uri":"{scheme}://{service}-{region}.amazonaws.com.cn",
+      "uri":"{scheme}://{service}.{region}.amazonaws.com.cn",
       "constraints":[
         ["region", "startsWith", "cn-"]
       ]


### PR DESCRIPTION
The endpoint heuristic rule is wrong. Also looks like the local region changes
weren't scripts/buildall'd, so that shows up in the diff
