### PR TITLE
Upgrade versions of six/unittest2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.3"
   - "3.4"
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2==0.5.1; pip install --use-mirrors -r requirements26.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements26.txt; fi
   - pip install -r requirements.txt
   - pip install coverage python-coveralls
 script: nosetests tests/unit --cover-erase --with-coverage --cover-package botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-six==1.1.0
+six>=1.8.0,<2.0.0
 tox==1.4
 Sphinx==1.1.3
-python-dateutil==2.1
+python-dateutil>=2.1,<3.0.0
 nose==1.3.0
 mock==1.0.1
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,3 +1,4 @@
 # For python2.6 we have a few additional dependencies.
 simplejson==3.3.0
 ordereddict==1.1
+unittest2==0.8.0

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ import botocore
 from setuptools import setup, find_packages
 
 
-requires = ['six>=1.1.0',
+requires = ['six>=1.8.0,<2.0.0',
             'jmespath==0.5.0',
-            'python-dateutil>=2.1']
+            'python-dateutil>=2.1,<3.0.0']
 
 
 if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
Confirmed there are no issues.  Six upgrade is a backwards
compatible change, and we can now use unittest2's latest version,
which we were previously unable to due to unittest2 using a newer
version of six.

cc @kyleknap @danielgtaylor 
