### PR TITLE
Provide better error message when timestamps are None

### DIFF
--- a/botocore/validate.py
+++ b/botocore/validate.py
@@ -253,7 +253,9 @@ class ParamValidator(object):
         try:
             parse_to_aware_datetime(value)
             return True
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, AttributeError):
+            # Yes, dateutil can sometimes through an AttributeError
+            # when parsing timestamps.
             return False
 
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -163,6 +163,16 @@ class TestValidateTypes(BaseTestValidate):
         error_msg = errors.generate_report()
         self.assertEqual(error_msg, '')
 
+    def test_can_handle_none_datetimes(self):
+        # This is particularly to workaround a bug in dateutil
+        # where low level exceptions can propogate back up to
+        # us.
+        errors = self.get_validation_error_message(
+            given_shapes=self.shapes,
+            input_params={'Timestamp': None})
+        error_msg = errors.generate_report()
+        self.assertIn('Invalid type for parameter Timestamp', error_msg)
+
 
 class TestValidateRanges(BaseTestValidate):
     def setUp(self):


### PR DESCRIPTION
Fixes aws/aws-cli#1366

Before you'd get:

```
$ aws ec2 describe-spot-price-history --cli-input-json file:///tmp/json

'NoneType' object has no attribute 'read'
```

Now you'll get:

```
$ aws ec2 describe-spot-price-history --cli-input-json file:///tmp/json

Parameter validation failed:
Invalid type for parameter StartTime, value: None, type: <type 'NoneType'>, valid types: <type 'datetime.datetime'>, timestamp-string
Invalid type for parameter EndTime, value: None, type: <type 'NoneType'>, valid types: <type 'datetime.datetime'>, timestamp-string
```

cc @kyleknap @mtdowling