### PR TITLE
Add service_model property to operation_model

### DIFF
--- a/botocore/model.py
+++ b/botocore/model.py
@@ -324,6 +324,10 @@ class OperationModel(object):
         self.metadata = service_model.metadata
         self.http = operation_model.get('http', {})
 
+    @property
+    def service_model(self):
+        return self._service_model
+
     @CachedProperty
     def input_shape(self):
         if 'input' not in self._operation_model:

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -122,6 +122,13 @@ class TestOperationModelFromService(unittest.TestCase):
         self.assertEqual(shape.name, 'OperationNameRequest')
         self.assertEqual(list(sorted(shape.members)), ['Arg1', 'Arg2'])
 
+    def test_service_model_available_from_operation_model(self):
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('OperationName')
+        self.assertEqual(
+            operation.service_model.service_name,
+            service_model.service_name)
+
     def test_operation_output_model(self):
         service_model = model.ServiceModel(self.model)
         operation = service_model.operation_model('OperationName')


### PR DESCRIPTION
This makes it so that given a reference to an operation model, you can access its parent object.  Otherwise, existing code needs to track the service model when needed, despite the fact that it's accessible via an internal attribute on the operation model.

This is also needed as part of the client switchover work in the CLI.

cc @kyleknap @danielgtaylor