### PR TITLE
Add back support for sigv4 overrides

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -270,7 +270,8 @@ def signature_overrides(service_data, service_name, session, **kwargs):
         logger.debug("Switching signature version for service %s "
                      "to version %s based on config file override.",
                      service_name, signature_version_override)
-        service_data['signature_version'] = signature_version_override
+        service_metadata = service_data['metadata']
+        service_metadata['signatureVersion'] = signature_version_override
 
 
 def add_expect_header(model, params, **kwargs):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -52,19 +52,23 @@ class TestHandlers(BaseSessionTest):
         mock_session.get_scoped_config.return_value = {
             's3': {'signature_version': 's3v4'}
         }
-        kwargs = {'service_data': {'signature_version': 's3'},
+        kwargs = {'service_data': {'metadata': {'signatureVersion': 's3'}},
                   'service_name': 's3', 'session': mock_session}
         self.session.emit(event, **kwargs)
-        self.assertEqual(kwargs['service_data']['signature_version'], 's3v4')
+        self.assertEqual(
+            kwargs['service_data']['metadata']['signatureVersion'],
+            's3v4')
 
     def test_noswitch_to_sigv4(self):
         event = self.session.create_event('service-data-loaded', 's3')
         mock_session = mock.Mock()
         mock_session.get_scoped_config.return_value = {}
-        kwargs = {'service_data': {'signature_version': 's3'},
+        kwargs = {'service_data': {'metadata': {'signatureVersion': 's3'}},
                   'service_name': 's3', 'session': mock_session}
         self.session.emit(event, **kwargs)
-        self.assertEqual(kwargs['service_data']['signature_version'], 's3')
+        self.assertEqual(
+            kwargs['service_data']['metadata']['signatureVersion'],
+            's3')
 
     def test_quote_source_header(self):
         for op in ('UploadPartCopy', 'CopyObject'):


### PR DESCRIPTION
This allows you to change the signature version used when
signing requests for a particular service.

This isn't strictly needed to communicate with various endpoints,
any region specific signature versions are captured in _endpoints.json.
However, with S3 we sometimes need to switch to sigv4 even if it
otherwise wouldn't be required.

Looks like this code was still in botocore, it just was never updated to work with the
new v2 models.  So this PR updates the handler to work with the new v2 format where
signature versions are specified in the metadata of a service (and is now camelCased).

cc @kyleknap @danielgtaylor 
