### PR TITLE
Fix BaseXMLResponseParser._handle_map to not crash

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -201,7 +201,7 @@ class BaseXMLResponseParser(ResponseParser):
                     val_name = self._parse_shape(value_shape, single_pair)
                 else:
                     raise ResponseParserError("Unknown tag: %s" % tag_name)
-            parsed[key_name] = val_name
+                parsed[key_name] = val_name
         return parsed
 
     def _node_tag(self, node):


### PR DESCRIPTION
key_name and val_name are set inside of the loop over
keyval_node pairs. parsed[key_name] = val_name should
also be in that loop.

The crash is caused by key_name and val_name being
referenced from outside of the loop, where they may be
used before they have been set.
