### PR TITLE
Initial commit of glacier support in botocore

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -36,6 +36,7 @@ if six.PY3:
     from io import IOBase as _IOBase
     from base64 import encodebytes
     from email.utils import formatdate
+    from itertools import zip_longest
     file_type = _IOBase
     zip = zip
 
@@ -72,6 +73,7 @@ else:
     from email.Utils import formatdate
     file_type = file
     from itertools import izip as zip
+    from itertools import izip_longest as zip_longest
     from httplib import HTTPResponse
     from base64 import encodestring as encodebytes
 

--- a/botocore/data/aws/glacier/2012-06-01.normal.json
+++ b/botocore/data/aws/glacier/2012-06-01.normal.json
@@ -1,0 +1,2132 @@
+{
+  "metadata":{
+    "apiVersion":"2012-06-01",
+    "checksumFormat":"sha256",
+    "endpointPrefix":"glacier",
+    "serviceFullName":"Amazon Glacier",
+    "signatureVersion":"v4",
+    "protocol":"rest-json"
+  },
+  "documentation":"<p>Amazon Glacier is a storage solution for \"cold data.\"</p> <p>Amazon Glacier is an extremely low-cost storage service that provides secure, durable, and easy-to-use storage for data backup and archival. With Amazon Glacier, customers can store their data cost effectively for months, years, or decades. Amazon Glacier also enables customers to offload the administrative burdens of operating and scaling storage to AWS, so they don't have to worry about capacity planning, hardware provisioning, data replication, hardware failure and recovery, or time-consuming hardware migrations.</p> <p>Amazon Glacier is a great storage choice when low storage cost is paramount, your data is rarely retrieved, and retrieval latency of several hours is acceptable. If your application requires fast or frequent access to your data, consider using Amazon S3. For more information, go to <a href=\"http://aws.amazon.com/s3/\">Amazon Simple Storage Service (Amazon S3)</a>.</p> <p>You can store any kind of data in any format. There is no maximum limit on the total amount of data you can store in Amazon Glacier. </p> <p>If you are a first-time user of Amazon Glacier, we recommend that you begin by reading the following sections in the <i>Amazon Glacier Developer Guide</i>:</p> <ul> <li><p><a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/introduction.html\">What is Amazon Glacier</a> - This section of the Developer Guide describes the underlying data model, the operations it supports, and the AWS SDKs that you can use to interact with the service.</p></li> <li><p><a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-getting-started.html\">Getting Started with Amazon Glacier</a> - The Getting Started section walks you through the process of creating a vault, uploading archives, creating jobs to download archives, retrieving the job output, and deleting archives.</p></li> </ul>",
+  "operations":{
+    "AbortMultipartUpload":{
+      "name":"AbortMultipartUpload",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}",
+        "responseCode":204
+      },
+      "input":{
+        "shape":"AbortMultipartUploadInput",
+        "documentation":"<p>Provides options to abort a multipart upload identified by the upload ID. </p> <p>For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html\">Abort Multipart Upload</a>. For conceptual information, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation aborts a multipart upload identified by the upload ID.</p> <p>After the Abort Multipart Upload request succeeds, you cannot upload any more parts to the multipart upload or complete the multipart upload. Aborting a completed upload fails. However, aborting an already-aborted upload will succeed, for a short time. For more information about uploading a part and completing a multipart upload, see <a>UploadMultipartPart</a> and <a>CompleteMultipartUpload</a>.</p> <p>This operation is idempotent.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html\">Abort Multipart Upload</a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "CompleteMultipartUpload":{
+      "name":"CompleteMultipartUpload",
+      "http":{
+        "method":"POST",
+        "requestUri":"/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}",
+        "responseCode":201
+      },
+      "input":{
+        "shape":"CompleteMultipartUploadInput",
+        "documentation":"<p>Provides options to complete a multipart upload operation. This informs Amazon Glacier that all the archive parts have been uploaded and Amazon Glacier can now assemble the archive from the uploaded parts. After assembling and saving the archive to the vault, Amazon Glacier returns the URI path of the newly created archive resource.</p>"
+      },
+      "output":{
+        "shape":"ArchiveCreationOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p> <p>For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html\">Upload Archive</a>. For conceptual information, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>You call this operation to inform Amazon Glacier that all the archive parts have been uploaded and that Amazon Glacier can now assemble the archive from the uploaded parts. After assembling and saving the archive to the vault, Amazon Glacier returns the URI path of the newly created archive resource. Using the URI path, you can then access the archive. After you upload an archive, you should save the archive ID returned to retrieve the archive at a later point. You can also get the vault inventory to obtain a list of archive IDs in a vault. For more information, see <a>InitiateJob</a>.</p> <p>In the request, you must include the computed SHA256 tree hash of the entire archive you have uploaded. For information about computing a SHA256 tree hash, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html\">Computing Checksums</a>. On the server side, Amazon Glacier also constructs the SHA256 tree hash of the assembled archive. If the values match, Amazon Glacier saves the archive to the vault; otherwise, it returns an error, and the operation fails. The <a>ListParts</a> operation returns a list of parts uploaded for a specific multipart upload. It includes checksum information for each uploaded part that can be used to debug a bad checksum issue.</p> <p>Additionally, Amazon Glacier also checks for any missing content ranges when assembling the archive, if missing content ranges are found, Amazon Glacier returns an error and the operation fails. </p> <p>Complete Multipart Upload is an idempotent operation. After your first successful complete multipart upload, if you call the operation again within a short period, the operation will succeed and return the same archive ID. This is useful in the event you experience a network issue that causes an aborted connection or receive a 500 server error, in which case you can repeat your Complete Multipart Upload request and get the same archive ID without creating duplicate archives. Note, however, that after the multipart upload completes, you cannot call the List Parts operation and the multipart upload will not appear in List Multipart Uploads response, even if idempotent complete is possible.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html\">Uploading Large Archives in Parts (Multipart Upload)</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-complete-upload.html\">Complete Multipart Upload</a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "CreateVault":{
+      "name":"CreateVault",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/{accountId}/vaults/{vaultName}",
+        "responseCode":201
+      },
+      "input":{
+        "shape":"CreateVaultInput",
+        "documentation":"<p>Provides options to create a vault.</p>"
+      },
+      "output":{
+        "shape":"CreateVaultOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        },
+        {
+          "shape":"LimitExceededException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if the request results in a vault or account limit being exceeded.</p>"
+        }
+      ],
+      "documentation":"<p>This operation creates a new vault with the specified name. The name of the vault must be unique within a region for an AWS account. You can create up to 1,000 vaults per account. If you need to create more vaults, contact Amazon Glacier.</p> <p>You must use the following guidelines when naming a vault. </p> <p> <ul> <li> <p> Names can be between 1 and 255 characters long. </p> </li> <li> <p>Allowed characters are a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), and '.' (period).</p> </li> </ul> </p> <p>This operation is idempotent.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/creating-vaults.html\">Creating a Vault in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-put.html\">Create Vault </a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "DeleteArchive":{
+      "name":"DeleteArchive",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/{accountId}/vaults/{vaultName}/archives/{archiveId}",
+        "responseCode":204
+      },
+      "input":{
+        "shape":"DeleteArchiveInput",
+        "documentation":"<p>Provides options for deleting an archive from an Amazon Glacier vault.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation deletes an archive from a vault. Subsequent requests to initiate a retrieval of this archive will fail. Archive retrievals that are in progress for this archive ID may or may not succeed according to the following scenarios:</p> <ul> <li>If the archive retrieval job is actively preparing the data for download when Amazon Glacier receives the delete archive request, the archival retrieval operation might fail. </li> <li>If the archive retrieval job has successfully prepared the archive for download when Amazon Glacier receives the delete archive request, you will be able to download the output. </li> </ul> <p>This operation is idempotent. Attempting to delete an already-deleted archive does not result in an error. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/deleting-an-archive.html\">Deleting an Archive in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-delete.html\">Delete Archive</a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "DeleteVault":{
+      "name":"DeleteVault",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/{accountId}/vaults/{vaultName}",
+        "responseCode":204
+      },
+      "input":{
+        "shape":"DeleteVaultInput",
+        "documentation":"<p>Provides options for deleting a vault from Amazon Glacier.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation deletes a vault. Amazon Glacier will delete a vault only if there are no archives in the vault as of the last inventory and there have been no writes to the vault since the last inventory. If either of these conditions is not satisfied, the vault deletion fails (that is, the vault is not removed) and Amazon Glacier returns an error. You can use <a>DescribeVault</a> to return the number of archives in a vault, and you can use <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html\">Initiate a Job (POST jobs)</a> to initiate a new inventory retrieval for a vault. The inventory contains the archive IDs you use to delete archives using <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-delete.html\">Delete Archive (DELETE archive)</a>.</p> <p>This operation is idempotent.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/deleting-vaults.html\">Deleting a Vault in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-delete.html\">Delete Vault </a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "DeleteVaultNotifications":{
+      "name":"DeleteVaultNotifications",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/{accountId}/vaults/{vaultName}/notification-configuration",
+        "responseCode":204
+      },
+      "input":{
+        "shape":"DeleteVaultNotificationsInput",
+        "documentation":"<p>Provides options for deleting a vault notification configuration from an Amazon Glacier vault.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation deletes the notification configuration set for a vault. The operation is eventually consistent;that is, it might take some time for Amazon Glacier to completely disable the notifications and you might still receive some notifications for a short time after you send the delete request. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/configuring-notifications.html\">Configuring Vault Notifications in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-delete.html\">Delete Vault Notification Configuration </a> in the Amazon Glacier Developer Guide. </p>"
+    },
+    "DescribeJob":{
+      "name":"DescribeJob",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults/{vaultName}/jobs/{jobId}"
+      },
+      "input":{
+        "shape":"DescribeJobInput",
+        "documentation":"<p>Provides options for retrieving a job description.</p>"
+      },
+      "output":{
+        "shape":"GlacierJobDescription",
+        "documentation":"<p>Describes an Amazon Glacier job.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation returns information about a job you previously initiated, including the job initiation date, the user who initiated the job, the job status code/message and the Amazon SNS topic to notify after Amazon Glacier completes the job. For more information about initiating a job, see <a>InitiateJob</a>. </p> <note><p>This operation enables you to check the status of your job. However, it is strongly recommended that you set up an Amazon SNS topic and specify it in your initiate job request so that Amazon Glacier can notify the topic after it completes the job. </p></note> <p>A job ID will not expire for at least 24 hours after Amazon Glacier completes the job. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-describe-job-get.html\">Working with Archives in Amazon Glacier</a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "DescribeVault":{
+      "name":"DescribeVault",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults/{vaultName}"
+      },
+      "input":{
+        "shape":"DescribeVaultInput",
+        "documentation":"<p>Provides options for retrieving metadata for a specific vault in Amazon Glacier.</p>"
+      },
+      "output":{
+        "shape":"DescribeVaultOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation returns information about a vault, including the vault's Amazon Resource Name (ARN), the date the vault was created, the number of archives it contains, and the total size of all the archives in the vault. The number of archives and their total size are as of the last inventory generation. This means that if you add or remove an archive from a vault, and then immediately use Describe Vault, the change in contents will not be immediately reflected. If you want to retrieve the latest inventory of the vault, use <a>InitiateJob</a>. Amazon Glacier generates vault inventories approximately daily. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html\">Downloading a Vault Inventory in Amazon Glacier</a>. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/retrieving-vault-info.html\">Retrieving Vault Metadata in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-get.html\">Describe Vault </a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "GetDataRetrievalPolicy":{
+      "name":"GetDataRetrievalPolicy",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/policies/data-retrieval"
+      },
+      "input":{"shape":"GetDataRetrievalPolicyInput"},
+      "output":{"shape":"GetDataRetrievalPolicyOutput"},
+      "errors":[
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ]
+    },
+    "GetJobOutput":{
+      "name":"GetJobOutput",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults/{vaultName}/jobs/{jobId}/output"
+      },
+      "input":{
+        "shape":"GetJobOutputInput",
+        "documentation":"<p>Provides options for downloading output of an Amazon Glacier job.</p>"
+      },
+      "output":{
+        "shape":"GetJobOutputOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation downloads the output of the job you initiated using <a>InitiateJob</a>. Depending on the job type you specified when you initiated the job, the output will be either the content of an archive or a vault inventory.</p> <p>A job ID will not expire for at least 24 hours after Amazon Glacier completes the job. That is, you can download the job output within the 24 hours period after Amazon Glacier completes the job.</p> <p>If the job output is large, then you can use the <code>Range</code> request header to retrieve a portion of the output. This allows you to download the entire output in smaller chunks of bytes. For example, suppose you have 1 GB of job output you want to download and you decide to download 128 MB chunks of data at a time, which is a total of eight Get Job Output requests. You use the following process to download the job output:</p> <ol> <li> <p>Download a 128 MB chunk of output by specifying the appropriate byte range using the <code>Range</code> header.</p> </li> <li> <p>Along with the data, the response includes a checksum of the payload. You compute the checksum of the payload on the client and compare it with the checksum you received in the response to ensure you received all the expected data.</p> </li> <li> <p>Repeat steps 1 and 2 for all the eight 128 MB chunks of output data, each time specifying the appropriate byte range.</p> </li> <li> <p>After downloading all the parts of the job output, you have a list of eight checksum values. Compute the tree hash of these values to find the checksum of the entire output. Using the <a>DescribeJob</a> API, obtain job information of the job that provided you the output. The response includes the checksum of the entire archive stored in Amazon Glacier. You compare this value with the checksum you computed to ensure you have downloaded the entire archive content with no errors.</p> </li> </ol> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html\">Downloading a Vault Inventory</a>, <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/downloading-an-archive.html\">Downloading an Archive</a>, and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-job-output-get.html\">Get Job Output </a> </p>"
+    },
+    "GetVaultNotifications":{
+      "name":"GetVaultNotifications",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults/{vaultName}/notification-configuration"
+      },
+      "input":{
+        "shape":"GetVaultNotificationsInput",
+        "documentation":"<p>Provides options for retrieving the notification configuration set on an Amazon Glacier vault.</p>"
+      },
+      "output":{
+        "shape":"GetVaultNotificationsOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation retrieves the <code class=\"code\">notification-configuration</code> subresource of the specified vault.</p> <p>For information about setting a notification configuration on a vault, see <a>SetVaultNotifications</a>. If a notification configuration for a vault is not set, the operation returns a <code class=\"code\">404 Not Found</code> error. For more information about vault notifications, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/configuring-notifications.html\">Configuring Vault Notifications in Amazon Glacier</a>. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/configuring-notifications.html\">Configuring Vault Notifications in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-get.html\">Get Vault Notification Configuration </a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "InitiateJob":{
+      "name":"InitiateJob",
+      "http":{
+        "method":"POST",
+        "requestUri":"/{accountId}/vaults/{vaultName}/jobs",
+        "responseCode":202
+      },
+      "input":{
+        "shape":"InitiateJobInput",
+        "documentation":"<p>Provides options for initiating an Amazon Glacier job.</p>"
+      },
+      "output":{
+        "shape":"InitiateJobOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"PolicyEnforcedException",
+          "error":{"httpStatusCode":400},
+          "exception":true
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation initiates a job of the specified type. In this release, you can initiate a job to retrieve either an archive or a vault inventory (a list of archives in a vault). </p> <p>Retrieving data from Amazon Glacier is a two-step process: </p> <ol> <li><p>Initiate a retrieval job.</p></li> <li><p>After the job completes, download the bytes.</p></li> </ol> <p>The retrieval request is executed asynchronously. When you initiate a retrieval job, Amazon Glacier creates a job and returns a job ID in the response. When Amazon Glacier completes the job, you can get the job output (archive or inventory data). For information about getting job output, see <a>GetJobOutput</a> operation. </p> <p>The job must complete before you can get its output. To determine when a job is complete, you have the following options:</p> <ul> <li> <p><b>Use Amazon SNS Notification</b> You can specify an Amazon Simple Notification Service (Amazon SNS) topic to which Amazon Glacier can post a notification after the job is completed. You can specify an SNS topic per job request. The notification is sent only after Amazon Glacier completes the job. In addition to specifying an SNS topic per job request, you can configure vault notifications for a vault so that job notifications are always sent. For more information, see <a>SetVaultNotifications</a>.</p> </li> <li> <p><b>Get job details</b> You can make a <a>DescribeJob</a> request to obtain job status information while a job is in progress. However, it is more efficient to use an Amazon SNS notification to determine when a job is complete.</p> </li> </ul> <note><p>The information you get via notification is same that you get by calling <a>DescribeJob</a>.</p></note> <p>If for a specific event, you add both the notification configuration on the vault and also specify an SNS topic in your initiate job request, Amazon Glacier sends both notifications. For more information, see <a>SetVaultNotifications</a>.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p><b>About the Vault Inventory</b></p> <p>Amazon Glacier prepares an inventory for each vault periodically, every 24 hours. When you initiate a job for a vault inventory, Amazon Glacier returns the last inventory for the vault. The inventory data you get might be up to a day or two days old. Also, the initiate inventory job might take some time to complete before you can download the vault inventory. So you do not want to retrieve a vault inventory for each vault operation. However, in some scenarios, you might find the vault inventory useful. For example, when you upload an archive, you can provide an archive description but not an archive name. Amazon Glacier provides you a unique archive ID, an opaque string of characters. So, you might maintain your own database that maps archive names to their corresponding Amazon Glacier assigned archive IDs. You might find the vault inventory useful in the event you need to reconcile information in your database with the actual vault inventory. </p> <p><b>Range Inventory Retrieval</b></p> <p>You can limit the number of inventory items retrieved by filtering on the archive creation date or by setting a limit.</p> <p><i>Filtering by Archive Creation Date</i></p> <p>You can retrieve inventory items for archives created between <code>StartDate</code> and <code>EndDate</code> by specifying values for these parameters in the <b>InitiateJob</b> request. Archives created on or after the <code>StartDate</code> and before the <code>EndDate</code> will be returned. If you only provide the <code>StartDate</code> without the <code>EndDate</code>, you will retrieve the inventory for all archives created on or after the <code>StartDate</code>. If you only provide the <code>EndDate</code> without the <code>StartDate</code>, you will get back the inventory for all archives created before the <code>EndDate</code>.</p> <p><i>Limiting Inventory Items per Retrieval</i></p> <p>You can limit the number of inventory items returned by setting the <code>Limit</code> parameter in the <b>InitiateJob</b> request. The inventory job output will contain inventory items up to the specified <code>Limit</code>. If there are more inventory items available, the result is paginated. After a job is complete you can use the <a>DescribeJob</a> operation to get a marker that you use in a subsequent <b>InitiateJob</b> request. The marker will indicate the starting point to retrieve the next set of inventory items. You can page through your entire inventory by repeatedly making <b>InitiateJob</b> requests with the marker from the previous <b>DescribeJob</b> output, until you get a marker from <b>DescribeJob</b> that returns null, indicating that there are no more inventory items available.</p> <p>You can use the <code>Limit</code> parameter together with the date range parameters.</p> <p><b>About Ranged Archive Retrieval</b></p> <p> You can initiate an archive retrieval for the whole archive or a range of the archive. In the case of ranged archive retrieval, you specify a byte range to return or the whole archive. The range specified must be megabyte (MB) aligned, that is the range start value must be divisible by 1 MB and range end value plus 1 must be divisible by 1 MB or equal the end of the archive. If the ranged archive retrieval is not megabyte aligned, this operation returns a 400 response. Furthermore, to ensure you get checksum values for data you download using Get Job Output API, the range must be tree hash aligned. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html\">Initiate a Job</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html\">Downloading a Vault Inventory</a> </p>"
+    },
+    "InitiateMultipartUpload":{
+      "name":"InitiateMultipartUpload",
+      "http":{
+        "method":"POST",
+        "requestUri":"/{accountId}/vaults/{vaultName}/multipart-uploads",
+        "responseCode":201
+      },
+      "input":{
+        "shape":"InitiateMultipartUploadInput",
+        "documentation":"<p>Provides options for initiating a multipart upload to an Amazon Glacier vault.</p>"
+      },
+      "output":{
+        "shape":"InitiateMultipartUploadOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation initiates a multipart upload. Amazon Glacier creates a multipart upload resource and returns its ID in the response. The multipart upload ID is used in subsequent requests to upload parts of an archive (see <a>UploadMultipartPart</a>).</p> <p>When you initiate a multipart upload, you specify the part size in number of bytes. The part size must be a megabyte (1024 KB) multiplied by a power of 2-for example, 1048576 (1 MB), 2097152 (2 MB), 4194304 (4 MB), 8388608 (8 MB), and so on. The minimum allowable part size is 1 MB, and the maximum is 4 GB.</p> <p>Every part you upload to this resource (see <a>UploadMultipartPart</a>), except the last one, must have the same size. The last one can be the same size or smaller. For example, suppose you want to upload a 16.2 MB file. If you initiate the multipart upload with a part size of 4 MB, you will upload four parts of 4 MB each and one part of 0.2 MB. </p> <note><p>You don't need to know the size of the archive when you start a multipart upload because Amazon Glacier does not require you to specify the overall archive size.</p></note> <p>After you complete the multipart upload, Amazon Glacier removes the multipart upload resource referenced by the ID. Amazon Glacier also removes the multipart upload resource if you cancel the multipart upload or it may be removed if there is no activity for a period of 24 hours.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html\">Uploading Large Archives in Parts (Multipart Upload)</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-initiate-upload.html\">Initiate Multipart Upload</a> in the <i>Amazon Glacier Developer Guide</i>.</p>"
+    },
+    "ListJobs":{
+      "name":"ListJobs",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults/{vaultName}/jobs"
+      },
+      "input":{
+        "shape":"ListJobsInput",
+        "documentation":"<p>Provides options for retrieving a job list for an Amazon Glacier vault.</p>"
+      },
+      "output":{
+        "shape":"ListJobsOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation lists jobs for a vault, including jobs that are in-progress and jobs that have recently finished. </p> <note><p>Amazon Glacier retains recently completed jobs for a period before deleting them; however, it eventually removes completed jobs. The output of completed jobs can be retrieved. Retaining completed jobs for a period of time after they have completed enables you to get a job output in the event you miss the job completion notification or your first attempt to download it fails. For example, suppose you start an archive retrieval job to download an archive. After the job completes, you start to download the archive but encounter a network error. In this scenario, you can retry and download the archive while the job exists. </p></note> <p>To retrieve an archive or retrieve a vault inventory from Amazon Glacier, you first initiate a job, and after the job completes, you download the data. For an archive retrieval, the output is the archive data, and for an inventory retrieval, it is the inventory list. The List Job operation returns a list of these jobs sorted by job initiation time.</p> <p>This List Jobs operation supports pagination. By default, this operation returns up to 1,000 jobs in the response. You should always check the response for a <code>marker</code> at which to continue the list; if there are no more items the <code>marker</code> is <code>null</code>. To return a list of jobs that begins at a specific job, set the <code>marker</code> request parameter to the value you obtained from a previous List Jobs request. You can also limit the number of jobs returned in the response by specifying the <code>limit</code> parameter in the request.</p> <p>Additionally, you can filter the jobs list returned by specifying an optional <code>statuscode</code> (InProgress, Succeeded, or Failed) and <code>completed</code> (true, false) parameter. The <code>statuscode</code> allows you to specify that only jobs that match a specified status are returned. The <code>completed</code> parameter allows you to specify that only jobs in a specific completion state are returned.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-jobs-get.html\">List Jobs </a> </p>"
+    },
+    "ListMultipartUploads":{
+      "name":"ListMultipartUploads",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults/{vaultName}/multipart-uploads"
+      },
+      "input":{
+        "shape":"ListMultipartUploadsInput",
+        "documentation":"<p>Provides options for retrieving list of in-progress multipart uploads for an Amazon Glacier vault.</p>"
+      },
+      "output":{
+        "shape":"ListMultipartUploadsOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation lists in-progress multipart uploads for the specified vault. An in-progress multipart upload is a multipart upload that has been initiated by an <a>InitiateMultipartUpload</a> request, but has not yet been completed or aborted. The list returned in the List Multipart Upload response has no guaranteed order. </p> <p>The List Multipart Uploads operation supports pagination. By default, this operation returns up to 1,000 multipart uploads in the response. You should always check the response for a <code>marker</code> at which to continue the list; if there are no more items the <code>marker</code> is <code>null</code>. To return a list of multipart uploads that begins at a specific upload, set the <code>marker</code> request parameter to the value you obtained from a previous List Multipart Upload request. You can also limit the number of uploads returned in the response by specifying the <code>limit</code> parameter in the request.</p> <p>Note the difference between this operation and listing parts (<a>ListParts</a>). The List Multipart Uploads operation lists all multipart uploads for a vault and does not require a multipart upload ID. The List Parts operation requires a multipart upload ID since parts are associated with a single upload.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-list-uploads.html\">List Multipart Uploads </a> in the <i>Amazon Glacier Developer Guide</i>.</p>"
+    },
+    "ListParts":{
+      "name":"ListParts",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}"
+      },
+      "input":{
+        "shape":"ListPartsInput",
+        "documentation":"<p>Provides options for retrieving a list of parts of an archive that have been uploaded in a specific multipart upload.</p>"
+      },
+      "output":{
+        "shape":"ListPartsOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation lists the parts of an archive that have been uploaded in a specific multipart upload. You can make this request at any time during an in-progress multipart upload before you complete the upload (see <a>CompleteMultipartUpload</a>. List Parts returns an error for completed uploads. The list returned in the List Parts response is sorted by part range. </p> <p>The List Parts operation supports pagination. By default, this operation returns up to 1,000 uploaded parts in the response. You should always check the response for a <code class=\"code\">marker</code> at which to continue the list; if there are no more items the <code class=\"code\">marker</code> is <code class=\"code\">null</code>. To return a list of parts that begins at a specific part, set the <code>marker</code> request parameter to the value you obtained from a previous List Parts request. You can also limit the number of parts returned in the response by specifying the <code>limit</code> parameter in the request. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-list-parts.html\">List Parts</a> in the <i>Amazon Glacier Developer Guide</i>.</p>"
+    },
+    "ListVaults":{
+      "name":"ListVaults",
+      "http":{
+        "method":"GET",
+        "requestUri":"/{accountId}/vaults"
+      },
+      "input":{
+        "shape":"ListVaultsInput",
+        "documentation":"<p>Provides options to retrieve the vault list owned by the calling user's account. The list provides metadata information for each vault.</p>"
+      },
+      "output":{
+        "shape":"ListVaultsOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation lists all vaults owned by the calling user's account. The list returned in the response is ASCII-sorted by vault name. </p> <p>By default, this operation returns up to 1,000 items. If there are more vaults to list, the response <code class=\"code\">marker</code> field contains the vault Amazon Resource Name (ARN) at which to continue the list with a new List Vaults request; otherwise, the <code class=\"code\">marker</code> field is <code class=\"code\">null</code>. To return a list of vaults that begins at a specific vault, set the <code class=\"code\">marker</code> request parameter to the vault ARN you obtained from a previous List Vaults request. You can also limit the number of vaults returned in the response by specifying the <code class=\"code\">limit</code> parameter in the request. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/retrieving-vault-info.html\">Retrieving Vault Metadata in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vaults-get.html\">List Vaults </a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "SetDataRetrievalPolicy":{
+      "name":"SetDataRetrievalPolicy",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/{accountId}/policies/data-retrieval",
+        "responseCode":204
+      },
+      "input":{"shape":"SetDataRetrievalPolicyInput"},
+      "errors":[
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ]
+    },
+    "SetVaultNotifications":{
+      "name":"SetVaultNotifications",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/{accountId}/vaults/{vaultName}/notification-configuration",
+        "responseCode":204
+      },
+      "input":{
+        "shape":"SetVaultNotificationsInput",
+        "documentation":"<p>Provides options to configure notifications that will be sent when specific events happen to a vault.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation configures notifications that will be sent when specific events happen to a vault. By default, you don't get any notifications. </p> <p>To configure vault notifications, send a PUT request to the <code class=\"code\">notification-configuration</code> subresource of the vault. The request should include a JSON document that provides an Amazon SNS topic and specific events for which you want Amazon Glacier to send notifications to the topic.</p> <p>Amazon SNS topics must grant permission to the vault to be allowed to publish notifications to the topic. You can configure a vault to publish a notification for the following vault events:</p> <ul> <li> <b>ArchiveRetrievalCompleted</b> This event occurs when a job that was initiated for an archive retrieval is completed (<a>InitiateJob</a>). The status of the completed job can be \"Succeeded\" or \"Failed\". The notification sent to the SNS topic is the same output as returned from <a>DescribeJob</a>. </li> <li> <b>InventoryRetrievalCompleted</b> This event occurs when a job that was initiated for an inventory retrieval is completed (<a>InitiateJob</a>). The status of the completed job can be \"Succeeded\" or \"Failed\". The notification sent to the SNS topic is the same output as returned from <a>DescribeJob</a>. </li> </ul> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p>For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/configuring-notifications.html\">Configuring Vault Notifications in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-put.html\">Set Vault Notification Configuration </a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "UploadArchive":{
+      "name":"UploadArchive",
+      "http":{
+        "method":"POST",
+        "requestUri":"/{accountId}/vaults/{vaultName}/archives",
+        "responseCode":201
+      },
+      "input":{
+        "shape":"UploadArchiveInput",
+        "documentation":"<p>Provides options to add an archive to a vault.</p>"
+      },
+      "output":{
+        "shape":"ArchiveCreationOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p> <p>For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html\">Upload Archive</a>. For conceptual information, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"RequestTimeoutException",
+          "error":{"httpStatusCode":408},
+          "exception":true,
+          "documentation":"<p>Returned if, when uploading an archive, Amazon Glacier times out while receiving the upload.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation adds an archive to a vault. This is a synchronous operation, and for a successful upload, your data is durably persisted. Amazon Glacier returns the archive ID in the <code class=\"code\">x-amz-archive-id</code> header of the response. </p> <p>You must use the archive ID to access your data in Amazon Glacier. After you upload an archive, you should save the archive ID returned so that you can retrieve or delete the archive later. Besides saving the archive ID, you can also index it and give it a friendly name to allow for better searching. You can also use the optional archive description field to specify how the archive is referred to in an external index of archives, such as you might create in Amazon DynamoDB. You can also get the vault inventory to obtain a list of archive IDs in a vault. For more information, see <a>InitiateJob</a>. </p> <p>You must provide a SHA256 tree hash of the data you are uploading. For information about computing a SHA256 tree hash, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html\">Computing Checksums</a>. </p> <p>You can optionally specify an archive description of up to 1,024 printable ASCII characters. You can get the archive description when you either retrieve the archive or get the vault inventory. For more information, see <a>InitiateJob</a>. Amazon Glacier does not interpret the description in any way. An archive description does not need to be unique. You cannot use the description to retrieve or sort the archive list. </p> <p>Archives are immutable. After you upload an archive, you cannot edit the archive or its description. </p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-an-archive.html\">Uploading an Archive in Amazon Glacier</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html\">Upload Archive</a> in the <i>Amazon Glacier Developer Guide</i>. </p>"
+    },
+    "UploadMultipartPart":{
+      "name":"UploadMultipartPart",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}",
+        "responseCode":204
+      },
+      "input":{
+        "shape":"UploadMultipartPartInput",
+        "documentation":"<p>Provides options to upload a part of an archive in a multipart upload operation.</p>"
+      },
+      "output":{
+        "shape":"UploadMultipartPartOutput",
+        "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ResourceNotFoundException",
+          "error":{"httpStatusCode":404},
+          "exception":true,
+          "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+        },
+        {
+          "shape":"InvalidParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+        },
+        {
+          "shape":"MissingParameterValueException",
+          "error":{"httpStatusCode":400},
+          "exception":true,
+          "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+        },
+        {
+          "shape":"RequestTimeoutException",
+          "error":{"httpStatusCode":408},
+          "exception":true,
+          "documentation":"<p>Returned if, when uploading an archive, Amazon Glacier times out while receiving the upload.</p>"
+        },
+        {
+          "shape":"ServiceUnavailableException",
+          "error":{"httpStatusCode":500},
+          "exception":true,
+          "documentation":"<p>Returned if the service cannot complete the request.</p>"
+        }
+      ],
+      "documentation":"<p>This operation uploads a part of an archive. You can upload archive parts in any order. You can also upload them in parallel. You can upload up to 10,000 parts for a multipart upload.</p> <p>Amazon Glacier rejects your upload part request if any of the following conditions is true:</p> <ul> <li> <p><b>SHA256 tree hash does not match</b>To ensure that part data is not corrupted in transmission, you compute a SHA256 tree hash of the part and include it in your request. Upon receiving the part data, Amazon Glacier also computes a SHA256 tree hash. If these hash values don't match, the operation fails. For information about computing a SHA256 tree hash, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html\">Computing Checksums</a>.</p> </li> <li> <p><b>Part size does not match</b>The size of each part except the last must match the size specified in the corresponding <a>InitiateMultipartUpload</a> request. The size of the last part must be the same size as, or smaller than, the specified size.</p> <note><p>If you upload a part whose size is smaller than the part size you specified in your initiate multipart upload request and that part is not the last part, then the upload part request will succeed. However, the subsequent Complete Multipart Upload request will fail.</p></note> </li> <li> <b>Range does not align</b>The byte range value in the request does not align with the part size specified in the corresponding initiate request. For example, if you specify a part size of 4194304 bytes (4 MB), then 0 to 4194303 bytes (4 MB - 1) and 4194304 (4 MB) to 8388607 (8 MB - 1) are valid part ranges. However, if you set a range value of 2 MB to 6 MB, the range does not align with the part size and the upload will fail. </li> </ul> <p>This operation is idempotent. If you upload the same part multiple times, the data included in the most recent request overwrites the previously uploaded data.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html\">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html\">Uploading Large Archives in Parts (Multipart Upload)</a> and <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-upload-part.html\">Upload Part </a> in the <i>Amazon Glacier Developer Guide</i>.</p>"
+    }
+  },
+  "shapes":{
+    "AbortMultipartUploadInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "uploadId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"uploadId",
+          "documentation":"<p>The upload ID of the multipart upload to delete.</p>"
+        }
+      },
+      "documentation":"<p>Provides options to abort a multipart upload identified by the upload ID. </p> <p>For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html\">Abort Multipart Upload</a>. For conceptual information, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>",
+      "required":[
+        "accountId",
+        "vaultName",
+        "uploadId"
+      ]
+    },
+    "ActionCode":{
+      "type":"string",
+      "enum":[
+        "ArchiveRetrieval",
+        "InventoryRetrieval"
+      ]
+    },
+    "ArchiveCreationOutput":{
+      "type":"structure",
+      "members":{
+        "location":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Location",
+          "documentation":"<p>The relative URI path of the newly added archive resource.</p>"
+        },
+        "checksum":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-sha256-tree-hash",
+          "documentation":"<p>The checksum of the archive computed by Amazon Glacier.</p>"
+        },
+        "archiveId":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-archive-id",
+          "documentation":"<p>The ID of the archive. This value is also included as part of the location.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p> <p>For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html\">Upload Archive</a>. For conceptual information, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>"
+    },
+    "CompleteMultipartUploadInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "uploadId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"uploadId",
+          "documentation":"<p>The upload ID of the multipart upload.</p>"
+        },
+        "archiveSize":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-archive-size",
+          "documentation":"<p>The total size, in bytes, of the entire archive. This value should be the sum of all the sizes of the individual parts that you uploaded.</p>"
+        },
+        "checksum":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-sha256-tree-hash",
+          "documentation":"<p>The SHA256 tree hash of the entire archive. It is the tree hash of SHA256 tree hash of the individual parts. If the value you specify in the request does not match the SHA256 tree hash of the final assembled archive as computed by Amazon Glacier, Amazon Glacier returns an error and the request fails.</p>"
+        }
+      },
+      "documentation":"<p>Provides options to complete a multipart upload operation. This informs Amazon Glacier that all the archive parts have been uploaded and Amazon Glacier can now assemble the archive from the uploaded parts. After assembling and saving the archive to the vault, Amazon Glacier returns the URI path of the newly created archive resource.</p>",
+      "required":[
+        "accountId",
+        "vaultName",
+        "uploadId"
+      ]
+    },
+    "CreateVaultInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        }
+      },
+      "documentation":"<p>Provides options to create a vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "CreateVaultOutput":{
+      "type":"structure",
+      "members":{
+        "location":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Location",
+          "documentation":"<p>The URI of the vault that was created.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "DataRetrievalPolicy":{
+      "type":"structure",
+      "members":{
+        "Rules":{"shape":"DataRetrievalRulesList"}
+      }
+    },
+    "DataRetrievalRule":{
+      "type":"structure",
+      "members":{
+        "Strategy":{"shape":"string"},
+        "BytesPerHour":{"shape":"NullableLong"}
+      }
+    },
+    "DataRetrievalRulesList":{
+      "type":"list",
+      "member":{"shape":"DataRetrievalRule"}
+    },
+    "DateTime":{"type":"string"},
+    "DeleteArchiveInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "archiveId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"archiveId",
+          "documentation":"<p>The ID of the archive to delete.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for deleting an archive from an Amazon Glacier vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName",
+        "archiveId"
+      ]
+    },
+    "DeleteVaultInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for deleting a vault from Amazon Glacier.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "DeleteVaultNotificationsInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for deleting a vault notification configuration from an Amazon Glacier vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "DescribeJobInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "jobId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"jobId",
+          "documentation":"<p>The ID of the job to describe.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for retrieving a job description.</p>",
+      "required":[
+        "accountId",
+        "vaultName",
+        "jobId"
+      ]
+    },
+    "DescribeVaultInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for retrieving metadata for a specific vault in Amazon Glacier.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "DescribeVaultOutput":{
+      "type":"structure",
+      "members":{
+        "VaultARN":{
+          "shape":"string",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the vault.</p>"
+        },
+        "VaultName":{
+          "shape":"string",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "CreationDate":{
+          "shape":"string",
+          "documentation":"<p>The UTC date when the vault was created. A string representation of ISO 8601 date format, for example, \"2012-03-20T17:03:43.221Z\".</p>"
+        },
+        "LastInventoryDate":{
+          "shape":"string",
+          "documentation":"<p>The UTC date when Amazon Glacier completed the last vault inventory. A string representation of ISO 8601 date format, for example, \"2012-03-20T17:03:43.221Z\".</p>"
+        },
+        "NumberOfArchives":{
+          "shape":"long",
+          "documentation":"<p>The number of archives in the vault as of the last inventory date. This field will return <code>null</code> if an inventory has not yet run on the vault, for example, if you just created the vault.</p>"
+        },
+        "SizeInBytes":{
+          "shape":"long",
+          "documentation":"<p>Total size, in bytes, of the archives in the vault as of the last inventory date. This field will return null if an inventory has not yet run on the vault, for example, if you just created the vault.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "GetDataRetrievalPolicyInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId"
+        }
+      },
+      "required":["accountId"]
+    },
+    "GetDataRetrievalPolicyOutput":{
+      "type":"structure",
+      "members":{
+        "Policy":{"shape":"DataRetrievalPolicy"}
+      }
+    },
+    "GetJobOutputInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "jobId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"jobId",
+          "documentation":"<p>The job ID whose data is downloaded.</p>"
+        },
+        "range":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Range",
+          "documentation":"<p>The range of bytes to retrieve from the output. For example, if you want to download the first 1,048,576 bytes, specify \"Range: bytes=0-1048575\". By default, this operation downloads the entire output. </p>"
+        }
+      },
+      "documentation":"<p>Provides options for downloading output of an Amazon Glacier job.</p>",
+      "required":[
+        "accountId",
+        "vaultName",
+        "jobId"
+      ]
+    },
+    "GetJobOutputOutput":{
+      "type":"structure",
+      "members":{
+        "body":{
+          "shape":"Stream",
+          "documentation":"<p>The job data, either archive data or inventory data.</p>"
+        },
+        "checksum":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-sha256-tree-hash",
+          "documentation":"<p> The checksum of the data in the response. This header is returned only when retrieving the output for an archive retrieval job. Furthermore, this header appears only under the following conditions: <ul> <li>You get the entire range of the archive.</li> <li>You request a range to return of the archive that starts and ends on a multiple of 1 MB. For example, if you have an 3.1 MB archive and you specify a range to return that starts at 1 MB and ends at 2 MB, then the x-amz-sha256-tree-hash is returned as a response header.</li> <li>You request a range of the archive to return that starts on a multiple of 1 MB and goes to the end of the archive. For example, if you have a 3.1 MB archive and you specify a range that starts at 2 MB and ends at 3.1 MB (the end of the archive), then the x-amz-sha256-tree-hash is returned as a response header.</li> </ul> </p>"
+        },
+        "status":{
+          "shape":"httpstatus",
+          "location":"statusCode",
+          "documentation":"<p>The HTTP response code for a job output request. The value depends on whether a range was specified in the request.</p>"
+        },
+        "contentRange":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Content-Range",
+          "documentation":"<p>The range of bytes returned by Amazon Glacier. If only partial output is downloaded, the response provides the range of bytes Amazon Glacier returned. For example, bytes 0-1048575/8388608 returns the first 1 MB from 8 MB.</p>"
+        },
+        "acceptRanges":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Accept-Ranges",
+          "documentation":"<p>Indicates the range units accepted. For more information, go to <a href=\"http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html\">RFC2616</a>. </p>"
+        },
+        "contentType":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Content-Type",
+          "documentation":"<p>The Content-Type depends on whether the job output is an archive or a vault inventory. For archive data, the Content-Type is application/octet-stream. For vault inventory, if you requested CSV format when you initiated the job, the Content-Type is text/csv. Otherwise, by default, vault inventory is returned as JSON, and the Content-Type is application/json. </p>"
+        },
+        "archiveDescription":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-archive-description",
+          "documentation":"<p>The description of an archive.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>",
+      "payload":"body"
+    },
+    "GetVaultNotificationsInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for retrieving the notification configuration set on an Amazon Glacier vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "GetVaultNotificationsOutput":{
+      "type":"structure",
+      "members":{
+        "vaultNotificationConfig":{
+          "shape":"VaultNotificationConfig",
+          "documentation":"<p>Returns the notification configuration set on the vault.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>",
+      "payload":"vaultNotificationConfig"
+    },
+    "GlacierJobDescription":{
+      "type":"structure",
+      "members":{
+        "JobId":{
+          "shape":"string",
+          "documentation":"<p>An opaque string that identifies an Amazon Glacier job.</p>"
+        },
+        "JobDescription":{
+          "shape":"string",
+          "documentation":"<p>The job description you provided when you initiated the job.</p>"
+        },
+        "Action":{
+          "shape":"ActionCode",
+          "documentation":"<p>The job type. It is either ArchiveRetrieval or InventoryRetrieval.</p>"
+        },
+        "ArchiveId":{
+          "shape":"string",
+          "documentation":"<p>For an ArchiveRetrieval job, this is the archive ID requested for download. Otherwise, this field is null.</p>"
+        },
+        "VaultARN":{
+          "shape":"string",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the vault from which the archive retrieval was requested.</p>"
+        },
+        "CreationDate":{
+          "shape":"string",
+          "documentation":"<p>The UTC date when the job was created. A string representation of ISO 8601 date format, for example, \"2012-03-20T17:03:43.221Z\".</p>"
+        },
+        "Completed":{
+          "shape":"boolean",
+          "documentation":"<p>The job status. When a job is completed, you get the job's output.</p>"
+        },
+        "StatusCode":{
+          "shape":"StatusCode",
+          "documentation":"<p>The status code can be InProgress, Succeeded, or Failed, and indicates the status of the job.</p>"
+        },
+        "StatusMessage":{
+          "shape":"string",
+          "documentation":"<p>A friendly message that describes the job status.</p>"
+        },
+        "ArchiveSizeInBytes":{
+          "shape":"Size",
+          "documentation":"<p>For an ArchiveRetrieval job, this is the size in bytes of the archive being requested for download. For the InventoryRetrieval job, the value is null.</p>"
+        },
+        "InventorySizeInBytes":{
+          "shape":"Size",
+          "documentation":"<p>For an InventoryRetrieval job, this is the size in bytes of the inventory requested for download. For the ArchiveRetrieval job, the value is null.</p>"
+        },
+        "SNSTopic":{
+          "shape":"string",
+          "documentation":"<p>An Amazon Simple Notification Service (Amazon SNS) topic that receives notification.</p>"
+        },
+        "CompletionDate":{
+          "shape":"string",
+          "documentation":"<p>The UTC time that the archive retrieval request completed. While the job is in progress, the value will be null.</p>"
+        },
+        "SHA256TreeHash":{
+          "shape":"string",
+          "documentation":"<p>For an ArchiveRetrieval job, it is the checksum of the archive. Otherwise, the value is null.</p> <p> The SHA256 tree hash value for the requested range of an archive. If the Initiate a Job request for an archive specified a tree-hash aligned range, then this field returns a value. </p> <p> For the specific case when the whole archive is retrieved, this value is the same as the ArchiveSHA256TreeHash value. </p> <p> This field is null in the following situations: <ul> <li><p>Archive retrieval jobs that specify a range that is not tree-hash aligned.</p></li> </ul> <ul> <li><p>Archival jobs that specify a range that is equal to the whole archive and the job status is InProgress.</p></li> </ul> <ul> <li><p>Inventory jobs.</p></li> </ul> </p>"
+        },
+        "ArchiveSHA256TreeHash":{
+          "shape":"string",
+          "documentation":"<p>The SHA256 tree hash of the entire archive for an archive retrieval. For inventory retrieval jobs, this field is null. </p>"
+        },
+        "RetrievalByteRange":{
+          "shape":"string",
+          "documentation":"<p>The retrieved byte range for archive retrieval jobs in the form \"<i>StartByteValue</i>-<i>EndByteValue</i>\" If no range was specified in the archive retrieval, then the whole archive is retrieved and <i>StartByteValue</i> equals 0 and <i>EndByteValue</i> equals the size of the archive minus 1. For inventory retrieval jobs this field is null. </p>"
+        },
+        "InventoryRetrievalParameters":{
+          "shape":"InventoryRetrievalJobDescription",
+          "documentation":"<p>Parameters used for range inventory retrieval.</p>"
+        }
+      },
+      "documentation":"<p>Describes an Amazon Glacier job.</p>"
+    },
+    "InitiateJobInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "jobParameters":{
+          "shape":"JobParameters",
+          "documentation":"<p>Provides options for specifying job information.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for initiating an Amazon Glacier job.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ],
+      "payload":"jobParameters"
+    },
+    "InitiateJobOutput":{
+      "type":"structure",
+      "members":{
+        "location":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Location",
+          "documentation":"<p>The relative URI path of the job.</p>"
+        },
+        "jobId":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-job-id",
+          "documentation":"<p>The ID of the job.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "InitiateMultipartUploadInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "archiveDescription":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-archive-description",
+          "documentation":"<p>The archive description that you are uploading in parts.</p> <p>The part size must be a megabyte (1024 KB) multiplied by a power of 2—for example, 1048576 (1 MB), 2097152 (2 MB), 4194304 (4 MB), 8388608 (8 MB), and so on. The minimum allowable part size is 1 MB, and the maximum is 4 GB (4096 MB).</p>"
+        },
+        "partSize":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-part-size",
+          "documentation":"<p>The size of each part except the last, in bytes. The last part can be smaller than this part size.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for initiating a multipart upload to an Amazon Glacier vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "InitiateMultipartUploadOutput":{
+      "type":"structure",
+      "members":{
+        "location":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Location",
+          "documentation":"<p>The relative URI path of the multipart upload ID Amazon Glacier created. </p>"
+        },
+        "uploadId":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-multipart-upload-id",
+          "documentation":"<p>The ID of the multipart upload. This value is also included as part of the location. </p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "InvalidParameterValueException":{
+      "type":"structure",
+      "members":{
+        "type":{
+          "shape":"string",
+          "documentation":"<p>Client</p>"
+        },
+        "code":{
+          "shape":"string",
+          "documentation":"<p>400 Bad Request</p>"
+        },
+        "message":{"shape":"string"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true,
+      "documentation":"<p>Returned if a parameter of the request is incorrectly specified. </p>"
+    },
+    "InventoryRetrievalJobDescription":{
+      "type":"structure",
+      "members":{
+        "Format":{
+          "shape":"string",
+          "documentation":"<p>The output format for the vault inventory list, which is set by the <b>InitiateJob</b> request when initiating a job to retrieve a vault inventory. Valid values are \"CSV\" and \"JSON\".</p>"
+        },
+        "StartDate":{
+          "shape":"DateTime",
+          "documentation":"<p>The start of the date range in UTC for vault inventory retrieval that includes archives created on or after this date. A string representation of ISO 8601 date format, for example, 2013-03-20T17:03:43Z.</p>"
+        },
+        "EndDate":{
+          "shape":"DateTime",
+          "documentation":"<p>The end of the date range in UTC for vault inventory retrieval that includes archives created before this date. A string representation of ISO 8601 date format, for example, 2013-03-20T17:03:43Z.</p>"
+        },
+        "Limit":{
+          "shape":"string",
+          "documentation":"<p>Specifies the maximum number of inventory items returned per vault inventory retrieval request. This limit is set when initiating the job with the a <b>InitiateJob</b> request. </p>"
+        },
+        "Marker":{
+          "shape":"string",
+          "documentation":"<p>An opaque string that represents where to continue pagination of the vault inventory retrieval results. You use the marker in a new <b>InitiateJob</b> request to obtain additional inventory items. If there are no more inventory items, this value is <code>null</code>. For more information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html#api-initiate-job-post-vault-inventory-list-filtering\"> Range Inventory Retrieval</a>.</p>"
+        }
+      },
+      "documentation":"<p>Describes the options for a range inventory retrieval job.</p>"
+    },
+    "InventoryRetrievalJobInput":{
+      "type":"structure",
+      "members":{
+        "StartDate":{
+          "shape":"string",
+          "documentation":"<p>The start of the date range in UTC for vault inventory retrieval that includes archives created on or after this date. A string representation of ISO 8601 date format, for example, 2013-03-20T17:03:43Z.</p>"
+        },
+        "EndDate":{
+          "shape":"string",
+          "documentation":"<p>The end of the date range in UTC for vault inventory retrieval that includes archives created before this date. A string representation of ISO 8601 date format, for example, 2013-03-20T17:03:43Z.</p>"
+        },
+        "Limit":{
+          "shape":"string",
+          "documentation":"<p>Specifies the maximum number of inventory items returned per vault inventory retrieval request. Valid values are greater than or equal to 1.</p>"
+        },
+        "Marker":{
+          "shape":"string",
+          "documentation":"<p>An opaque string that represents where to continue pagination of the vault inventory retrieval results. You use the marker in a new <b>InitiateJob</b> request to obtain additional inventory items. If there are no more inventory items, this value is <code>null</code>.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for specifying a range inventory retrieval job.</p>"
+    },
+    "JobList":{
+      "type":"list",
+      "member":{"shape":"GlacierJobDescription"}
+    },
+    "JobParameters":{
+      "type":"structure",
+      "members":{
+        "Format":{
+          "shape":"string",
+          "documentation":"<p>When initiating a job to retrieve a vault inventory, you can optionally add this parameter to your request to specify the output format. If you are initiating an inventory job and do not specify a Format field, JSON is the default format. Valid values are \"CSV\" and \"JSON\". </p>"
+        },
+        "Type":{
+          "shape":"string",
+          "documentation":"<p>The job type. You can initiate a job to retrieve an archive or get an inventory of a vault. Valid values are \"archive-retrieval\" and \"inventory-retrieval\".</p>"
+        },
+        "ArchiveId":{
+          "shape":"string",
+          "documentation":"<p>The ID of the archive that you want to retrieve. This field is required only if <code>Type</code> is set to archive-retrieval. An error occurs if you specify this request parameter for an inventory retrieval job request. </p>"
+        },
+        "Description":{
+          "shape":"string",
+          "documentation":"<p>The optional description for the job. The description must be less than or equal to 1,024 bytes. The allowable characters are 7-bit ASCII without control codes-specifically, ASCII values 32-126 decimal or 0x20-0x7E hexadecimal.</p>"
+        },
+        "SNSTopic":{
+          "shape":"string",
+          "documentation":"<p>The Amazon SNS topic ARN to which Amazon Glacier sends a notification when the job is completed and the output is ready for you to download. The specified topic publishes the notification to its subscribers. The SNS topic must exist.</p>"
+        },
+        "RetrievalByteRange":{
+          "shape":"string",
+          "documentation":"<p>The byte range to retrieve for an archive retrieval. in the form \"<i>StartByteValue</i>-<i>EndByteValue</i>\" If not specified, the whole archive is retrieved. If specified, the byte range must be megabyte (1024*1024) aligned which means that <i>StartByteValue</i> must be divisible by 1 MB and <i>EndByteValue</i> plus 1 must be divisible by 1 MB or be the end of the archive specified as the archive byte size value minus 1. If RetrievalByteRange is not megabyte aligned, this operation returns a 400 response. </p> <p>An error occurs if you specify this field for an inventory retrieval job request. </p>"
+        },
+        "InventoryRetrievalParameters":{
+          "shape":"InventoryRetrievalJobInput",
+          "documentation":"<p>Input parameters used for range inventory retrieval.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for defining a job.</p>"
+    },
+    "LimitExceededException":{
+      "type":"structure",
+      "members":{
+        "type":{
+          "shape":"string",
+          "documentation":"<p>Client</p>"
+        },
+        "code":{
+          "shape":"string",
+          "documentation":"<p>400 Bad Request</p>"
+        },
+        "message":{"shape":"string"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true,
+      "documentation":"<p>Returned if the request results in a vault or account limit being exceeded.</p>"
+    },
+    "ListJobsInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "limit":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"limit",
+          "documentation":"<p>Specifies that the response be limited to the specified number of items or fewer. If not specified, the List Jobs operation returns up to 1,000 jobs.</p>"
+        },
+        "marker":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"marker",
+          "documentation":"<p>An opaque string used for pagination. This value specifies the job at which the listing of jobs should begin. Get the marker value from a previous List Jobs response. You need only include the marker if you are continuing the pagination of results started in a previous List Jobs request.</p>"
+        },
+        "statuscode":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"statuscode",
+          "documentation":"<p>Specifies the type of job status to return. You can specify the following values: \"InProgress\", \"Succeeded\", or \"Failed\".</p>"
+        },
+        "completed":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"completed",
+          "documentation":"<p>Specifies the state of the jobs to return. You can specify <code>true</code> or <code>false</code>.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for retrieving a job list for an Amazon Glacier vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "ListJobsOutput":{
+      "type":"structure",
+      "members":{
+        "JobList":{
+          "shape":"JobList",
+          "documentation":"<p>A list of job objects. Each job object contains metadata describing the job. </p>"
+        },
+        "Marker":{
+          "shape":"string",
+          "documentation":"<p>An opaque string that represents where to continue pagination of the results. You use this value in a new List Jobs request to obtain more jobs in the list. If there are no more jobs, this value is <code>null</code>. </p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "ListMultipartUploadsInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "marker":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"marker",
+          "documentation":"<p>An opaque string used for pagination. This value specifies the upload at which the listing of uploads should begin. Get the marker value from a previous List Uploads response. You need only include the marker if you are continuing the pagination of results started in a previous List Uploads request.</p>"
+        },
+        "limit":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"limit",
+          "documentation":"<p>Specifies the maximum number of uploads returned in the response body. If this value is not specified, the List Uploads operation returns up to 1,000 uploads.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for retrieving list of in-progress multipart uploads for an Amazon Glacier vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "ListMultipartUploadsOutput":{
+      "type":"structure",
+      "members":{
+        "UploadsList":{
+          "shape":"UploadsList",
+          "documentation":"<p>A list of in-progress multipart uploads.</p>"
+        },
+        "Marker":{
+          "shape":"string",
+          "documentation":"<p>An opaque string that represents where to continue pagination of the results. You use the marker in a new List Multipart Uploads request to obtain more uploads in the list. If there are no more uploads, this value is <code>null</code>.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "ListPartsInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "uploadId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"uploadId",
+          "documentation":"<p>The upload ID of the multipart upload.</p>"
+        },
+        "marker":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"marker",
+          "documentation":"<p>An opaque string used for pagination. This value specifies the part at which the listing of parts should begin. Get the marker value from the response of a previous List Parts response. You need only include the marker if you are continuing the pagination of results started in a previous List Parts request.</p>"
+        },
+        "limit":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"limit",
+          "documentation":"<p>Specifies the maximum number of parts returned in the response body. If this value is not specified, the List Parts operation returns up to 1,000 uploads.</p>"
+        }
+      },
+      "documentation":"<p>Provides options for retrieving a list of parts of an archive that have been uploaded in a specific multipart upload.</p>",
+      "required":[
+        "accountId",
+        "vaultName",
+        "uploadId"
+      ]
+    },
+    "ListPartsOutput":{
+      "type":"structure",
+      "members":{
+        "MultipartUploadId":{
+          "shape":"string",
+          "documentation":"<p>The ID of the upload to which the parts are associated.</p>"
+        },
+        "VaultARN":{
+          "shape":"string",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the vault to which the multipart upload was initiated.</p>"
+        },
+        "ArchiveDescription":{
+          "shape":"string",
+          "documentation":"<p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>"
+        },
+        "PartSizeInBytes":{
+          "shape":"long",
+          "documentation":"<p>The part size in bytes.</p>"
+        },
+        "CreationDate":{
+          "shape":"string",
+          "documentation":"<p>The UTC time at which the multipart upload was initiated.</p>"
+        },
+        "Parts":{
+          "shape":"PartList",
+          "documentation":"<p>A list of the part sizes of the multipart upload.</p>"
+        },
+        "Marker":{
+          "shape":"string",
+          "documentation":"<p>An opaque string that represents where to continue pagination of the results. You use the marker in a new List Parts request to obtain more jobs in the list. If there are no more parts, this value is <code>null</code>.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "ListVaultsInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "marker":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"marker",
+          "documentation":"<p>A string used for pagination. The marker specifies the vault ARN after which the listing of vaults should begin.</p>"
+        },
+        "limit":{
+          "shape":"string",
+          "location":"querystring",
+          "locationName":"limit",
+          "documentation":"<p>The maximum number of items returned in the response. If you don't specify a value, the List Vaults operation returns up to 1,000 items.</p>"
+        }
+      },
+      "documentation":"<p>Provides options to retrieve the vault list owned by the calling user's account. The list provides metadata information for each vault.</p>",
+      "required":["accountId"]
+    },
+    "ListVaultsOutput":{
+      "type":"structure",
+      "members":{
+        "VaultList":{
+          "shape":"VaultList",
+          "documentation":"<p>List of vaults.</p>"
+        },
+        "Marker":{
+          "shape":"string",
+          "documentation":"<p>The vault ARN at which to continue pagination of the results. You use the marker in another List Vaults request to obtain more vaults in the list.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "MissingParameterValueException":{
+      "type":"structure",
+      "members":{
+        "type":{
+          "shape":"string",
+          "documentation":"<p>Client.</p>"
+        },
+        "code":{
+          "shape":"string",
+          "documentation":"<p>400 Bad Request</p>"
+        },
+        "message":{"shape":"string"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true,
+      "documentation":"<p>Returned if a required header or parameter is missing from the request.</p>"
+    },
+    "NotificationEventList":{
+      "type":"list",
+      "member":{"shape":"string"}
+    },
+    "NullableLong":{"type":"long"},
+    "PartList":{
+      "type":"list",
+      "member":{"shape":"PartListElement"}
+    },
+    "PartListElement":{
+      "type":"structure",
+      "members":{
+        "RangeInBytes":{
+          "shape":"string",
+          "documentation":"<p>The byte range of a part, inclusive of the upper value of the range.</p>"
+        },
+        "SHA256TreeHash":{
+          "shape":"string",
+          "documentation":"<p>The SHA256 tree hash value that Amazon Glacier calculated for the part. This field is never <code>null</code>.</p>"
+        }
+      },
+      "documentation":"<p>A list of the part sizes of the multipart upload.</p>"
+    },
+    "PolicyEnforcedException":{
+      "type":"structure",
+      "members":{
+        "type":{"shape":"string"},
+        "code":{"shape":"string"},
+        "message":{"shape":"string"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true
+    },
+    "RequestTimeoutException":{
+      "type":"structure",
+      "members":{
+        "type":{
+          "shape":"string",
+          "documentation":"<p>Client</p>"
+        },
+        "code":{
+          "shape":"string",
+          "documentation":"<p>408 Request Timeout</p>"
+        },
+        "message":{"shape":"string"}
+      },
+      "error":{"httpStatusCode":408},
+      "exception":true,
+      "documentation":"<p>Returned if, when uploading an archive, Amazon Glacier times out while receiving the upload.</p>"
+    },
+    "ResourceNotFoundException":{
+      "type":"structure",
+      "members":{
+        "type":{
+          "shape":"string",
+          "documentation":"<p>Client</p>"
+        },
+        "code":{
+          "shape":"string",
+          "documentation":"<p>404 Not Found</p>"
+        },
+        "message":{"shape":"string"}
+      },
+      "error":{"httpStatusCode":404},
+      "exception":true,
+      "documentation":"<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>"
+    },
+    "ServiceUnavailableException":{
+      "type":"structure",
+      "members":{
+        "type":{
+          "shape":"string",
+          "documentation":"<p>Server</p>"
+        },
+        "code":{
+          "shape":"string",
+          "documentation":"<p>500 Internal Server Error</p>"
+        },
+        "message":{"shape":"string"}
+      },
+      "error":{"httpStatusCode":500},
+      "exception":true,
+      "documentation":"<p>Returned if the service cannot complete the request.</p>"
+    },
+    "SetDataRetrievalPolicyInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId"
+        },
+        "Policy":{"shape":"DataRetrievalPolicy"}
+      },
+      "required":["accountId"]
+    },
+    "SetVaultNotificationsInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "vaultNotificationConfig":{
+          "shape":"VaultNotificationConfig",
+          "documentation":"<p>Provides options for specifying notification configuration.</p>"
+        }
+      },
+      "documentation":"<p>Provides options to configure notifications that will be sent when specific events happen to a vault.</p>",
+      "required":[
+        "accountId",
+        "vaultName"
+      ],
+      "payload":"vaultNotificationConfig"
+    },
+    "Size":{"type":"long"},
+    "StatusCode":{
+      "type":"string",
+      "enum":[
+        "InProgress",
+        "Succeeded",
+        "Failed"
+      ]
+    },
+    "Stream":{
+      "type":"blob",
+      "streaming":true
+    },
+    "UploadArchiveInput":{
+      "type":"structure",
+      "members":{
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "archiveDescription":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-archive-description",
+          "documentation":"<p>The optional description of the archive you are uploading. </p>"
+        },
+        "checksum":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-sha256-tree-hash",
+          "documentation":"<p>The SHA256 checksum (a linear hash) of the payload.</p>"
+        },
+        "body":{
+          "shape":"Stream",
+          "documentation":"<p>The data to upload.</p>"
+        }
+      },
+      "documentation":"<p>Provides options to add an archive to a vault.</p>",
+      "required":[
+        "vaultName",
+        "accountId"
+      ],
+      "payload":"body"
+    },
+    "UploadListElement":{
+      "type":"structure",
+      "members":{
+        "MultipartUploadId":{
+          "shape":"string",
+          "documentation":"<p>The ID of a multipart upload.</p>"
+        },
+        "VaultARN":{
+          "shape":"string",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the vault that contains the archive.</p>"
+        },
+        "ArchiveDescription":{
+          "shape":"string",
+          "documentation":"<p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>"
+        },
+        "PartSizeInBytes":{
+          "shape":"long",
+          "documentation":"<p>The part size, in bytes, specified in the Initiate Multipart Upload request. This is the size of all the parts in the upload except the last part, which may be smaller than this size.</p>"
+        },
+        "CreationDate":{
+          "shape":"string",
+          "documentation":"<p>The UTC time at which the multipart upload was initiated.</p>"
+        }
+      },
+      "documentation":"<p>A list of in-progress multipart uploads for a vault.</p>"
+    },
+    "UploadMultipartPartInput":{
+      "type":"structure",
+      "members":{
+        "accountId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"accountId",
+          "documentation":"<p>The <code>AccountId</code> is the AWS Account ID. You can specify either the AWS Account ID or optionally a '-', in which case Amazon Glacier uses the AWS Account ID associated with the credentials used to sign the request. If you specify your Account ID, do not include hyphens in it. </p>"
+        },
+        "vaultName":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"vaultName",
+          "documentation":"<p>The name of the vault.</p>"
+        },
+        "uploadId":{
+          "shape":"string",
+          "location":"uri",
+          "locationName":"uploadId",
+          "documentation":"<p>The upload ID of the multipart upload.</p>"
+        },
+        "checksum":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-sha256-tree-hash",
+          "documentation":"<p>The SHA256 tree hash of the data being uploaded. </p>"
+        },
+        "range":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"Content-Range",
+          "documentation":"<p>Identifies the range of bytes in the assembled archive that will be uploaded in this part. Amazon Glacier uses this information to assemble the archive in the proper sequence. The format of this header follows RFC 2616. An example header is Content-Range:bytes 0-4194303/*.</p>"
+        },
+        "body":{
+          "shape":"Stream",
+          "documentation":"<p>The data to upload.</p>"
+        }
+      },
+      "documentation":"<p>Provides options to upload a part of an archive in a multipart upload operation.</p>",
+      "required":[
+        "accountId",
+        "vaultName",
+        "uploadId"
+      ],
+      "payload":"body"
+    },
+    "UploadMultipartPartOutput":{
+      "type":"structure",
+      "members":{
+        "checksum":{
+          "shape":"string",
+          "location":"header",
+          "locationName":"x-amz-sha256-tree-hash",
+          "documentation":"<p>The SHA256 tree hash that Amazon Glacier computed for the uploaded part.</p>"
+        }
+      },
+      "documentation":"<p>Contains the Amazon Glacier response to your request.</p>"
+    },
+    "UploadsList":{
+      "type":"list",
+      "member":{"shape":"UploadListElement"}
+    },
+    "VaultList":{
+      "type":"list",
+      "member":{"shape":"DescribeVaultOutput"}
+    },
+    "VaultNotificationConfig":{
+      "type":"structure",
+      "members":{
+        "SNSTopic":{
+          "shape":"string",
+          "documentation":"<p>The Amazon Simple Notification Service (Amazon SNS) topic Amazon Resource Name (ARN).</p>"
+        },
+        "Events":{
+          "shape":"NotificationEventList",
+          "documentation":"<p>A list of one or more events for which Amazon Glacier will send a notification to the specified Amazon SNS topic.</p>"
+        }
+      },
+      "documentation":"<p>Represents a vault's notification configuration.</p>"
+    },
+    "boolean":{"type":"boolean"},
+    "httpstatus":{"type":"integer"},
+    "long":{"type":"long"},
+    "string":{"type":"string"}
+  }
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -24,6 +24,7 @@ import xml.etree.cElementTree
 
 from botocore.compat import urlsplit, urlunsplit, unquote, json, quote, six
 from botocore import retryhandler
+from botocore import utils
 from botocore import translate
 import botocore.auth
 
@@ -400,6 +401,53 @@ def fix_route53_ids(params, model, **kwargs):
             logger.debug('%s %s -> %s', name, orig_value, params[name])
 
 
+def inject_account_id(params, **kwargs):
+    if params.get('accountId') is None:
+        # Glacier requires accountId, but allows you
+        # to specify '-' for the current owners account.
+        # We add this default value if the user does not
+        # provide the accountId as a convenience.
+        params['accountId'] = '-'
+
+
+def add_glacier_version(model, params, **kwargs):
+    request_dict = params
+    request_dict['headers']['x-amz-glacier-version'] = \
+            model.metadata['apiVersion']
+
+
+def add_glacier_checksums(params, **kwargs):
+    """Add glacier checksums to the http request.
+
+    This will add two headers to the http request:
+
+        * x-amz-content-sha256
+        * x-amz-sha256-tree-hash
+
+    These values will only be added if they are not present
+    in the HTTP request.
+
+    """
+    request_dict = params
+    headers = request_dict['headers']
+    body = request_dict['body']
+    if isinstance(body, six.binary_type):
+        # If the user provided a bytes type instead of a file
+        # like object, we're temporarily create a BytesIO object
+        # so we can use the util functions to calculate the
+        # checksums which assume file like objects.  Note that
+        # we're not actually changing the body in the request_dict.
+        body = six.BytesIO(body)
+    starting_position = body.tell()
+    if 'x-amz-content-sha256' not in headers:
+        headers['x-amz-content-sha256'] = utils.calculate_sha256(
+            body, as_hex=True)
+    body.seek(starting_position)
+    if 'x-amz-sha256-tree-hash' not in headers:
+        headers['x-amz-sha256-tree-hash'] = utils.calculate_tree_hash(body)
+    body.seek(starting_position)
+
+
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be
 # automatically registered with that Session.
@@ -418,6 +466,9 @@ BUILTIN_HANDLERS = [
     ('before-call.s3.UploadPartCopy', quote_source_header),
     ('before-call.s3.CopyObject', quote_source_header),
     ('before-call.s3', add_expect_header),
+    ('before-call.glacier', add_glacier_version),
+    ('before-call.glacier.UploadArchive', add_glacier_checksums),
+    ('before-call.glacier.UploadMultipartPart', add_glacier_checksums),
     ('before-call.ec2.CopySnapshot', copy_snapshot_encrypted),
     ('before-auth.s3', fix_s3_host),
     ('needs-retry.s3.UploadPartCopy', check_for_200_error, REGISTER_FIRST),
@@ -436,5 +487,6 @@ BUILTIN_HANDLERS = [
     ('before-parameter-build.ec2.RunInstances', base64_encode_user_data),
     ('before-parameter-build.autoscaling.CreateLaunchConfiguration',
      base64_encode_user_data),
-    ('before-parameter-build.route53', fix_route53_ids)
+    ('before-parameter-build.route53', fix_route53_ids),
+    ('before-parameter-build.glacier', inject_account_id),
 ]

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -637,6 +637,8 @@ class RestJSONParser(BaseRestParser, BaseJSONParser):
             # x-amzn-errortype: ValidationException:
             code = code.split(':')[0]
             error['Error']['Code'] = code
+        elif 'code' in body:
+            error['Error']['Code'] = body['code']
         return error
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -113,10 +113,7 @@ class TestParamSerialization(BaseSessionTest):
 
     def assert_params_serialize_to(self, dotted_name, input_params,
                                    serialized_params):
-        service_name, operation_name = dotted_name.split('.')
-        service = self.session.get_service(service_name)
-        operation = service.get_operation(operation_name)
-        serialized = operation.build_parameters(**input_params)
+        serialized = self.get_serialized_params(dotted_name, input_params)
         actual_body_params = serialized['body']
         # For query, we can remove the Action and Version params.
         if isinstance(actual_body_params, dict):
@@ -125,3 +122,10 @@ class TestParamSerialization(BaseSessionTest):
             self.assertDictEqual(serialized_params, actual_body_params)
         else:
             self.assertEqual(serialized_params, actual_body_params)
+
+    def get_serialized_params(self, dotted_name, input_params):
+        service_name, operation_name = dotted_name.split('.')
+        service = self.session.get_service(service_name)
+        operation = service.get_operation(operation_name)
+        serialized = operation.build_parameters(**input_params)
+        return serialized

--- a/tests/integration/test_glacier.py
+++ b/tests/integration/test_glacier.py
@@ -1,0 +1,72 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+import random
+
+from botocore.exceptions import ClientError
+from botocore.vendored import six
+import botocore.session
+
+
+class TestGlacier(unittest.TestCase):
+    # We have to use a single vault for all the integration tests.
+    # This is because if we create a vault and upload then delete
+    # an archive, we cannot immediately clean up and delete the vault.
+    # The compromise is that we'll use a single vault and use
+    # get_or_create semantics for the integ tests.  This does mean you
+    # need to be careful when writing tests.  Assume that other code
+    # is also using this vault in parallel, so don't rely on things like
+    # number of archives in a vault.
+
+    VAULT_NAME = 'botocore-integ-test-vault'
+
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client('glacier', 'us-west-2')
+        # There's no error if the vault already exists so we don't
+        # need to catch any exceptions here.
+        self.client.create_vault(vaultName=self.VAULT_NAME)
+
+    def test_can_list_vaults_without_account_id(self):
+        response = self.client.list_vaults()
+        self.assertIn('VaultList', response)
+
+    def test_can_handle_error_responses(self):
+        with self.assertRaises(ClientError):
+            self.client.list_vaults(accountId='asdf')
+
+    def test_can_upload_archive(self):
+        body = six.BytesIO(b"bytes content")
+        response = self.client.upload_archive(vaultName=self.VAULT_NAME,
+                                              archiveDescription='test upload',
+                                              body=body)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 201)
+        archive_id = response['archiveId']
+        response = self.client.delete_archive(vaultName=self.VAULT_NAME,
+                                              archiveId=archive_id)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 204)
+
+    def test_can_upload_archive_from_bytes(self):
+        response = self.client.upload_archive(vaultName=self.VAULT_NAME,
+                                              archiveDescription='test upload',
+                                              body=b'bytes body')
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 201)
+        archive_id = response['archiveId']
+        response = self.client.delete_archive(vaultName=self.VAULT_NAME,
+                                              archiveId=archive_id)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 204)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -38,6 +38,7 @@ SMOKE_TESTS = {
  'elastictranscoder': {'ListPipelines': {}},
  'elb': {'DescribeLoadBalancers': {}},
  'emr': {'ListClusters': {}},
+ 'glacier': {'ListVaults': {}},
  'iam': {'ListUsers': {}},
  # Does not work with session credentials so
  # importexport tests are not run.

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -395,6 +395,28 @@ class TestHandlers(BaseSessionTest):
         # And verify that the body can still be read.
         self.assertEqual(request_dict['body'].read(), b'hello world')
 
+    def test_tree_hash_added_only_if_not_exists(self):
+        request_dict = {
+            'headers': {
+                'x-amz-sha256-tree-hash': 'pre-exists',
+            },
+            'body': six.BytesIO(b'hello world'),
+        }
+        handlers.add_glacier_checksums(request_dict)
+        self.assertEqual(request_dict['headers']['x-amz-sha256-tree-hash'],
+                         'pre-exists')
+
+    def test_checksum_added_only_if_not_exists(self):
+        request_dict = {
+            'headers': {
+                'x-amz-content-sha256': 'pre-exists',
+            },
+            'body': six.BytesIO(b'hello world'),
+        }
+        handlers.add_glacier_checksums(request_dict)
+        self.assertEqual(request_dict['headers']['x-amz-content-sha256'],
+                         'pre-exists')
+
     def test_glacier_checksums_support_raw_bytes(self):
         request_dict = {
             'headers': {},

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -257,6 +257,18 @@ class TestResponseMetadataParsed(unittest.TestCase):
             'HTTPStatusCode': 404,
         })
 
+    def test_can_parse_glacier_error_response(self):
+        body = (b'{"code":"AccessDeniedException","type":"Client","message":'
+                b'"Access denied"}')
+        headers = {
+             'x-amzn-requestid': 'request-id'
+        }
+        parser = parsers.RestJSONParser()
+        parsed = parser.parse(
+            {'body': body, 'headers': headers, 'status_code': 400}, None)
+        self.assertEqual(parsed['Error'], {'Message': 'Access denied',
+                                           'Code': 'AccessDeniedException'})
+
 
 class TestResponseParsingDatetimes(unittest.TestCase):
     def test_can_parse_float_timestamps(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,6 +14,7 @@
 from tests import unittest
 from dateutil.tz import tzutc, tzoffset
 import datetime
+import six
 
 import mock
 
@@ -29,6 +30,8 @@ from botocore.utils import parse_timestamp
 from botocore.utils import parse_to_aware_datetime
 from botocore.utils import CachedProperty
 from botocore.utils import ArgumentGenerator
+from botocore.utils import calculate_tree_hash
+from botocore.utils import calculate_sha256
 from botocore.model import DenormalizedStructureBuilder
 from botocore.model import ShapeResolver
 
@@ -402,6 +405,60 @@ class TestArgumentGenerator(unittest.TestCase):
             'B': ''
         }
         self.assertEqual(actual, expected)
+
+
+class TestChecksums(unittest.TestCase):
+    def test_empty_hash(self):
+        self.assertEqual(
+            calculate_sha256(six.BytesIO(b''), as_hex=True),
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+
+    def test_as_hex(self):
+        self.assertEqual(
+            calculate_sha256(six.BytesIO(b'hello world'), as_hex=True),
+            'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9')
+
+    def test_as_binary(self):
+        self.assertEqual(
+            calculate_sha256(six.BytesIO(b'hello world'), as_hex=False),
+            (b"\xb9M'\xb9\x93M>\x08\xa5.R\xd7\xda}\xab\xfa\xc4\x84\xef"
+             b"\xe3zS\x80\xee\x90\x88\xf7\xac\xe2\xef\xcd\xe9"))
+
+
+class TestTreeHash(unittest.TestCase):
+    # Note that for these tests I've independently verified
+    # what the expected tree hashes should be from other
+    # SDK implementations.
+
+    def test_empty_tree_hash(self):
+        self.assertEqual(
+            calculate_tree_hash(six.BytesIO(b'')),
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+
+    def test_tree_hash_less_than_one_mb(self):
+        one_k = six.BytesIO(b'a' * 1024)
+        self.assertEqual(
+            calculate_tree_hash(one_k),
+            '2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a')
+
+    def test_tree_hash_exactly_one_mb(self):
+        one_meg_bytestring = b'a' * (1 * 1024 * 1024)
+        one_meg = six.BytesIO(one_meg_bytestring)
+        self.assertEqual(
+            calculate_tree_hash(one_meg),
+            '9bc1b2a288b26af7257a36277ae3816a7d4f16e89c1e7e77d0a5c48bad62b360')
+
+    def test_tree_hash_multiple_of_one_mb(self):
+        four_mb = six.BytesIO(b'a' * (4 * 1024 * 1024))
+        self.assertEqual(
+            calculate_tree_hash(four_mb),
+            '9491cb2ed1d4e7cd53215f4017c23ec4ad21d7050a1e6bb636c4f67e8cddb844')
+
+    def test_tree_hash_offset_of_one_mb_multiple(self):
+        offset_four_mb = six.BytesIO(b'a' * (4 * 1024 * 1024) + b'a' * 20)
+        self.assertEqual(
+            calculate_tree_hash(offset_four_mb),
+            '12f3cbd6101b981cde074039f6f728071da8879d6f632de8afc7cdf00661b08f')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In addition to including the JSON model for the service,
there were also three customizations needed:

* Add the x-amz-glacier-version header to all glacier requests
* Add a default value of '-' for the accountId param if it's not
  provided
* Add (and compute) the x-amz-content-sha256 and the
  x-amz-sha256-tree-hash header (also the "checksum" param)
  automatically for the user.

I verified I got the same tree hash values from boto2 and I
also added some integration tests to double check this.  The
tree hash is somewhat similar to boto's version, with some
slight performance improvements (about ~33% faster tree hashes).

We'll need to make a corresponding change to the the CLI to
make the --account-id param optional since botocore will
fill that value in.

cc @kyleknap 