### PR TITLE
Standardize env vars to use AWS_ prefix

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -72,7 +72,7 @@ class Session(object):
     SessionVariables = {
         # logical:  config_file, env_var,        default_value
         'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None),
-        'region': ('region', ['AWS_DEFAULT_REGION', 'AWS_REGION'], None),
+        'region': ('region', 'AWS_DEFAULT_REGION', None),
         'data_path': ('data_path', 'AWS_DATA_PATH', None),
         'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config'),
         'provider': ('provider', 'BOTO_PROVIDER_NAME', 'aws'),

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -299,8 +299,9 @@ class Session(object):
                 config_name = None
             if logical_name == 'profile' and self._profile:
                 value = self._profile
-            elif 'env' in methods and envvar_name and envvar_name in os.environ:
-                value = os.environ[envvar_name]
+            elif 'env' in methods and envvar_name and self._handle_env_vars(
+                    envvar_name, os.environ) is not None:
+                value = self._handle_env_vars(envvar_name, os.environ)
             elif 'config' in methods:
                 if config_name:
                     config = self.get_scoped_config()
@@ -313,6 +314,16 @@ class Session(object):
         if value is None and config_default is not None:
             value = config_default
         return value
+
+    def _handle_env_vars(self, names, environ):
+        # We need to handle the case where names is either
+        # a single value or a list of variables.
+        if not isinstance(names, list):
+            names = [names]
+        for name in names:
+            if name in environ:
+                return environ[name]
+        return None
 
     def set_config_variable(self, logical_name, value):
         """Set a configuration variable to a specific value.

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -71,9 +71,9 @@ class Session(object):
 
     SessionVariables = {
         # logical:  config_file, env_var,        default_value
-        'profile': (None, 'BOTO_DEFAULT_PROFILE', None),
-        'region': ('region', 'BOTO_DEFAULT_REGION', None),
-        'data_path': ('data_path', 'BOTO_DATA_PATH', None),
+        'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None),
+        'region': ('region', ['AWS_DEFAULT_REGION', 'AWS_REGION'], None),
+        'data_path': ('data_path', 'AWS_DATA_PATH', None),
         'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config'),
         'provider': ('provider', 'BOTO_PROVIDER_NAME', 'aws'),
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -26,7 +26,7 @@ class TestConfig(BaseSessionTest):
 
     def setUp(self):
         data_path = os.path.join(os.path.dirname(__file__), 'data')
-        super(TestConfig, self).setUp(BOTO_DATA_PATH=data_path)
+        super(TestConfig, self).setUp(AWS_DATA_PATH=data_path)
 
     def test_data_not_found(self):
         self.assertRaises(botocore.exceptions.DataNotFoundError,


### PR DESCRIPTION
This standards the environment variables used in botocore.session to be consistent with other SDKs.  This includes two things:

1. Support `AWS_PROFILE` and `AWS_REGION` (the former is from aws/aws-cli#1281)
2. Change the default `BOTO_` env vars to use `AWS_` instead.

This is a backwards incompatible change, but there is a mitigation path is customers do in fact want the old mapping.  They can provide the old env var mapping to the `__init__` when creating a session.

cc @kyleknap @danielgtaylor