### PR TITLE
Fix regression in EC2 credential provider parsing

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -211,8 +211,13 @@ def parse_key_val_file(filename, _open=open):
 
 
 def parse_key_val_file_contents(contents):
+    # This was originally extracted from the EC2 credential provider, which was
+    # fairly lenient in its parsing.  We only try to parse key/val pairs if
+    # there's a '=' in the line.
     final = {}
     for line in contents.splitlines():
+        if '=' not in line:
+            continue
         key, val = line.split('=', 1)
         key = key.strip()
         val = val.strip()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -151,6 +151,26 @@ class TestParseEC2CredentialsFile(unittest.TestCase):
         contents = ""
         self.assertEqual(parse_key_val_file_contents(contents), {})
 
+    def test_key_val_pair_with_blank_lines(self):
+        # The \n\n has an extra blank between the access/secret keys.
+        contents = "AWSAccessKeyId=a\n\nAWSSecretKey=b\n"
+        self.assertEqual(parse_key_val_file_contents(contents),
+                         {'AWSAccessKeyId': 'a',
+                          'AWSSecretKey': 'b'})
+
+    def test_key_val_parser_lenient(self):
+        # Ignore any line that does not have a '=' char in it.
+        contents = "AWSAccessKeyId=a\nNOTKEYVALLINE\nAWSSecretKey=b\n"
+        self.assertEqual(parse_key_val_file_contents(contents),
+                         {'AWSAccessKeyId': 'a',
+                          'AWSSecretKey': 'b'})
+
+    def test_multiple_equals_on_line(self):
+        contents = "AWSAccessKeyId=a\nAWSSecretKey=secret_key_with_equals=b\n"
+        self.assertEqual(parse_key_val_file_contents(contents),
+                         {'AWSAccessKeyId': 'a',
+                          'AWSSecretKey': 'secret_key_with_equals=b'})
+
     def test_os_error_raises_config_not_found(self):
         mock_open = mock.Mock()
         mock_open.side_effect = OSError()


### PR DESCRIPTION
The only parser basically had::

```
config = dict(line.split('=', 1) for line in lines if '=' in line)
```

   access_key = config.get('AWSAccessKeyId')
   secret_key = config.get('AWSSecretKey')

Which ignores lines that don't have a '=' char in it. This behavior has been
re-added and additional tests to cover a few of these edge cases have also
been added.

cc @danielgtaylor
