### PR TITLE
Fix pagination issue

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -212,8 +212,12 @@ class PageIterator(object):
         next_tokens = []
         for token in self._output_token:
             next_token = token.search(parsed)
+            # We do not want to include any empty strings as actual tokens.
+            # Treat them as None.
             if next_token:
                 next_tokens.append(next_token)
+            else:
+                next_tokens.append(None)
         return next_tokens
 
     def result_key_iters(self):

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -211,7 +211,9 @@ class PageIterator(object):
                 return [None]
         next_tokens = []
         for token in self._output_token:
-            next_tokens.append(token.search(parsed))
+            next_token = token.search(parsed)
+            if next_token:
+                next_tokens.append(next_token)
         return next_tokens
 
     def result_key_iters(self):

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -210,6 +210,23 @@ class TestFuturePaginator(unittest.TestCase):
              mock.call(Marker='m2', MaxKeys=1)]
         )
 
+    def test_with_empty_markers(self):
+        responses = [
+            {"Users": ["User1"], "Marker": ""},
+            {"Users": ["User1"], "Marker": ""},
+            {"Users": ["User1"], "Marker": ""}
+        ]
+        self.method.side_effect = responses
+        users = []
+        for page in self.paginator.paginate():
+            users += page['Users']
+        # We want to stop paginating if the next token is empty.
+        self.assertEqual(
+            self.method.call_args_list,
+            [mock.call()]
+        )
+        self.assertEqual(users, ['User1'])
+
     def test_build_full_result_with_single_key(self):
         responses = [
             {"Users": ["User1"], "Marker": "m1"},


### PR DESCRIPTION
The issue is we need to stop paginating if we recieve an empty string for
a next token marker. Before, if we did not have a check to see that the next
token was not the same as the previous token and throw an error, we would have
hit an infinite loop.