### PR TITLE
Fix header parsing for scalar values

### DIFF
--- a/tests/unit/protocols/output/rest-xml.json
+++ b/tests/unit/protocols/output/rest-xml.json
@@ -533,5 +533,122 @@
         }
       }
     ]
+  },
+  {
+    "description": "Scalar members in headers",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Str": {
+            "locationName": "x-str",
+            "shape": "StringHeaderType"
+          },
+          "Integer": {
+            "locationName": "x-int",
+            "shape": "IntegerHeaderType"
+          },
+          "TrueBool": {
+            "locationName": "x-true-bool",
+            "shape": "BooleanHeaderType"
+          },
+          "FalseBool": {
+            "locationName": "x-false-bool",
+            "shape": "BooleanHeaderType"
+          },
+          "Float": {
+            "locationName": "x-float",
+            "shape": "FloatHeaderType"
+          },
+          "Double": {
+            "locationName": "x-double",
+            "shape": "DoubleHeaderType"
+          },
+          "Long": {
+            "locationName": "x-long",
+            "shape": "LongHeaderType"
+          },
+          "Char": {
+            "locationName": "x-char",
+            "shape": "CharHeaderType"
+          },
+          "Timestamp": {
+            "locationName": "x-timestamp",
+            "shape": "TimestampHeaderType"
+          }
+        }
+      },
+      "StringHeaderType": {
+        "location": "header",
+        "type": "string"
+      },
+      "IntegerHeaderType": {
+        "location": "header",
+        "type": "integer"
+      },
+      "BooleanHeaderType": {
+        "location": "header",
+        "type": "boolean"
+      },
+      "FloatHeaderType": {
+        "location": "header",
+        "type": "float"
+      },
+      "DoubleHeaderType": {
+        "location": "header",
+        "type": "double"
+      },
+      "LongHeaderType": {
+        "location": "header",
+        "type": "long"
+      },
+      "CharHeaderType": {
+        "location": "header",
+        "type": "character"
+      },
+      "TimestampHeaderType": {
+        "location": "header",
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "string",
+          "Integer": 1,
+          "TrueBool": true,
+          "FalseBool": false,
+          "Float": 1.5,
+          "Double": 1.5,
+          "Long": 100,
+          "Char": "a",
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-str": "string",
+            "x-int": "1",
+            "x-true-bool": "true",
+            "x-false-bool": "false",
+            "x-float": "1.5",
+            "x-double": "1.5",
+            "x-long": "100",
+            "x-char": "a",
+            "x-timestamp": "Sun, 25 Jan 2015 08:00:00 -0000"
+          },
+          "body": ""
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
All the scalar handlers can now work with either XML nodes
or with the header strings directly.  This fixes a bug where
non-string scalar values were present in the headers (integers,
booleans, doubles, etc.) but were being called with handlers
only expecting XML nodes.

Fixes aws/aws-cli#940.

cc @kyleknap @danielgtaylor 
