### PR TITLE
Add integration tests for new services

### DIFF
--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -23,17 +23,21 @@ SMOKE_TESTS = {
                     'ListStacks': {}},
  'cloudfront': {'ListDistributions': {},
                 'ListStreamingDistributions': {}},
+ 'cloudhsm': {'ListAvailableZones': {}},
  'cloudsearch': {'DescribeDomains': {},
                  'ListDomainNames': {}},
  'cloudtrail': {'DescribeTrails': {}},
  'cloudwatch': {'ListMetrics': {}},
+ 'codedeploy': {'ListApplications': {}},
  'cognito-identity': {'ListIdentityPools': {'MaxResults': 1}},
  'cognito-sync': {'ListIdentityPoolUsage': {}},
+ 'config': {'DescribeDeliveryChannels': {}},
  'datapipeline': {'ListPipelines': {}},
  'directconnect': {'DescribeConnections': {}},
  'dynamodb': {'ListTables': {}},
  'ec2': {'DescribeRegions': {},
          'DescribeInstances': {}},
+ 'ecs': {'DescribeClusters': {}},
  'elasticache': {'DescribeCacheClusters': {}},
  'elasticbeanstalk': {'DescribeApplications': {}},
  'elastictranscoder': {'ListPipelines': {}},
@@ -46,7 +50,10 @@ SMOKE_TESTS = {
  #'importexport': {'ListJobs': {}},
  'importexport': {},
  'kinesis': {'ListStreams': {}},
+ 'kms': {'ListKeys': {}},
+ 'lambda': {'ListFunctions': {}},
  'logs': {'DescribeLogGroups': {}},
+ 'machinelearning': {'DescribeMLModels': {}},
  'opsworks': {'DescribeStacks': {}},
  'rds': {'DescribeDBInstances': {}},
  'redshift': {'DescribeClusters': {}},
@@ -57,6 +64,7 @@ SMOKE_TESTS = {
  'ses': {'ListIdentities': {}},
  'sns': {'ListTopics': {}},
  'sqs': {'ListQueues': {}},
+ 'ssm': {'ListDocuments': {}},
  'storagegateway': {'ListGateways': {}},
  # sts tests would normally go here, but
  # there aren't any calls you can make when
@@ -67,6 +75,7 @@ SMOKE_TESTS = {
  # Subscription needed for support API calls.
  'support': {},
  'swf': {'ListDomains': {'registrationStatus': 'REGISTERED'}},
+ 'workspaces': {'DescribeWorkspaces': {}},
 }
 
 # Same thing as the SMOKE_TESTS hash above, except these verify


### PR DESCRIPTION
This adds basic smoke tests for the services added in the last
6 months or so.


cc @kyleknap