### PR TITLE
Use class instance to lock signing

### DIFF
--- a/botocore/operation.py
+++ b/botocore/operation.py
@@ -49,6 +49,7 @@ class Operation(BotoCoreObject):
         if paginator_cls is None:
             paginator_cls = self._DEFAULT_PAGINATOR_CLS
         self._paginator_cls = paginator_cls
+        self._lock = threading.Lock()
 
     def __repr__(self):
         return 'Operation:%s' % self.name
@@ -152,7 +153,7 @@ class Operation(BotoCoreObject):
             # a request has already been signed without needing
             # to acquire the lock.
             if not getattr(request, '_is_signed', False):
-                with threading.Lock():
+                with self._lock:
                     if not getattr(request, '_is_signed', False):
                         signer.sign(self.name, request)
                         request._is_signed = True


### PR DESCRIPTION
The `with threading.Lock()` statement does not actually lock
anything because we're creating a new lock each time.  The
fix here is to use an instance level lock.  We need to ensure that
the signer is not called in multiple threads as it is _not_ thread
safe.

This bug surfaces via S3 signature version 4 multithreaded uploads.
If you run "aws s3 cp/sync" in eu-central-1 or cn-north-1, you'll
see signature errors because the timestamp will be off be one or more
seconds.  Given this is a race condition, you'll need a fairly large
file (1GB to be safe) to see this issue.

Introduced in v0.86.0 of botocore (v1.7.5 of the AWS CLI).

cc @danielgtaylor @kyleknap 