### PR TITLE
support TemplateSpecification element

### DIFF
--- a/botocore/data/aws/elasticbeanstalk/2010-12-01.api.json
+++ b/botocore/data/aws/elasticbeanstalk/2010-12-01.api.json
@@ -1208,6 +1208,10 @@
         "OptionsToRemove":{
           "shape":"OptionsSpecifierList",
           "documentation":"<p> A list of custom user-defined configuration options to remove from the configuration set for this new environment. </p>"
+        },
+        "TemplateSpecification":{
+          "shape":"EnvironmentTemplateSpecification",
+          "documentation":""
         }
       },
       "documentation":"<p></p>"
@@ -1925,6 +1929,50 @@
     "OptionsSpecifierList":{
       "type":"list",
       "member":{"shape":"OptionSpecification"}
+    },
+    "S3LocationUrl":{"type":"string"},
+    "SnippetOrder":{"type":"integer"},
+    "TemplateSnippet":{
+      "type":"structure",
+      "members":{
+        "SnippetName":{
+          "shape":"String"
+        },
+        "SourceUrl":{
+          "shape":"S3LocationUrl"
+        },
+        "Order":{
+          "shape":"SnippetOrder"
+        }
+      }
+    },
+    "TemplateSnippetList":{
+      "type":"list",
+      "member":{"shape":"TemplateSnippet"}
+    },
+    "TemplateSource":{
+      "type":"structure",
+      "members":{
+        "EnvironmentName":{
+          "shape":"EnvironmentName"
+        },
+        "SourceContents":{
+          "shape":"String"
+        }
+      }
+    },
+    "EnvironmentTemplateSpecification":{
+      "type": "structure",
+      "members": {
+        "TemplateSource":{
+          "shape":"TemplateSource",
+          "documentation": ""
+        },
+        "TemplateSnippets":{
+          "shape": "TemplateSnippetList",
+          "documentation":""
+        }
+      }
     },
     "Queue":{
       "type":"structure",


### PR DESCRIPTION
- this is what EB CLI uses to create an RDS resource as part of CreateEnvironment.
- i really don't like EB CLI. AWS CLI is much cleaner and more comprehensive.
- this change exposes a --template-specification option on aws elasticbeanstalk create-environment.

Example usage:

```
aws elasticbeanstalk create-environment ... --template-specification file://rds.us-west-2.json
```

where rds.us-west-2.json is:

```
{
  "TemplateSnippets": [{
    "SnippetName": "RdsExtensionEB",
    "Order": 10000,
    "SourceUrl":
"https://s3.amazonaws.com/elasticbeanstalk-env-resources-us-west-2/eb_snippets/rds/rds.json"
    }]
}
```

I realize this is an undocumented API feature so I'm not really expecting a quick n' easy merge here, but I thought I would at least try, and thereby raise the issue as it is a pretty major omission functionality-wise for the API and AWS CLI tool.
