### PR TITLE
Add Route53 ID customization to Botocore.

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -377,14 +377,21 @@ def base64_encode_user_data(params, **kwargs):
             params['UserData'].encode('utf-8')).decode('utf-8')
 
 
-def fix_route53_ids(params, **kwargs):
+def fix_route53_ids(params, model, **kwargs):
     """
     Check for and split apart Route53 resource IDs, setting
     only the last piece. This allows the output of one operation
     (e.g. ``'foo/1234'``) to be used as input in another
     operation (e.g. it expects just ``'1234'``).
     """
-    for name in ['Id', 'HostedZoneId', 'ResourceId', 'DelegationSetId']:
+    input_shape = model.input_shape
+    if not input_shape or not hasattr(input_shape, 'members'):
+        return
+
+    members = [name for (name, shape) in input_shape.members.items()
+               if shape.name in ['ResourceId', 'DelegationSetId']]
+
+    for name in members:
         if name in params:
             orig_value = params[name]
             params[name] = orig_value.split('/')[-1]


### PR DESCRIPTION
This change moves and adds to the customization [currently in the AWS CLI](https://github.com/aws/aws-cli/blob/develop/awscli/customizations/route53resourceid.py)
that handles automatically splitting Route53 resource IDs.

For example, `/hostedzone/ABC123` will be changed to just `ABC123` when
used as input to a Route53 service operation. The `Id`, `HostedZoneId`,
`ResourceId`, and `DelegationSetId` input parameters are all handled by
this customization. We do not need to handle `HealthCheckId` because the
format is different and as such it doesn't have this issue.

This fixes an issue encountered in boto/boto3#28.

A corresponding change will need to be made to the AWS CLI to remove the
customizations there after this is merged in.

cc @jamesls, @kyleknap
