### PR TITLE
use encodebytes for Python 3 to avoid DeprecationWarning

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -23,11 +23,13 @@ from operator import itemgetter
 import functools
 import time
 
+
 from botocore.exceptions import NoCredentialsError
 from botocore.utils import normalize_url_path
 from botocore.compat import HTTPHeaders
 from botocore.compat import quote, unquote, urlsplit, parse_qs, urlencode
 from botocore.compat import urlunsplit
+from botocore.compat import encodebytes
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +120,7 @@ class SigV3Auth(BaseSigner):
         new_hmac = hmac.new(self.credentials.secret_key.encode('utf-8'),
                             digestmod=sha256)
         new_hmac.update(request.headers['Date'].encode('utf-8'))
-        encoded_signature = base64.encodestring(new_hmac.digest()).strip()
+        encoded_signature = encodebytes(new_hmac.digest()).strip()
         signature = ('AWS3-HTTPS AWSAccessKeyId=%s,Algorithm=%s,Signature=%s' %
                      (self.credentials.access_key, 'HmacSHA256',
                       encoded_signature.decode('utf-8')))
@@ -453,7 +455,7 @@ class HmacV1Auth(BaseSigner):
         new_hmac = hmac.new(self.credentials.secret_key.encode('utf-8'),
                             digestmod=sha1)
         new_hmac.update(string_to_sign.encode('utf-8'))
-        return base64.encodestring(new_hmac.digest()).strip().decode('utf-8')
+        return encodebytes(new_hmac.digest()).strip().decode('utf-8')
 
     def canonical_standard_headers(self, headers):
         interesting_headers = ['content-md5', 'content-type', 'date']

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -33,6 +33,7 @@ if six.PY3:
     from urllib.parse import urlencode
     from http.client import HTTPResponse
     from io import IOBase as _IOBase
+    from base64 import encodebytes
     file_type = _IOBase
     zip = zip
 
@@ -69,6 +70,7 @@ else:
     file_type = file
     from itertools import izip as zip
     from httplib import HTTPResponse
+    from base64 import encodestring as encodebytes
 
     class HTTPHeaders(Message):
 


### PR DESCRIPTION
This solves the DeprecationWarning from https://github.com/boto/botocore/issues/319 which also affects us.

botocore/auth.py:453: DeprecationWarning: encodestring() is a deprecated alias, use encodebytes() return base64.encodestring(new_hmac.digest()).strip().decode('utf-8')
