### PR TITLE
fix #420. Make available to use client host URL.

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -115,7 +115,7 @@ class Serializer(object):
         # Creates a boilerplate default request dict that subclasses
         # can use as a starting point.
         serialized = {
-            'url_path': '/',
+            'url_path': '',
             'query_string': '',
             'method': self.DEFAULT_METHOD,
             'headers': {},

--- a/tests/unit/protocols/input/ec2.json
+++ b/tests/unit/protocols/input/ec2.json
@@ -34,7 +34,7 @@
           "Bar": "val2"
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&Foo=val1&Bar=val2"
         }
       }
@@ -82,7 +82,7 @@
           "Yuck": "val3"
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&Foo=val1&BarLocationName=val2&yuckQueryName=val3"
         }
       }
@@ -131,7 +131,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&Struct.Scalar=foo"
         }
       }
@@ -178,7 +178,7 @@
           ]
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&ListArg.1=foo&ListArg.2=bar&ListArg.3=baz"
         }
       }
@@ -227,7 +227,7 @@
           ]
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&ListMemberName.1=a&ListMemberName.2=b&ListMemberName.3=c"
         }
       }
@@ -277,7 +277,7 @@
           ]
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&ListQueryName.1=a&ListQueryName.2=b&ListQueryName.3=c"
         }
       }
@@ -314,7 +314,7 @@
           "BlobArg": "foo"
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&BlobArg=Zm9v"
         }
       }
@@ -351,7 +351,7 @@
           "TimeArg": 1422172800
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z"
         }
       }

--- a/tests/unit/protocols/input/json.json
+++ b/tests/unit/protocols/input/json.json
@@ -39,7 +39,7 @@
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
           },
-          "uri": "/"
+          "uri": ""
         }
       }
     ]
@@ -81,7 +81,7 @@
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
           },
-          "uri": "/"
+          "uri": ""
         }
       }
     ]
@@ -134,7 +134,7 @@
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
           },
-          "uri": "/"
+          "uri": ""
         }
       },
       {
@@ -156,7 +156,7 @@
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
           },
-          "uri": "/"
+          "uri": ""
         }
       }
     ]
@@ -203,7 +203,7 @@
         },
         "serialized": {
           "body": "{\"ListParam\": [\"Zm9v\", \"YmFy\"]}",
-          "uri": "/",
+          "uri": "",
           "headers": {"X-Amz-Target": "com.amazonaws.foo.OperationName",
                       "Content-Type": "application/x-amz-json-1.1"}
         }
@@ -276,7 +276,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "headers": {
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
@@ -299,7 +299,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "headers": {
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
@@ -326,7 +326,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "headers": {
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
@@ -354,7 +354,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "headers": {
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
@@ -384,7 +384,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "headers": {
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
@@ -412,7 +412,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "headers": {
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"

--- a/tests/unit/protocols/input/query.json
+++ b/tests/unit/protocols/input/query.json
@@ -34,7 +34,7 @@
           "Bar": "val2"
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&Foo=val1&Bar=val2"
         }
       }
@@ -81,7 +81,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&StructArg.ScalarArg=foo"
         }
       }
@@ -128,7 +128,7 @@
           ]
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&ListArg.member.1=foo&ListArg.member.2=bar&ListArg.member.3=baz"
         }
       }
@@ -180,7 +180,7 @@
           ]
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&ScalarArg=foo&ListArg.1=a&ListArg.2=b&ListArg.3=c"
         }
       }
@@ -229,7 +229,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&MapArg.entry.1.key=key1&MapArg.entry.1.value=val1&MapArg.entry.2.key=key2&MapArg.entry.2.value=val2"
         }
       }
@@ -266,7 +266,7 @@
           "BlobArg": "foo"
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&BlobArg=Zm9v"
         }
       }
@@ -303,7 +303,7 @@
           "TimeArg": 1422172800
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z"
         }
       }
@@ -374,7 +374,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&RecursiveStruct.NoRecurse=foo"
         }
       },
@@ -393,7 +393,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&RecursiveStruct.RecursiveStruct.NoRecurse=foo"
         }
       },
@@ -416,7 +416,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&RecursiveStruct.RecursiveStruct.RecursiveStruct.RecursiveStruct.NoRecurse=foo"
         }
       },
@@ -440,7 +440,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&RecursiveStruct.RecursiveList.member.1.NoRecurse=foo&RecursiveStruct.RecursiveList.member.2.NoRecurse=bar"
         }
       },
@@ -466,7 +466,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&RecursiveStruct.RecursiveList.member.1.NoRecurse=foo&RecursiveStruct.RecursiveList.member.2.RecursiveStruct.NoRecurse=bar"
         }
       },
@@ -490,7 +490,7 @@
           }
         },
         "serialized": {
-          "uri": "/",
+          "uri": "",
           "body": "Action=OperationName&Version=2014-01-01&RecursiveStruct.RecursiveMap.entry.1.key=foo&RecursiveStruct.RecursiveMap.entry.1.value.NoRecurse=foo&RecursiveStruct.RecursiveMap.entry.2.key=bar&RecursiveStruct.RecursiveMap.entry.2.value.NoRecurse=bar"
         }
       }

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -652,7 +652,7 @@
         "given": {
           "http": {
             "method": "POST",
-            "requestUri": "/"
+            "requestUri": ""
           },
           "input": {
             "shape": "InputShape",
@@ -670,7 +670,7 @@
         "serialized": {
           "method": "POST",
           "body": "",
-          "uri": "/",
+          "uri": "",
           "headers": {
             "x-foo-a": "b",
             "x-foo-c": "d"
@@ -703,7 +703,7 @@
         "given": {
           "http": {
             "method": "POST",
-            "requestUri": "/"
+            "requestUri": ""
           },
           "input": {
             "shape": "InputShape",
@@ -717,7 +717,7 @@
         "serialized": {
           "method": "POST",
           "body": "bar",
-          "uri": "/"
+          "uri": ""
         }
       }
     ]
@@ -746,7 +746,7 @@
         "given": {
           "http": {
             "method": "POST",
-            "requestUri": "/"
+            "requestUri": ""
           },
           "input": {
             "shape": "InputShape",
@@ -760,14 +760,14 @@
         "serialized": {
           "method": "POST",
           "body": "bar",
-          "uri": "/"
+          "uri": ""
         }
       },
       {
         "given": {
           "http": {
             "method": "POST",
-            "requestUri": "/"
+            "requestUri": ""
           },
           "input": {
             "shape": "InputShape",
@@ -780,7 +780,7 @@
         "serialized": {
           "method": "POST",
           "body": "",
-          "uri": "/"
+          "uri": ""
         }
       }
     ]
@@ -818,7 +818,7 @@
         "given": {
           "http": {
             "method": "POST",
-            "requestUri": "/"
+            "requestUri": ""
           },
           "input": {
             "shape": "InputShape",
@@ -834,14 +834,14 @@
         "serialized": {
           "method": "POST",
           "body": "<foo><baz>bar</baz></foo>",
-          "uri": "/"
+          "uri": ""
         }
       },
       {
         "given": {
           "http": {
             "method": "POST",
-            "requestUri": "/"
+            "requestUri": ""
           },
           "input": {
             "shape": "InputShape",
@@ -853,7 +853,7 @@
         "serialized": {
           "method": "POST",
           "body": "",
-          "uri": "/"
+          "uri": ""
         }
       }
     ]
@@ -911,7 +911,7 @@
         "given": {
           "http": {
             "method": "POST",
-            "requestUri": "/"
+            "requestUri": ""
           },
           "input": {
             "shape": "InputShape",
@@ -930,7 +930,7 @@
         "serialized": {
           "method": "POST",
           "body": "<Grant><Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\"><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>",
-          "uri": "/"
+          "uri": ""
         }
       }
     ]


### PR DESCRIPTION
urlparse uses '/'(as taken from default request) instead of client URL.
I suggest to set default URL as empty to allow using path from client host URL
like 'http://host/path'

I couldn't merge this patch with HEAD in https://github.com/boto/botocore/pull/447
so I've created a new one...