### PR TITLE
Adding documentation customizations.

### DIFF
--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -20,8 +20,8 @@ class BaseDocsFunctionalTest(unittest.TestCase):
         self.assertIn(line, contents)
 
     def assert_contains_lines_in_order(self, lines, contents):
-       contents = contents.decode('utf-8')
-       for line in lines:
+        contents = contents.decode('utf-8')
+        for line in lines:
             self.assertIn(line, contents)
             beginning = contents.find(line)
             contents = contents[(beginning + len(line)):]
@@ -42,7 +42,7 @@ class BaseDocsFunctionalTest(unittest.TestCase):
         self.assertNotEqual(start_index, -1, 'Method is not found in contents')
         contents = contents[start_index:]
         end_index = contents.find(
-            '  ..py:method::', len(start_method_document))
+            '  .. py:method::', len(start_method_document))
         contents = contents[:end_index]
         return contents.encode('utf-8')
 
@@ -56,8 +56,16 @@ class BaseDocsFunctionalTest(unittest.TestCase):
         contents = contents[:end_index]
         return contents.encode('utf-8')
 
-    def assert_is_documented_as_autopopulated_param(
+    def get_parameter_documentation_from_service(
             self, service_name, method_name, param_name):
+        contents = ServiceDocumenter(service_name).document_service()
+        method_contents = self.get_method_document_block(
+            method_name, contents)
+        return self.get_parameter_document_block(
+            param_name, method_contents)
+
+    def assert_is_documented_as_autopopulated_param(
+            self, service_name, method_name, param_name, doc_string=None):
         contents = ServiceDocumenter(service_name).document_service()
         # Pick an arbitrary method that uses AccountId.
         method_contents = self.get_method_document_block(
@@ -75,5 +83,6 @@ class BaseDocsFunctionalTest(unittest.TestCase):
         self.assert_not_contains_line('REQUIRED', param_contents)
 
         # Ensure the note about autopopulation was added.
-        self.assert_contains_line(
-            'Note this parameter is autopopulated', param_contents) 
+        if doc_string is None:
+            doc_string = 'Please note that this parameter is automatically'
+        self.assert_contains_line(doc_string, param_contents)

--- a/tests/functional/docs/test_autoscaling.py
+++ b/tests/functional/docs/test_autoscaling.py
@@ -13,16 +13,8 @@
 from tests.functional.docs import BaseDocsFunctionalTest
 
 
-class TestGlacierDocs(BaseDocsFunctionalTest):
-    def test_account_id(self):
-        self.assert_is_documented_as_autopopulated_param(
-            service_name='glacier',
-            method_name='abort_multipart_upload',
-            param_name='accountId',
-            doc_string='Note: this parameter is set to "-"')
-
-    def test_checksum(self):
-        self.assert_is_documented_as_autopopulated_param(
-            service_name='glacier',
-            method_name='upload_archive',
-            param_name='checksum')
+class TestAutoscalingDocs(BaseDocsFunctionalTest):
+    def test_documents_encoding_of_user_data(self):
+        docs = self.get_parameter_documentation_from_service(
+            'autoscaling', 'create_launch_configuration', 'UserData')
+        self.assertIn('automatically base64 encoded', docs)

--- a/tests/functional/docs/test_autoscaling.py
+++ b/tests/functional/docs/test_autoscaling.py
@@ -17,4 +17,4 @@ class TestAutoscalingDocs(BaseDocsFunctionalTest):
     def test_documents_encoding_of_user_data(self):
         docs = self.get_parameter_documentation_from_service(
             'autoscaling', 'create_launch_configuration', 'UserData')
-        self.assertIn('automatically base64 encoded', docs)
+        self.assertIn('automatically base64', docs.decode('utf-8'))

--- a/tests/functional/docs/test_ec2.py
+++ b/tests/functional/docs/test_ec2.py
@@ -13,16 +13,20 @@
 from tests.functional.docs import BaseDocsFunctionalTest
 
 
-class TestGlacierDocs(BaseDocsFunctionalTest):
-    def test_account_id(self):
-        self.assert_is_documented_as_autopopulated_param(
-            service_name='glacier',
-            method_name='abort_multipart_upload',
-            param_name='accountId',
-            doc_string='Note: this parameter is set to "-"')
+class TestEc2Docs(BaseDocsFunctionalTest):
+    def test_documents_encoding_of_user_data(self):
+        docs = self.get_parameter_documentation_from_service(
+            'ec2', 'run_instances', 'UserData')
+        self.assertIn('automatically base64 encoded', docs)
 
-    def test_checksum(self):
+    def test_copy_snapshot_presigned_url_is_autopopulated(self):
         self.assert_is_documented_as_autopopulated_param(
-            service_name='glacier',
-            method_name='upload_archive',
-            param_name='checksum')
+            service_name='ec2',
+            method_name='copy_snapshot',
+            param_name='PresignedUrl')
+
+    def test_copy_snapshot_destination_region_is_autopopulated(self):
+        self.assert_is_documented_as_autopopulated_param(
+            service_name='ec2',
+            method_name='copy_snapshot',
+            param_name='DestinationRegion')

--- a/tests/functional/docs/test_ec2.py
+++ b/tests/functional/docs/test_ec2.py
@@ -17,7 +17,7 @@ class TestEc2Docs(BaseDocsFunctionalTest):
     def test_documents_encoding_of_user_data(self):
         docs = self.get_parameter_documentation_from_service(
             'ec2', 'run_instances', 'UserData')
-        self.assertIn('automatically base64 encoded', docs)
+        self.assertIn('automatically base64', docs.decode('utf-8'))
 
     def test_copy_snapshot_presigned_url_is_autopopulated(self):
         self.assert_is_documented_as_autopopulated_param(

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -1,0 +1,36 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.functional.docs import BaseDocsFunctionalTest
+from botocore.docs.service import ServiceDocumenter
+
+
+class TestS3Docs(BaseDocsFunctionalTest):
+    def test_auto_populates_sse_customer_key_md5(self):
+        self.assert_is_documented_as_autopopulated_param(
+            service_name='s3',
+            method_name='put_object',
+            param_name='SSECustomerKeyMD5')
+
+    def test_hides_content_md5_when_impossible_to_provide(self):
+        modified_methods = ['delete_objects', 'put_bucket_acl',
+                            'put_bucket_cors', 'put_bucket_lifecycle',
+                            'put_bucket_logging', 'put_bucket_policy',
+                            'put_bucket_notification', 'put_bucket_tagging',
+                            'put_bucket_replication', 'put_bucket_website',
+                            'put_bucket_request_payment', 'put_object_acl',
+                            'put_bucket_versioning']
+        service_contents = ServiceDocumenter('s3').document_service()
+        for method_name in modified_methods:
+            method_contents = self.get_method_document_block(
+                method_name, service_contents)
+            self.assertNotIn('ContentMD5=\'string\'', method_contents)

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -33,4 +33,5 @@ class TestS3Docs(BaseDocsFunctionalTest):
         for method_name in modified_methods:
             method_contents = self.get_method_document_block(
                 method_name, service_contents)
-            self.assertNotIn('ContentMD5=\'string\'', method_contents)
+            self.assertNotIn('ContentMD5=\'string\'',
+                             method_contents.decode('utf-8'))


### PR DESCRIPTION
This commit adds two new customization classes:

1. HideParamFromOperations - hides a parameter from one or more
   operations.
2. AppendParamDocumentation - appends documentation to a parameter.

Documentation customizations have been added for each customization
listed in handlers.py.

@kyleknap @jamesls 