### PR TITLE
Fix BaseXMLResponseParser._handle_map to not crash

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -192,6 +192,8 @@ class BaseXMLResponseParser(ResponseParser):
         key_location_name = key_shape.serialization.get('name') or 'key'
         value_location_name = value_shape.serialization.get('name') or 'value'
         for keyval_node in node:
+            key_name = None
+            val_name = None
             for single_pair in keyval_node:
                 # Within each <entry> there's a <key> and a <value>
                 tag_name = self._node_tag(single_pair)
@@ -201,7 +203,8 @@ class BaseXMLResponseParser(ResponseParser):
                     val_name = self._parse_shape(value_shape, single_pair)
                 else:
                     raise ResponseParserError("Unknown tag: %s" % tag_name)
-            parsed[key_name] = val_name
+            if key_name is not None and val_name is not None:
+                parsed[key_name] = val_name
         return parsed
 
     def _node_tag(self, node):


### PR DESCRIPTION
key_name and val_name are set inside of the loop over
keyval_node pairs.  The crash is caused by key_name and
val_name being referenced from outside of the loop, where
they may be used before they have been set.

Fix this by setting key_name and val_name to None before
the loop, and set parsed[key_name] to val_name only if both
key_name and val_name have both been given values from the
loop.
