### PR TITLE
Fix regression in older versions of pip with cond deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import botocore
+import sys
 
 from setuptools import setup, find_packages
 
@@ -7,6 +8,19 @@ from setuptools import setup, find_packages
 requires = ['jmespath==0.7.1',
             'bcdoc>=0.16.0,<0.17.0',
             'python-dateutil>=2.1,<3.0.0']
+
+
+if sys.version_info[:2] == (2, 6):
+    # For python2.6 we have a few other dependencies.
+    # First we need an ordered dictionary so we use the
+    # 2.6 backport.
+    requires.append('ordereddict==1.1')
+    # Then we need simplejson.  This is because we need
+    # a json version that allows us to specify we want to
+    # use an ordereddict instead of a normal dict for the
+    # JSON objects.  The 2.7 json module has this.  For 2.6
+    # we need simplejson.
+    requires.append('simplejson==3.3.0')
 
 
 setup(


### PR DESCRIPTION
Verify with:

```
<mkvirtualenv with python2.6>
pip install pip==1.4.1
<create botocore and awscli sdists>
pip install botocore/dist/<sdist>.tar.gz
pip install awscli/dist/<sdist>.tar.gz
aws --version
```

cc @kyleknap @mtdowling