### PR TITLE
Handle urllib3 timeout errors

### DIFF
--- a/botocore/retryhandler.py
+++ b/botocore/retryhandler.py
@@ -18,7 +18,8 @@ import logging
 from binascii import crc32
 
 from botocore.vendored.requests import ConnectionError, Timeout
-from botocore.vendored.requests.packages.urllib3.exceptions import ClosedPoolError
+from botocore.vendored.requests.packages.urllib3.exceptions import \
+    ClosedPoolError, TimeoutError
 
 from botocore.exceptions import ChecksumError
 
@@ -29,7 +30,8 @@ logger = logging.getLogger(__name__)
 # to get more specific exceptions from requests we can update
 # this mapping with more specific exceptions.
 EXCEPTION_MAP = {
-    'GENERAL_CONNECTION_ERROR': [ConnectionError, ClosedPoolError, Timeout],
+    'GENERAL_CONNECTION_ERROR': [
+        ConnectionError, ClosedPoolError, Timeout, TimeoutError],
 }
 
 


### PR DESCRIPTION
This is an attempt to fix an issue where a successful HTTP request is made
but while reading the raw low-level response we may get a `urllib3` error
raised instead of the corresponding `requests` error.

The error presents itself when sending/receiving large files to/from S3
with the AWS CLI when on a bad network connection.

This makes sure that our retry handler is capable of handling this case
and adds a test for it.

Traceback sample:
```python
Traceback (most recent call last):
  File ".../site-packages/awscli/customizations/s3/tasks.py", line 347, in __call__
    self._download_part()
  File ".../site-packages/awscli/customizations/s3/tasks.py", line 376, in _download_part
    self._queue_writes(body)
  File ".../site-packages/awscli/customizations/s3/tasks.py", line 407, in _queue_writes
    self._queue_writes_in_chunks(body, iterate_chunk_size)
  File ".../site-packages/awscli/customizations/s3/tasks.py", line 438, in _queue_writes_in_chunks
    current = body.read(iterate_chunk_size)
  File ".../site-packages/botocore/response.py", line 70, in read
    chunk = self._raw_stream.read(amt)
  File ".../site-packages/botocore/vendored/requests/packages/urllib3/response.py", line 210, in read
    raise ReadTimeoutError(self._pool, None, 'Read timed out.')
ReadTimeoutError: HTTPSConnectionPool(host='s3.amazonaws.com', port=443): Read timed out.
```

It's difficult to reproduce the issue and test the fix. Any ideas you have would be appreciated.

cc @kyleknap @jamesls 