### PR TITLE
Add waiters for elasticache

### DIFF
--- a/botocore/data/aws/elasticache/2014-09-30.waiters.json
+++ b/botocore/data/aws/elasticache/2014-09-30.waiters.json
@@ -44,8 +44,8 @@
       "maxAttempts": 60,
       "acceptors": [
         {
-          "expected": 404,
-          "matcher": "status",
+          "expected": "CacheClusterNotFound",
+          "matcher": "error",
           "state": "success"
         },
         {
@@ -111,8 +111,8 @@
       "maxAttempts": 60,
       "acceptors": [
         {
-          "expected": 404,
-          "matcher": "status",
+          "expected": "ReplicationGroupNotFoundFault",
+          "matcher": "error",
           "state": "success"
         },
         {

--- a/botocore/data/aws/elasticache/2014-09-30.waiters.json
+++ b/botocore/data/aws/elasticache/2014-09-30.waiters.json
@@ -1,0 +1,139 @@
+{
+  "version": 2,
+  "waiters": {
+    "CacheClusterAvailable": {
+      "delay": 30,
+      "operation": "DescribeCacheClusters",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": "available",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        },
+        {
+          "expected": "deleted",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        },
+        {
+          "expected": "deleting",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        },
+        {
+          "expected": "incompatible-network",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        },
+        {
+          "expected": "restore-failed",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        }
+      ]
+    },
+    "CacheClusterDeleted": {
+      "delay": 30,
+      "operation": "DescribeCacheClusters",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": 404,
+          "matcher": "status",
+          "state": "success"
+        },
+        {
+          "expected": "creating",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        },
+        {
+          "expected": "modifying",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        },
+        {
+          "expected": "rebooting",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "CacheClusters[].CacheClusterStatus"
+        }
+      ]
+    },
+    "ReplicationGroupAvailable": {
+      "delay": 30,
+      "operation": "DescribeReplicationGroups",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": "available",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "ReplicationGroups[].Status"
+        },
+        {
+          "expected": "deleted",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "ReplicationGroups[].Status"
+        },
+        {
+          "expected": "deleting",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "ReplicationGroups[].Status"
+        },
+        {
+          "expected": "incompatible-network",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "ReplicationGroups[].Status"
+        },
+        {
+          "expected": "restore-failed",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "ReplicationGroups[].Status"
+        }
+      ]
+    },
+    "ReplicationGroupDeleted": {
+      "delay": 30,
+      "operation": "DescribeReplicationGroups",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": 404,
+          "matcher": "status",
+          "state": "success"
+        },
+        {
+          "expected": "creating",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "ReplicationGroups[].Status"
+        },
+        {
+          "expected": "modifying",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "ReplicationGroups[].Status"
+        },
+        {
+          "expected": "rebooting",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "ReplicationGroups[].Status"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds 4 new waiters i've needed recently. I've used the same delays/attempts as RDS, which works for me quite well so far.