### PR TITLE
Restore back-compat for timestamp input formats

### DIFF
--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -12,6 +12,8 @@ spec.  This can happen for a number of reasons:
 
 """
 import base64
+import datetime
+import dateutil.tz
 from tests import unittest
 
 from botocore.model import ServiceModel
@@ -78,3 +80,67 @@ class TestBinaryTypes(unittest.TestCase):
         request = self.serialize_to_request(input_params={'Blob': body})
         self.assert_serialized_blob_equals(
             request, blob_bytes=body.encode('utf-8'))
+
+
+class TestTimestamps(unittest.TestCase):
+    def setUp(self):
+        self.model = {
+            'metadata': {'protocol': 'query', 'apiVersion': '2014-01-01'},
+            'documentation': '',
+            'operations': {
+                'TestOperation': {
+                    'name': 'TestOperation',
+                    'http': {
+                        'method': 'POST',
+                        'requestUri': '/',
+                    },
+                    'input': {'shape': 'InputShape'},
+                }
+            },
+            'shapes': {
+                'InputShape': {
+                    'type': 'structure',
+                    'members': {
+                        'Timestamp': {'shape': 'TimestampType'},
+                    }
+                },
+                'TimestampType': {
+                    'type': 'timestamp',
+                }
+            }
+        }
+        self.service_model = ServiceModel(self.model)
+
+    def serialize_to_request(self, input_params):
+        request_serializer = serialize.create_serializer(
+            self.service_model.metadata['protocol'])
+        return request_serializer.serialize_to_request(
+            input_params, self.service_model.operation_model('TestOperation'))
+
+    def test_accepts_datetime_object(self):
+        request = self.serialize_to_request(
+            {'Timestamp': datetime.datetime(2014, 1, 1, 12, 12, 12,
+                                            tzinfo=dateutil.tz.tzutc())})
+        self.assertEqual(request['body']['Timestamp'], '2014-01-01T12:12:12Z')
+
+    def test_accepts_naive_datetime_object(self):
+        request = self.serialize_to_request(
+            {'Timestamp': datetime.datetime(2014, 1, 1, 12, 12, 12)})
+        self.assertEqual(request['body']['Timestamp'], '2014-01-01T12:12:12Z')
+
+    def test_accepts_iso_8601_format(self):
+        request = self.serialize_to_request({'Timestamp': '2014-01-01T12:12:12Z'})
+        self.assertEqual(request['body']['Timestamp'], '2014-01-01T12:12:12Z')
+
+    def test_accepts_timestamp_without_tz_info(self):
+        # If a timezone/utc is not specified, assume they meant
+        # UTC.  This is also the previous behavior from older versions
+        # of botocore so we want to make sure we preserve this behavior.
+        request = self.serialize_to_request({'Timestamp': '2014-01-01T12:12:12'})
+        self.assertEqual(request['body']['Timestamp'], '2014-01-01T12:12:12Z')
+
+    def test_microsecond_timestamp_without_tz_info(self):
+        request = self.serialize_to_request(
+            {'Timestamp': '2014-01-01T12:12:12.123456'})
+        self.assertEqual(request['body']['Timestamp'],
+                         '2014-01-01T12:12:12.123456Z')


### PR DESCRIPTION
While we want to encourage users to provide the appropriate
timezone info, this commit adds back the previous behavior, which
was to serialize the request assuming the user meant UTC.  I double
checked, and in prior versions, we weren't sending any tzinfo at all,
whereas now, we're at least explicitly specifying the UTC suffix if
none is provided.

Fixes aws/aws-cli#982

cc @kyleknap @danielgtaylor 
