### PR TITLE
Parse metadata_service_num_attempts & metadata_service_timeout as integers. Fixes #395

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -19,6 +19,11 @@ from six.moves import configparser
 
 import botocore.exceptions
 
+INTEGER_CONFIG_OPTIONS = (
+    "metadata_service_num_attempts",
+    "metadata_service_timeout",
+)
+
 
 def multi_file_load_config(*filenames):
     """Load and combine multiple INI configs with profiles.
@@ -135,16 +140,19 @@ def raw_config_parse(config_filename):
             for section in cp.sections():
                 config[section] = {}
                 for option in cp.options(section):
-                    config_value = cp.get(section, option)
-                    if config_value.startswith('\n'):
-                        # Then we need to parse the inner contents as
-                        # hierarchical.  We support a single level
-                        # of nesting for now.
-                        try:
-                            config_value = _parse_nested(config_value)
-                        except ValueError:
-                            raise botocore.exceptions.ConfigParseError(
-                                path=path)
+                    if option in INTEGER_CONFIG_OPTIONS:
+                        config_value = cp.getint(section, option)
+                    else:
+                        config_value = cp.get(section, option)
+                        if config_value.startswith('\n'):
+                            # Then we need to parse the inner contents as
+                            # hierarchical.  We support a single level
+                            # of nesting for now.
+                            try:
+                                config_value = _parse_nested(config_value)
+                            except ValueError:
+                                raise botocore.exceptions.ConfigParseError(
+                                    path=path)
                     config[section][option] = config_value
     return config
 

--- a/tests/unit/cfg/metadata_service
+++ b/tests/unit/cfg/metadata_service
@@ -1,0 +1,3 @@
+[default]
+metadata_service_timeout = 1
+metadata_service_num_attempts = 2

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -71,6 +71,12 @@ class TestConfig(BaseEnvVar):
         with self.assertRaises(botocore.exceptions.ConfigParseError):
             loaded_config = load_config(filename)
 
+    def test_metadata_service(self):
+        filename = path('metadata_service')
+        loaded_config = load_config(filename)
+        config = loaded_config['profiles']['default']
+        self.assertEqual(config['metadata_service_timeout'], 1)
+        self.assertEqual(config['metadata_service_num_attempts'], 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -583,8 +583,8 @@ class TestCreateCredentialResolver(BaseEnvVar):
             'credentials_file': 'a',
             'legacy_config_file': 'b',
             'config_file': 'c',
-            'metadata_service_timeout': 'd',
-            'metadata_service_num_attempts': 'e',
+            'metadata_service_timeout': 1,
+            'metadata_service_num_attempts': 2,
             'profile': 'profilename',
         }
         fake_session.get_config_variable = lambda x: config[x]


### PR DESCRIPTION
This pull request fixes issue #395 by parsing integer values with `RawConfigParser.getint()`.

An alternative to this PR is to add `int()` to https://github.com/boto/botocore/blob/d4094511f7c5f084133578bb4d5a30befa7ccbe8/botocore/credentials.py#L47 or https://github.com/boto/botocore/blob/42b49b103662048fed22fc9debfbde78e11d5686/botocore/utils.py#L135, but this would fix the problem in a single place, rather than fixing the root cause, that is parsing.