### PR TITLE
Add per-operation auth overrides.

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -399,6 +399,16 @@ def fix_route53_ids(params, model, **kwargs):
             logger.debug('%s %s -> %s', name, orig_value, params[name])
 
 
+def set_no_auth(request, **kwargs):
+    """
+    Prevent signing of this request.
+    """
+    # Any non-None response prevents the automatic signing
+    # of a request. Instead of doing our own signing, we do
+    # nothing so the request never gets signed.
+    return True
+
+
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be
 # automatically registered with that Session.
@@ -435,5 +445,7 @@ BUILTIN_HANDLERS = [
     ('before-parameter-build.ec2.RunInstances', base64_encode_user_data),
     ('before-parameter-build.autoscaling.CreateLaunchConfiguration',
      base64_encode_user_data),
-    ('before-parameter-build.route53', fix_route53_ids)
+    ('before-parameter-build.route53', fix_route53_ids),
+    ('before-auth.cognito-identity.GetId', set_no_auth),
+    ('before-auth.cognito-identity.GetOpenIdToken', set_no_auth),
 ]

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -180,6 +180,18 @@ class TestEndpointFeatures(TestEndpointBase):
         self.assertNotIn('Authorization', prepared_request.headers)
 
 
+    def test_auth_override_event(self):
+        op = Mock()
+        op.name = 'DescribeInstances'
+        op.metadata = {'protocol': 'json'}
+        self.event_emitter.emit.side_effect = [
+            [(None, True)], # For initially preparing request
+            [(None, None)],  # Check if retry needed. Retry needed.
+        ]
+        self.endpoint.make_request(op, request_dict())
+        self.assertFalse(self.auth.add_auth.called)
+
+
 class TestRetryInterface(TestEndpointBase):
     def setUp(self):
         super(TestRetryInterface, self).setUp()
@@ -231,11 +243,11 @@ class TestRetryInterface(TestEndpointBase):
         self.assertEqual(self.event_emitter.emit.call_count, 4)
         # Check that all of the events are as expected.
         self.assertEqual(call_args[0][0][0],
-                         'before-auth.ec2')
+                         'before-auth.ec2.DescribeInstances')
         self.assertEqual(call_args[1][0][0],
                          'needs-retry.ec2.DescribeInstances')
         self.assertEqual(call_args[2][0][0],
-                         'before-auth.ec2')
+                         'before-auth.ec2.DescribeInstances')
         self.assertEqual(call_args[3][0][0],
                          'needs-retry.ec2.DescribeInstances')
 
@@ -254,11 +266,11 @@ class TestRetryInterface(TestEndpointBase):
         self.assertEqual(self.event_emitter.emit.call_count, 4)
         # Check that all of the events are as expected.
         self.assertEqual(call_args[0][0][0],
-                         'before-auth.ec2')
+                         'before-auth.ec2.DescribeInstances')
         self.assertEqual(call_args[1][0][0],
                          'needs-retry.ec2.DescribeInstances')
         self.assertEqual(call_args[2][0][0],
-                         'before-auth.ec2')
+                         'before-auth.ec2.DescribeInstances')
         self.assertEqual(call_args[3][0][0],
                          'needs-retry.ec2.DescribeInstances')
 


### PR DESCRIPTION
This change makes several updates to support boto/boto3#30:
- Update the `before-auth` event to include operation name.
- Update the `before-auth` event to emit the operation model.
- Allow overriding auth by returning a non-`None` response before
  a request is sent over the wire.
- Add handlers for Cognito Identity `GetId` & `GetOpenIdToken` to
  prevent authenticating the requests.

This behavior is very similar to the [JS SDK](https://github.com/aws/aws-sdk-js/blob/42fbec2ee2d5f695e1cc6996da68e68fc908db50/lib/services/cognitoidentity.js)

cc @jamesls, @kyleknap 
