### PR TITLE
Make the sigv4 signer thread safe

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -42,6 +42,7 @@ EMPTY_SHA256_HASH = (
 # gave the best result (in terms of performance).
 PAYLOAD_BUFFER = 1024 * 1024
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
+SIGV4_TIMESTAMP = '%Y%m%dT%H%M%SZ'
 
 
 class BaseSigner(object):
@@ -304,7 +305,7 @@ class SigV4Auth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError
         datetime_now = datetime.datetime.utcnow()
-        request.context['timestamp'] = datetime_now.strftime('%Y%m%dT%H%M%SZ')
+        request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
         self._modify_request_before_signing(request)
@@ -342,7 +343,7 @@ class SigV4Auth(BaseSigner):
         if 'Date' in request.headers:
             del request.headers['Date']
             datetime_timestamp = datetime.datetime.strptime(
-                request.context['timestamp'], '%Y%m%dT%H%M%SZ')
+                request.context['timestamp'], SIGV4_TIMESTAMP)
             request.headers['Date'] = formatdate(
                 int(calendar.timegm(datetime_timestamp.timetuple())))
             if 'X-Amz-Date' in request.headers:

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -263,6 +263,7 @@ class AWSRequest(models.RequestEncodingMixin, models.Request):
             for key, value in self.headers.items():
                 headers[key] = value
         self.headers = headers
+        self.context = {}
 
     def prepare(self):
         """Constructs a :class:`AWSPreparedRequest <AWSPreparedRequest>`."""

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -263,6 +263,13 @@ class AWSRequest(models.RequestEncodingMixin, models.Request):
             for key, value in self.headers.items():
                 headers[key] = value
         self.headers = headers
+        # This is a dictionary to hold information that is used when
+        # processing the request. What is inside of ``context`` is open-ended.
+        # For example, it may have a timestamp key that is used for holding
+        # what the timestamp is when signing the request. Note that none
+        # of the information that is inside of ``context`` is directly
+        # sent over the wire; the information is only used to assist in
+        # creating what is sent over the wire.
         self.context = {}
 
     def prepare(self):

--- a/botocore/operation.py
+++ b/botocore/operation.py
@@ -49,7 +49,6 @@ class Operation(BotoCoreObject):
         if paginator_cls is None:
             paginator_cls = self._DEFAULT_PAGINATOR_CLS
         self._paginator_cls = paginator_cls
-        self._lock = threading.Lock()
 
     def __repr__(self):
         return 'Operation:%s' % self.name
@@ -151,10 +150,8 @@ class Operation(BotoCoreObject):
             # a request has already been signed without needing
             # to acquire the lock.
             if not getattr(request, '_is_signed', False):
-                with self._lock:
-                    if not getattr(request, '_is_signed', False):
-                        signer.sign(self.name, request)
-                        request._is_signed = True
+                signer.sign(self.name, request)
+                request._is_signed = True
 
         event_emitter.register('request-created.{0}.{1}'.format(
             self.service.endpoint_prefix, self.name), request_created)

--- a/botocore/operation.py
+++ b/botocore/operation.py
@@ -49,6 +49,7 @@ class Operation(BotoCoreObject):
         if paginator_cls is None:
             paginator_cls = self._DEFAULT_PAGINATOR_CLS
         self._paginator_cls = paginator_cls
+        self._lock = threading.Lock()
 
     def __repr__(self):
         return 'Operation:%s' % self.name
@@ -150,8 +151,10 @@ class Operation(BotoCoreObject):
             # a request has already been signed without needing
             # to acquire the lock.
             if not getattr(request, '_is_signed', False):
-                signer.sign(self.name, request)
-                request._is_signed = True
+                with self._lock:
+                    if not getattr(request, '_is_signed', False):
+                        signer.sign(self.name, request)
+                        request._is_signed = True
 
         event_emitter.register('request-created.{0}.{1}'.format(
             self.service.endpoint_prefix, self.name), request_created)

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -122,6 +122,8 @@ def create_request_from_raw_request(raw_request):
     if raw.error_code is not None:
         raise Exception(raw.error_message)
     request.method = raw.command
+    datetime_now = datetime.datetime(2011, 9, 9, 23, 36)
+    request.context['timestamp'] = datetime_now.strftime('%Y%m%dT%H%M%SZ')
     for key, val in raw.headers.items():
         request.headers[key] = val
     request.data = raw.rfile.read().decode('utf-8')


### PR DESCRIPTION
This includes making it thread safe for clients and operation objects. Also removed the locking for signing in operation objects since it is not needed anymore.

To do this, I removed the shared utcnow() state and added a ``context`` attribute to ``AWSRequest`` where a timestamp can be assigned when doing the signing. The timestamp attached to the request is set every time at the beginning of ``add_auth`` and other sigv4 signing helper functions then rely on the request's timestamp, that was set at the very beginning of the signing process.

I ran the integration tests for botocore and the CLI to make sure nothing is affected. I also uploaded/downloaded a couple of gigabytes to my ``eu-central-1`` s3 bucket using the s3 commands to further ensure nothing was affected.

Fixes https://github.com/boto/botocore/issues/468

cc @jamesls @danielgtaylor 