### PR TITLE
Don't create auth class if signature_version is None

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -32,6 +32,7 @@ from botocore.compat import urljoin, json, quote
 logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 60
 
+
 class Endpoint(object):
     """
     Represents an endpoint for a particular service in a specific
@@ -268,7 +269,8 @@ def get_endpoint(service, region_name, endpoint_url, verify=None):
             service_style=service.type)
     service_name = getattr(service, 'signing_name', service.endpoint_prefix)
     auth = None
-    if hasattr(service, 'signature_version'):
+    if hasattr(service, 'signature_version') and \
+            service.signature_version is not None:
         auth = _get_auth(service.signature_version,
                          credentials=service.session.get_credentials(),
                          service_name=service_name,

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -100,6 +100,17 @@ class TestGetEndpoint(unittest.TestCase):
                                 'https://service.region.amazonaws.com')
         self.assertIsNone(endpoint.auth)
 
+    def test_signature_version_is_none(self):
+        # If signature_version is set to None, we don't assign any auth classes
+        # to the endpoint.
+        service = self.create_mock_service('query', signature_version=None)
+        # Verify we have a signature_version attr and that it's None.  This is
+        # a different case from not having the 'signature_version' at all.
+        self.assertIsNone(service.signature_version)
+        endpoint = get_endpoint(service, 'us-west-2',
+                                'https://service.region.amazonaws.com')
+        self.assertIsNone(endpoint.auth)
+
     def test_get_endpoint_default_verify_ssl(self):
         service = self.create_mock_service('query')
         endpoint = get_endpoint(service, 'us-west-2',


### PR DESCRIPTION
No auth class is created if either
1. No signature_version exists
2. The signature_version attr exists, but it is None.

cc @danielgtaylor @kyleknap
