### PR TITLE
Allow using OrderedDict for structure builder.

### DIFF
--- a/botocore/model.py
+++ b/botocore/model.py
@@ -497,12 +497,19 @@ class DenormalizedStructureBuilder(object):
         }).build_model()
         # ``shape`` is now an instance of botocore.model.StructureShape
 
+    :type dict_type: class
+    :param dict_type: The dictionary type to use, allowing you to opt-in
+                      to using OrderedDict or another dict type. This can
+                      be particularly useful for testing when order
+                      matters, such as for documentation.
+
     """
-    def __init__(self, name=None):
-        self.members = {}
+    def __init__(self, name=None, dict_type=dict):
+        self.members = dict_type()
         self._name_generator = ShapeNameGenerator()
         if name is None:
             self.name = self._name_generator.new_shape_name('structure')
+        self._dict_type = dict_type
 
     def with_members(self, members):
         """
@@ -523,7 +530,7 @@ class DenormalizedStructureBuilder(object):
         :return: The built StructureShape object.
 
         """
-        shapes = {}
+        shapes = self._dict_type()
         denormalized = {
             'type': 'structure',
             'members': self._members,
@@ -548,7 +555,7 @@ class DenormalizedStructureBuilder(object):
             raise InvalidShapeError("Unknown shape type: %s" % model['type'])
 
     def _build_structure(self, model, shapes):
-        members = {}
+        members = self._dict_type()
         shape = self._build_initial_shape(model)
         shape['members'] = members
 

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -504,12 +504,11 @@ class DenormalizedStructureBuilder(object):
                       matters, such as for documentation.
 
     """
-    def __init__(self, name=None, dict_type=dict):
-        self.members = dict_type()
+    def __init__(self, name=None):
+        self.members = OrderedDict()
         self._name_generator = ShapeNameGenerator()
         if name is None:
             self.name = self._name_generator.new_shape_name('structure')
-        self._dict_type = dict_type
 
     def with_members(self, members):
         """
@@ -530,7 +529,7 @@ class DenormalizedStructureBuilder(object):
         :return: The built StructureShape object.
 
         """
-        shapes = self._dict_type()
+        shapes = OrderedDict()
         denormalized = {
             'type': 'structure',
             'members': self._members,
@@ -555,7 +554,7 @@ class DenormalizedStructureBuilder(object):
             raise InvalidShapeError("Unknown shape type: %s" % model['type'])
 
     def _build_structure(self, model, shapes):
-        members = self._dict_type()
+        members = OrderedDict()
         shape = self._build_initial_shape(model)
         shape['members'] = members
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -631,7 +631,7 @@ class TestBuilders(unittest.TestCase):
             }).build_model()
 
     def test_ordered_shape_builder(self):
-        b = model.DenormalizedStructureBuilder(dict_type=OrderedDict)
+        b = model.DenormalizedStructureBuilder()
         shape = b.with_members(OrderedDict(
             [
                 ('A', {

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,6 +1,7 @@
 from tests import unittest
 
 from botocore import model
+from botocore.compat import OrderedDict
 
 
 def test_missing_model_attribute_raises_exception():
@@ -628,6 +629,35 @@ class TestBuilders(unittest.TestCase):
                     'type': 'brand-new-shape-type',
                 },
             }).build_model()
+
+    def test_ordered_shape_builder(self):
+        b = model.DenormalizedStructureBuilder(dict_type=OrderedDict)
+        shape = b.with_members(OrderedDict(
+            [
+                ('A', {
+                    'type': 'string'
+                }),
+                ('B', {
+                    'type': 'structure',
+                    'members': OrderedDict(
+                        [
+                            ('C', {
+                                'type': 'string'
+                            }),
+                            ('D', {
+                                'type': 'string'
+                            })
+                        ]
+                    )
+                })
+            ]
+        )).build_model()
+
+        # Members should be in order
+        self.assertEqual(['A', 'B'], shape.members.keys())
+
+        # Nested structure members should *also* stay ordered
+        self.assertEqual(['C', 'D'], shape.members['B'].members.keys())
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -654,10 +654,10 @@ class TestBuilders(unittest.TestCase):
         )).build_model()
 
         # Members should be in order
-        self.assertEqual(['A', 'B'], shape.members.keys())
+        self.assertEqual(['A', 'B'], list(shape.members.keys()))
 
         # Nested structure members should *also* stay ordered
-        self.assertEqual(['C', 'D'], shape.members['B'].members.keys())
+        self.assertEqual(['C', 'D'], list(shape.members['B'].members.keys()))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change will make it much easier to test documentation, e.g. given
this structure expect this output. Order matters for this use case.

cc @jamesls, @kyleknap