### PR TITLE
Add option to specify endpoint's signature version

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -35,6 +35,7 @@ from botocore import parsers
 
 logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 60
+NOT_SET = object()
 
 
 def convert_to_response_dict(http_response, operation_model):
@@ -306,7 +307,8 @@ class EndpointCreator(object):
 
     def create_endpoint(self, service_model, region_name=None, is_secure=True,
                         endpoint_url=None, verify=None, credentials=None,
-                        response_parser_factory=None):
+                        response_parser_factory=None,
+                        signature_version=NOT_SET):
         if region_name is None:
             region_name = self._configured_region
         # Use the endpoint resolver heuristics to build the endpoint url.
@@ -328,9 +330,10 @@ class EndpointCreator(object):
         # provided region name.
         region_name_override = endpoint['properties'].get(
             'credentialScope', {}).get('region')
-        signature_version = service_model.signature_version
-        if 'signatureVersion' in endpoint['properties']:
-            signature_version = endpoint['properties']['signatureVersion']
+        if signature_version is NOT_SET:
+            signature_version = service_model.signature_version
+            if 'signatureVersion' in endpoint['properties']:
+                signature_version = endpoint['properties']['signatureVersion']
         if region_name_override is not None:
             # Letting the heuristics rule override the region_name
             # allows for having a default region of something like us-west-2

--- a/botocore/service.py
+++ b/botocore/service.py
@@ -160,7 +160,8 @@ class Service(object):
                                            credentials, user_agent)
         return endpoint_creator.create_endpoint(
             self._model, region_name, is_secure, endpoint_url, verify,
-            response_parser_factory=response_parser_factory)
+            response_parser_factory=response_parser_factory,
+            signature_version=self.signature_version)
 
     def get_operation(self, operation_name):
         """

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -179,6 +179,20 @@ class TestEndpointFeatures(TestEndpointBase):
         prepared_request = self.http_session.send.call_args[0][0]
         self.assertNotIn('Authorization', prepared_request.headers)
 
+    def test_make_request_no_signature_version(self):
+        self.endpoint = Endpoint(
+            'us-west-2', 'https://ec2.us-west-2.amazonaws.com/',
+            auth=self.auth, user_agent='botoore', signature_version=None,
+            endpoint_prefix='ec2', event_emitter=self.event_emitter)
+        self.endpoint.http_session = self.http_session
+
+        self.endpoint.make_request(self.op, request_dict())
+
+        # http_session should be used to send the request.
+        self.assertTrue(self.http_session.send.called)
+        prepared_request = self.http_session.send.call_args[0][0]
+        self.assertNotIn('Authorization', prepared_request.headers)
+
 
 class TestRetryInterface(TestEndpointBase):
     def setUp(self):

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -11,6 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import mock
 
 from tests import BaseSessionTest
 
@@ -82,6 +83,17 @@ class TestService(BaseSessionTest):
             region_name=None,
             endpoint_url='http://custom-endpoint/')
         self.assertEqual(endpoint.host, 'http://custom-endpoint/')
+
+    def test_turnoff_signing(self):
+        service = self.session.get_service('ec2')
+        service.signature_version = None
+        with mock.patch('botocore.endpoint.EndpointCreator.create_endpoint') \
+                as mock_create_endpoint:
+            service.get_endpoint('us-east-1')
+            self.assertEqual(
+                mock_create_endpoint.call_args[1]['signature_version'],
+                None
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add option to pass ``signature_version`` to EndpointCreator's ``create_endpoint`` method.

When ``get_endpoint`` is called from Service objects, it will pass in its signature version to ``create_endpoint``. That is required for the CLI's ``--no-sign-request`` flag to work because the handler changes the service object's signature version.

I will be sending a PR out real soon for the CLI, that will add a test to catch that --no-sign-request is adhered to.

cc @jamesls @danielgtaylor 