### PR TITLE
Parse empty XML string nodes as an empty Python string

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -428,11 +428,6 @@ class QueryParser(BaseXMLResponseParser):
                 sub_mapping[key] = value.text
             inject_into['ResponseMetadata'] = sub_mapping
 
-    def _handle_string(self, shape, node):
-        return node.text
-
-    _handle_character = _handle_string
-
 
 class EC2QueryParser(QueryParser):
 

--- a/tests/unit/protocols/output/ec2.json
+++ b/tests/unit/protocols/output/ec2.json
@@ -413,5 +413,42 @@
         }
       }
     ]
+  },
+  {
+    "description": "Empty string",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Foo": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/protocols/output/query.json
+++ b/tests/unit/protocols/output/query.json
@@ -772,5 +772,42 @@
         }
       }
     ]
+  },
+  {
+    "description": "Empty string",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Foo": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/protocols/output/rest-xml.json
+++ b/tests/unit/protocols/output/rest-xml.json
@@ -679,5 +679,42 @@
         }
       }
     ]
+  },
+  {
+    "description": "Empty string",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Foo": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/response_parsing/xml/responses/ec2-create-network-interface.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-create-network-interface.json
@@ -1,47 +1,47 @@
 {
     "ResponseMetadata": {
         "RequestId": "bd78c839-0895-4fac-a17f-98b559b6b630"
-    }, 
+    },
     "NetworkInterface": {
-        "Status": "pending", 
-        "MacAddress": "02:74:b0:70:7f:1a", 
-        "SourceDestCheck": true, 
-        "VpcId": "vpc-c31dafaa", 
-        "Description": null, 
-        "NetworkInterfaceId": "eni-1bcb7772", 
+        "Status": "pending",
+        "MacAddress": "02:74:b0:70:7f:1a",
+        "SourceDestCheck": true,
+        "VpcId": "vpc-c31dafaa",
+        "Description": "",
+        "NetworkInterfaceId": "eni-1bcb7772",
         "PrivateIpAddresses": [
             {
-                "Primary": true, 
+                "Primary": true,
                 "PrivateIpAddress": "10.0.2.140"
-            }, 
+            },
             {
-                "Primary": false, 
+                "Primary": false,
                 "PrivateIpAddress": "10.0.2.172"
-            }, 
+            },
             {
-                "Primary": false, 
+                "Primary": false,
                 "PrivateIpAddress": "10.0.2.169"
-            }, 
+            },
             {
-                "Primary": false, 
+                "Primary": false,
                 "PrivateIpAddress": "10.0.2.170"
-            }, 
+            },
             {
-                "Primary": false, 
+                "Primary": false,
                 "PrivateIpAddress": "10.0.2.171"
             }
-        ], 
-        "RequesterManaged": false, 
-        "AvailabilityZone": "ap-southeast-1b", 
+        ],
+        "RequesterManaged": false,
+        "AvailabilityZone": "ap-southeast-1b",
         "Groups": [
             {
-                "GroupName": "default", 
+                "GroupName": "default",
                 "GroupId": "sg-1a2b3c4d"
             }
-        ], 
-        "SubnetId": "subnet-a61dafcf", 
-        "OwnerId": "251839141158", 
-        "TagSet": [], 
+        ],
+        "SubnetId": "subnet-a61dafcf",
+        "OwnerId": "251839141158",
+        "TagSet": [],
         "PrivateIpAddress": "10.0.2.140"
     }
 }

--- a/tests/unit/response_parsing/xml/responses/ec2-create-volume.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-create-volume.json
@@ -1,12 +1,12 @@
 {
-    "AvailabilityZone": "us-east-1a", 
+    "AvailabilityZone": "us-east-1a",
     "ResponseMetadata": {
         "RequestId": "59dbff89-35bd-4eac-99ed-be587EXAMPLE"
-    }, 
-    "VolumeType": "standard", 
-    "VolumeId": "vol-1a2b3c4d", 
-    "State": "creating", 
-    "SnapshotId": null, 
-    "CreateTime": "YYYY-MM-DDTHH:MM:SS.000Z", 
+    },
+    "VolumeType": "standard",
+    "VolumeId": "vol-1a2b3c4d",
+    "State": "creating",
+    "SnapshotId": "",
+    "CreateTime": "YYYY-MM-DDTHH:MM:SS.000Z",
     "Size": 80
 }

--- a/tests/unit/response_parsing/xml/responses/ec2-describe-addresses.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-describe-addresses.json
@@ -5,12 +5,12 @@
     "Addresses": [
         {
             "PublicIp": "54.245.81.77",
-            "InstanceId": null,
+            "InstanceId": "",
             "Domain": "standard"
         },
         {
             "PublicIp": "54.245.99.8",
-            "InstanceId": null,
+            "InstanceId": "",
             "Domain": "standard"
         },
         {

--- a/tests/unit/response_parsing/xml/responses/ec2-describe-instances.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-describe-instances.json
@@ -14,7 +14,7 @@
                     "Monitoring": {
                         "State": "disabled"
                     },
-                    "PublicDnsName": null,
+                    "PublicDnsName": "",
                     "KernelId": "aki-98e26fa8",
                     "State": {
                         "Code": 80,
@@ -26,7 +26,7 @@
                     "StateTransitionReason": "User initiated (2013-03-01 17:24:16 GMT)",
                     "InstanceId": "i-fde9cece",
                     "ImageId": "ami-30fe7300",
-                    "PrivateDnsName": null,
+                    "PrivateDnsName": "",
                     "KeyName": "aws",
                     "SecurityGroups": [
                         {
@@ -34,12 +34,12 @@
                             "GroupId": "sg-4e970e7e"
                         }
                     ],
-                    "ClientToken": null,
+                    "ClientToken": "",
                     "InstanceType": "m1.small",
                     "NetworkInterfaces": [],
                     "Placement": {
                         "Tenancy": "default",
-                        "GroupName": null,
+                        "GroupName": "",
                         "AvailabilityZone": "us-west-2a"
                     },
                     "Hypervisor": "xen",
@@ -64,7 +64,7 @@
                     "RootDeviceType": "ebs",
                     "Tags": [
                         {
-                            "Value": null,
+                            "Value": "",
                             "Key": "notebook"
                         }
                     ],
@@ -97,7 +97,7 @@
                     "PublicIpAddress": "54.245.16.142",
                     "PrivateIpAddress": "10.253.17.74",
                     "ProductCodes": [],
-                    "StateTransitionReason": null,
+                    "StateTransitionReason": "",
                     "InstanceId": "i-78f1b94a",
                     "ImageId": "ami-c4d643f4",
                     "PrivateDnsName": "ip-10-253-17-74.us-west-2.compute.internal",
@@ -113,7 +113,7 @@
                     "NetworkInterfaces": [],
                     "Placement": {
                         "Tenancy": "default",
-                        "GroupName": null,
+                        "GroupName": "",
                         "AvailabilityZone": "us-west-2b"
                     },
                     "Hypervisor": "xen",

--- a/tests/unit/response_parsing/xml/responses/ec2-describe-network-interfaces.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-describe-network-interfaces.json
@@ -6,7 +6,7 @@
                                          "InstanceOwnerId": "123456789012",
                                          "Status": "attached"},
                          "AvailabilityZone": "ap-southeast-1b",
-                         "Description": null,
+                         "Description": "",
                          "Groups": [{"GroupId": "sg-3f4b5653",
                                       "GroupName": "default"}],
                          "MacAddress": "02:81:60:cb:27:37",

--- a/tests/unit/response_parsing/xml/responses/ec2-describe-snapshots.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-describe-snapshots.json
@@ -14,7 +14,7 @@
             "OwnerId": "123456789012"
         },
         {
-            "Description": null,
+            "Description": "",
             "VolumeId": "vol-213dd14a",
             "State": "completed",
             "VolumeSize": 90,
@@ -24,7 +24,7 @@
             "OwnerId": "123456789012"
         },
         {
-            "Description": null,
+            "Description": "",
             "VolumeId": "vol-4ab8dc22",
             "State": "completed",
             "VolumeSize": 8,

--- a/tests/unit/response_parsing/xml/responses/ec2-describe-tags.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-describe-tags.json
@@ -6,7 +6,7 @@
         {
             "ResourceType": "instance",
             "ResourceId": "i-fde9cece",
-            "Value": null,
+            "Value": "",
             "Key": "notebook"
         }
     ]

--- a/tests/unit/response_parsing/xml/responses/ec2-import-instance.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-import-instance.json
@@ -1,29 +1,29 @@
 {
     "ConversionTask": {
-        "ConversionTaskId": "import-i-ffvko9js", 
+        "ConversionTaskId": "import-i-ffvko9js",
         "ImportInstance": {
-            "InstanceId": "i-12655a7f", 
-            "Description": null, 
+            "InstanceId": "i-12655a7f",
+            "Description": "",
             "Volumes": [
                 {
-                    "Status": "active", 
-                    "AvailabilityZone": "us-east-1a", 
-                    "Description": null, 
+                    "Status": "active",
+                    "AvailabilityZone": "us-east-1a",
+                    "Description": "",
                     "Image": {
-                        "Size": 1179593728, 
-                        "ImportManifestUrl": "https://s3.amazonaws.com/myawsbucket/a3a5e1b6-590d-43cc-97c1-15c7325d3f41/Win_2008_Server_Data_Center_SP2_32-bit.vmdkmanifest.xml?AWSaccessKeyId=AKIAIOSFODNN7EXAMPLE%26Expires=1294855591%26Signature=5snej01T1TtL0uR7KExtEXAMPLE%3D", 
+                        "Size": 1179593728,
+                        "ImportManifestUrl": "https://s3.amazonaws.com/myawsbucket/a3a5e1b6-590d-43cc-97c1-15c7325d3f41/Win_2008_Server_Data_Center_SP2_32-bit.vmdkmanifest.xml?AWSaccessKeyId=AKIAIOSFODNN7EXAMPLE%26Expires=1294855591%26Signature=5snej01T1TtL0uR7KExtEXAMPLE%3D",
                         "Format": "VMDK"
-                    }, 
+                    },
                     "Volume": {
-                        "Id": "vol-1a2b3c4d", 
+                        "Id": "vol-1a2b3c4d",
                         "Size": 12
-                    }, 
-                    "BytesConverted": 0, 
-                    "StatusMessage": null
+                    },
+                    "BytesConverted": 0,
+                    "StatusMessage": ""
                 }
             ]
-        }, 
+        },
         "ExpirationTime": "2010-12-22T12:01Z"
-    }, 
+    },
     "ResponseMetadata": {"RequestId": "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE"}
 }

--- a/tests/unit/response_parsing/xml/responses/ec2-import-volume.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-import-volume.json
@@ -1,24 +1,24 @@
 {
     "ConversionTask": {
-        "ConversionTaskId": "import-i-fh95npoc", 
+        "ConversionTaskId": "import-i-fh95npoc",
         "ImportVolume": {
             "Volume": {
-                "Id": "vol-34d8a2ff", 
+                "Id": "vol-34d8a2ff",
                 "Size": 8
-            }, 
+            },
             "Image": {
-                "Checksum": "ccb1b0536a4a70e86016b85229b5c6b10b14a4eb", 
-                "Size": 128696320, 
-                "ImportManifestUrl": "https://s3.amazonaws.com/myawsbucket/a3a5e1b6-590d-43cc-97c1-15c7325d3f41/Win_2008_Server_Data_Center_SP2_32-bit.vmdkmanifest.xml?AWSaccessKeyId=AKIAIOSFODNN7EXAMPLE%26Expires=1294855591%26Signature=5snej01T1TtL0uR7KExtEXAMPLE%3D", 
+                "Checksum": "ccb1b0536a4a70e86016b85229b5c6b10b14a4eb",
+                "Size": 128696320,
+                "ImportManifestUrl": "https://s3.amazonaws.com/myawsbucket/a3a5e1b6-590d-43cc-97c1-15c7325d3f41/Win_2008_Server_Data_Center_SP2_32-bit.vmdkmanifest.xml?AWSaccessKeyId=AKIAIOSFODNN7EXAMPLE%26Expires=1294855591%26Signature=5snej01T1TtL0uR7KExtEXAMPLE%3D",
                 "Format": "VDMK"
-            }, 
-            "BytesConverted": 0, 
-            "Description": null, 
+            },
+            "BytesConverted": 0,
+            "Description": "",
             "AvailabilityZone": "us-east-1c"
-        }, 
-        "ExpirationTime": "2010-12-22T12:01Z", 
-        "State": "active", 
-        "StatusMessage": null
-    }, 
+        },
+        "ExpirationTime": "2010-12-22T12:01Z",
+        "State": "active",
+        "StatusMessage": ""
+    },
     "ResponseMetadata": {"RequestId": "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE"}
 }

--- a/tests/unit/response_parsing/xml/responses/ec2-request-spot-instances.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-request-spot-instances.json
@@ -1,28 +1,28 @@
 {
     "SpotInstanceRequests": [
         {
-            "ProductDescription": "Linux/UNIX", 
-            "SpotInstanceRequestId": "sir-1a2b3c4d", 
-            "State": "open", 
-            "AvailabilityZoneGroup": "MyAzGroup", 
+            "ProductDescription": "Linux/UNIX",
+            "SpotInstanceRequestId": "sir-1a2b3c4d",
+            "State": "open",
+            "AvailabilityZoneGroup": "MyAzGroup",
             "LaunchSpecification": {
-                "EbsOptimized": false, 
-                "BlockDeviceMappings": [], 
+                "EbsOptimized": false,
+                "BlockDeviceMappings": [],
                 "Monitoring": {"Enabled":  false},
                 "SecurityGroups": [
                     {
-                        "GroupName": null, 
-                        "GroupId": null
+                        "GroupName": "",
+                        "GroupId": ""
                     }
-                ], 
-                "InstanceType": "m1.small", 
+                ],
+                "InstanceType": "m1.small",
                 "ImageId": "ami-1a2b3c4d"
-            }, 
-            "Type": "one-time", 
-            "CreateTime": "YYYY-MM-DDTHH:MM:SS.000Z", 
+            },
+            "Type": "one-time",
+            "CreateTime": "YYYY-MM-DDTHH:MM:SS.000Z",
             "SpotPrice": "0.5"
         }
-    ], 
+    ],
     "ResponseMetadata": {
         "RequestId": "59dbff89-35bd-4eac-99ed-be587EXAMPLE"
     }

--- a/tests/unit/response_parsing/xml/responses/ec2-run-instances.json
+++ b/tests/unit/response_parsing/xml/responses/ec2-run-instances.json
@@ -1,79 +1,79 @@
 {
-    "OwnerId": "111122223333", 
-    "ReservationId": "r-157ad274", 
+    "OwnerId": "111122223333",
+    "ReservationId": "r-157ad274",
     "ResponseMetadata": {
         "RequestId": "e86ff3c8-2400-45e3-a4e7-f158a69283d4"
-    }, 
-    "Groups": [], 
+    },
+    "Groups": [],
     "Instances": [
         {
             "Monitoring": {
                 "State": "disabled"
-            }, 
-            "PublicDnsName": null, 
+            },
+            "PublicDnsName": "",
             "StateReason": {
-                "Message": "pending", 
+                "Message": "pending",
                 "Code": "pending"
-            }, 
+            },
             "State": {
-                "Code": 0, 
+                "Code": 0,
                 "Name": "pending"
-            }, 
-            "LaunchTime": "2011-12-20T08:29:31.000Z", 
-            "PrivateIpAddress": "10.0.0.142", 
-            "ProductCodes": [], 
-            "VpcId": "vpc-1ea24976", 
-            "StateTransitionReason": null, 
-            "InstanceId": "i-0ee0356c", 
-            "ImageId": "ami-31814f58", 
-            "PrivateDnsName": null, 
+            },
+            "LaunchTime": "2011-12-20T08:29:31.000Z",
+            "PrivateIpAddress": "10.0.0.142",
+            "ProductCodes": [],
+            "VpcId": "vpc-1ea24976",
+            "StateTransitionReason": "",
+            "InstanceId": "i-0ee0356c",
+            "ImageId": "ami-31814f58",
+            "PrivateDnsName": "",
             "SecurityGroups": [
                 {
-                    "GroupName": "default", 
+                    "GroupName": "default",
                     "GroupId": "sg-050c1369"
                 }
-            ], 
-            "ClientToken": null, 
-            "SubnetId": "subnet-b2a249da", 
-            "InstanceType": "m1.small", 
+            ],
+            "ClientToken": "",
+            "SubnetId": "subnet-b2a249da",
+            "InstanceType": "m1.small",
             "NetworkInterfaces": [
                 {
-                    "Status": "in-use", 
-                    "SourceDestCheck": true, 
-                    "VpcId": "vpc-1ea24976", 
-                    "Description": null, 
-                    "NetworkInterfaceId": "eni-c6bb50ae", 
+                    "Status": "in-use",
+                    "SourceDestCheck": true,
+                    "VpcId": "vpc-1ea24976",
+                    "Description": "",
+                    "NetworkInterfaceId": "eni-c6bb50ae",
                     "Attachment": {
-                        "Status": "attaching", 
-                        "DeviceIndex": 0, 
-                        "DeleteOnTermination": true, 
-                        "AttachmentId": "eni-attach-0326646a", 
+                        "Status": "attaching",
+                        "DeviceIndex": 0,
+                        "DeleteOnTermination": true,
+                        "AttachmentId": "eni-attach-0326646a",
                         "AttachTime": "2011-12-20T08:29:31.000Z"
-                    }, 
+                    },
                     "Groups": [
                         {
-                            "GroupName": "default", 
+                            "GroupName": "default",
                             "GroupId": "sg-050c1369"
                         }
-                    ], 
-                    "SubnetId": "subnet-b2a249da", 
-                    "OwnerId": "111122223333", 
+                    ],
+                    "SubnetId": "subnet-b2a249da",
+                    "OwnerId": "111122223333",
                     "PrivateIpAddress": "10.0.0.142"
                 }
-            ], 
-            "SourceDestCheck": true, 
+            ],
+            "SourceDestCheck": true,
             "Placement": {
-                "GroupName": null, 
-                "Tenancy": "default", 
+                "GroupName": "",
+                "Tenancy": "default",
                 "AvailabilityZone": "us-east-1b"
-            }, 
-            "Hypervisor": "xen", 
-            "BlockDeviceMappings": [], 
-            "Architecture": "i386", 
-            "KernelId": "aki-805ea7e9", 
-            "RootDeviceName": "/dev/sda1", 
-            "VirtualizationType": "paravirtual", 
-            "RootDeviceType": "ebs", 
+            },
+            "Hypervisor": "xen",
+            "BlockDeviceMappings": [],
+            "Architecture": "i386",
+            "KernelId": "aki-805ea7e9",
+            "RootDeviceName": "/dev/sda1",
+            "VirtualizationType": "paravirtual",
+            "RootDeviceType": "ebs",
             "AmiLaunchIndex": 0
         }
     ]

--- a/tests/unit/response_parsing/xml/responses/elasticbeanstalk-create-configuration-template.json
+++ b/tests/unit/response_parsing/xml/responses/elasticbeanstalk-create-configuration-template.json
@@ -1,243 +1,243 @@
 {
-    "ApplicationName": "SampleApp", 
-    "Description": "ConfigTemplateDescription", 
+    "ApplicationName": "SampleApp",
+    "Description": "ConfigTemplateDescription",
     "ResponseMetadata": {
         "RequestId": "846cd905-f1fd-11df-8a78-9f77047e0d0c"
-    }, 
-    "TemplateName": "AppTemplate", 
-    "DateCreated": "2010-11-17T03:48:19.640Z", 
+    },
+    "TemplateName": "AppTemplate",
+    "DateCreated": "2010-11-17T03:48:19.640Z",
     "OptionSettings": [
         {
-            "Namespace": "aws:autoscaling:launchconfiguration", 
-            "OptionName": "ImageId", 
+            "Namespace": "aws:autoscaling:launchconfiguration",
+            "OptionName": "ImageId",
             "Value": "ami-f2f0069b"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:sns:topics", 
-            "OptionName": "Notification Endpoint", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:sns:topics",
+            "OptionName": "Notification Endpoint",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "PARAM4", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "PARAM4",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "JDBC_CONNECTION_STRING", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "JDBC_CONNECTION_STRING",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:autoscaling:launchconfiguration", 
-            "OptionName": "SecurityGroups", 
+            "Namespace": "aws:autoscaling:launchconfiguration",
+            "OptionName": "SecurityGroups",
             "Value": "elasticbeanstalk-default"
-        }, 
+        },
         {
-            "Namespace": "aws:elb:healthcheck", 
-            "OptionName": "UnhealthyThreshold", 
+            "Namespace": "aws:elb:healthcheck",
+            "OptionName": "UnhealthyThreshold",
             "Value": "5"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:launchconfiguration", 
-            "OptionName": "InstanceType", 
+            "Namespace": "aws:autoscaling:launchconfiguration",
+            "OptionName": "InstanceType",
             "Value": "t1.micro"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "Statistic", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "Statistic",
             "Value": "Average"
-        }, 
+        },
         {
-            "Namespace": "aws:elb:loadbalancer", 
-            "OptionName": "LoadBalancerHTTPSPort", 
+            "Namespace": "aws:elb:loadbalancer",
+            "OptionName": "LoadBalancerHTTPSPort",
             "Value": "OFF"
-        }, 
+        },
         {
-            "Namespace": "aws:elb:policies", 
-            "OptionName": "Stickiness Cookie Expiration", 
+            "Namespace": "aws:elb:policies",
+            "OptionName": "Stickiness Cookie Expiration",
             "Value": "0"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "PARAM5", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "PARAM5",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "MeasureName", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "MeasureName",
             "Value": "NetworkOut"
-        }, 
+        },
         {
-            "Namespace": "aws:elb:healthcheck", 
-            "OptionName": "Interval", 
+            "Namespace": "aws:elb:healthcheck",
+            "OptionName": "Interval",
             "Value": "30"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application", 
-            "OptionName": "Application Healthcheck URL", 
+            "Namespace": "aws:elasticbeanstalk:application",
+            "OptionName": "Application Healthcheck URL",
             "Value": "/"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:sns:topics", 
-            "OptionName": "Notification Topic ARN", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:sns:topics",
+            "OptionName": "Notification Topic ARN",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "LowerBreachScaleIncrement", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "LowerBreachScaleIncrement",
             "Value": "-1"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions", 
-            "OptionName": "XX:MaxPermSize", 
+            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions",
+            "OptionName": "XX:MaxPermSize",
             "Value": "64m"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "UpperBreachScaleIncrement", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "UpperBreachScaleIncrement",
             "Value": "1"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:asg", 
-            "OptionName": "MinSize", 
+            "Namespace": "aws:autoscaling:asg",
+            "OptionName": "MinSize",
             "Value": "1"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:asg", 
-            "OptionName": "Custom Availability Zones", 
+            "Namespace": "aws:autoscaling:asg",
+            "OptionName": "Custom Availability Zones",
             "Value": "us-east-1a"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:asg", 
-            "OptionName": "Availability Zones", 
+            "Namespace": "aws:autoscaling:asg",
+            "OptionName": "Availability Zones",
             "Value": "Any 1"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:hostmanager", 
-            "OptionName": "LogPublicationControl", 
+            "Namespace": "aws:elasticbeanstalk:hostmanager",
+            "OptionName": "LogPublicationControl",
             "Value": "false"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions", 
-            "OptionName": "JVM Options", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions",
+            "OptionName": "JVM Options",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:sns:topics", 
-            "OptionName": "Notification Topic Name", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:sns:topics",
+            "OptionName": "Notification Topic Name",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "PARAM2", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "PARAM2",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elb:loadbalancer", 
-            "OptionName": "LoadBalancerHTTPPort", 
+            "Namespace": "aws:elb:loadbalancer",
+            "OptionName": "LoadBalancerHTTPPort",
             "Value": "80"
-        }, 
+        },
         {
-            "Namespace": "aws:elb:healthcheck", 
-            "OptionName": "Timeout", 
+            "Namespace": "aws:elb:healthcheck",
+            "OptionName": "Timeout",
             "Value": "5"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "BreachDuration", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "BreachDuration",
             "Value": "2"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:launchconfiguration", 
-            "OptionName": "MonitoringInterval", 
+            "Namespace": "aws:autoscaling:launchconfiguration",
+            "OptionName": "MonitoringInterval",
             "Value": "5 minute"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "PARAM1", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "PARAM1",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:autoscaling:asg", 
-            "OptionName": "MaxSize", 
+            "Namespace": "aws:autoscaling:asg",
+            "OptionName": "MaxSize",
             "Value": "4"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "LowerThreshold", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "LowerThreshold",
             "Value": "2000000"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "AWS_SECRET_KEY", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "AWS_SECRET_KEY",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "AWS_ACCESS_KEY_ID", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "AWS_ACCESS_KEY_ID",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "UpperThreshold", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "UpperThreshold",
             "Value": "6000000"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:sns:topics", 
-            "OptionName": "Notification Protocol", 
+            "Namespace": "aws:elasticbeanstalk:sns:topics",
+            "OptionName": "Notification Protocol",
             "Value": "email"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "Unit", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "Unit",
             "Value": "Bytes"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions", 
-            "OptionName": "Xmx", 
+            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions",
+            "OptionName": "Xmx",
             "Value": "256m"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:asg", 
-            "OptionName": "Cooldown", 
+            "Namespace": "aws:autoscaling:asg",
+            "OptionName": "Cooldown",
             "Value": "360"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:trigger", 
-            "OptionName": "Period", 
+            "Namespace": "aws:autoscaling:trigger",
+            "OptionName": "Period",
             "Value": "1"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions", 
-            "OptionName": "Xms", 
+            "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions",
+            "OptionName": "Xms",
             "Value": "256m"
-        }, 
+        },
         {
-            "Namespace": "aws:autoscaling:launchconfiguration", 
-            "OptionName": "EC2KeyName", 
-            "Value": null
-        }, 
+            "Namespace": "aws:autoscaling:launchconfiguration",
+            "OptionName": "EC2KeyName",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elb:policies", 
-            "OptionName": "Stickiness Policy", 
+            "Namespace": "aws:elb:policies",
+            "OptionName": "Stickiness Policy",
             "Value": "false"
-        }, 
+        },
         {
-            "Namespace": "aws:elasticbeanstalk:application:environment", 
-            "OptionName": "PARAM3", 
-            "Value": null
-        }, 
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "PARAM3",
+            "Value": ""
+        },
         {
-            "Namespace": "aws:elb:healthcheck", 
-            "OptionName": "HealthyThreshold", 
+            "Namespace": "aws:elb:healthcheck",
+            "OptionName": "HealthyThreshold",
             "Value": "3"
-        }, 
+        },
         {
-            "Namespace": "aws:elb:loadbalancer", 
-            "OptionName": "SSLCertificateId", 
-            "Value": null
+            "Namespace": "aws:elb:loadbalancer",
+            "OptionName": "SSLCertificateId",
+            "Value": ""
         }
-    ], 
-    "DateUpdated": "2010-11-17T03:48:19.640Z", 
+    ],
+    "DateUpdated": "2010-11-17T03:48:19.640Z",
     "SolutionStackName": "32bit Amazon Linux running Tomcat 7"
 }

--- a/tests/unit/response_parsing/xml/responses/elasticbeanstalk-describe-configuration-options.json
+++ b/tests/unit/response_parsing/xml/responses/elasticbeanstalk-describe-configuration-options.json
@@ -11,12 +11,12 @@
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
-            "DefaultValue": null
+            "DefaultValue": ""
         },
         {
             "Name": "PARAM1",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
@@ -33,12 +33,12 @@
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
-            "DefaultValue": null
+            "DefaultValue": ""
         },
         {
             "Name": "PARAM2",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
@@ -55,12 +55,12 @@
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
-            "DefaultValue": null
+            "DefaultValue": ""
         },
         {
             "Name": "PARAM3",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
@@ -69,7 +69,7 @@
         {
             "Name": "PARAM4",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
@@ -78,7 +78,7 @@
         {
             "Name": "PARAM5",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "MaxLength": 200,
@@ -126,7 +126,7 @@
         {
             "Name": "JVM Options",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "RestartApplicationServer",
             "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions",
             "MaxLength": 200,
@@ -135,7 +135,7 @@
         {
             "Name": "Notification Endpoint",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "NoInterruption",
             "Namespace": "aws:elasticbeanstalk:sns:topics",
             "MaxLength": 200,
@@ -144,7 +144,7 @@
         {
             "Name": "Notification Topic ARN",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "NoInterruption",
             "Namespace": "aws:elasticbeanstalk:sns:topics",
             "MaxLength": 200,
@@ -168,7 +168,7 @@
         {
             "Name": "Notification Topic Name",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "NoInterruption",
             "Namespace": "aws:elasticbeanstalk:sns:topics",
             "MaxLength": 200,
@@ -260,7 +260,7 @@
         {
             "Name": "SSLCertificateId",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "NoInterruption",
             "Namespace": "aws:elb:loadbalancer",
             "MaxLength": 200,
@@ -424,7 +424,7 @@
         {
             "Name": "Custom Availability Zones",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "NoInterruption",
             "Namespace": "aws:autoscaling:asg",
             "ValueType": "List",
@@ -449,7 +449,7 @@
         {
             "Name": "EC2KeyName",
             "UserDefined": false,
-            "DefaultValue": null,
+            "DefaultValue": "",
             "ChangeSeverity": "RestartEnvironment",
             "Namespace": "aws:autoscaling:launchconfiguration",
             "MaxLength": 200,


### PR DESCRIPTION
This changes the output of the XML-based parsers and adds protocol tests for
each of `query`, `ec2`, and `rest-xml`. This is required to support new
waiters as in aws/aws-cli#1252.

cc @jamesls @kyleknap do either of you know why the code had a custom string
handler? Everything seems to work fine without it and removing it fixes the CLI
bug linked above.