### PR TITLE
Correctly handle non-ascii header values

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -123,7 +123,9 @@ class AWSHTTPConnection(HTTPConnection):
 
     def _send_output(self, message_body=None):
         self._buffer.extend((b"", b""))
-        msg = b"\r\n".join(self._buffer)
+        msg = b"\r\n".join(
+            b.encode('utf-8') if isinstance(b, six.text_type) else b
+            for b in self._buffer)
         del self._buffer[:]
         # If msg and message_body are sent in a single send() call,
         # it will avoid performance problems caused by the interaction

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -121,11 +121,22 @@ class AWSHTTPConnection(HTTPConnection):
         self._expect_header_set = False
         return rval
 
+    def _convert_to_bytes(self, mixed_buffer):
+        # Take a list of mixed str/bytes and convert it
+        # all into a single bytestring.
+        # Any six.text_types will be encoded as utf-8.
+        bytes_buffer = []
+        for chunk in mixed_buffer:
+            if isinstance(chunk, six.text_type):
+                bytes_buffer.append(chunk.encode('utf-8'))
+            else:
+                bytes_buffer.append(chunk)
+        msg = b"\r\n".join(bytes_buffer)
+        return msg
+
     def _send_output(self, message_body=None):
         self._buffer.extend((b"", b""))
-        msg = b"\r\n".join(
-            b.encode('utf-8') if isinstance(b, six.text_type) else b
-            for b in self._buffer)
+        msg = self._convert_to_bytes(self._buffer)
         del self._buffer[:]
         # If msg and message_body are sent in a single send() call,
         # it will avoid performance problems caused by the interaction

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -19,6 +19,7 @@ import threading
 
 from botocore.vendored.requests.sessions import Session
 from botocore.vendored.requests.utils import get_environ_proxies
+from botocore.vendored import six
 
 from botocore.exceptions import UnknownEndpointError
 from botocore.awsrequest import AWSRequest
@@ -131,10 +132,17 @@ class Endpoint(object):
                 url += '?%s' % encoded_query_string
             else:
                 url += '&%s' % encoded_query_string
+        self._encode_headers(headers)
         request = AWSRequest(method=r['method'], url=url,
                              data=r['body'],
                              headers=headers)
         return request
+
+    def _encode_headers(self, headers):
+        # In place encoding of headers to utf-8 if they are unicode.
+        for key, value in headers.items():
+            if isinstance(value, six.text_type):
+                headers[key] = value.encode('utf-8')
 
     def prepare_request(self, request):
         return request.prepare()

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
@@ -777,6 +778,18 @@ class TestSSEKeyParamValidation(unittest.TestCase):
                                    SSECustomerAlgorithm='AES256',
                                    SSECustomerKey=key_str)['Body'].read(),
             b'mycontents2')
+
+
+class TestS3UTF8Headers(BaseS3ClientTest):
+    def test_can_set_utf_8_headers(self):
+        bucket_name = self.create_bucket()
+        body = six.BytesIO(b"Hello world!")
+        response = self.client.put_object(
+            Bucket=bucket_name, Key="foo.txt", Body=body,
+            ContentDisposition="attachment; filename=5小時接力起跑.jpg;")
+        self.assert_status_code(response, 200)
+        self.addCleanup(self.client.delete_object,
+                        Bucket=bucket_name, Key="foo.txt")
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -328,6 +328,17 @@ class TestAWSHTTPConnection(unittest.TestCase):
             conn._tunnel()
             self.assertTrue(mock_tunnel.called)
 
+    def test_encodes_unicode_method_line(self):
+        s = FakeSocket(b'HTTP/1.1 200 OK\r\n')
+        conn = AWSHTTPConnection('s3.amazonaws.com', 443)
+        conn.sock = s
+        # Note the combination of unicode 'GET' and
+        # bytes 'Utf8-Header' value.
+        conn.request(u'GET', '/bucket/foo', b'body',
+                     headers={"Utf8-Header": b"\xe5\xb0\x8f"})
+        response = conn.getresponse()
+        self.assertEqual(response.status, 200)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes aws/aws-cli#1124

cc @kyleknap @danielgtaylor 