### PR TITLE
Simplify retry configuration

### DIFF
--- a/botocore/data/aws/_retry.json
+++ b/botocore/data/aws/_retry.json
@@ -55,133 +55,9 @@
           "general_socket_errors": {"$ref": "general_socket_errors"},
           "general_server_error": {"$ref": "general_server_error"},
           "service_unavailable": {"$ref": "service_unavailable"},
-          "limit_exceeded": {"$ref": "limit_exceeded"}
-      }
-    },
-    "autoscaling": {
-      "__default__": {
-        "policies": {
+          "limit_exceeded": {"$ref": "limit_exceeded"},
+          "throttling_exception": {"$ref": "throttling_exception"},
           "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "elasticmapreduce": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling_exception"}
-        }
-      }
-    },
-    "rds": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "elasticache": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "redshift": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "elasticbeanstalk": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "cloudformation": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "datapipeline": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "opsworks": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "iam": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "sts": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "swf": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "sns": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "ses": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "cloudwatch": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "route53": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "directconnect": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
-      }
-    },
-    "elb": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling"}
-        }
       }
     },
     "dynamodb": {
@@ -201,7 +77,6 @@
               }
             }
           },
-          "throttling": {"$ref": "throttling_exception"},
           "crc32": {
             "applies_when": {
               "response": {
@@ -209,20 +84,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "glacier": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling_exception"}
-        }
-      }
-    },
-    "storagegateway": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling_exception"}
         }
       }
     },
@@ -279,13 +140,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "elastictranscoder": {
-      "__default__": {
-        "policies": {
-          "throttling": {"$ref": "throttling_exception"}
         }
       }
     }


### PR DESCRIPTION
This changes two things:

* Move the ``throttling_exception`` rule up to the default errors to retry
* Move the ``throttling`` rule up to the default errors to retry

This came about because the ``workspaces`` service would receive
400/ThrottlingException errors that were not being retried.

The simple fix would be to add this missing condition to a new
``workspaces`` entry.

However, the error can occur for any json or rest-json service and
we'd need to keep this up to date every time we added support for a new
json/rest-json service.  Same thing with the 400/Throttling exception.
This will happen for any query service.  Moving this up to the default
set of errors to retry means we won't have to keep updating this as new
errors are added.

It also has the benefit that the remaining per-service conditions are
just the special cases.

cc @kyleknap