### PR TITLE
Don't use credential provider if credentials are given

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -795,7 +795,9 @@ class Session(object):
 
         """
         loader = self.get_component('data_loader')
-        endpoint_creator = self._create_endpoint_creator()
+        endpoint_creator = self._create_endpoint_creator(aws_access_key_id,
+                                                         aws_secret_access_key,
+                                                         aws_session_token)
         event_emitter = self.get_component('event_emitter')
         client_creator = botocore.client.ClientCreator(loader, endpoint_creator,
                                                        event_emitter)
@@ -806,11 +808,15 @@ class Session(object):
                                               aws_session_token)
         return client
 
-    def _create_endpoint_creator(self):
+    def _create_endpoint_creator(self, aws_access_key_id, aws_secret_access_key,
+                                 aws_session_token):
         resolver = self.get_component('endpoint_resolver')
         region = self.get_config_variable('region')
         event_emitter = self.get_component('event_emitter')
-        credentials = self.get_credentials()
+        if aws_secret_access_key is None:
+            credentials = self.get_credentials()
+        else:
+            credentials = None
         user_agent= self.user_agent()
         endpoint_creator = EndpointCreator(resolver, region, event_emitter,
                                            credentials, user_agent)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -282,13 +282,13 @@ class TestSessionConfigurationVars(BaseSessionTest):
         self.assertEqual(self.session.get_config_variable(
             'foobar', methods=('env', 'config')), 'default')
 
-
     def test_default_value_can_be_overriden(self):
         self.session.session_var_map['foobar'] = (None, 'FOOBAR', 'default')
         # Default value.
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
         self.assertEqual(
-            self.session.get_config_variable('foobar', default='per-call-default'),
+            self.session.get_config_variable('foobar',
+                                             default='per-call-default'),
             'per-call-default')
 
 
@@ -303,7 +303,8 @@ class TestSessionUserAgent(BaseSessionTest):
 
     def test_can_append_to_user_agent(self):
         self.session.user_agent_extra = 'custom-thing/other'
-        self.assertTrue(self.session.user_agent().endswith('custom-thing/other'))
+        self.assertTrue(
+            self.session.user_agent().endswith('custom-thing/other'))
 
 
 class TestConfigLoaderObject(BaseSessionTest):
@@ -334,6 +335,20 @@ class TestCreateClient(BaseSessionTest):
     def test_can_create_client(self):
         sts_client = self.session.create_client('sts', 'us-west-2')
         self.assertIsInstance(sts_client, client.BaseClient)
+
+    def test_credential_provider_not_called_when_creds_provided(self):
+        cred_provider = mock.Mock()
+        self.session.register_component(
+            'credential_provider', cred_provider)
+        self.session.create_client(
+            'sts', 'us-west-2',
+            aws_access_key_id='foo',
+            aws_secret_access_key='bar',
+            aws_session_token='baz')
+        self.assertFalse(cred_provider.load_credentials.called,
+                         "Credential provider was called even though "
+                         "explicit credentials were provided to the "
+                         "create_client call.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the `aws_*` params are provided in a `create_client()` call,
we still call `session.get_credentials()`, which is an unnecessary
call.  We should only invoke the credential lookup process if
explicit credentials are not provided in the call to
`create_client()`.

cc @kyleknap @danielgtaylor 
