### PR TITLE
Fix serialization of ChangeTagsForResource

### DIFF
--- a/botocore/parameters.py
+++ b/botocore/parameters.py
@@ -406,7 +406,7 @@ class ListParameter(Parameter):
             return inner_xml
         else:
             if not label:
-                label = self.xmlname
+                label = self.xmlname or self.name
             return '<%s>' % label + inner_xml + '</%s>' % label
 
 


### PR DESCRIPTION
This was serialization an xmlnode of 'None', because there was no xmlname in
the parameter.  This adds a fallback to the `name` attribute if `xmlname`
is not available.
