### PR TITLE
Add slow tags to ~ top 15 slowest tests

### DIFF
--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -13,6 +13,8 @@
 from tests import unittest
 import itertools
 
+from nose.plugins.attrib import attr
+
 import botocore.session
 
 
@@ -58,6 +60,7 @@ class TestEC2Pagination(unittest.TestCase):
             self.assertEqual(len(reserved_inst_offer), 1)
 
 
+@attr('slow')
 class TestCopySnapshotCustomization(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -14,6 +14,8 @@ import time
 import random
 from tests import unittest
 
+from nose.plugins.attrib import attr
+
 import botocore.session
 
 
@@ -44,6 +46,7 @@ class TestKinesisListStreams(unittest.TestCase):
         parsed = self.client.list_streams()
         self.assertIn('StreamNames', parsed)
 
+    @attr('slow')
     def test_can_put_stream_blob(self):
         self.client.put_record(
             StreamName=self.stream_name, PartitionKey='foo', Data='foobar')
@@ -61,6 +64,7 @@ class TestKinesisListStreams(unittest.TestCase):
         self.assertTrue(len(records['Records']) > 0)
         self.assertEqual(records['Records'][0]['Data'], b'foobar')
 
+    @attr('slow')
     def test_can_put_records_single_blob(self):
         self.client.put_records(
             StreamName=self.stream_name,
@@ -83,6 +87,7 @@ class TestKinesisListStreams(unittest.TestCase):
         self.assertTrue(len(records['Records']) > 0)
         self.assertEqual(records['Records'][0]['Data'], b'foobar')
 
+    @attr('slow')
     def test_can_put_records_multiple_blob(self):
         self.client.put_records(
             StreamName=self.stream_name,

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     from itertools import zip_longest
 
+from nose.plugins.attrib import attr
+
 from botocore.vendored.requests import adapters
 from botocore.vendored.requests.exceptions import ConnectionError
 from botocore.compat import six
@@ -174,6 +176,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                                   key=key_name)[0]
         self.assertEqual(response.status_code, 204)
 
+    @attr('slow')
     def test_can_paginate(self):
         for i in range(5):
             key_name = 'key%s' % i
@@ -190,6 +193,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                      for el in data]
         self.assertEqual(key_names, ['key0', 'key1', 'key2', 'key3', 'key4'])
 
+    @attr('slow')
     def test_can_paginate_with_page_size(self):
         for i in range(5):
             key_name = 'key%s' % i
@@ -206,6 +210,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                      for el in data]
         self.assertEqual(key_names, ['key0', 'key1', 'key2', 'key3', 'key4'])
 
+    @attr('slow')
     def test_client_can_paginate_with_page_size(self):
         for i in range(5):
             key_name = 'key%s' % i
@@ -223,6 +228,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                      for el in data]
         self.assertEqual(key_names, ['key0', 'key1', 'key2', 'key3', 'key4'])
 
+    @attr('slow')
     def test_result_key_iters(self):
         for i in range(5):
             key_name = 'key/%s/%s' % (i, i)
@@ -245,6 +251,7 @@ class TestS3Objects(TestS3BaseWithBucket):
         self.assertIn('Contents', response)
         self.assertIn('CommonPrefixes', response)
 
+    @attr('slow')
     def test_can_get_and_put_object(self):
         self.create_object('foobarbaz', body='body contents')
         time.sleep(3)
@@ -649,6 +656,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
             self.assert_status_code(response, 200)
             self.keys.append('foo.txt')
 
+    @attr('slow')
     def test_paginate_list_objects_unicode(self):
         key_names = [
             u'non-ascii-key-\xe4\xf6\xfc-01.txt',
@@ -671,6 +679,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
 
         self.assertEqual(key_names, key_refs)
 
+    @attr('slow')
     def test_paginate_list_objects_safe_chars(self):
         key_names = [
             u'-._~safe-chars-key-01.txt',

--- a/tests/integration/test_waiters.py
+++ b/tests/integration/test_waiters.py
@@ -14,10 +14,13 @@ import time
 import random
 from tests import unittest
 
+from nose.plugins.attrib import attr
+
 import botocore.session
 from botocore.client import ClientError
 
 
+@attr('slow')
 class TestWaiterLegacy(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
@@ -46,6 +49,7 @@ class TestWaiterLegacy(unittest.TestCase):
 
 
 # This is the same test as above, except using the client interface.
+@attr('slow')
 class TestWaiterForDynamoDB(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()


### PR DESCRIPTION
This tags the slowest integ tests we have
(via --with-timer --timer-top-n 50) so that you can quickly
run a subset of integration tests.

If I now run "nosetests -a '!slow' tests/integration", the run
takes only 3 minutes or so, which cuts the runtime in half.

Here's the list of the slowest tests:

```
tests.integration.test_ec2.TestCopySnapshotCustomization.test_can_copy_encrypted_snapshot: 198.5485s
tests.integration.test_ec2.TestCopySnapshotCustomization.test_can_copy_snapshot: 114.1209s
tests.integration.test_waiters.TestWaiterForDynamoDB.test_create_table_and_wait: 20.6681s
tests.integration.test_waiters.TestWaiterLegacy.test_create_table_and_wait: 20.2473s
tests.integration.test_kinesis.TestKinesisListStreams.test_can_put_stream_blob: 11.4781s
tests.integration.test_kinesis.TestKinesisListStreams.test_can_put_records_multiple_blob: 11.2058s
tests.integration.test_kinesis.TestKinesisListStreams.test_can_put_records_single_blob: 11.1689s
tests.integration.test_s3.TestS3Objects.test_result_key_iters: 5.5921s
tests.integration.test_s3.TestS3Objects.test_can_paginate_with_page_size: 5.2767s
tests.integration.test_s3.TestS3Objects.test_can_paginate: 5.0847s
tests.integration.test_s3.TestS3Objects.test_client_can_paginate_with_page_size: 5.0642s
tests.integration.test_ec2.TestEC2.test_can_make_request: 4.7397s
tests.integration.test_s3.TestS3Objects.test_can_get_and_put_object: 4.3756s
tests.integration.test_s3.TestS3SigV4Client.test_paginate_list_objects_unicode: 3.1710s
tests.integration.test_s3.TestS3SigV4Client.test_paginate_list_objects_safe_chars: 3.0921s
tests.integration.test_s3.TestS3SigV4Client.test_request_retried_for_sigv4: 2.7808s
tests.integration.test_s3.TestSSEKeyParamValidation.test_make_request_with_sse: 2.6149s
tests.integration.test_s3.TestCreateBucketInOtherRegion.test_bucket_in_other_region: 2.4233s
tests.integration.test_s3.TestCreateBucketInOtherRegion.test_bucket_in_other_region_using_http: 2.2643s
tests.integration.test_smoke.test_can_retry_request_properly(<botocore.session.Session object at 0x120e7c710>, 'cloudwatch', 'us-east-1', 'ListMetrics', {}): 2.2121s
```


cc @kyleknap @danielgtaylor 