### PR TITLE
Serialize blobs as base64 strings for rest-json

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -501,10 +501,12 @@ class BaseRestSerializer(Serializer):
             return value
 
 
-class RestJSONSerializer(BaseRestSerializer):
+class RestJSONSerializer(BaseRestSerializer, JSONSerializer):
 
     def _serialize_body_params(self, params, shape):
-        return json.dumps(params)
+        serialized_body = {}
+        self._serialize(serialized_body, params, shape)
+        return json.dumps(serialized_body)
 
 
 class RestXMLSerializer(BaseRestSerializer):

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -317,7 +317,7 @@ class JSONSerializer(Serializer):
             # of the passed in serialized dict.  We'll then add
             # all the structure members as key/vals in the new serialized
             # dictionary we just created.
-            new_serialized = {}
+            new_serialized = self.MAP_TYPE()
             serialized[key] = new_serialized
             serialized = new_serialized
         members = shape.members
@@ -504,7 +504,7 @@ class BaseRestSerializer(Serializer):
 class RestJSONSerializer(BaseRestSerializer, JSONSerializer):
 
     def _serialize_body_params(self, params, shape):
-        serialized_body = {}
+        serialized_body = self.MAP_TYPE()
         self._serialize(serialized_body, params, shape)
         return json.dumps(serialized_body)
 

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -363,6 +363,57 @@
     ]
   },
   {
+    "description": "Serialize blobs in body",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType",
+            "location": "uri",
+            "locationName": "Foo"
+          },
+          "Bar": {"shape": "BlobType"}
+        },
+        "required": [
+          "Foo"
+        ]
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "BlobType": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/2014-01-01/{Foo}"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Foo": "foo_name",
+          "Bar": "Blob param"
+        },
+        "serialized": {
+          "body": "{\"Bar\": \"QmxvYiBwYXJhbQ==\"}",
+          "uri": "/2014-01-01/foo_name"
+        }
+      }
+    ]
+  },
+  {
     "description": "Omits null query params, but serializes empty strings",
     "metadata": {
       "protocol": "rest-json",


### PR DESCRIPTION
We were not serializing blobs for rest-json. We just dumped the entire json body into the body with no serialization. Now it follows the serialization code path for the JSON serializer.

cc @jamesls @danielgtaylor 