### PR TITLE
Add waiter config and fix config lookup

### DIFF
--- a/botocore/data/aws/emr/2009-03-31.waiters.json
+++ b/botocore/data/aws/emr/2009-03-31.waiters.json
@@ -1,0 +1,22 @@
+{
+  "waiters": {
+    "__default__": {
+      "interval": 30,
+      "max_attempts": 60,
+      "acceptor_type": "output"
+    },
+    "__ClusterState": {
+      "operation": "DescribeCluster",
+      "acceptor_path": "Cluster.Status.State"
+    },
+    "ClusterRunning": {
+      "extends": "__ClusterState",
+      "success_value": ["RUNNING", "WAITING"],
+      "failure_value": [
+        "TERMINATING",
+        "TERMINATED",
+        "TERMINATED_WITH_ERRORS"
+      ]
+    }
+  }
+}

--- a/botocore/service.py
+++ b/botocore/service.py
@@ -186,7 +186,8 @@ class Service(object):
     def _load_waiter_config(self):
         loader = self.session.get_component('data_loader')
         api_version = self.api_version
-        config = loader.load_data('aws/%s/%s.waiters' % (self.endpoint_prefix, api_version))
+        config = loader.load_data('aws/%s/%s.waiters' % (
+            self.service_name, api_version))
         config = denormalize_waiters(config['waiters'])
         return config
 

--- a/tests/integration/test_emr.py
+++ b/tests/integration/test_emr.py
@@ -1,0 +1,49 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import unittest
+
+import botocore.session
+from botocore.paginate import DeprecatedPageIterator
+
+
+# I consider these integration tests because they're
+# testing more than a single unit, we're ensuring everything
+# accessible from the session works as expected.
+class TestEMRGetExtraResources(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.service = self.session.get_service('emr')
+        self.endpoint = self.service.get_endpoint('us-west-2')
+
+    def test_can_access_pagination_configs(self):
+        # Using an operation that we know will paginate.
+        operation = self.service.get_operation('ListClusters')
+        paginator = operation.paginate(self.endpoint)
+        self.assertIsInstance(paginator, DeprecatedPageIterator)
+
+    def test_operation_cant_be_paginated(self):
+        operation = self.service.get_operation('AddInstanceGroups')
+        with self.assertRaises(TypeError):
+            operation.paginate(self.endpoint)
+
+    def test_can_get_waiters(self):
+        waiter = self.service.get_waiter('ClusterRunning')
+        self.assertTrue(hasattr(waiter, 'wait'))
+
+    def test_waiter_does_not_exist(self):
+        with self.assertRaises(ValueError):
+            self.service.get_waiter('DoesNotExist')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There were two issues:
1. The emr waiter config was not there, I've now added that.
2. We were using the endpoint prefix instead of the service_name (elasticmapreduce vs. emr).

We need to use the service_name and not the endpoint prefix.
These aren't always the same thing (emr vs. elasticmapreduce).

Also added some integ tests to ensure we don't regress on this again.

Fixes aws/aws-cli#937.

cc @danielgtaylor @kyleknap 
