### PR TITLE
Add `emit_until_response` to event emitter.

### DIFF
--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -162,14 +162,14 @@ class HierarchicalEmitter(BaseEventHooks):
         # registered once.
         self._unique_id_cache = {}
 
-    def _emit(self, event_name, args, stop_on_response=False):
+    def _emit(self, event_name, kwargs, stop_on_response=False):
         """
         Emit an event with optional keyword arguments.
 
         :type event_name: string
         :param event_name: Name of the event
-        :type args: dict
-        :param args: Arguments to be passed to the handler functions.
+        :type kwargs: dict
+        :param kwargs: Arguments to be passed to the handler functions.
         :type stop_on_response: boolean
         :param stop_on_response: Whether to stop on the first non-None
                                 response. If False, then all handlers
@@ -192,11 +192,11 @@ class HierarchicalEmitter(BaseEventHooks):
             # no handlers to call.  This is the common case where
             # for the majority of signals, nothing is listening.
             return []
-        args['event_name'] = event_name
+        kwargs['event_name'] = event_name
         responses = []
         for handler in handlers_to_call:
             logger.debug('Event %s: calling handler %s', event_name, handler)
-            response = handler(**args)
+            response = handler(**kwargs)
             responses.append((handler, response))
             if stop_on_response and response is not None:
                 return responses

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -69,11 +69,23 @@ class TestStopProcessing(unittest.TestCase):
 
     def hook2(self, **kwargs):
         self.hook_calls.append('hook2')
-        return True
+        return 'hook2-response'
 
     def hook3(self, **kwargs):
         self.hook_calls.append('hook3')
-        return True
+        return 'hook3-response'
+
+    def test_all_hooks(self):
+        # Here we register three hooks and sanity check
+        # that all three would be called by a normal emit.
+        # This ensures our hook calls are setup properly for
+        # later tests.
+        self.emitter.register('foo', self.hook1)
+        self.emitter.register('foo', self.hook2)
+        self.emitter.register('foo', self.hook3)
+        self.emitter.emit('foo')
+
+        self.assertEqual(self.hook_calls, ['hook1', 'hook2', 'hook3'])
 
     def test_stop_processing_after_first_response(self):
         # Here we register three hooks, but only the first
@@ -83,8 +95,25 @@ class TestStopProcessing(unittest.TestCase):
         self.emitter.register('foo', self.hook3)
         handler, response = self.emitter.emit_until_response('foo')
 
-        self.assertEqual(response, True)
+        self.assertEqual(response, 'hook2-response')
         self.assertEqual(self.hook_calls, ['hook1', 'hook2'])
+
+    def test_no_responses(self):
+        # Here we register a handler that will not return a response
+        # and ensure we get back proper values.
+        self.emitter.register('foo', self.hook1)
+        responses = self.emitter.emit('foo')
+
+        self.assertEqual(self.hook_calls, ['hook1'])
+        self.assertEqual(responses, [(self.hook1, None)])
+
+    def test_no_handlers(self):
+        # Here we have no handlers, but still expect a tuple of return
+        # values.
+        handler, response = self.emitter.emit_until_response('foo')
+
+        self.assertIsNone(handler)
+        self.assertIsNone(response)
 
 
 class TestFirstNonNoneResponse(unittest.TestCase):


### PR DESCRIPTION
This adds a new method called `emit_until_response` which will call
all of the handlers for an event in order **until** one of them
returns a non-`None` response. Once that handler is reached, processing
of the remaining handlers stops.

It is currently not used by anything, but is included as part of #414.

cc @jamesls 
