### PR TITLE
Fix issue with rest-xml serialization

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -445,7 +445,7 @@ class BaseRestSerializer(Serializer):
             # If there's a payload member, we serialized that
             # member to they body.
             body_params = parameters.get(payload_member)
-            if body_params:
+            if body_params is not None:
                 serialized['body'] = self._serialize_body_params(
                     body_params,
                     shape_members[payload_member])

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -855,6 +855,27 @@
           "body": "",
           "uri": "/"
         }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "foo": {}
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "<foo />",
+          "uri": "/"
+        }
       }
     ]
   },

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -876,6 +876,27 @@
           "body": "<foo />",
           "uri": "/"
         }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "foo": null
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/"
+        }
       }
     ]
   },


### PR DESCRIPTION
If a parameter was a payload and that was something empty like an empty dictionary, it would get serialized to an empty body but really needs to get serialized to an empty xml structure. This caused issues when trying to turn off logging or notification for s3. Here is an example of what happens:
```
>>> import botocore.session
>>> session = botocore.session.get_session()
>>> s3 = session.create_client('s3')
>>> s3.put_bucket_logging(Bucket='mybucket', BucketLoggingStatus={})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "botocore/client.py", line 187, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "botocore/client.py", line 242, in _make_api_call
    raise ClientError(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (MalformedXML) when calling the PutBucketLogging operation: The XML you provided was not well-formed or did not validate against our published schema
``` 

From the CLI, here is a snippet of what we used to send over
```
DEBUG - Making request for <botocore.model.OperationModel object at 0x1044ac590> 
(verify_ssl=True) with params: {'query_string': {}, 'headers': {}, 'url_path': u'/mybucket?logging', 'body': '',
 'method': u'PUT'}
```

Note it is correctly this now:
```
DEBUG - Making request for <botocore.model.OperationModel object at 0x10cda6f10> (verify_ssl=True)
 with params: {'query_string': {}, 'headers': {}, 'url_path': u'/mybucket?logging', 'body': 
u'<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />', 'method': u'PUT'}
```

Here is reference to the s3 api docs as well: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html

cc @jamesls @danielgtaylor 