### PR TITLE
support `aws rds wait db-snapshot-completed`

### DIFF
--- a/botocore/data/aws/rds/2014-10-31.waiters.json
+++ b/botocore/data/aws/rds/2014-10-31.waiters.json
@@ -97,6 +97,24 @@
           "argument": "DBInstances[].DBInstanceStatus"
         }
       ]
+    },
+    "DBSnapshotCompleted": {
+      "delay": 15,
+      "operation": "DescribeDBSnapshots",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": "DBSnapshotNotFound",
+          "matcher": "error",
+          "state": "success"
+        },
+        {
+          "expected": "available",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "DBSnapshots[].Status"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
`aws ec2 wait` has `snapshot-completed` command, but `rds wait` didn't have its counterpart.
http://docs.aws.amazon.com/cli/latest/reference/ec2/wait/snapshot-completed.html

```
$ aws rds create-db-snapshot --db-instance-identifier db-id --db-snapshot-identifier foo
$ aws rds wait db-snapshot-completed --db-snapshot-identifier bar # For 404:DBSnapshotNotFound snapshot-id, wait command exits.
$ aws rds wait db-snapshot-completed --db-snapshot-identifier foo
... wait till db-snapshot completes.
```

This is an API change, so creating new API files(including dates) may be required, but release management is  out of my control.
This PR just tries to demonstrate if this feature is put into production, how changes should be made.