### PR TITLE
Added a PaginatorModel

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -19,6 +19,19 @@ from botocore.compat import zip
 from botocore.utils import set_value_from_jmespath, merge_dicts
 
 
+class PaginatorModel(object):
+    def __init__(self, paginator_config):
+        self._paginator_config = paginator_config['pagination']
+
+    def get_paginator(self, operation_name):
+        try:
+            single_paginator_config = self._paginator_config[operation_name]
+        except KeyError:
+            raise ValueError("Paginator for operation does not exist: %s"
+                             % operation_name)
+        return single_paginator_config
+
+
 class PageIterator(object):
     def __init__(self, method, input_token, output_token, more_results,
                  result_keys, non_aggregate_keys, limit_key, max_items,

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -35,6 +35,7 @@ from botocore.provider import get_provider
 from botocore.parsers import ResponseParserFactory
 from botocore import regions
 from botocore.model import ServiceModel
+from botocore import paginate
 import botocore.service
 from botocore import waiter
 from botocore import retryhandler, translate
@@ -509,6 +510,14 @@ class Session(object):
         waiter_path = latest.replace('.normal', '.waiters')
         waiter_config = loader.load_data(waiter_path)
         return waiter.WaiterModel(waiter_config)
+
+    def get_paginator_model(self, service_name, api_version=None):
+        loader = self.get_component('data_loader')
+        latest = loader.determine_latest('%s/%s' % (
+            self.provider.name, service_name), api_version)
+        paginator_path = latest.replace('.normal', '.paginators')
+        paginator_config = loader.load_data(paginator_path)
+        return paginate.PaginatorModel(paginator_config)
 
     def get_service_data(self, service_name, api_version=None):
         """

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -14,10 +14,37 @@
 from tests import unittest
 from botocore.paginate import Paginator as FuturePaginator
 from botocore.paginate import DeprecatedPaginator as Paginator
+from botocore.paginate import PaginatorModel
 from botocore.exceptions import PaginationError
 from botocore.operation import Operation
 
 import mock
+
+
+class TestPaginatorModel(unittest.TestCase):
+    def setUp(self):
+        self.paginator_config = {}
+        self.paginator_config['pagination'] = {
+            'ListFoos': {
+                'output_token': 'NextToken',
+                'input_token': 'NextToken',
+                'result_key': 'Foo'
+            }
+        }
+        self.paginator_model = PaginatorModel(self.paginator_config)
+
+    def test_get_paginator(self):
+        paginator_config = self.paginator_model.get_paginator('ListFoos')
+        self.assertEqual(
+            paginator_config,
+            {'output_token': 'NextToken', 'input_token': 'NextToken',
+             'result_key': 'Foo'}
+        )
+
+    def test_get_paginator_no_exists(self):
+        with self.assertRaises(ValueError):
+            paginator_config = self.paginator_model.get_paginator('ListBars')
+
 
 # TODO: FuturePaginator tests should be merged into tests that used the renamed
 # Deprecated paginators when we completely remove the Deprecated

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -27,6 +27,7 @@ from botocore.model import ServiceModel
 from botocore import client
 from botocore.hooks import HierarchicalEmitter
 from botocore.waiter import WaiterModel
+from botocore.paginate import PaginatorModel
 
 
 class BaseSessionTest(unittest.TestCase):
@@ -344,6 +345,22 @@ class TestGetServiceModel(BaseSessionTest):
         model = self.session.get_service_model('made_up')
         self.assertIsInstance(model, ServiceModel)
         self.assertEqual(model.service_name, 'made_up')
+
+
+class TestGetPaginatorModel(BaseSessionTest):
+    def test_get_paginator_model(self):
+        loader = mock.Mock()
+        loader.determine_latest.return_value = 'aws/foo/2014-01-01.normal.json'
+        loader.load_data.return_value = {"pagination": {}}
+        self.session.register_component('data_loader', loader)
+
+        model = self.session.get_paginator_model('foo')
+
+        # Verify we get a PaginatorModel back
+        self.assertIsInstance(model, PaginatorModel)
+        # Verify we called the loader correctly.
+        loader.load_data.assert_called_with(
+            'aws/foo/2014-01-01.paginators.json')
 
 
 class TestGetWaiterModel(BaseSessionTest):


### PR DESCRIPTION
This pretty much provides a parallel to the ``WaiterModel`` in waiters.py and ``session.get_waiter_model()`` for paginators. It is pretty light-weight right now. We can add to this as we see needed.

cc @jamesls @danielgtaylor 

