### PR TITLE
Use GMT for timestamp format

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -137,7 +137,7 @@ class Serializer(object):
         return int(calendar.timegm(value.timetuple()))
 
     def _timestamp_rfc822(self, value):
-        return formatdate(value)
+        return formatdate(value, usegmt=True)
 
     def _convert_timestamp_to_str(self, value):
         datetime_obj = parse_to_aware_datetime(value)

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -696,7 +696,7 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {"x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 -0000"},
+          "headers": {"x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT"},
           "body": ""
         }
       }

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -1305,7 +1305,7 @@
           "method": "POST",
           "body": "",
           "uri": "/path",
-          "headers": {"x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 -0000"}
+          "headers": {"x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT"}
         }
       }
     ]


### PR DESCRIPTION
This changes our date serialization to
use an IMF-fixdate timestamp in headers for the rest serializers.

RFC 7231 describes the preferred date-time format in HTTP messages as an
IMF-fixdate timestamp. This timestamp format is a subset of the format
described in RFC 5322 except the format always used a fixed timezone offset of
"GMT". S3 also uses this timestamp format in their documentation and in the
response headers they return.

cc @kyleknap @danielgtaylor 