### PR TITLE
Update paginate parameters

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -351,22 +351,23 @@ class Paginator(object):
             self._output_token, self._more_results,
             self._result_keys, self._non_aggregate_keys,
             self._limit_key,
-            page_params['max_items'],
-            page_params['starting_token'],
-            page_params['page_size'],
+            page_params['MaxItems'],
+            page_params['StartingToken'],
+            page_params['PageSize'],
             kwargs)
 
     def _extract_paging_params(self, kwargs):
-        max_items = kwargs.pop('max_items', None)
+        pagination_config = kwargs.pop('PaginationConfig', {})
+        max_items = pagination_config.get('MaxItems', None)
         if max_items is not None:
             max_items = int(max_items)
-        page_size = kwargs.pop('page_size', None)
+        page_size = pagination_config.get('PageSize', None)
         if page_size is not None:
             page_size = int(page_size)
         return {
-            'max_items': max_items,
-            'starting_token': kwargs.pop('starting_token', None),
-            'page_size': page_size,
+            'MaxItems': max_items,
+            'StartingToken': pagination_config.get('StartingToken', None),
+            'PageSize': page_size,
         }
 
 

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -50,7 +50,7 @@ class TestEC2Pagination(unittest.TestCase):
         # Using an operation that we know will paginate.
         paginator = self.client.get_paginator(
             'describe_reserved_instances_offerings')
-        pages = paginator.paginate(page_size=1)
+        pages = paginator.paginate(PaginationConfig={'PageSize': 1})
         results = list(itertools.islice(pages, 0, 3))
         self.assertEqual(len(results), 3)
         for parsed in results:

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -26,7 +26,7 @@ class TestRDSPagination(unittest.TestCase):
         # Route53 has a string type for MaxItems.  We need to ensure that this
         # still works without any issues.
         paginator = self.client.get_paginator('list_hosted_zones')
-        results = list(paginator.paginate(max_items='1'))
+        results = list(paginator.paginate(PaginationConfig={'MaxItems': '1'}))
         self.assertTrue(len(results) >= 0)
 
 


### PR DESCRIPTION
Took all pagination related parameters and camel cased them and wrapped them into an overlying structure, PaginationConfig. Before, a pagination call looked something like this:
```
paginator.paginate(max_items=1)
```
Now it looks like this:
```
paginator.paginate(PaginationConfig={'MaxItems': 1})
```
Other parameters that are included in PaginationConfig are MaxItems, PageSize, and
StartingToken. Their snake cased versions are no longer used.

I will have subsequent pull requests that will update the CLI and boto3 as well.

cc @jamesls @mtdowling