### PR TITLE
Validate that endpoint url has a valid hostname

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -26,6 +26,7 @@ from botocore.awsrequest import AWSRequest
 from botocore.compat import filter_ssl_san_warnings, urlsplit
 from botocore.compat import urlunsplit
 from botocore.utils import percent_encode_sequence
+from botocore.utils import is_valid_endpoint_url
 from botocore.hooks import first_non_none_response
 from botocore.response import StreamingBody
 from botocore import parsers
@@ -343,6 +344,8 @@ class EndpointCreator(object):
             final_endpoint_url = endpoint_url
         else:
             final_endpoint_url = endpoint['uri']
+        if not is_valid_endpoint_url(final_endpoint_url):
+            raise ValueError("Invalid endpoint: %s" % final_endpoint_url)
         return self._get_endpoint(service_model, region_name,
                                   final_endpoint_url, verify,
                                   response_parser_factory)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -545,6 +545,10 @@ def is_valid_endpoint_url(endpoint_url):
     hostname = parts.hostname
     if hostname is None:
         return False
+    # Hostname validation is based on http://tools.ietf.org/html/rfc952
+    # and http://tools.ietf.org/html/rfc1123#page-13
+    # with the validation taken from:
+    # http://stackoverflow.com/questions/2532053/validate-a-hostname-string
     if len(hostname) > 255:
         return False
     if hostname[-1] == ".":

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -127,7 +127,7 @@ class TestAcceptedDateTimeFormats(unittest.TestCase):
         self.assertIn('Clusters', response)
 
 
-class TestClientCanBeCloned(unittest.TestCase):
+class TestCreateClients(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
 
@@ -141,3 +141,8 @@ class TestClientCanBeCloned(unittest.TestCase):
         # We really just want to ensure create_client doesn't raise
         # an exception, but we'll double check that the client looks right.
         self.assertTrue(hasattr(client, 'list_buckets'))
+
+    def test_client_raises_exception_invalid_region(self):
+        with self.assertRaisesRegexp(ValueError, 'Invalid endpoint'):
+            self.session.create_client('cloudformation',
+                                       region_name='invalid region name')

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -147,7 +147,6 @@ class TestEndpointFeatures(TestEndpointBase):
             prepared_request, verify=True, stream=False,
             proxies=proxies, timeout=DEFAULT_TIMEOUT)
 
-
     def test_make_request_with_no_auth(self):
         self.endpoint.auth = None
         self.endpoint.make_request(self.op, request_dict())

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -200,13 +200,17 @@ class TestS3Addressing(BaseSessionTest):
             prepared_request.url,
             'https://s3-us-west-2.amazonaws.com/192.168.5.256/mykeyname')
 
+    def test_invalid_endpoint_raises_exception(self):
+        with self.assertRaisesRegexp(ValueError, 'Invalid endpoint'):
+            self.s3.get_endpoint('bad region name')
+
     def test_non_existent_region(self):
         # If I ask for a region that does not
         # exist on a global endpoint, such as:
-        endpoint = self.s3.get_endpoint('REGION DOES NOT EXIST')
+        endpoint = self.s3.get_endpoint('REGION-DOES-NOT-EXIST')
         # Then the default endpoint heuristic will apply and we'll
         # get the region name as specified.
-        self.assertEqual(endpoint.region_name, 'REGION DOES NOT EXIST')
+        self.assertEqual(endpoint.region_name, 'REGION-DOES-NOT-EXIST')
         # Why not fixed this?  Well backwards compatability for one thing.
         # The other reason is because it was intended to accomodate this
         # use case.  Let's say I have us-west-2 set as my default region,


### PR DESCRIPTION
Otherwise, we'll try to make a request with an invalid hostname
which will either fail at the http layer, or even worse, may
generate invalid signatures if the endpoint_url mistakenly has
an endpoint url.

This can also happen sometimes because of misconfigured region
values in the config file.

cc @kyleknap @danielgtaylor 