### PR TITLE
Fix deepcopies of _PrefixTrie

### DIFF
--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -125,3 +125,19 @@ class TestAcceptedDateTimeFormats(unittest.TestCase):
         response = self.client.list_clusters(
             CreatedAfter='2014-01-01T00:00:00-08:00')
         self.assertIn('Clusters', response)
+
+
+class TestClientCanBeCloned(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+
+    def test_client_can_clone_with_service_events(self):
+        # While the Service/Operation objects exist, we need
+        # to ensure they can interop.  Specifically, if we create
+        # a service object:
+        service = self.session.get_service('s3')
+        # We should also be able to create a client object.
+        client = self.session.create_client('s3', region_name='us-west-2')
+        # We really just want to ensure create_client doesn't raise
+        # an exception, but we'll double check that the client looks right.
+        self.assertTrue(hasattr(client, 'list_buckets'))

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import copy
+import functools
 
 from tests import unittest
 from functools import partial
@@ -505,6 +506,19 @@ class TestWildcardHandlers(unittest.TestCase):
         self.emitter.register('foo.bar.baz', first_handler)
         self.emitter.emit('foo.bar.baz', id_name='last-time')
         self.assertEqual(second, ['third-time'])
+
+    def test_copy_events_with_partials(self):
+        # There's a bug in python2.6 where you can't deepcopy
+        # a partial object.  We want to ensure that doesn't
+        # break when a partial is hooked up as an event handler.
+        def handler(a, b, **kwargs):
+            return b
+
+        f = functools.partial(handler, 1)
+        self.emitter.register('a.b', f)
+        copied = copy.copy(self.emitter)
+        self.assertEqual(copied.emit_until_response(
+            'a.b', b='return-val')[1], 'return-val')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We only want to copy the structure of the nodes, we don't actually
want to copy the handlers.  In order to do this properly, we need
to implement a recursive copy ourselves.

I also needed to make the NodeList, which is used to store which
partition a handler is assigned to, copyable.

I've also added an explicit integration test that shows how the
bug can surface in practice, but I've also added a unit test
that shows the exact issue in test_hooks.py

cc @danielgtaylor 
