### PR TITLE
Fix copy_snapshot handler to work with clients

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -263,7 +263,8 @@ class BaseClient(object):
                 endpoint_prefix=self._service_model.endpoint_prefix,
                 operation_name=operation_name),
             model=operation_model, params=request_dict,
-            request_signer=self._request_signer
+            request_signer=self._request_signer,
+            endpoint=self._endpoint
         )
         return request_dict
 

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -21,13 +21,12 @@ import botocore.session
 class TestEC2(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
+        self.client = self.session.create_client(
+            'ec2', region_name='us-west-2')
 
     def test_can_make_request(self):
         # Basic smoke test to ensure we can talk to ec2.
-        service = self.session.get_service('ec2')
-        endpoint = service.get_endpoint('us-west-2')
-        operation = service.get_operation('DescribeAvailabilityZones')
-        http, result = operation.call(endpoint)
+        result = self.client.describe_availability_zones()
         zones = list(sorted(a['ZoneName'] for a in result['AvailabilityZones']))
         self.assertEqual(zones, ['us-west-2a', 'us-west-2b', 'us-west-2c'])
 
@@ -35,25 +34,26 @@ class TestEC2(unittest.TestCase):
 class TestEC2Pagination(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
-        self.service = self.session.get_service('ec2')
-        self.endpoint = self.service.get_endpoint('us-west-2')
+        self.client = self.session.create_client(
+            'ec2', region_name='us-west-2')
 
     def test_can_paginate(self):
         # Using an operation that we know will paginate.
-        operation = self.service.get_operation('DescribeReservedInstancesOfferings')
-        generator = operation.paginate(self.endpoint)
-        results = list(itertools.islice(generator, 0, 3))
+        paginator = self.client.get_paginator(
+            'describe_reserved_instances_offerings')
+        pages = paginator.paginate()
+        results = list(itertools.islice(pages, 0, 3))
         self.assertEqual(len(results), 3)
-        self.assertTrue(results[0][1]['NextToken'] != results[1][1]['NextToken'])
+        self.assertTrue(results[0]['NextToken'] != results[1]['NextToken'])
 
     def test_can_paginate_with_page_size(self):
         # Using an operation that we know will paginate.
-        operation = self.service.get_operation('DescribeReservedInstancesOfferings')
-        generator = operation.paginate(self.endpoint, page_size=1)
-        results = list(itertools.islice(generator, 0, 3))
+        paginator = self.client.get_paginator(
+            'describe_reserved_instances_offerings')
+        pages = paginator.paginate(page_size=1)
+        results = list(itertools.islice(pages, 0, 3))
         self.assertEqual(len(results), 3)
-        for result in results:
-            parsed = result[1]
+        for parsed in results:
             reserved_inst_offer = parsed['ReservedInstancesOfferings']
             # There should only be one reserved instance offering on each
             # page.
@@ -64,17 +64,11 @@ class TestEC2Pagination(unittest.TestCase):
 class TestCopySnapshotCustomization(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
-        # Note, the EBS copy snapshot customization is not ported
-        # over to the client interface so we have to use the
-        # Service/Operation objects for the actual CopySnapshot
-        # operation being tested.
-        self.service = self.session.get_service('ec2')
-        self.copy_snapshot = self.service.get_operation('CopySnapshot')
         # However, all the test fixture setup/cleanup can use
         # the client interface.
         self.client = self.session.create_client('ec2', 'us-west-2')
-        self.us_east_1 = self.service.get_endpoint('us-east-1')
-        self.us_west_2 = self.service.get_endpoint('us-west-2')
+        self.client_us_east_1 = self.session.create_client(
+            'ec2', 'us-east-1')
 
     def create_volume(self, encrypted=False):
         available_zones = self.client.describe_availability_zones()
@@ -105,25 +99,25 @@ class TestCopySnapshotCustomization(unittest.TestCase):
         volume_id = self.create_volume()
         snapshot_id = self.create_snapshot(volume_id)
 
-        http, parsed = self.copy_snapshot.call(
-            self.us_east_1, SourceRegion='us-west-2',
+        result = self.client_us_east_1.copy_snapshot(
+            SourceRegion='us-west-2',
             SourceSnapshotId=snapshot_id)
-        self.assertEqual(http.status_code, 200)
+        self.assertIn('SnapshotId', result)
 
         # Cleanup code.  We can wait for the snapshot to be complete
         # and then we can delete the snapshot.
-        self.cleanup_copied_snapshot(parsed['SnapshotId'])
+        self.cleanup_copied_snapshot(result['SnapshotId'])
 
     def test_can_copy_encrypted_snapshot(self):
         # Note that we're creating an encrypted volume here.
         volume_id = self.create_volume(encrypted=True)
         snapshot_id = self.create_snapshot(volume_id)
 
-        http, parsed = self.copy_snapshot.call(
-            self.us_east_1, SourceRegion='us-west-2',
+        result = self.client_us_east_1.copy_snapshot(
+            SourceRegion='us-west-2',
             SourceSnapshotId=snapshot_id)
-        self.assertEqual(http.status_code, 200)
-        self.cleanup_copied_snapshot(parsed['SnapshotId'])
+        self.assertIn('SnapshotId', result)
+        self.cleanup_copied_snapshot(result['SnapshotId'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This handler still relied on operation objects, which no
longer works with the client switchover.

As part of this change, I switched over the test_ec2 integ
tests over to clients.

cc @kyleknap @danielgtaylor