### PR TITLE
Let exceptions propogate from make_request

### DIFF
--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -240,7 +240,8 @@ class TestRetryInterface(TestEndpointBase):
             [(None, None)]  # Check if retry needed. Retry not needed.
         ]
         self.http_session.send.side_effect = ConnectionError()
-        self.endpoint.make_request(op, request_dict())
+        with self.assertRaises(ConnectionError):
+            self.endpoint.make_request(op, request_dict())
         call_args = self.event_emitter.emit.call_args_list
         self.assertEqual(self.event_emitter.emit.call_count, 4)
         # Check that all of the events are as expected.


### PR DESCRIPTION
This prevents a value of None from ever being returned
from make_request.  Previously, exceptions were caught and
after the retry logic would just return a value of None.

Now, if things like `ConnectionError`s, `socket.error`s, etc.
are raised, then this will propogate.  This also fixed the
client interface that expected that a tuple was always returned
from `make_request`.  This is now the case.

Noticed this while working on another bug fix.  Now instead
of:

```
  File "t.py", line 10, in <module>
    ContentDisposition="attachment; filename=5小時接力起跑.jpg;")
  File "botocore/botocore/client.py", line 292, in _api_call
    operation_model, request_dict)
TypeError: 'NoneType' object is not iterable
```

you'll get:

```
Traceback (most recent call last):
  File "t.py", line 10, in <module>
    ContentDisposition="attachment; filename=5小時接力起跑.jpg;")
  File "botocore/botocore/client.py", line 292, in _api_call
    operation_model, request_dict)
  File "botocore/botocore/endpoint.py", line 109, in make_request
    return self._send_request(request_dict, operation_model)
  File "botocore/botocore/endpoint.py", line 161, in _send_request
    raise exception
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 43: ordinal not in range(128)
```

Though keep in mind the above traceback is actually also a bug and will be fixed
shortly.

cc @danielgtaylor @kyleknap 