### PR TITLE
Give better error message for invalid regions

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -47,6 +47,12 @@ class ApiVersionNotFoundError(BotoCoreError):
     fmt = 'Unable to load data {data_path} for: {api_version}'
 
 
+class EndpointConnectionError(BotoCoreError):
+    fmt = (
+        'Could not connect to the endpoint "{endpoint}", please verify '
+        'your region value.')
+
+
 class NoCredentialsError(BotoCoreError):
     """
     No credentials could be found

--- a/botocore/retryhandler.py
+++ b/botocore/retryhandler.py
@@ -20,7 +20,7 @@ from binascii import crc32
 from botocore.vendored.requests import ConnectionError, Timeout
 from botocore.vendored.requests.packages.urllib3.exceptions import ClosedPoolError
 
-from botocore.exceptions import ChecksumError
+from botocore.exceptions import ChecksumError, EndpointConnectionError
 
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,10 @@ logger = logging.getLogger(__name__)
 # to get more specific exceptions from requests we can update
 # this mapping with more specific exceptions.
 EXCEPTION_MAP = {
-    'GENERAL_CONNECTION_ERROR': [ConnectionError, ClosedPoolError, Timeout],
+    'GENERAL_CONNECTION_ERROR': [
+        ConnectionError, ClosedPoolError, Timeout,
+        EndpointConnectionError
+    ],
 }
 
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -19,6 +19,7 @@ from tests import unittest
 import botocore.session
 from botocore.client import ClientError
 from botocore.compat import six
+from botocore.exceptions import EndpointConnectionError
 from six import StringIO
 
 
@@ -146,3 +147,13 @@ class TestCreateClients(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, 'Invalid endpoint'):
             self.session.create_client('cloudformation',
                                        region_name='invalid region name')
+
+
+class TestClientErrorMessages(unittest.TestCase):
+    def test_region_mentioned_in_invalid_region(self):
+        session = botocore.session.get_session()
+        client = session.create_client(
+            'cloudformation', region_name='bad-region-name')
+        with self.assertRaisesRegexp(EndpointConnectionError,
+                                     'verify your region'):
+            client.list_stacks()

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -11,11 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, BaseSessionTest, create_session
+from tests import unittest
 
-from mock import Mock, patch, sentinel
+from mock import Mock, patch
 from botocore.vendored.requests import ConnectionError
-from botocore.vendored.requests.models import Response
 
 from botocore.compat import six
 from botocore.awsrequest import AWSRequest
@@ -23,10 +22,6 @@ from botocore.endpoint import get_endpoint, Endpoint, DEFAULT_TIMEOUT
 from botocore.endpoint import EndpointCreator
 from botocore.endpoint import PreserveAuthSession
 from botocore.endpoint import RequestCreator
-from botocore.auth import SigV4Auth
-from botocore.session import Session
-from botocore.exceptions import UnknownServiceStyle
-from botocore.exceptions import UnknownSignatureVersionError
 from botocore.exceptions import EndpointConnectionError
 
 
@@ -226,10 +221,10 @@ class TestRetryInterface(TestEndpointBase):
         op.name = 'DescribeInstances'
         op.metadata = {'protocol': 'json'}
         self.event_emitter.emit.side_effect = [
-            [(None, None)], # Request created.
-            [(None, 0)],  # Check if retry needed. Retry needed.
-            [(None, None)], # Request created.
-            [(None, None)]  # Check if retry needed. Retry not needed.
+            [(None, None)],    # Request created.
+            [(None, 0)],       # Check if retry needed. Retry needed.
+            [(None, None)],    # Request created.
+            [(None, None)]     # Check if retry needed. Retry not needed.
         ]
         self.endpoint.make_request(op, request_dict())
         call_args = self.event_emitter.emit.call_args_list
@@ -248,10 +243,10 @@ class TestRetryInterface(TestEndpointBase):
         op = Mock()
         op.name = 'DescribeInstances'
         self.event_emitter.emit.side_effect = [
-            [(None, None)], # Request created.
-            [(None, 0)],  # Check if retry needed. Retry needed.
-            [(None, None)], # Request created
-            [(None, None)]  # Check if retry needed. Retry not needed.
+            [(None, None)],    # Request created.
+            [(None, 0)],       # Check if retry needed. Retry needed.
+            [(None, None)],    # Request created
+            [(None, None)]     # Check if retry needed. Retry not needed.
         ]
         self.http_session.send.side_effect = ConnectionError()
         with self.assertRaises(ConnectionError):
@@ -292,12 +287,12 @@ class TestS3ResetStreamOnRetry(TestEndpointBase):
         request = request_dict()
         request['body'] = body
         self.event_emitter.emit.side_effect = [
-            [(None, None)], # Request created.
-            [(None, 0)],  # Check if retry needed. Needs Retry.
-            [(None, None)], # Request created.
-            [(None, 0)],  # Check if retry needed again. Needs Retry.
-            [(None, None)], # Request created.
-            [(None, None)], # Finally emit no rety is needed.
+            [(None, None)],   # Request created.
+            [(None, 0)],      # Check if retry needed. Needs Retry.
+            [(None, None)],   # Request created.
+            [(None, 0)],      # Check if retry needed again. Needs Retry.
+            [(None, None)],   # Request created.
+            [(None, None)],   # Finally emit no rety is needed.
         ]
         self.endpoint.make_request(op, request)
         self.assertEqual(body.total_resets, 2)
@@ -336,7 +331,7 @@ class TestEndpointCreator(unittest.TestCase):
         endpoint = creator.create_endpoint(self.service_model)
         self.assertEqual(endpoint.region_name, 'us-east-1')
 
-    def test_endpoint_resolver_no_uses_credential_scope_with_endpoint_url(self):
+    def test_resolver_no_uses_cred_scope_with_endpoint_url(self):
         resolver = Mock()
         resolver_region_override = 'us-east-1'
         resolver.construct_endpoint.return_value = {
@@ -350,10 +345,11 @@ class TestEndpointCreator(unittest.TestCase):
         original_region_name = 'us-west-2'
         creator = EndpointCreator(resolver, original_region_name,
                                   Mock(), 'user-agent')
-        endpoint = creator.create_endpoint(self.service_model, endpoint_url='https://foo')
+        endpoint = creator.create_endpoint(self.service_model,
+                                           endpoint_url='https://foo')
         self.assertEqual(endpoint.region_name, 'us-west-2')
 
-    def test_endpoint_resolver_uses_credential_scope_with_endpoint_url_and_no_region(self):
+    def test_resolver_uses_cred_scope_with_endpoint_url_and_no_region(self):
         resolver = Mock()
         resolver_region_override = 'us-east-1'
         resolver.construct_endpoint.return_value = {
@@ -367,7 +363,8 @@ class TestEndpointCreator(unittest.TestCase):
         original_region_name = None
         creator = EndpointCreator(resolver, original_region_name,
                                   Mock(), 'user-agent')
-        endpoint = creator.create_endpoint(self.service_model, endpoint_url='https://foo')
+        endpoint = creator.create_endpoint(self.service_model,
+                                           endpoint_url='https://foo')
         self.assertEqual(endpoint.region_name, resolver_region_override)
 
 
@@ -396,7 +393,7 @@ class TestAWSSession(unittest.TestCase):
         session = PreserveAuthSession()
         session.send = Mock(return_value=success_response)
 
-        responses = list(session.resolve_redirects(
+        list(session.resolve_redirects(
             fake_response, prepared_request, stream=False))
 
         redirected_request = session.send.call_args[0][0]


### PR DESCRIPTION
We need to be giving better error messages when a user provides
an invalid region instead of the ConnectionError/gaierror
info that's not helpful.  We also will display the endpoint
we were trying to connect to.

Fixes aws/aws-cli#902

cc @kyleknap @danielgtaylor 


### Before
```
$ aws s3 ls --region does-not-exist-foo

('Connection aborted.', gaierror(8, 'nodename nor servname provided, or not known'))
```

### After

```
$ aws s3 ls --region does-not-exist-foo

Could not connect to the endpoint "https://s3.does-not-exist-foo.amazonaws.com/", please verify your region value.
```