### PR TITLE
Add back response headers to debug log

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -95,6 +95,7 @@ import base64
 import json
 import xml.etree.cElementTree
 import logging
+from pprint import pformat
 
 from six.moves import http_client
 
@@ -165,6 +166,7 @@ class ResponseParser(object):
             ``RequestId`` will always be present.
 
         """
+        LOG.debug('Response headers:\n%s', pformat(dict(response['headers'])))
         LOG.debug('Response body:\n%s', response['body'])
         if response['status_code'] >= 301:
             return self._do_error_parse(response, shape)

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -57,7 +57,10 @@ class TestResponseMetadataParsed(unittest.TestCase):
                 }
             })
         )
-        parsed = parser.parse({'body': response, 'status_code': 200}, output_shape)
+        parsed = parser.parse(
+            {'body': response,
+             'headers': {},
+             'status_code': 200}, output_shape)
         self.assertEqual(
             parsed, {'Str': 'myname',
                      'ResponseMetadata': {'RequestId': 'request-id'}})
@@ -82,7 +85,9 @@ class TestResponseMetadataParsed(unittest.TestCase):
             },
             model.ShapeResolver({'StringType': {'type': 'string'}})
         )
-        parsed = parser.parse({'body': response, 'status_code': 200}, output_shape)
+        parsed = parser.parse({'headers': {},
+                               'body': response,
+                               'status_code': 200}, output_shape)
         # Note that the response metadata is normalized to match the query
         # protocol, even though this is not how it appears in the output.
         self.assertEqual(


### PR DESCRIPTION
Also added an integration test to ensure we don't remove
this feature in the future.

cc @kyleknap @danielgtaylor 
