### PR TITLE
Raise more specific exception when no region is configured

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -22,7 +22,7 @@ from botocore.vendored.requests.utils import get_environ_proxies
 from botocore.vendored.requests.exceptions import ConnectionError
 from botocore.vendored import six
 
-from botocore.exceptions import UnknownEndpointError
+from botocore.exceptions import BaseEndpointResolverError
 from botocore.exceptions import EndpointConnectionError
 from botocore.awsrequest import AWSRequest
 from botocore.compat import filter_ssl_san_warnings, urlsplit
@@ -344,7 +344,7 @@ class EndpointCreator(object):
             endpoint = self._endpoint_resolver.construct_endpoint(
                 service_model.endpoint_prefix,
                 region_name, scheme=scheme)
-        except UnknownEndpointError:
+        except BaseEndpointResolverError:
             if endpoint_url is not None:
                 # If the user provides an endpoint_url, it's ok
                 # if the heuristics didn't find anything.  We use the

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -69,18 +69,6 @@ class PartialCredentialsError(BotoCoreError):
     fmt = 'Partial credentials found in {provider}, missing: {cred_var}'
 
 
-class NoRegionError(BotoCoreError):
-    """
-    No region was specified
-
-    :ivar env_var: The name of the environment variable to use to
-        specify the default region.
-    """
-    fmt = (
-        'You must specify a region or set the {env_var} environment variable.'
-    )
-
-
 class UnknownSignatureVersionError(BotoCoreError):
     """
     Requested Signature Version is not known.
@@ -100,7 +88,29 @@ class ServiceNotInRegionError(BotoCoreError):
     fmt = 'Service {service_name} not available in region {region_name}'
 
 
-class UnknownEndpointError(BotoCoreError):
+class BaseEndpointResolverError(BotoCoreError):
+    """Base error for endpoint resolving errors.
+
+    Should never be raised directly, but clients can catch
+    this exception if they want to generically handle any errors
+    during the endpoint resolution process.
+
+    """
+
+
+class NoRegionError(BaseEndpointResolverError):
+    """
+    No region was specified
+
+    :ivar env_var: The name of the environment variable to use to
+        specify the default region.
+    """
+    fmt = (
+        'You must specify a region or set the {env_var} environment variable.'
+    )
+
+
+class UnknownEndpointError(BaseEndpointResolverError):
     """
     Could not construct an endpoint.
 

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -105,9 +105,7 @@ class NoRegionError(BaseEndpointResolverError):
     :ivar env_var: The name of the environment variable to use to
         specify the default region.
     """
-    fmt = (
-        'You must specify a region or set the {env_var} environment variable.'
-    )
+    fmt = 'You must specify a region.'
 
 
 class UnknownEndpointError(BaseEndpointResolverError):

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -99,12 +99,7 @@ class BaseEndpointResolverError(BotoCoreError):
 
 
 class NoRegionError(BaseEndpointResolverError):
-    """
-    No region was specified
-
-    :ivar env_var: The name of the environment variable to use to
-        specify the default region.
-    """
+    """No region was specified."""
     fmt = 'You must specify a region.'
 
 

--- a/botocore/operation.py
+++ b/botocore/operation.py
@@ -72,7 +72,7 @@ class Operation(BotoCoreObject):
         resolver = self.session.get_component('endpoint_resolver')
         scheme = endpoint.host.split(':')[0]
         if endpoint.region_name is None:
-            raise NoRegionError(env_var='region')
+            raise NoRegionError()
         endpoint_config = resolver.construct_endpoint(
                 service_model.endpoint_prefix,
                 endpoint.region_name, scheme=scheme)

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -70,7 +70,7 @@ class EndpointResolver(object):
                 raise NoRegionError()
             else:
                 raise UnknownEndpointError(service_name=service_name,
-                                        region_name=region_name)
+                                           region_name=region_name)
         return endpoint
 
     def _match_rules(self, service_rules, region_name, **kwargs):

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -18,6 +18,7 @@ region name, and a scheme) and it gives you a complete url.
 
 """
 from botocore.exceptions import UnknownEndpointError
+from botocore.exceptions import NoRegionError
 
 
 class EndpointResolver(object):
@@ -63,8 +64,13 @@ class EndpointResolver(object):
                                          region_name, **kwargs)
 
         if endpoint is None:
-            raise UnknownEndpointError(service_name=service_name,
-                                       region_name=region_name)
+            if region_name is None:
+                # Raise a more specific error message that will give
+                # better guidance to the user what needs to happen.
+                raise NoRegionError(env_var='AWS_DEFAULT_REGION')
+            else:
+                raise UnknownEndpointError(service_name=service_name,
+                                        region_name=region_name)
         return endpoint
 
     def _match_rules(self, service_rules, region_name, **kwargs):

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -67,7 +67,7 @@ class EndpointResolver(object):
             if region_name is None:
                 # Raise a more specific error message that will give
                 # better guidance to the user what needs to happen.
-                raise NoRegionError(env_var='AWS_DEFAULT_REGION')
+                raise NoRegionError()
             else:
                 raise UnknownEndpointError(service_name=service_name,
                                         region_name=region_name)

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -124,8 +124,7 @@ class RequestSigner(object):
             kwargs = {'credentials': self._credentials}
             if cls.REQUIRES_REGION:
                 if self._region_name is None:
-                    raise botocore.exceptions.NoRegionError(
-                        env_var='AWS_DEFAULT_REGION')
+                    raise botocore.exceptions.NoRegionError()
                 kwargs['region_name'] = region_name
                 kwargs['service_name'] = signing_name
             auth = cls(**kwargs)

--- a/tests/unit/test_regions.py
+++ b/tests/unit/test_regions.py
@@ -17,6 +17,7 @@ from nose.tools import assert_equals
 
 from botocore import regions
 from botocore.exceptions import UnknownEndpointError
+from botocore.exceptions import NoRegionError
 
 
 # NOTE: sqs endpoint updated to be the CN in the SSL cert because
@@ -344,6 +345,17 @@ class TestEndpointHeuristics(unittest.TestCase):
         with self.assertRaises(UnknownEndpointError):
             resolver.construct_endpoint(service_name='iam',
                                         region_name='not-us-gov-2')
+
+    def test_no_region_throws_specific_error(self):
+        resolver = self.create_endpoint_resolver({
+            'iam': [
+                {'uri': 'https://{service}.us-gov.amazonaws.com',
+                 'constraints': [['region', 'startsWith', 'us-gov']]}
+            ]
+        })
+        with self.assertRaises(NoRegionError):
+            resolver.construct_endpoint(service_name='iam',
+                                        region_name=None)
 
     def test_use_default_section_if_no_service_name(self):
         resolver = self.create_endpoint_resolver({

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -65,7 +65,7 @@ class TestService(BaseSessionTest):
         # If you don't provide an endpoint_url, than you need to
         # provide a region_name.
         service = self.session.get_service('ec2')
-        with self.assertRaises(botocore.exceptions.UnknownEndpointError):
+        with self.assertRaises(botocore.exceptions.NoRegionError):
             service.get_endpoint()
 
     def test_region_not_required_if_endpoint_url_given(self):


### PR DESCRIPTION
Currently, if no region is configured, you get a vague error message that isn't very clear:

```
In [1]: s.create_client('ec2')
UnknownEndpointError: Unable to construct an endpoint for ec2 in region None
```

Now, if the endpoint heuristics fail and there's no region name you'll get a `NoRegionError`:

```
In [1]: s.create_client('ec2')
NoRegionError: You must specify a region.
```

This also translates to better error messages in the CLI:

BEFORE:

```
$ aws ec2 describe-instances

Unable to construct an endpoint for ec2 in region None
```

AFTER:

```
$ aws ec2 describe-instances
You must specify a region. You can also configure your region by running "aws configure".
```

One of the other changes I made was to remove the `env_var` value from the NoRegionError.  From the commit message:


> First, we were using this inconsistently.  In the botocore
layer, this is actually BOTO_DEFAULT_REGION, and in some
places we were using AWS_DEFAULT_REGION.  Secondly, this value
is technically pluggable via session_vars in the Session
__init__.  And finally, you can actually set this value in the
config file so it's weird to only mention env vars.

I don't think there's any loss in helpfulness by removing this variable from the exception message.


cc @kyleknap @danielgtaylor