### PR TITLE
Log the response body

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -94,11 +94,13 @@ import re
 import base64
 import json
 import xml.etree.cElementTree
+import logging
 
 from six.moves import http_client
 
 from botocore.utils import parse_timestamp
 
+LOG = logging.getLogger(__name__)
 
 DEFAULT_TIMESTAMP_PARSER = parse_timestamp
 
@@ -148,6 +150,7 @@ class ResponseParser(object):
             ``RequestId`` will always be present.
 
         """
+        LOG.debug('Response body:\n%s', response['body'])
         if response['status_code'] >= 301:
             return self._do_error_parse(response, shape)
         else:


### PR DESCRIPTION
I find it incredibly useful to see the full body of the response in the debug output.  We lost that in https://github.com/boto/botocore/commit/dd5aad504fd6bbe13e327460f10fbac96cc632b9 but this puts it back.

If you would prefer to handle it somewhere else, that's fine with me but I do think it needs to be there.
