### PR TITLE
Add api_name property to OperationModel

### DIFF
--- a/botocore/model.py
+++ b/botocore/model.py
@@ -233,7 +233,7 @@ class ServiceModel(object):
             model = self._service_description['operations'][operation_name]
         except KeyError:
             raise OperationNotFoundError(operation_name)
-        return OperationModel(model, self)
+        return OperationModel(model, self, operation_name)
 
     @CachedProperty
     def documentation(self):
@@ -308,7 +308,7 @@ class ServiceModel(object):
 
 
 class OperationModel(object):
-    def __init__(self, operation_model, service_model):
+    def __init__(self, operation_model, service_model, name=None):
         """
 
         :type operation_model: dict
@@ -322,11 +322,18 @@ class OperationModel(object):
         """
         self._operation_model = operation_model
         self._service_model = service_model
+        self._api_name = name
         # Clients can access '.name' to get the operation name
         # and '.metadata' to get the top level metdata of the service.
         self.name = operation_model.get('name')
         self.metadata = service_model.metadata
         self.http = operation_model.get('http', {})
+
+    @property
+    def api_name(self):
+        if self._api_name is None:
+            self._api_name = self.name
+        return self._api_name
 
     @property
     def service_model(self):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -115,6 +115,30 @@ class TestOperationModelFromService(unittest.TestCase):
         }
         self.service_model = model.ServiceModel(self.model)
 
+    def test_api_name(self):
+        service_model = model.ServiceModel(self.model)
+        operation = model.OperationModel(
+            self.model['operations']['OperationName'], service_model, 'Foo')
+        self.assertEqual(operation.api_name, 'Foo')
+
+    def test_api_name_default(self):
+        service_model = model.ServiceModel(self.model)
+        operation = model.OperationModel(
+            self.model['operations']['OperationName'], service_model)
+        self.assertEqual(operation.api_name, 'OperationName')
+
+    def test_api_name_from_service(self):
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('OperationName')
+        self.assertEqual(operation.api_name, 'OperationName')
+
+    def test_api_name_from_service_model_when_differs_from_name(self):
+        self.model['operations']['Foo'] = \
+            self.model['operations']['OperationName']
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('Foo')
+        self.assertEqual(operation.api_name, 'Foo')
+
     def test_operation_input_model(self):
         service_model = model.ServiceModel(self.model)
         operation = service_model.operation_model('OperationName')


### PR DESCRIPTION
It is needed when the name exposed in the service model is different from the operation model's name attribute in the JSON model so sometimes OperationModel.name did not match with the name used by the client. This will allow us to fix the cloudfront commands in the CLI.

cc @jamesls @danielgtaylor 