### PR TITLE
Update CONTRIBUTING guide with latest guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,45 +1,75 @@
 Contributing
 ============
 
-For more information, please see the official docs at
-http://botocore.readthedocs.org/
+We work hard to provide a high-quality and useful SDK, and we greatly value
+feedback and contributions from our community. Whether it's a new feature,
+correction, or additional documentation, we welcome your pull requests. Please
+submit any `issues <https://github.com/boto/botocore/issues>`__
+or `pull requests <https://github.com/boto/botocore/pulls>`__ through GitHub.
+
+This document contains guidelines for contributing code and filing issues.
 
 Contributing Code
 -----------------
 
--  A good pull request:
+The list below are guidelines to use when submitting pull requests.
+These are the same set of guidelines that the core contributors use
+when submitting changes, and we ask the same of all community
+contributions as well:
 
--  Is clear.
--  Works across all supported versions of Python.
--  Follows the existing style of the code base (PEP-8).
--  Has comments included as needed.
+* The SDK is released under the
+  `Apache license <http://aws.amazon.com/apache2.0/>`__.
+  Any code you submit will be released under that license.
+* We maintain a high percentage of code coverage in our unit tests.  As
+  a general rule of thumb, code changes should not lower the overall
+  code coverage percentage for the project.  To help with this,
+  we use `coveralls <https://coveralls.io/r/boto/botocore>`__, which will
+  comment on every pull request with any changes in code coverage.
+  In practice, this means that every bug fix and feature addition should
+  include unit tests.
+* We may choose not to accept pull requests that change the JSON service descriptions,
+  such as ``botocore/data/aws/s3/2006-03-01.normal.json``.  We generate these
+  files upstream based on our internal knowledge of the AWS services. If there
+  is something incorrect with or missing from a service description, it may be
+  more appropriate to submit an
+  `issue <https://github.com/boto/botocore/issues>`__ so we can get the issue
+  fixed upstream.  This constraint only applies to the ``*.normal.json`` files.
+  We do accept, and encourage, changes to any of the following files
+  in ``botocore/data/aws/``:
 
--  A test case that demonstrates the previous flaw that now passes with
-   the included patch, or demonstrates the newly added feature.
--  If it adds/changes a public API, it must also include documentation
-   for those changes.
--  Must be appropriately licensed (New BSD).
+  * ``_endpoints.json``
+  * ``_retry.json``
+  * ``*.paginators.json``
+  * ``*.waiters.json``
+
+* Code should follow `pep 8 <https://www.python.org/dev/peps/pep-0008/>`__,
+  although if you are modifying an existing module, it is more important
+  for the code to be consistent if there are any discrepancies.
+* Code must work on ``python2.6``, ``python2.7``, and ``python3.3`` and higher.
+* Botocore is cross platform and code must work on at least linux, Windows,
+  and Mac OS X.
+* If you would like to implement support for a significant feature that is not
+  yet available in botocore, please talk to us beforehand to avoid any duplication
+  of effort.  You can file an
+  `issue <https://github.com/boto/botocore/issues>`__
+  to discuss the feature request further.
+
 
 Reporting An Issue/Feature
 --------------------------
 
--  Check to see if there's an existing issue/pull request for the
+*  Check to see if there's an existing issue/pull request for the
    bug/feature. All issues are at
    https://github.com/boto/botocore/issues and pull reqs are at
    https://github.com/boto/botocore/pulls.
--  If there isn't an existing issue there, please file an issue. The
+*  If there isn't an existing issue there, please file an issue. The
    ideal report includes:
 
--  A description of the problem/suggestion.
--  How to recreate the bug.
--  If relevant, including the versions of your:
+   * A description of the problem/suggestion.
+   * A code sample that demonstrates the issue.
+   * Including the versions of your:
 
-   -  Python interpreter
-   -  botocore
-   -  Optionally of the other dependencies involved
-
--  If possible, create a pull request with a (failing) test case
-   demonstrating what's wrong. This makes the process for fixing bugs
-   quicker & gets issues resolved sooner.
-
-
+     * python interpreter
+     * OS
+     * botocore (accessible via ``botocore.__version__``)
+     * optionally any other python dependencies involved

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,7 +24,7 @@ contributions as well:
   a general rule of thumb, code changes should not lower the overall
   code coverage percentage for the project.  To help with this,
   we use `coveralls <https://coveralls.io/r/boto/botocore>`__, which will
-  comment on every pull request with any changes in code coverage.
+  comment on changes in code coverage for every pull request.
   In practice, this means that every bug fix and feature addition should
   include unit tests.
 * We may choose not to accept pull requests that change the JSON service descriptions,


### PR DESCRIPTION
This also brings it more in sync with the contributing
guidelines for other SDKs.

For reference:

https://github.com/aws/aws-sdk-core-ruby/blob/master/CONTRIBUTING.md
https://github.com/aws/aws-sdk-php/blob/master/CONTRIBUTING.md

cc @kyleknap 