### PR TITLE
Explicit profile overrides environment variables

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -72,8 +72,8 @@ def create_credential_resolver(session):
         # or credentials.
         providers.insert(0, EnvProvider())
     else:
-        logger.info('Skipping environment variable credential check'
-                    ' because profile name was explicitly set.')
+        logger.debug('Skipping environment variable credential check'
+                     ' because profile name was explicitly set.')
 
     resolver = CredentialResolver(providers=providers)
     return resolver

--- a/tests/integration/test-credentials
+++ b/tests/integration/test-credentials
@@ -1,0 +1,7 @@
+[default]
+aws_access_key_id = default
+aws_secret_access_key = default-secret
+
+[test]
+aws_access_key_id = test
+aws_secret_access_key = test-secret

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -92,8 +92,7 @@ class TestCredentialPrecedence(BaseEnvVar):
         credentials_cls.assert_called_with(
             access_key='code', secret_key='code-secret', token=mock.ANY)
 
-    @mock.patch('botocore.credentials.Credentials')
-    def test_access_secret_env_vs_profile_code(self, credentials_cls):
+    def test_access_secret_env_vs_profile_code(self):
         # If access/secret keys are set in the environment, but then a
         # specific profile is passed via code, then the access/secret
         # keys defined in that profile should take precedence over
@@ -106,7 +105,7 @@ class TestCredentialPrecedence(BaseEnvVar):
         s = self.create_session()
         s.profile = 'test'
 
-        client = s.create_client('s3')
+        credentials = s.get_credentials()
 
-        credentials_cls.assert_called_with(
-            'test', 'test-secret', None, method='shared-credentials-file')
+        self.assertEqual(credentials.access_key, 'test')
+        self.assertEqual(credentials.secret_key, 'test-secret')

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -1,0 +1,106 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import os
+import mock
+
+from botocore.session import Session
+from tests import unittest
+
+
+class TestCredentialPrecedence(unittest.TestCase):
+    def setUp(self):
+        # Clean up any existing environment
+        for name in ['AWS_ACCESS_KEY_ID',
+                     'AWS_SECRET_ACCESS_KEY',
+                     'BOTO_DEFAULT_PROFILE']:
+            if name in os.environ:
+                del os.environ[name]
+
+        # Set the config file to something that doesn't exist, then
+        # set the shared credential file to our test config.
+        os.environ['AWS_CONFIG_FILE'] = '~/.aws/config-missing'
+        Session.SessionVariables['credentials_file'] = (
+            None, None,
+            os.path.join(os.path.dirname(__file__), 'test-credentials'))
+
+    def test_access_secret_vs_profile_env(self):
+        # If all three are given, then the access/secret keys should
+        # take precedence.
+        os.environ['AWS_ACCESS_KEY_ID'] = 'env'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'env-secret'
+        os.environ['BOTO_DEFAULT_PROFILE'] = 'test'
+
+        s = Session()
+        credentials = s.get_credentials()
+
+        self.assertEqual(credentials.access_key, 'env')
+        self.assertEqual(credentials.secret_key, 'env-secret')
+
+    @mock.patch('botocore.credentials.Credentials')
+    def test_access_secret_vs_profile_code(self, credentials_cls):
+        # If all three are given, then the access/secret keys should
+        # take precedence.
+        s = Session()
+        s.profile = 'test'
+
+        client = s.create_client('s3', aws_access_key_id='code',
+                                 aws_secret_access_key='code-secret')
+
+        credentials_cls.assert_called_with(
+            access_key='code', secret_key='code-secret', token=mock.ANY)
+
+    def test_profile_env_vs_code(self):
+        # If the profile is set both by the env var and by code,
+        # then the one set by code should take precedence.
+        os.environ['BOTO_DEFAULT_PROFILE'] = 'test'
+        s = Session()
+        s.profile = 'default'
+
+        credentials = s.get_credentials()
+
+        self.assertEqual(credentials.access_key, 'default')
+        self.assertEqual(credentials.secret_key, 'default-secret')
+
+    @mock.patch('botocore.credentials.Credentials')
+    def test_access_secret_env_vs_code(self, credentials_cls):
+        # If the access/secret keys are set both as env vars and via
+        # code, then those set by code should take precedence.
+        os.environ['AWS_ACCESS_KEY_ID'] = 'env'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'secret'
+        s = Session()
+
+        client = s.create_client('s3', aws_access_key_id='code',
+                                 aws_secret_access_key='code-secret')
+
+        credentials_cls.assert_called_with(
+            access_key='code', secret_key='code-secret', token=mock.ANY)
+
+    @mock.patch('botocore.credentials.Credentials')
+    def test_access_secret_env_vs_profile_code(self, credentials_cls):
+        # If access/secret keys are set in the environment, but then a
+        # specific profile is passed via code, then the access/secret
+        # keys defined in that profile should take precedence over
+        # the environment variables. Example:
+        #
+        # ``aws --profile dev s3 ls``
+        #
+        os.environ['AWS_ACCESS_KEY_ID'] = 'env'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'env-secret'
+        s = Session()
+        s.profile = 'test'
+
+        client = s.create_client('s3')
+
+        credentials_cls.assert_called_with(
+            'test', 'test-secret', None, method='shared-credentials-file')

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -576,9 +576,11 @@ class CredentialResolverTest(BaseEnvVar):
 
 
 class TestCreateCredentialResolver(BaseEnvVar):
-    def test_create_credential_resolver(self):
-        fake_session = mock.Mock()
-        config = {
+    def setUp(self):
+        super(TestCreateCredentialResolver, self).setUp()
+
+        self.session = mock.Mock()
+        self.config = {
             'credentials_file': 'a',
             'legacy_config_file': 'b',
             'config_file': 'c',
@@ -586,9 +588,37 @@ class TestCreateCredentialResolver(BaseEnvVar):
             'metadata_service_num_attempts': 'e',
             'profile': 'profilename',
         }
-        fake_session.get_config_variable = lambda x: config[x]
-        resolver = credentials.create_credential_resolver(fake_session)
+        self.session.get_config_variable = lambda x: self.config[x]
+
+    def test_create_credential_resolver(self):
+        resolver = credentials.create_credential_resolver(self.session)
         self.assertIsInstance(resolver, credentials.CredentialResolver)
+
+    def test_explicit_profile_ignores_env_provider(self):
+        self.config['profile'] = 'dev'
+        resolver = credentials.create_credential_resolver(self.session)
+
+        for provider in resolver.providers:
+            self.assertNotIsInstance(provider, credentials.EnvProvider)
+
+    def test_no_profile_checks_env_provider(self):
+        self.config['profile'] = None
+        self.session.profile = None
+        resolver = credentials.create_credential_resolver(self.session)
+
+        found = False
+        for provider in resolver.providers:
+            if isinstance(provider, credentials.EnvProvider):
+                found = True
+
+        self.assertTrue(found)
+
+    def test_no_profile_env_provider_is_first(self):
+        self.config['profile'] = None
+        self.session.profile = None
+        resolver = credentials.create_credential_resolver(self.session)
+
+        self.assertIsInstance(resolver.providers[0], credentials.EnvProvider)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -195,6 +195,18 @@ class TestEnvVar(BaseEnvVar):
         with self.assertRaises(botocore.exceptions.PartialCredentialsError):
             provider.load()
 
+    def test_profile_override_returns_none(self):
+        # If a profile has been explicitly set, e.g. by something
+        # like ``session.profile = 'dev'``, then we want to ignore
+        # the environment variables in favor of loading the correct
+        # info from the config file based on the profile name.
+        environ = {
+            'AWS_ACCESS_KEY_ID': 'prod',
+            'AWS_SECRET_ACCESS_KEY': 'abc123'
+        }
+        provider = credentials.EnvProvider(environ, profile_name='dev')
+        creds = provider.load()
+        self.assertEqual(creds, None)
 
 class TestSharedCredentialsProvider(BaseEnvVar):
     def setUp(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -195,19 +195,6 @@ class TestEnvVar(BaseEnvVar):
         with self.assertRaises(botocore.exceptions.PartialCredentialsError):
             provider.load()
 
-    def test_profile_override_returns_none(self):
-        # If a profile has been explicitly set, e.g. by something
-        # like ``session.profile = 'dev'``, then we want to ignore
-        # the environment variables in favor of loading the correct
-        # info from the config file based on the profile name.
-        environ = {
-            'AWS_ACCESS_KEY_ID': 'prod',
-            'AWS_SECRET_ACCESS_KEY': 'abc123'
-        }
-        provider = credentials.EnvProvider(environ, profile_name='dev')
-        creds = provider.load()
-        self.assertEqual(creds, None)
-
 class TestSharedCredentialsProvider(BaseEnvVar):
     def setUp(self):
         super(TestSharedCredentialsProvider, self).setUp()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -19,6 +19,7 @@ import os
 from dateutil.tz import tzlocal
 
 from botocore import credentials
+from botocore.credentials import EnvProvider
 import botocore.exceptions
 import botocore.session
 from tests import unittest, BaseEnvVar
@@ -598,20 +599,16 @@ class TestCreateCredentialResolver(BaseEnvVar):
         self.config['profile'] = 'dev'
         resolver = credentials.create_credential_resolver(self.session)
 
-        for provider in resolver.providers:
-            self.assertNotIsInstance(provider, credentials.EnvProvider)
+        self.assertTrue(
+            all(not isinstance(p, EnvProvider) for p in resolver.providers))
 
     def test_no_profile_checks_env_provider(self):
         self.config['profile'] = None
         self.session.profile = None
         resolver = credentials.create_credential_resolver(self.session)
 
-        found = False
-        for provider in resolver.providers:
-            if isinstance(provider, credentials.EnvProvider):
-                found = True
-
-        self.assertTrue(found)
+        self.assertTrue(
+            any(isinstance(p, EnvProvider) for p in resolver.providers))
 
     def test_no_profile_env_provider_is_first(self):
         self.config['profile'] = None


### PR DESCRIPTION
This changes the behavior of environment variable credential loading to
function as described in aws/aws-cli#113. Here is what this looks like
for both the CLI and Botocore/Boto 3:

CLI:
```bash
# Use the environment variables
$ AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar aws s3 ls

# Ignore the environment variables and use a profile from the config instead
$ AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar aws --profile dev s3 ls
```

Python:
```python
$ AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar python
>>> import boto3
>>> boto3.setup_default_session(profile_name='dev')
>>> # The following will use the profile, not the env vars!
>>> s3dev = boto3.resource('s3')
```

Added a test and a new log message to ensure it's obvious what is happening.

cc @jamesls @kyleknap 