### PR TITLE
Add compat for legacy operation methods on waiters

### DIFF
--- a/tests/unit/test_waiters.py
+++ b/tests/unit/test_waiters.py
@@ -508,6 +508,28 @@ class TestOperationMethods(unittest.TestCase):
         operation_object.call.assert_called_with(
             endpoint, Foo='a', Bar='b')
 
+    def test_legacy_method_handles_exceptions(self):
+        operation_object = mock.Mock()
+        exception = Exception()
+        exception.error_message = 'Foo'
+        exception.error_code = 'MyCode'
+        operation_object.call.side_effect = exception
+        endpoint = mock.Mock()
+        op = LegacyOperationMethod(operation_object, endpoint)
+        response = op(Foo='a', Bar='b')
+        self.assertEqual(response,
+                         {'Error': {'Code': 'MyCode', 'Message': 'Foo'}})
+
+    def test_legacy_method_with_unknown_exception(self):
+        operation_object = mock.Mock()
+        # A generic exception missing the error_message and error_code
+        # attrs will just be reraised.
+        operation_object.call.side_effect = ValueError
+        endpoint = mock.Mock()
+        op = LegacyOperationMethod(operation_object, endpoint)
+        with self.assertRaises(ValueError):
+            op(Foo='a', Bar='b')
+
 
 class ServiceWaiterFunctionalTest(BaseEnvVar):
     """


### PR DESCRIPTION
While pulling in https://github.com/boto/botocore/pull/437,
I noticed that we aren't handling the 'error' matcher properly
because of a CLI customization that will raise an error on
non 200 responses.  This handles that case so, for example, the
command
`aws rds wait db-instance-deleted --db-instance-identifier foo`
will work as expected.  Previously, the error was being propogated
and the CLI command would exit with a non-zero RC and a client error
message.

cc @kyleknap @danielgtaylor 