### PR TITLE
Properly percent encode values in URI strings

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -24,9 +24,10 @@ import functools
 import time
 
 from botocore.exceptions import NoCredentialsError
-from botocore.utils import normalize_url_path
+from botocore.utils import normalize_url_path, percent_encode_sequence
+from botocore.utils import percent_encode
 from botocore.compat import HTTPHeaders
-from botocore.compat import quote, unquote, urlsplit, parse_qs, urlencode
+from botocore.compat import quote, unquote, urlsplit, parse_qs
 from botocore.compat import urlunsplit
 
 logger = logging.getLogger(__name__)
@@ -379,7 +380,7 @@ class SigV4QueryAuth(SigV4Auth):
         # You can't mix the two types of params together, i.e just keep doing
         # new_query_params.update(op_params)
         # new_query_params.update(auth_params)
-        # urlencode(new_query_params)
+        # percent_encode_sequence(new_query_params)
         operation_params = ''
         if request.data:
             # We also need to move the body params into the query string.
@@ -389,8 +390,9 @@ class SigV4QueryAuth(SigV4Auth):
             query_dict.update(request.data)
             request.data = ''
         if query_dict:
-            operation_params = urlencode(query_dict) + '&'
-        new_query_string = operation_params + urlencode(auth_params)
+            operation_params = percent_encode_sequence(query_dict) + '&'
+        new_query_string = operation_params + \
+                percent_encode_sequence(auth_params)
         # url_parts is a tuple (and therefore immutable) so we need to create
         # a new url_parts with the new query string.
         # <part>   - <index>

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -228,6 +228,14 @@ class TestSigV4Presign(unittest.TestCase):
         self.assertIn(
             '?Action=MyOperation&X-Amz', request.url)
 
+    def test_presign_with_spaces_in_param(self):
+        request = AWSRequest()
+        request.url = 'https://ec2.us-east-1.amazonaws.com/'
+        request.data = {'Action': 'MyOperation', 'Description': 'With Spaces'}
+        self.auth.add_auth(request)
+        # Verify we encode spaces as '%20, and we don't use '+'.
+        self.assertIn('Description=With%20Spaces', request.url)
+
     def test_s3_sigv4_presign(self):
         auth = botocore.auth.S3SigV4QueryAuth(
             self.credentials, self.service_name, self.region_name, expires=60)


### PR DESCRIPTION
This is causing an issue with CopySnapshot when the
description has spaces in it.
