### PR TITLE
Add machinelearning wait commands

### DIFF
--- a/botocore/data/machinelearning/2014-12-12/waiters-2.json
+++ b/botocore/data/machinelearning/2014-12-12/waiters-2.json
@@ -1,0 +1,105 @@
+{
+  "version": 2,
+  "waiters": {
+    "DataSourceAvailable": {
+      "delay": 30,
+      "operation": "DescribeDataSources",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": "COMPLETED",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "FAILED",
+          "matcher": "pathAny",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "INPROGRESS",
+          "matcher": "pathAny",
+          "state": "retry",
+          "argument": "Results[].Status"
+        }
+      ]
+    },
+    "MLModelAvailable": {
+      "delay": 30,
+      "operation": "DescribeMLModels",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": "COMPLETED",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "FAILED",
+          "matcher": "pathAny",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "INPROGRESS",
+          "matcher": "pathAny",
+          "state": "retry",
+          "argument": "Results[].Status"
+        }
+      ]
+    },
+    "EvaluationAvailable": {
+      "delay": 30,
+      "operation": "DescribeEvaluations",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": "COMPLETED",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "FAILED",
+          "matcher": "pathAny",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "INPROGRESS",
+          "matcher": "pathAny",
+          "state": "retry",
+          "argument": "Results[].Status"
+        }
+      ]
+    },
+    "BatchPredictionAvailable": {
+      "delay": 30,
+      "operation": "DescribeBatchPredictions",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "expected": "COMPLETED",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "FAILED",
+          "matcher": "pathAny",
+          "state": "success",
+          "argument": "Results[].Status"
+        },
+        {
+          "expected": "INPROGRESS",
+          "matcher": "pathAny",
+          "state": "retry",
+          "argument": "Results[].Status"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
machinelearnig's create operations are basically asynchronous but there's no wait commands, so I've added following wait commands.

* DataSourceAvailable:
  Wait until JMESPath query Results[].Status returns COMPLETED for all elements when polling with describe-data-sources.
  Useful for `aws machinelearning create-data-source-from-s3` operation.

* MLModelAvailable:
  Wait until JMESPath query Results[].Status returns COMPLETED for all elements when polling with describe-ml-models.
  Useful for `aws machinelearning create-ml-model` operation.

* EvaluationAvailable:
  Wait until JMESPath query Results[].Status returns COMPLETED for all elements when polling with describe-evaluations.
  Useful for `aws machinelearning create-evaluation` operation.

* BatchPredictionAvailable:
  Wait until JMESPath query Results[].Status returns COMPLETED for all elements when polling with describe-batch-predictions.
  Useful for `aws machinelearning create-batch-prediction` operation.

Feedback is welcome.