### PR TITLE
Fix failing integ tests due to requests/urllib3 upgrade

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -22,7 +22,7 @@ from botocore.vendored.requests.utils import get_environ_proxies
 
 from botocore.exceptions import UnknownEndpointError
 from botocore.awsrequest import AWSRequest
-from botocore.compat import urljoin
+from botocore.compat import urljoin, filter_ssl_san_warnings
 from botocore.utils import percent_encode_sequence
 from botocore.hooks import first_non_none_response
 from botocore.response import StreamingBody
@@ -32,6 +32,7 @@ from botocore import parsers
 logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 60
 NOT_SET = object()
+filter_ssl_san_warnings()
 
 
 def convert_to_response_dict(http_response, operation_model):

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,6 +1,7 @@
 """Smoke tests to verify basic communication to all AWS services."""
 import mock
 from pprint import pformat
+import warnings
 from nose.tools import assert_equals, assert_true
 
 from botocore import xform_name
@@ -108,8 +109,12 @@ def test_can_make_request_with_client():
 
 def _make_client_call(client, operation_name, kwargs):
     method = getattr(client, operation_name)
-    response = method(**kwargs)
-    assert_true('Errors' not in response)
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        response = method(**kwargs)
+        assert_equals(len(caught_warnings), 0,
+                      "Warnings were emitted during smoke test: %s"
+                      % caught_warnings)
+        assert_true('Errors' not in response)
 
 
 def test_can_make_request_and_understand_errors_with_client():


### PR DESCRIPTION
We need to ignore warnings about missing SAN's in SSL certs
in py26.  This is due to a python bug and we have to validate
using the CN.

These actually were caught by AWS CLI integ tests.  Given they're
warnings, they don't actually cause anything in botocore to hard
fail, whereas the CLI is very sensitive to what shows up in stdout
and stderr which explains why the CLI tests are more likely to
catch this.

I've also updated our integ smoke tests in botocore.  We now will
also verify that the smoke tests generate no warnings.  This will
catch any regressions against this issue.

cc @kyleknap @danielgtaylor 