### PR TITLE
Don't check for reason phrase in 100 continue response

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -235,8 +235,8 @@ class AWSHTTPConnection(HTTPConnection):
         parts = maybe_status_line.split(None, 2)
         # Check for HTTP/<version> 100 Continue\r\n
         return (
-            len(parts) == 3 and parts[0].startswith(b'HTTP/') and
-            parts[1] == b'100' and parts[2].startswith(b'Continue'))
+            len(parts) >= 3 and parts[0].startswith(b'HTTP/') and
+            parts[1] == b'100')
 
 
 class AWSHTTPSConnection(VerifiedHTTPSConnection):


### PR DESCRIPTION
As per the HTTP RFC, the reason phrase is intended for the
human user and the "client is not required to examine or
display the Reason-Phrase...they MAY be replaced by local
equivalents without affecting the protocol."

This isn't an issue for S3, but allows for better interop
for other services.

cc @kyleknap @danielgtaylor 