### PR TITLE
Add paginators / waiters for ECS

### DIFF
--- a/botocore/data/aws/ecs/2014-11-13.paginators.json
+++ b/botocore/data/aws/ecs/2014-11-13.paginators.json
@@ -1,0 +1,40 @@
+{
+	"pagination": {
+		"ListClusters": {
+			"input_token": "nextToken",
+			"output_token": "nextToken",
+			"limit_key": "maxResults",
+			"result_key": "clusterArns"
+		},
+		"ListContainerInstances": {
+			"input_token": "nextToken",
+			"output_token": "nextToken",
+			"limit_key": "maxResults",
+			"result_key": "containerInstanceArns"
+		},
+		"ListTaskDefinitions": {
+			"input_token": "nextToken",
+			"output_token": "nextToken",
+			"limit_key": "maxResults",
+			"result_key": "taskDefinitionArns"
+		},
+		"ListTaskDefinitionFamilies": {
+			"input_token": "nextToken",
+			"output_token": "nextToken",
+			"limit_key": "maxResults",
+			"result_key": "families"
+		},
+		"ListTasks": {
+			"input_token": "nextToken",
+			"output_token": "nextToken",
+			"limit_key": "maxResults",
+			"result_key": "taskArns"
+		},
+		"ListServices": {
+			"input_token": "nextToken",
+			"output_token": "nextToken",
+			"limit_key": "maxResults",
+			"result_key": "serviceArns"
+		}
+	}
+}

--- a/botocore/data/aws/ecs/2014-11-13.waiters.json
+++ b/botocore/data/aws/ecs/2014-11-13.waiters.json
@@ -1,0 +1,99 @@
+{
+  "version": 2,
+  "waiters": {
+    "TasksRunning": {
+      "delay": 6,
+      "operation": "DescribeTasks",
+      "maxAttempts": 100,
+      "acceptors": [
+        {
+          "expected": "STOPPED",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "tasks[].lastStatus"
+        },
+        {
+          "expected": "MISSING",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "failures[].reason"
+        },
+        {
+          "expected": "RUNNING",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "tasks[].lastStatus"
+        }
+      ]
+    },
+    "TasksStopped": {
+      "delay": 6,
+      "operation": "DescribeTasks",
+      "maxAttempts": 100,
+      "acceptors": [
+        {
+          "expected": "MISSING",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "failures[].reason"
+        },
+        {
+          "expected": "STOPPED",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "tasks[].lastStatus"
+        }
+      ]
+    },
+    "ServicesStable": {
+      "delay": 15,
+      "operation": "DescribeServices",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": "MISSING",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "failures[].reason"
+        },
+        {
+          "expected": "DRAINING",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "services[].status"
+        },
+        {
+          "expected": "INACTIVE",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "services[].status"
+        },
+        {
+          "expected": true,
+          "matcher": "path",
+          "state": "success",
+          "argument": "services | [@[?length(deployments)!=`1`], @[?desiredCount!=runningCount]][] | length(@) == `0`"
+        }
+      ]
+    },
+    "ServicesInactive": {
+      "delay": 15,
+      "operation": "DescribeServices",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": "MISSING",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "failures[].reason"
+        },
+        {
+          "expected": "INACTIVE",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "services[].status"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I had a go at writing paginators and waiters for ECS.
Currently I have only tested them in botocore via the aws cli, but all of them appear to work well there.