### PR TITLE
Handle capitalized keys in error responses

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -635,15 +635,17 @@ class RestJSONParser(BaseRestParser, BaseJSONParser):
     def _do_error_parse(self, response, shape):
         body = self._initial_body_parse(response['body'])
         error = {'Error': {}, 'ResponseMetadata': {}}
-        error['Error']['Message'] = body.get('message', '')
+        error['Error']['Message'] = body.get('message',
+                                             body.get('Message', ''))
         if 'x-amzn-errortype' in response['headers']:
             code = response['headers']['x-amzn-errortype']
             # Could be:
             # x-amzn-errortype: ValidationException:
             code = code.split(':')[0]
             error['Error']['Code'] = code
-        elif 'code' in body:
-            error['Error']['Code'] = body['code']
+        elif 'code' in body or 'Code' in body:
+            error['Error']['Code'] = body.get(
+                'code', body.get('Code', ''))
         return error
 
 

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -269,6 +269,18 @@ class TestResponseMetadataParsed(unittest.TestCase):
         self.assertEqual(parsed['Error'], {'Message': 'Access denied',
                                            'Code': 'AccessDeniedException'})
 
+    def test_can_parse_with_case_insensitive_keys(self):
+        body = (b'{"Code":"AccessDeniedException","type":"Client","Message":'
+                b'"Access denied"}')
+        headers = {
+             'x-amzn-requestid': 'request-id'
+        }
+        parser = parsers.RestJSONParser()
+        parsed = parser.parse(
+            {'body': body, 'headers': headers, 'status_code': 400}, None)
+        self.assertEqual(parsed['Error'], {'Message': 'Access denied',
+                                           'Code': 'AccessDeniedException'})
+
 
 class TestResponseParsingDatetimes(unittest.TestCase):
     def test_can_parse_float_timestamps(self):


### PR DESCRIPTION
For rest-json, we should handle the case where
the keys can come back as either code/Code and
message/Message.

cc @kyleknap @danielgtaylor 