### PR TITLE
Add pending deprecations to old style interface

### DIFF
--- a/botocore/operation.py
+++ b/botocore/operation.py
@@ -15,6 +15,8 @@
 import functools
 import logging
 import threading
+import warnings
+
 from botocore.exceptions import MissingParametersError
 from botocore.exceptions import UnknownParameterError
 from botocore.exceptions import NoRegionError
@@ -98,6 +100,8 @@ class Operation(BotoCoreObject):
         return signature_version, endpoint.region_name
 
     def call(self, endpoint, **kwargs):
+        warnings.warn("call() is deprecated and will be removed.  "
+                      "Use clients instead.", PendingDeprecationWarning)
         logger.debug("%s called with kwargs: %s", self, kwargs)
         # It probably seems a little weird to be firing two different
         # events here.  The reason is that the first event is fired
@@ -184,6 +188,9 @@ class Operation(BotoCoreObject):
 
     @property
     def can_paginate(self):
+        warnings.warn("can_paginate is deprecated and will be removed.  "
+                      "Use client.can_paginate instead.",
+                      PendingDeprecationWarning)
         try:
             self._load_pagination_config()
         except Exception as e:
@@ -193,12 +200,19 @@ class Operation(BotoCoreObject):
     def paginate(self, endpoint, **kwargs):
         """Iterate over the responses of an operation.
 
+        .. warning::
+            This method is deprecated and will be removed in the
+            near future.  Use ``client.get_paginator`` instead.
+
         This will return an iterator with each element
         being a tuple of (``http_response``, ``parsed_response``).
         If the operation does not paginate, a ``TypeError`` will
         be raised.  You can check if an operation can be paginated
         by using the ``can_paginate`` arg.
         """
+        warnings.warn("paginate is deprecated and will be removed.  "
+                      "Use client.get_paginator instead.",
+                      PendingDeprecationWarning)
         if not self.can_paginate:
             raise TypeError("Operation cannot be paginated: %s" % self)
         config = self._load_pagination_config()

--- a/botocore/service.py
+++ b/botocore/service.py
@@ -13,6 +13,7 @@
 # language governing permissions and limitations under the License.
 
 import logging
+import warnings
 
 from .endpoint import EndpointCreator
 from .operation import Operation
@@ -134,6 +135,10 @@ class Service(object):
         Return the Endpoint object for this service in a particular
         region.
 
+        .. warning::
+            This method is deprecated and will be removed in the
+            near future.  Use ``Session.create_client`` instead.
+
         :type region_name: str
         :param region_name: The name of the region.
 
@@ -151,6 +156,8 @@ class Service(object):
             use in the signature calculation).
 
         """
+        warnings.warn("get_endpoint is deprecated and will be removed.  "
+                      "Use create_client instead.", PendingDeprecationWarning)
         resolver = self.session.get_component('endpoint_resolver')
         region = self.session.get_config_variable('region')
         event_emitter = self.session.get_component('event_emitter')
@@ -177,6 +184,8 @@ class Service(object):
         :type operation_name: str
         :param operation_name: The name of the operation.
         """
+        warnings.warn("get_operation is deprecated and will be removed.  "
+                      "Use create_client instead.", PendingDeprecationWarning)
         for operation in self.operations:
             op_names = (operation.name, operation.py_name, operation.cli_name)
             if operation_name in op_names:
@@ -184,6 +193,9 @@ class Service(object):
         return None
 
     def get_waiter(self, waiter_name, endpoint):
+        warnings.warn("get_waiter is deprecated and will be removed.  "
+                      "Use client.get_waiter instead.",
+                      PendingDeprecationWarning)
         try:
             config = self._load_waiter_config()
         except Exception as e:
@@ -203,11 +215,18 @@ def get_service(session, service_name, provider, api_version=None):
     """
     Return a Service object for a given provider name and service name.
 
+    .. warning::
+        This function is deprecated and will be removed in the
+        near future.  Use ``Session.create_client`` instead.
+
     :type service_name: str
     :param service_name: The name of the service.
 
     :type provider: Provider
     :param provider: The Provider object associated with the session.
     """
+    warnings.warn("get_service is deprecated and will be removed.  "
+                  "Use Session.create_client instead.",
+                  PendingDeprecationWarning)
     logger.debug("Creating service object for: %s", service_name)
     return Service(session, provider, service_name)

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -21,6 +21,7 @@ import logging
 import os
 import platform
 import shlex
+import warnings
 
 from botocore import __version__
 import botocore.config
@@ -545,11 +546,17 @@ class Session(object):
         """
         Get information about a service.
 
+        .. warning::
+            This method is deprecated and will be removed in the
+            near future.  Use ``session.create_client`` instead.
+
         :type service_name: str
         :param service_name: The name of the service (e.g. 'ec2')
 
         :returns: :class:`botocore.service.Service`
         """
+        warnings.warn("get_service is deprecated and will be removed.  "
+                      "Use create_client instead.", PendingDeprecationWarning)
         service = botocore.service.get_service(self, service_name,
                                                self.provider,
                                                api_version=api_version)

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,0 +1,58 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import sys
+from tests import unittest
+import contextlib
+import warnings
+
+from nose.tools import assert_equal
+from nose.tools import assert_true
+
+import botocore.session
+
+
+@contextlib.contextmanager
+def assert_warns(warning_type, contains=''):
+    # The warnings module keeps state at the module level.
+    # In order to give each test a clean slate we need to wipe
+    # this state out before yielding back to the test.
+    for v in sys.modules.values():
+        if getattr(v, '__warningregistry__', None):
+            v.__warningregistry__ = {}
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        yield
+    assert_true(len(w) > 0)
+    assert_equal(w[0].category, warning_type)
+    if contains:
+        assert_true(contains in str(w[0].message),
+                    '"%s" not in: %s"' % (contains, w[0].message))
+
+
+class TestDeprecationsHaveWarnings(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+
+    def test_get_service_deprecated(self):
+        with assert_warns(PendingDeprecationWarning, contains='get_service'):
+            self.session.get_service('cloudformation')
+
+    def test_service_get_operation_deprecated(self):
+        service = self.session.get_service('cloudformation')
+        with assert_warns(PendingDeprecationWarning, contains='get_operation'):
+            service.get_operation('ListStacks')
+
+    def test_get_endpoint(self):
+        service = self.session.get_service('cloudformation')
+        with assert_warns(PendingDeprecationWarning, contains='get_endpoint'):
+            service.get_endpoint('us-east-1')


### PR DESCRIPTION
I only added them to the most common methods used in botocore
with the old interface.

Later we'll change these to deprecation warnings, but for now,
we'll use PendingDeprecationWarning so you have to opt in.

### Examples
```
$ python
>>> import botocore.session
>>> s = botocore.session.get_session()
>>> s.get_service('ec2')
Service(ec2)

# Running with warnings:
$ python -Wd
>>> import botocore.session
>>> s = botocore.session.get_session()
>>> ec2 = s.get_service('ec2')
session.py:559: PendingDeprecationWarning: get_service is deprecated and will be removed.  Use create_client instead.
  "Use create_client instead.", PendingDeprecationWarning)
service.py:230: PendingDeprecationWarning: get_service is deprecated and will be removed.  Use Session.create_client instead.
  PendingDeprecationWarning)
>>> endpoint = ec2.get_endpoint('us-east-1')
service.py:160: PendingDeprecationWarning: get_endpoint is deprecated and will be removed.  Use create_client instead.
  "Use create_client instead.", PendingDeprecationWarning)
```
cc @kyleknap @danielgtaylor