### PR TITLE
Move auth_path handling to the request.

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -143,7 +143,7 @@ class TestS3Objects(TestS3BaseWithBucket):
         super(TestS3Objects, self).tearDown()
 
     def increment_auth(self, request, auth, **kwargs):
-        self.auth_paths.append(auth.auth_path)
+        self.auth_paths.append(request.auth_path)
 
     def test_can_delete_urlencoded_object(self):
         key_name = 'a+b/foo'

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -19,6 +19,7 @@ import mock
 
 import botocore.session
 from botocore.hooks import first_non_none_response
+from botocore.awsrequest import AWSRequest
 from botocore.compat import quote
 from botocore import handlers
 
@@ -160,6 +161,33 @@ class TestHandlers(BaseSessionTest):
             self.assertEqual(
                 params['headers'][prefix + 'key-MD5'],
                 'N7UdGUp1E+RbVvZSTy1R8g==')
+
+    def test_fix_s3_host_initial(self):
+        endpoint = mock.Mock(region_name='us-west-2')
+        request = AWSRequest(
+            method='PUT',headers={},
+            url='https://s3-us-west-2.amazonaws.com/bucket/key.txt'
+        )
+        auth = mock.Mock()
+        handlers.fix_s3_host('foo', endpoint, request, auth)
+        self.assertEqual(request.url, 'https://bucket.s3.amazonaws.com/key.txt')
+        self.assertEqual(request.auth_path, '/bucket/key.txt')
+
+    def test_fix_s3_host_only_applied_once(self):
+        endpoint = mock.Mock(region_name='us-west-2')
+        request = AWSRequest(
+            method='PUT',headers={},
+            url='https://s3-us-west-2.amazonaws.com/bucket/key.txt'
+        )
+        auth = mock.Mock()
+        handlers.fix_s3_host('foo', endpoint, request, auth)
+        # Calling the handler again should not affect the end result:
+        handlers.fix_s3_host('foo', endpoint, request, auth)
+        self.assertEqual(request.url, 'https://bucket.s3.amazonaws.com/key.txt')
+        # This was a bug previously.  We want to make sure that
+        # calling fix_s3_host() again does not alter the auth_path.
+        # Otherwise we'll get signature errors.
+        self.assertEqual(request.auth_path, '/bucket/key.txt')
 
 
 class TestRetryHandlerOrder(BaseSessionTest):


### PR DESCRIPTION
This fixes the previous issue where this was not fixed
previously by checking if the auth_path was not None.
By moving the handling of the auth_path onto the request
itself, this makes is easier to ensure that the auth_path
manipulation only happens on a per request basis.

cc @kyleknap mind taking another look?  I believe I've fixed the integ test issues.  They're all passing for me.
