### PR TITLE
Old style interface should warn to stderr by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,12 +21,14 @@ backwards compatibility is not guaranteed. The plan for GA is as follows:
 
 1. Add client interface to botocore.
 2. Add pending deprecation warnings to the use of ``Service`` and ``Operation``
-   objects.
-3. Change the pending deprecation warnings to deprecation warnings.
+   objects (added in version 0.96.0).
+3. Change the pending deprecation warnings to deprecation warnings
+   (added in version 0.99.0).
 4. Create a `clients-only <https://github.com/boto/botocore/tree/clients-only>`_
    branch that completely removes ``Service`` and ``Operation`` objects.
 5. Changing the deprecation warnings to ImminentRemovalWarning.  These will
-   now print to stderr by default so the warnings are more visible.
+   now print to stderr by default so the warnings are more visible
+   (added in version 0.104.0).
 6. Merge ``clients-only`` branch to develop branch, and make an alpha
    release of botocore.
 7. Make a beta release of botocore.

--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,14 @@ backwards compatibility is not guaranteed. The plan for GA is as follows:
 3. Change the pending deprecation warnings to deprecation warnings.
 4. Create a `clients-only <https://github.com/boto/botocore/tree/clients-only>`_
    branch that completely removes ``Service`` and ``Operation`` objects.
-5. Merge ``clients-only`` branch to develop branch, and make an alpha
+5. Changing the deprecation warnings to ImminentRemovalWarning.  These will
+   now print to stderr by default so the warnings are more visible.
+6. Merge ``clients-only`` branch to develop branch, and make an alpha
    release of botocore.
-6. Make a beta release of botocore.
-7. Make GA release of botocore.
+7. Make a beta release of botocore.
+8. Make GA release of botocore.
 
-The project is currently at step **4**.
+The project is currently at step **5**.
 
 If you need a stable interface, please consider using
 `boto <https://github.com/boto/boto>`__.

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -300,3 +300,7 @@ class ClientError(Exception):
             operation_name=operation_name)
         super(ClientError, self).__init__(msg)
         self.response = error_response
+
+
+class ImminentRemovalWarning(Warning):
+    pass

--- a/botocore/operation.py
+++ b/botocore/operation.py
@@ -20,6 +20,7 @@ import warnings
 from botocore.exceptions import MissingParametersError
 from botocore.exceptions import UnknownParameterError
 from botocore.exceptions import NoRegionError
+from botocore.exceptions import ImminentRemovalWarning
 from botocore.paginate import DeprecatedPaginator
 from botocore.signers import RequestSigner
 from botocore import serialize
@@ -101,7 +102,7 @@ class Operation(BotoCoreObject):
 
     def call(self, endpoint, **kwargs):
         warnings.warn("call() is deprecated and will be removed.  "
-                      "Use clients instead.", DeprecationWarning)
+                      "Use clients instead.", ImminentRemovalWarning)
         logger.debug("%s called with kwargs: %s", self, kwargs)
         # It probably seems a little weird to be firing two different
         # events here.  The reason is that the first event is fired
@@ -190,7 +191,7 @@ class Operation(BotoCoreObject):
     def can_paginate(self):
         warnings.warn("can_paginate is deprecated and will be removed.  "
                       "Use client.can_paginate instead.",
-                      DeprecationWarning)
+                      ImminentRemovalWarning)
         try:
             self._load_pagination_config()
         except Exception as e:
@@ -212,7 +213,7 @@ class Operation(BotoCoreObject):
         """
         warnings.warn("paginate is deprecated and will be removed.  "
                       "Use client.get_paginator instead.",
-                      DeprecationWarning)
+                      ImminentRemovalWarning)
         if not self.can_paginate:
             raise TypeError("Operation cannot be paginated: %s" % self)
         config = self._load_pagination_config()

--- a/botocore/service.py
+++ b/botocore/service.py
@@ -18,6 +18,7 @@ import warnings
 from .endpoint import EndpointCreator
 from .operation import Operation
 from .exceptions import ServiceNotInRegionError, NoRegionError
+from .exceptions import ImminentRemovalWarning
 from .exceptions import UnknownEndpointError
 from .model import ServiceModel, OperationModel
 from .translate import denormalize_waiters
@@ -157,7 +158,7 @@ class Service(object):
 
         """
         warnings.warn("get_endpoint is deprecated and will be removed.  "
-                      "Use create_client instead.", DeprecationWarning)
+                      "Use create_client instead.", ImminentRemovalWarning)
         resolver = self.session.get_component('endpoint_resolver')
         region = self.session.get_config_variable('region')
         event_emitter = self.session.get_component('event_emitter')
@@ -185,7 +186,7 @@ class Service(object):
         :param operation_name: The name of the operation.
         """
         warnings.warn("get_operation is deprecated and will be removed.  "
-                      "Use create_client instead.", DeprecationWarning)
+                      "Use create_client instead.", ImminentRemovalWarning)
         for operation in self.operations:
             op_names = (operation.name, operation.py_name, operation.cli_name)
             if operation_name in op_names:
@@ -195,7 +196,7 @@ class Service(object):
     def get_waiter(self, waiter_name, endpoint):
         warnings.warn("get_waiter is deprecated and will be removed.  "
                       "Use client.get_waiter instead.",
-                      DeprecationWarning)
+                      ImminentRemovalWarning)
         try:
             config = self._load_waiter_config()
         except Exception as e:
@@ -227,6 +228,6 @@ def get_service(session, service_name, provider, api_version=None):
     """
     warnings.warn("get_service is deprecated and will be removed.  "
                   "Use Session.create_client instead.",
-                  DeprecationWarning)
+                  ImminentRemovalWarning)
     logger.debug("Creating service object for: %s", service_name)
     return Service(session, provider, service_name)

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -29,6 +29,7 @@ import botocore.credentials
 import botocore.client
 from botocore.endpoint import EndpointCreator
 from botocore.exceptions import EventNotFound, ConfigNotFound, ProfileNotFound
+from botocore.exceptions import ImminentRemovalWarning
 from botocore import handlers
 from botocore.hooks import HierarchicalEmitter, first_non_none_response
 from botocore.loaders import Loader
@@ -556,7 +557,7 @@ class Session(object):
         :returns: :class:`botocore.service.Service`
         """
         warnings.warn("get_service is deprecated and will be removed.  "
-                      "Use create_client instead.", DeprecationWarning)
+                      "Use create_client instead.", ImminentRemovalWarning)
         service = botocore.service.get_service(self, service_name,
                                                self.provider,
                                                api_version=api_version)

--- a/docs/source/client_upgrades.rst
+++ b/docs/source/client_upgrades.rst
@@ -1,0 +1,250 @@
+.. _client-upgrades:
+
+Upgrading to Clients
+====================
+
+Background
+----------
+
+Version 0.66.0 of botocore added support for clients (10/16/2014)
+added initial support for clients.  This provided an alternate
+interface to making AWS calls that provided a number of benefits over
+the existing interface.  At the time, both interfaces were added
+so that users could opt in to trying the new clients.
+
+Below is an example of the old interface:
+
+.. code-block:: python
+
+    import botocore.session
+    session = botocore.session.get_session()
+    s3 = session.get_service('s3')
+    endpoint = s3.get_endpoint('us-west-2')
+    list_objects = s3.get_operation('ListObjects')
+    http, response = list_objects.call(endpoint, Bucket='mybucket')
+    if http.status_code == 200:
+        print("Contents: %s" % response['Contents])
+    else:
+        print("API call failed, status code: %s, error: %s" % (
+            http.status_code, http.content))
+
+
+Here's an example of the newer (preferred) client interface:
+
+.. code-block:: python
+
+    import botocore.session
+    session = botocore.session.get_session()
+    s3 = session.create_client('s3', 'us-west-2')
+    response = s3.list_objects(Bucket='mybucket')
+    print("Contents: %s" % response['Contents'])
+
+
+While there are many improvements with the new interface, here's
+a few notable improvements:
+
+* Less boilerplate.  With clients, the ``Endpoints`` are abstracted
+  from the user.  The ``Operations`` are also abstracted.  The user
+  only needs to deal with a single class, the client class.
+* Exceptions.  With clients, exceptions are raised on failed requests.
+  You do not have to check the error code of the http response object
+* Return values.  The http response is abstracted from the user.  The
+  client method makes an API call and returns a simple python dict.
+* More granular context.  Clients allow you to have a context that's
+  smaller than on a Service/Operation.  For example, you can now
+  create a client and add specific customizations and event handlers
+  that apply to only that specific client, instead of any S3 client.
+        
+
+Deprecation Timeline
+--------------------
+
+Botocore has not had a GA (1.0) release yet.  In version 1.0,
+the Service/Operation object **will be removed**.  Leading
+up to 1.0, we will be deprecating the old interface according
+to this schedule:
+
+* (**done**) Version 0.66.0 introduced client
+* (**done**) Version 0.96.0 emitted a ``PendingDeprecationWarning`` when using
+  the old interface.  By default, these warnings are not printed to
+  stderr.  A developer will need to opt in to these warnings to
+  see any emitted warnings.
+* (**done**) Version 0.99.0 emitted a ``DeprecationWarning`` when using
+  the old interface.  This has the same behavior as
+  ``PendingDeprecationWarning``, in which by default nothing is
+  printed to stderr.
+* Version 0.104.0 emitted an ``ImminentRemovalWarning`` when using
+  the old interface.  This warning is now printed to stderr by default.
+  A user can still turn off these warnings via the ``warnings`` module.
+* The ``develop`` branch on github will be updated to completely remove
+  the old interface.  At this point the client interface will be the
+  only interface available when using the ``develop`` branch on github.
+* A 1.0 alpha version will be released.  By default, ``pip`` will not
+  pick up any alpha/beta releases.
+* A 1.0 beta version will be released.
+* A GA (1.0) version of botocore will be released.
+  
+
+How To Upgrade
+==============
+
+Migrating to clients is straightforward.  This section outlines how
+to upgrade and some common scenarios and how to upgrade.
+
+Keyword Arg Casing
+------------------
+
+In botocore's old interface, kwargs could either be snake_cased or
+CamelCased and botocore would map them to the correct version needed
+by the service which is CamelCase.
+
+Botocore's client interface accepts **only** CamelCased args.  More
+specifically, botocore uses the same casing used by the respective
+AWS service.  Most AWS services uses CamelCasing.  Some AWS services
+use lowerCamelCase.
+
+**Old**
+
+.. code-block:: python
+
+    list_objects.call(endpoint, bucket='foo', key='bar')
+
+**New**
+
+.. code-block:: python
+
+    client.list_objects(Bucket='foo', Key='bar')
+
+
+Connection Pooling
+------------------
+
+In the old interface, the connection pooling was tied to an endpoint
+object.  To reuse existing HTTP connection, you needed to keep a reference
+to the endpoint objects.  With clients, connection pooling is tied to a client.
+Use a single client to make multiple API calls.
+
+**Old**
+
+.. code-block:: python
+
+    service = session.get_service('s3')
+    endpoint = service.get_endpoint('us-west-2')
+    operation = service.get_operation('ListObjects')
+    head_object = service.get_operation('HeadObject')
+    parsed = operation.call(endpoint, Bucket='mybucket')[1]
+    for obj in parsed['Contents']:
+        name = obj['Key']
+        # Use existing connection be passing in the same endpoint.
+        print(head_object.call(endpoint, Bucket='mybucket', Key=name))
+
+**New**
+
+.. code-block:: python
+
+    s3 = session.get_client('s3', 'us-west-2')
+    for obj in s3.list_objects(Bucket='mybucket')['Contents']:
+        name = obj['Key']
+        # Using the same client will reuse any existing HTTP
+        # connections the client was using.
+        print(s3.head_object(Bucket='mybucket', Key=name))
+
+
+Operation and Method Names
+--------------------------
+
+In the old interface, you would retrieve an API operation using the
+casing defined by the service, which is typically CamelCase.  For example,
+you'd use ``service.get_operation('ListObjects')``, not
+``service.get_operation('list_objects')``.  With clients, method names,
+which map 1 - 1 to operation names are snake_cased, as is common in python
+code.
+
+
+**Old**
+
+.. code-block:: python
+
+    service = session.get_service('s3')
+    list_objects = service.get_operation('ListObjects')
+    head_object = service.get_operation('HeadObject')
+    get_object = service.get_operation('GetObject')
+
+**New**
+
+.. code-block:: python
+
+    s3 = session.get_client('s3', 'us-west-2')
+    list_objects = s3.list_objects
+    head_object = s3.head_object
+    get_object = s3.get_object
+
+
+
+Return Values
+-------------
+
+In the old interface, the return value for an ``operation.call`` invocation is
+a tuple of the HTTP response object, and the parsed dict that results from
+parsing the HTTP object.  In the client interface, only the parsed
+response is returned.  The HTTP response object is not returned.
+
+**Old**
+
+.. code-block:: python
+
+    ec2 = session.get_service('ec2')
+    endpoint = ec2.get_endpoint('ec2')
+    describe_instances = ec2.get_operation('DescribeInstances')
+    http, parsed = describe_instances.call(endpoint)
+
+**New**
+
+.. code-block:: python
+
+    ec2 = session.get_client('ec2', 'us-west-2')
+    parsed = ec2.describe_instances()
+
+The main reason for returning the HTTP response was to check if an
+error occurred via the HTTP response status code.  This is now no longer
+required (discussed below).  Exception are automatically raised.
+
+Note that if for some reason you do need to see the response status code,
+it is available via the ``ResponseMetadata`` in the parsed dict that's
+returned.
+
+.. code-block:: python
+
+    ec2 = session.get_client('ec2', 'us-west-2')
+    parsed = ec2.describe_instances()
+    print("The status code is:",
+          parsed['ResponseMetadata']['HTTPStatusCode']))
+
+
+Error Handling
+--------------
+
+With clients, exceptions are now raised on any non 200 response.
+A ``ClientError`` exception has both a ``.msg`` attribute as well
+as the parsed error response (which is a dictionary).  There isn't
+really equivalent functionality in the old interface, but below is
+an example of how you can handle an error:
+
+**New**
+
+.. code-block:: python
+
+    from botocore.exceptions import ClientError
+
+    ec2 = session.get_client('ec2', 'us-west-2')
+    try:
+        parsed = ec2.describe_instances()
+    except ClientError as e:
+        logger.error("Received error: %s", e, exc_info=True)
+        # Only worry about a specific service error code
+        if e.response['Error']['Code'] == 'ResourceUnavailable':
+            raise
+
+If you run into any issues migrating from the old interface to the newer
+client interface, please file an issue on github and let us know.  We'd
+be happy to help.

--- a/docs/source/client_upgrades.rst
+++ b/docs/source/client_upgrades.rst
@@ -224,7 +224,7 @@ returned.
 Error Handling
 --------------
 
-With clients, exceptions are now raised on any non 200 response.
+With clients, exceptions are now raised on any non 2xx response.
 A ``ClientError`` exception has both a ``.msg`` attribute as well
 as the parsed error response (which is a dictionary).  There isn't
 really equivalent functionality in the old interface, but below is

--- a/docs/source/client_upgrades.rst
+++ b/docs/source/client_upgrades.rst
@@ -54,7 +54,7 @@ a few notable improvements:
   smaller than on a Service/Operation.  For example, you can now
   create a client and add specific customizations and event handlers
   that apply to only that specific client, instead of any S3 client.
-        
+
 
 Deprecation Timeline
 --------------------
@@ -83,7 +83,7 @@ to this schedule:
   pick up any alpha/beta releases.
 * A 1.0 beta version will be released.
 * A GA (1.0) version of botocore will be released.
-  
+
 
 How To Upgrade
 ==============
@@ -238,11 +238,11 @@ an example of how you can handle an error:
 
     ec2 = session.get_client('ec2', 'us-west-2')
     try:
-        parsed = ec2.describe_instances()
+        parsed = ec2.describe_instances(InstanceIds=['i-badid'])
     except ClientError as e:
         logger.error("Received error: %s", e, exc_info=True)
         # Only worry about a specific service error code
-        if e.response['Error']['Code'] == 'ResourceUnavailable':
+        if e.response['Error']['Code'] == 'InvalidInstanceID.NotFound':
             raise
 
 If you run into any issues migrating from the old interface to the newer

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,16 @@ Contents:
 Upgrade Notes
 =============
 
+Upgrading to 0.104.0
+--------------------
+
+* Warnings about imminent removal of service/operation objects are
+  now printed to stderr by default.  It is highly encouraged that
+  you switch to clients as soon as possible, as the deprecated
+  service/operation object is going away.  See :ref:`client-upgrades`
+  for more information.
+
+
 Upgrading to 0.66.0
 -------------------
 

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -19,6 +19,7 @@ from nose.tools import assert_equal
 from nose.tools import assert_true
 
 import botocore.session
+from botocore.exceptions import ImminentRemovalWarning
 
 
 @contextlib.contextmanager
@@ -44,15 +45,15 @@ class TestDeprecationsHaveWarnings(unittest.TestCase):
         self.session = botocore.session.get_session()
 
     def test_get_service_deprecated(self):
-        with assert_warns(DeprecationWarning, contains='get_service'):
+        with assert_warns(ImminentRemovalWarning, contains='get_service'):
             self.session.get_service('cloudformation')
 
     def test_service_get_operation_deprecated(self):
         service = self.session.get_service('cloudformation')
-        with assert_warns(DeprecationWarning, contains='get_operation'):
+        with assert_warns(ImminentRemovalWarning, contains='get_operation'):
             service.get_operation('ListStacks')
 
     def test_get_endpoint(self):
         service = self.session.get_service('cloudformation')
-        with assert_warns(DeprecationWarning, contains='get_endpoint'):
+        with assert_warns(ImminentRemovalWarning, contains='get_endpoint'):
             service.get_endpoint('us-east-1')


### PR DESCRIPTION
I noticed when I was trying out the old interface that the `DeprecationWarning` does *not* print to stderr.  We really should be at the point out where the error is front and center whenever you try to do anything with the old interface.  This change does that.

In order to help with migration I also sketched out a migration guide for going from the old interface to the new client interface so we have something we can point customer to when they run into issues.

I also manually verified the errors are on stderr now:

```
>>> import botocore.session
>>> s = botocore.session.get_session()
>>> s.get_service('ec2')
botocore/session.py:560: ImminentRemovalWarning: get_service is deprecated and will be removed.  Use create_client instead.
  "Use create_client instead.", ImminentRemovalWarning)
botocore/service.py:231: ImminentRemovalWarning: get_service is deprecated and will be removed.  Use Session.create_client instead.
  ImminentRemovalWarning)
Service(ec2)
```

cc @kyleknap @danielgtaylor