### PR TITLE
Fix error with parsing iam policies response

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -340,7 +340,8 @@ def _decode_policy_types(parsed, shape):
     if shape.type_name == 'structure':
         for member_name, member_shape in shape.members.items():
             if member_shape.type_name == 'string' and \
-                    member_shape.name == shape_name:
+                    member_shape.name == shape_name and \
+                    member_name in parsed:
                 parsed[member_name] = decode_quoted_jsondoc(parsed[member_name])
             elif member_name in parsed:
                 _decode_policy_types(parsed[member_name], member_shape)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -348,6 +348,46 @@ class TestHandlers(BaseSessionTest):
         # an error response.
         self.assertEqual(original, handler_input)
 
+    def test_decode_json_policy(self):
+        parsed = {
+            'Document': '{"foo": "foobarbaz"}',
+            'Other': 'bar',
+        }
+        service_def = {
+            'operations': {
+                'Foo': {
+                    'output': {'shape': 'PolicyOutput'},
+                }
+            },
+            'shapes': {
+                'PolicyOutput': {
+                    'type': 'structure',
+                    'members': {
+                        'Document': {
+                            'shape': 'policyDocumentType'
+                        },
+                        'Other': {
+                            'shape': 'stringType'
+                        }
+                    }
+                },
+                'policyDocumentType': {
+                    'type': 'string'
+                },
+                'stringType': {
+                    'type': 'string'
+                },
+            }
+        }
+        model = ServiceModel(service_def)
+        op_model = model.operation_model('Foo')
+        handlers.json_decode_policies(parsed, op_model)
+        self.assertEqual(parsed['Document'], {'foo': 'foobarbaz'})
+
+        no_document = {'Other': 'bar'}
+        handlers.json_decode_policies(no_document, op_model)
+        self.assertEqual(no_document, {'Other': 'bar'})
+
     def test_inject_account_id(self):
         params = {}
         handlers.inject_account_id(params)


### PR DESCRIPTION
We were making an assumption that the member names were always
in the response, but in the case of ListPolicyVersions the
'Document' key is _not_ in the response.

Before you'd just get:

```
$ aws iam list-policy-versions --policy-arn 'arn:aws:iam::asdf:policy/AdministratorAccess-asdf'

u'Document'
```
cc @kyleknap @danielgtaylor 