### PR TITLE
Update 2014-10-31.waiters.json

### DIFF
--- a/botocore/data/aws/rds/2014-10-31.waiters.json
+++ b/botocore/data/aws/rds/2014-10-31.waiters.json
@@ -62,6 +62,11 @@
       "maxAttempts": 60,
       "acceptors": [
         {
+          "expected": 404,
+          "matcher": "status",
+          "state": "success"
+        },
+        {
           "expected": "deleted",
           "matcher": "pathAll",
           "state": "success",


### PR DESCRIPTION
Handle the case where RDS returns a 404 for the DBInstanceDeleted waiter