### PR TITLE
Don't parse response body when output shape is None

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -450,9 +450,11 @@ class JSONParser(BaseJSONParser):
         # The json.loads() gives us the primitive JSON types,
         # but we need to traverse the parsed JSON data to convert
         # to richer types (blobs, timestamps, etc.
-        body = response['body'].decode(self.DEFAULT_ENCODING)
-        original_parsed = json.loads(body)
-        parsed = self._parse_shape(shape, original_parsed)
+        parsed = {}
+        if shape is not None:
+            body = response['body'].decode(self.DEFAULT_ENCODING)
+            original_parsed = json.loads(body)
+            parsed = self._parse_shape(shape, original_parsed)
         self._inject_response_metadata(parsed, response['headers'])
         return parsed
 

--- a/tests/integration/test_cognito_identity.py
+++ b/tests/integration/test_cognito_identity.py
@@ -1,0 +1,32 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+import random
+
+import botocore.session
+
+
+class TestCognitoIdentity(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client('cognito-identity', 'us-east-1')
+
+    def test_can_create_and_delete_identity_pool(self):
+        pool_name = 'botocoretest%s' % random.randint(1, 100000)
+        response = self.client.create_identity_pool(
+            IdentityPoolName=pool_name, AllowUnauthenticatedIdentities=True)
+        self.client.delete_identity_pool(IdentityPoolId=response['IdentityPoolId'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #352.  To ensure no other protocols were susceptible,
I reorganized part of the response parsing unit tests such that
testing for output shapes of None are grouped in a single class.

I've also added an integration test to ensure this functionality
with an actual AWS service.  This helps ensure we don't regress
in the future.

cc @danielgtaylor @kyleknap 
