### PR TITLE
Add output key validation to pagination configs

### DIFF
--- a/botocore/data/aws/cloudfront/2014-05-31.json
+++ b/botocore/data/aws/cloudfront/2014-05-31.json
@@ -5603,18 +5603,12 @@
             ],
             "documentation": "\n    List origin access identities.\n  ",
             "pagination": {
-                "input_token": [
-                    "Marker"
-                ],
+                "input_token": "Marker",
+                "output_token": "CloudFrontOriginAccessIdentityList.NextMarker",
                 "limit_key": "MaxItems",
-                "more_results": "IsTruncated",
-                "output_token": [
-                    "NextMarker"
-                ],
-                "result_key": "CloudFrontOriginAccessIdentityList",
-                "py_input_token": [
-                    "marker"
-                ]
+                "more_results": "CloudFrontOriginAccessIdentityList.IsTruncated",
+                "result_key": "CloudFrontOriginAccessIdentityList.Items",
+                "py_input_token": "marker"
             }
         },
         "ListDistributions": {
@@ -6375,18 +6369,12 @@
             ],
             "documentation": "\n    List distributions.\n  ",
             "pagination": {
-                "input_token": [
-                    "Marker"
-                ],
+                "input_token": "Marker",
+                "output_token": "DistributionList.NextMarker",
                 "limit_key": "MaxItems",
-                "more_results": "IsTruncated",
-                "output_token": [
-                    "NextMarker"
-                ],
-                "result_key": "DistributionList",
-                "py_input_token": [
-                    "marker"
-                ]
+                "more_results": "DistributionList.IsTruncated",
+                "result_key": "DistributionList.Items",
+                "py_input_token": "marker"
             }
         },
         "ListInvalidations": {
@@ -6536,18 +6524,12 @@
             ],
             "documentation": "\n    List invalidation batches.\n  ",
             "pagination": {
-                "input_token": [
-                    "Marker"
-                ],
+                "input_token": "Marker",
+                "output_token": "InvalidationList.NextMarker",
                 "limit_key": "MaxItems",
-                "more_results": "IsTruncated",
-                "output_token": [
-                    "NextMarker"
-                ],
-                "result_key": "InvalidationList",
-                "py_input_token": [
-                    "marker"
-                ]
+                "more_results": "InvalidationList.IsTruncated",
+                "result_key": "InvalidationList.Items",
+                "py_input_token": "marker"
             }
         },
         "ListStreamingDistributions": {
@@ -6771,18 +6753,12 @@
             ],
             "documentation": "\n    List streaming distributions.\n  ",
             "pagination": {
-                "input_token": [
-                    "Marker"
-                ],
+                "input_token": "Marker",
+                "output_token": "StreamingDistributionList.NextMarker",
                 "limit_key": "MaxItems",
-                "more_results": "IsTruncated",
-                "output_token": [
-                    "NextMarker"
-                ],
-                "result_key": "StreamingDistributionList",
-                "py_input_token": [
-                    "marker"
-                ]
+                "more_results": "StreamingDistributionList.IsTruncated",
+                "result_key": "StreamingDistributionList.Items",
+                "py_input_token": "marker"
             }
         },
         "UpdateCloudFrontOriginAccessIdentity": {
@@ -9426,60 +9402,36 @@
     },
     "pagination": {
         "ListCloudFrontOriginAccessIdentities": {
-            "input_token": [
-                "Marker"
-            ],
+            "input_token": "Marker",
+            "output_token": "CloudFrontOriginAccessIdentityList.NextMarker",
             "limit_key": "MaxItems",
-            "more_results": "IsTruncated",
-            "output_token": [
-                "NextMarker"
-            ],
-            "result_key": "CloudFrontOriginAccessIdentityList",
-            "py_input_token": [
-                "marker"
-            ]
+            "more_results": "CloudFrontOriginAccessIdentityList.IsTruncated",
+            "result_key": "CloudFrontOriginAccessIdentityList.Items",
+            "py_input_token": "marker"
         },
         "ListDistributions": {
-            "input_token": [
-                "Marker"
-            ],
+            "input_token": "Marker",
+            "output_token": "DistributionList.NextMarker",
             "limit_key": "MaxItems",
-            "more_results": "IsTruncated",
-            "output_token": [
-                "NextMarker"
-            ],
-            "result_key": "DistributionList",
-            "py_input_token": [
-                "marker"
-            ]
+            "more_results": "DistributionList.IsTruncated",
+            "result_key": "DistributionList.Items",
+            "py_input_token": "marker"
         },
         "ListInvalidations": {
-            "input_token": [
-                "Marker"
-            ],
+            "input_token": "Marker",
+            "output_token": "InvalidationList.NextMarker",
             "limit_key": "MaxItems",
-            "more_results": "IsTruncated",
-            "output_token": [
-                "NextMarker"
-            ],
-            "result_key": "InvalidationList",
-            "py_input_token": [
-                "marker"
-            ]
+            "more_results": "InvalidationList.IsTruncated",
+            "result_key": "InvalidationList.Items",
+            "py_input_token": "marker"
         },
         "ListStreamingDistributions": {
-            "input_token": [
-                "Marker"
-            ],
+            "input_token": "Marker",
+            "output_token": "StreamingDistributionList.NextMarker",
             "limit_key": "MaxItems",
-            "more_results": "IsTruncated",
-            "output_token": [
-                "NextMarker"
-            ],
-            "result_key": "StreamingDistributionList",
-            "py_input_token": [
-                "marker"
-            ]
+            "more_results": "StreamingDistributionList.IsTruncated",
+            "result_key": "StreamingDistributionList.Items",
+            "py_input_token": "marker"
         }
     },
     "retry": {

--- a/botocore/data/aws/dynamodb/2012-08-10.json
+++ b/botocore/data/aws/dynamodb/2012-08-10.json
@@ -4798,6 +4798,11 @@
                 "output_token": "LastEvaluatedKey",
                 "limit_key": "Limit",
                 "result_key": "Items",
+                "non_aggregate_keys": [
+                    "Count",
+                    "ScannedCount",
+                    "ConsumedCapacity"
+                ],
                 "py_input_token": "exclusive_start_key"
             }
         },
@@ -5314,6 +5319,11 @@
                 "output_token": "LastEvaluatedKey",
                 "limit_key": "Limit",
                 "result_key": "Items",
+                "non_aggregate_keys": [
+                    "Count",
+                    "ScannedCount",
+                    "ConsumedCapacity"
+                ],
                 "py_input_token": "exclusive_start_key"
             }
         },
@@ -6500,6 +6510,11 @@
             "output_token": "LastEvaluatedKey",
             "limit_key": "Limit",
             "result_key": "Items",
+            "non_aggregate_keys": [
+                "Count",
+                "ScannedCount",
+                "ConsumedCapacity"
+            ],
             "py_input_token": "exclusive_start_key"
         },
         "Scan": {
@@ -6507,6 +6522,11 @@
             "output_token": "LastEvaluatedKey",
             "limit_key": "Limit",
             "result_key": "Items",
+            "non_aggregate_keys": [
+                "Count",
+                "ScannedCount",
+                "ConsumedCapacity"
+            ],
             "py_input_token": "exclusive_start_key"
         }
     },

--- a/botocore/data/aws/elasticache/2014-03-24.json
+++ b/botocore/data/aws/elasticache/2014-03-24.json
@@ -3332,6 +3332,9 @@
                 "output_token": "Marker",
                 "limit_key": "MaxRecords",
                 "result_key": "Parameters",
+                "non_aggregate_keys": [
+                    "CacheNodeTypeSpecificParameters"
+                ],
                 "py_input_token": "marker"
             }
         },
@@ -6467,6 +6470,9 @@
             "output_token": "Marker",
             "limit_key": "MaxRecords",
             "result_key": "Parameters",
+            "non_aggregate_keys": [
+                "CacheNodeTypeSpecificParameters"
+            ],
             "py_input_token": "marker"
         },
         "DescribeCacheSecurityGroups": {

--- a/botocore/data/aws/iam/2010-05-08.json
+++ b/botocore/data/aws/iam/2010-05-08.json
@@ -2700,6 +2700,9 @@
                 "more_results": "IsTruncated",
                 "limit_key": "MaxItems",
                 "result_key": "Users",
+                "non_aggregate_keys": [
+                    "Group"
+                ],
                 "py_input_token": "marker"
             }
         },
@@ -6881,6 +6884,9 @@
             "more_results": "IsTruncated",
             "limit_key": "MaxItems",
             "result_key": "Users",
+            "non_aggregate_keys": [
+                "Group"
+            ],
             "py_input_token": "marker"
         },
         "ListAccessKeys": {

--- a/botocore/data/aws/s3/2006-03-01.json
+++ b/botocore/data/aws/s3/2006-03-01.json
@@ -3817,6 +3817,11 @@
                 "output_token": "NextPartNumberMarker",
                 "input_token": "PartNumberMarker",
                 "result_key": "Parts",
+                "non_aggregate_keys": [
+                    "Initiator",
+                    "Owner",
+                    "StorageClass"
+                ],
                 "py_input_token": "part_number_marker"
             }
         },
@@ -5697,6 +5702,11 @@
             "output_token": "NextPartNumberMarker",
             "input_token": "PartNumberMarker",
             "result_key": "Parts",
+            "non_aggregate_keys": [
+                "Initiator",
+                "Owner",
+                "StorageClass"
+            ],
             "py_input_token": "part_number_marker"
         }
     },

--- a/scripts/buildall
+++ b/scripts/buildall
@@ -53,7 +53,10 @@ for filename in os.listdir(SERVICES_DIR):
     elif filename.endswith('.json') and filename.count('.') == 1:
         full_cmd = '%s %s' % (BUILD_MODELS, service_filename)
         print("Running command: %s" % full_cmd)
-        new_model = check_output(full_cmd, shell=True).decode('utf-8')
+        try:
+            new_model = check_output(full_cmd, shell=True).decode('utf-8')
+        except Exception:
+            continue
         final_filename = build_final_filename(service_filename)
         try:
             # Ensure the directory is there if the service is new.

--- a/services/cloudfront.extra.json
+++ b/services/cloudfront.extra.json
@@ -3,32 +3,32 @@
   },
   "pagination": {
     "ListCloudFrontOriginAccessIdentities": {
-      "input_token": ["Marker"],
+      "input_token": "Marker",
+      "output_token": "CloudFrontOriginAccessIdentityList.NextMarker",
       "limit_key": "MaxItems",
-      "more_results": "IsTruncated",
-      "output_token": ["NextMarker"],
-      "result_key": "CloudFrontOriginAccessIdentityList"
+      "more_results": "CloudFrontOriginAccessIdentityList.IsTruncated",
+      "result_key": "CloudFrontOriginAccessIdentityList.Items"
     },
     "ListDistributions": {
-      "input_token": ["Marker"],
+      "input_token": "Marker",
+      "output_token": "DistributionList.NextMarker",
       "limit_key": "MaxItems",
-      "more_results": "IsTruncated",
-      "output_token": ["NextMarker"],
-      "result_key": "DistributionList"
+      "more_results": "DistributionList.IsTruncated",
+      "result_key": "DistributionList.Items"
     },
     "ListInvalidations": {
-      "input_token": ["Marker"],
+      "input_token": "Marker",
+      "output_token": "InvalidationList.NextMarker",
       "limit_key": "MaxItems",
-      "more_results": "IsTruncated",
-      "output_token": ["NextMarker"],
-      "result_key": "InvalidationList"
+      "more_results": "InvalidationList.IsTruncated",
+      "result_key": "InvalidationList.Items"
     },
     "ListStreamingDistributions": {
-      "input_token": ["Marker"],
+      "input_token": "Marker",
+      "output_token": "StreamingDistributionList.NextMarker",
       "limit_key": "MaxItems",
-      "more_results": "IsTruncated",
-      "output_token": ["NextMarker"],
-      "result_key": "StreamingDistributionList"
+      "more_results": "StreamingDistributionList.IsTruncated",
+      "result_key": "StreamingDistributionList.Items"
     }
   },
   "transformations": {

--- a/services/dynamodb.extra.json
+++ b/services/dynamodb.extra.json
@@ -43,13 +43,15 @@
       "input_token": "ExclusiveStartKey",
       "output_token": "LastEvaluatedKey",
       "limit_key": "Limit",
-      "result_key": "Items"
+      "result_key": "Items",
+      "non_aggregate_keys": ["Count", "ScannedCount", "ConsumedCapacity"]
     },
     "Scan": {
       "input_token": "ExclusiveStartKey",
       "output_token": "LastEvaluatedKey",
       "limit_key": "Limit",
-      "result_key": "Items"
+      "result_key": "Items",
+      "non_aggregate_keys": ["Count", "ScannedCount", "ConsumedCapacity"]
     }
   }
 }

--- a/services/elasticache.extra.json
+++ b/services/elasticache.extra.json
@@ -24,7 +24,8 @@
       "input_token": "Marker",
       "output_token": "Marker",
       "limit_key": "MaxRecords",
-      "result_key": "Parameters"
+      "result_key": "Parameters",
+      "non_aggregate_keys": ["CacheNodeTypeSpecificParameters"]
     },
     "DescribeCacheSecurityGroups": {
       "input_token": "Marker",

--- a/services/iam.extra.json
+++ b/services/iam.extra.json
@@ -7,7 +7,8 @@
       "output_token": "Marker",
       "more_results": "IsTruncated",
       "limit_key": "MaxItems",
-      "result_key": "Users"
+      "result_key": "Users",
+      "non_aggregate_keys": ["Group"]
     },
     "ListAccessKeys": {
       "input_token": "Marker",

--- a/services/s3.extra.json
+++ b/services/s3.extra.json
@@ -100,7 +100,8 @@
       "limit_key": "MaxParts",
       "output_token": "NextPartNumberMarker",
       "input_token": "PartNumberMarker",
-      "result_key": "Parts"
+      "result_key": "Parts",
+      "non_aggregate_keys": ["Initiator", "Owner", "StorageClass"]
     }
   },
   "waiters": {


### PR DESCRIPTION
This also updates some of the pagination configs based on the
newly added validation finding several issues with the existing keys.
The resulting changes required adding `non_aggregate_key` configs to
several paginated responses.

cc @danielgtaylor
