### PR TITLE
Raise exception if partial credentials are found

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -61,7 +61,7 @@ class PartialCredentialsError(BotoCoreError):
     :ivar cred_var: The missing credential variable name.
 
     """
-    fmt = 'Partial credentials found, missing: {cred_var}'
+    fmt = 'Partial credentials found in {provider}, missing: {cred_var}'
 
 
 class NoRegionError(BotoCoreError):


### PR DESCRIPTION
This was previously raising an unhelpful `KeyError`.
Now, whenever a cred provider has at least the access key,
it is an error if the corresponding secret key is not also
available via the same provider.  You also get a better
error message now as well::

```
Partial credentials found in config-file, missing: aws_secret_access_key
```

Fixes https://github.com/aws/aws-cli/issues/690

cc @kyleknap @danielgtaylor
