### PR TITLE
Add service_name when using get_service_model

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -500,7 +500,7 @@ class Session(object):
 
         """
         service_description = self.get_service_data(service_name, api_version)
-        return ServiceModel(service_description)
+        return ServiceModel(service_description, service_name=service_name)
 
     def get_waiter_model(self, service_name, api_version=None):
         loader = self.get_component('data_loader')

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -47,3 +47,17 @@ class TestCanChangeParsing(unittest.TestCase):
         dates = [bucket['CreationDate'] for bucket in parsed['Buckets']]
         self.assertTrue(all(isinstance(date, str) for date in dates),
                         "Expected all str types but instead got: %s" % dates)
+
+    def test_maps_service_name_when_overriden(self):
+        ses = self.session.get_service_model('ses')
+        self.assertEqual(ses.endpoint_prefix, 'email')
+        # But we should map the service_name to be the same name
+        # used when calling get_service_model which is different
+        # than the endpoint_prefix.
+        self.assertEqual(ses.service_name, 'ses')
+
+    def test_maps_service_name_from_client(self):
+        # Same thing as test_maps_service_name_from_client,
+        # except through the client interface.
+        client = self.session.create_client('ses')
+        self.assertEqual(client.meta.service_model.service_name, 'ses')

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -343,6 +343,7 @@ class TestGetServiceModel(BaseSessionTest):
         self.session.register_component('data_loader', loader)
         model = self.session.get_service_model('made_up')
         self.assertIsInstance(model, ServiceModel)
+        self.assertEqual(model.service_name, 'made_up')
 
 
 class TestGetWaiterModel(BaseSessionTest):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -390,6 +390,7 @@ class TestCreateClient(BaseSessionTest):
             mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
             scoped_config=mock.ANY, client_config=config)
 
+
 class TestPerformOperation(BaseSessionTest):
     def test_s3(self):
         service = self.session.get_service('s3')


### PR DESCRIPTION
Clients did this, but not session.get_service_model.

Need this in the the CLI refactor, otherwise the model doesn't know the "service name" to use to create the client when endpoint_prefix != service_name.

cc @kyleknap @danielgtaylor 