### PR TITLE
Fix build_full_result for clients

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -212,7 +212,15 @@ class PageIterator(object):
         for result_expression in self.result_keys:
             set_value_from_jmespath(complete_result,
                                     result_expression.expression, [])
-        for _, page in self:
+        for response in self:
+            page = response
+            # We want to try to catch operation object pagination
+            # and format correctly for those. They come in the form
+            # of a tuple of two elements: (http_response, parsed_responsed).
+            # We want the parsed_response as that is what the page iterator
+            # uses. We can remove it though once operation objects are removed.
+            if isinstance(response, tuple) and len(response) == 2:
+                page = response[1]
             # We're incrementally building the full response page
             # by page.  For each page in the response we need to
             # inject the necessary components from the page

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -183,6 +183,17 @@ class TestFuturePaginator(unittest.TestCase):
              mock.call(Marker='m2', MaxKeys=1)]
         )
 
+    def test_build_full_result_with_single_key(self):
+        responses = [
+            {"Users": ["User1"], "Marker": "m1"},
+            {"Users": ["User2"], "Marker": "m2"},
+            {"Users": ["User3"]}
+        ]
+        self.method.side_effect = responses
+        pages = self.paginator.paginate()
+        complete = pages.build_full_result()
+        self.assertEqual(complete, {'Users': ['User1', 'User2', 'User3']})
+
 
 class TestPaginatorObjectConstruction(unittest.TestCase):
     def test_pagination_delegates_to_paginator(self):


### PR DESCRIPTION
Fixes ``build_full_result()`` for clients.

Before this would happen:
```
>>> import botocore.session
>>> session = botocore.session.get_session()
>>> client = session.create_client('s3')
>>> paginator = client.get_paginator('list_objects')
>>> pages = paginator.paginate(Bucket='mybucketfoo')
>>> pages.build_full_result()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "botocore/paginate.py", line 215, in build_full_result
    for _, page in self:
ValueError: too many values to unpack
```

Now this lists all of my objects.

Note that I only included that one unit test for clients to have a smoke test even though operation objects have much more tests. I was considering switching all of the operation object pagination test to clients, but I was hesitant to do that since the CLI still uses operation object pagination. Let me know what you think.

cc @jamesls @danielgtaylor 