### PR TITLE
Account for squid proxy adding unexpected headers

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -154,6 +154,18 @@ class AWSHTTPConnection(HTTPConnection):
             # we must run the risk of Nagle.
             self.send(message_body)
 
+    def _consume_headers(self, fp):
+        # Most servers (including S3) will just return
+        # the CLRF after the 100 continue response.  However,
+        # some servers (I've specifically seen this for squid when
+        # used as a straight HTTP proxy) will also inject a
+        # Connection: keep-alive header.  To account for this
+        # we'll read until we read '\r\n', and ignore any headers
+        # that come immediately after the 100 continue response.
+        current = None
+        while current != b'\r\n':
+            current = fp.readline()
+
     def _handle_expect_response(self, message_body):
         # This is called when we sent the request headers containing
         # an Expect: 100-continue header and received a response.
@@ -163,8 +175,7 @@ class AWSHTTPConnection(HTTPConnection):
             maybe_status_line = fp.readline()
             parts = maybe_status_line.split(None, 2)
             if self._is_100_continue_status(maybe_status_line):
-                # Read an empty line as per the RFC.
-                fp.readline()
+                self._consume_headers(fp)
                 logger.debug("100 Continue response seen, now sending request body.")
                 self._send_message_body(message_body)
             elif len(parts) == 3 and parts[0].startswith(b'HTTP/'):

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -23,10 +23,14 @@ from botocore.vendored.requests import models
 from botocore.vendored.requests.sessions import REDIRECT_STATI
 from botocore.compat import HTTPHeaders, HTTPResponse
 from botocore.exceptions import UnseekableStreamError
-from botocore.vendored.requests.packages.urllib3.connection import VerifiedHTTPSConnection
-from botocore.vendored.requests.packages.urllib3.connection import HTTPConnection
-from botocore.vendored.requests.packages.urllib3.connectionpool import HTTPConnectionPool
-from botocore.vendored.requests.packages.urllib3.connectionpool import HTTPSConnectionPool
+from botocore.vendored.requests.packages.urllib3.connection import \
+    VerifiedHTTPSConnection
+from botocore.vendored.requests.packages.urllib3.connection import \
+    HTTPConnection
+from botocore.vendored.requests.packages.urllib3.connectionpool import \
+    HTTPConnectionPool
+from botocore.vendored.requests.packages.urllib3.connectionpool import \
+    HTTPSConnectionPool
 
 
 logger = logging.getLogger(__name__)
@@ -90,8 +94,8 @@ class AWSHTTPConnection(HTTPConnection):
         for header, value in self._tunnel_headers.iteritems():
             self.send("%s: %s\r\n" % (header, value))
         self.send("\r\n")
-        response = self.response_class(self.sock, strict = self.strict,
-                                       method = self._method)
+        response = self.response_class(self.sock, strict=self.strict,
+                                       method=self._method)
         (version, code, message) = response._read_status()
 
         if code != 200:
@@ -176,7 +180,8 @@ class AWSHTTPConnection(HTTPConnection):
             parts = maybe_status_line.split(None, 2)
             if self._is_100_continue_status(maybe_status_line):
                 self._consume_headers(fp)
-                logger.debug("100 Continue response seen, now sending request body.")
+                logger.debug("100 Continue response seen, "
+                             "now sending request body.")
                 self._send_message_body(message_body)
             elif len(parts) == 3 and parts[0].startswith(b'HTTP/'):
                 # From the RFC:
@@ -192,7 +197,7 @@ class AWSHTTPConnection(HTTPConnection):
                 # whatever the server has sent back is the final response
                 # and don't send the message_body.
                 logger.debug("Received a non 100 Continue response "
-                            "from the server, NOT sending request body.")
+                             "from the server, NOT sending request body.")
                 status_tuple = (parts[0].decode('ascii'),
                                 int(parts[1]), parts[2].decode('ascii'))
                 response_class = functools.partial(

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -194,7 +194,8 @@ class TestAWSHTTPConnection(unittest.TestCase):
             conn = AWSHTTPConnection('s3.amazonaws.com', 443)
             conn.sock = s
             select_mock.return_value = ([s], [], [])
-            conn.request('GET', '/bucket/foo', b'body', {'Expect': '100-continue'})
+            conn.request('GET', '/bucket/foo', b'body',
+                         {'Expect': '100-continue'})
             response = conn.getresponse()
             # Now we should verify that our final response is the 200 OK
             self.assertEqual(response.status, 200)
@@ -216,7 +217,8 @@ class TestAWSHTTPConnection(unittest.TestCase):
             conn = AWSHTTPConnection('s3.amazonaws.com', 443)
             conn.sock = s
             select_mock.return_value = ([s], [], [])
-            conn.request('GET', '/bucket/foo', b'body', {'Expect': '100-continue'})
+            conn.request('GET', '/bucket/foo', b'body',
+                         {'Expect': '100-continue'})
             response = conn.getresponse()
             self.assertEqual(response.status, 500)
 
@@ -232,7 +234,8 @@ class TestAWSHTTPConnection(unittest.TestCase):
             conn = AWSHTTPConnection('s3.amazonaws.com', 443)
             conn.sock = s
             select_mock.return_value = ([s], [], [])
-            conn.request('GET', '/bucket/foo', b'body', {'Expect': '100-continue'})
+            conn.request('GET', '/bucket/foo', b'body',
+                         {'Expect': '100-continue'})
             response = conn.getresponse()
             # Now we should verify that our final response is the 307.
             self.assertEqual(response.status, 307)
@@ -250,7 +253,8 @@ class TestAWSHTTPConnection(unittest.TestCase):
             # that the server did not send any response.  In this situation
             # we should just send the request anyways.
             select_mock.return_value = ([], [], [])
-            conn.request('GET', '/bucket/foo', b'body', {'Expect': '100-continue'})
+            conn.request('GET', '/bucket/foo', b'body',
+                         {'Expect': '100-continue'})
             response = conn.getresponse()
             self.assertEqual(response.status, 307)
 


### PR DESCRIPTION
Most servers (including S3) will just return the CLRF after the 100
continue response.  However, some servers (I've specifically seen this
for squid when used as a straight HTTP proxy) will also inject a
Connection: keep-alive header.  To account for this we'll read until we
read '\r\n', and ignore any headers that come immediately after the 100
continue response.

Fixes aws/aws-cli#1116

I've also added an additional commit, https://github.com/jamesls/botocore/commit/7ca5d35c1b3af2872d16800eb7a3fceefcf1e863, that cleans up the pep8 formatting.

cc @kyleknap @danielgtaylor 