### PR TITLE
Allow config variables to provide conversion functions

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -236,15 +236,6 @@ class OperationNotPageableError(BotoCoreError):
     fmt = 'Operation cannot be paginated: {operation_name}'
 
 
-class EventNotFound(BotoCoreError):
-    """
-    The specified event name is unknown to the system.
-
-    :ivar event_name: The name of the event the user attempted to use.
-    """
-    fmt = 'The event ({event_name}) is not known'
-
-
 class ChecksumError(BotoCoreError):
     """The expected checksum did not match the calculated checksum.
 

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -20,17 +20,12 @@ import copy
 import logging
 import os
 import platform
-import shlex
-import warnings
-from collections import namedtuple
 
 from botocore import __version__
 import botocore.config
 import botocore.credentials
 import botocore.client
-from botocore.endpoint import EndpointCreator
 from botocore.exceptions import EventNotFound, ConfigNotFound, ProfileNotFound
-from botocore.exceptions import ImminentRemovalWarning
 from botocore import handlers
 from botocore.hooks import HierarchicalEmitter, first_non_none_response
 from botocore.loaders import create_loader
@@ -206,7 +201,7 @@ class Session(object):
                 event_name, handler, register_type = spec
                 if register_type is handlers.REGISTER_FIRST:
                     self._events.register_first(event_name, handler)
-                elif register_first is handlers.REGISTER_LAST:
+                elif register_type is handlers.REGISTER_LAST:
                     self._events.register_last(event_name, handler)
 
     @property
@@ -336,7 +331,6 @@ class Session(object):
 
         """
         self._session_instance_vars[logical_name] = value
-
 
     def get_scoped_config(self):
         """
@@ -757,26 +751,28 @@ class Session(object):
             of the client.
 
         :type use_ssl: boolean
-        :param use_ssl: Whether or not to use SSL.  By default, SSL is used.  Note that
-            not all services support non-ssl connections.
+        :param use_ssl: Whether or not to use SSL.  By default, SSL is used.
+            Note that not all services support non-ssl connections.
 
         :type verify: boolean/string
-        :param verify: Whether or not to verify SSL certificates.  By default SSL certificates
-            are verified.  You can provide the following values:
+        :param verify: Whether or not to verify SSL certificates.
+            By default SSL certificates are verified.  You can provide the
+            following values:
 
             * False - do not validate SSL certificates.  SSL will still be
               used (unless use_ssl is False), but SSL certificates
               will not be verified.
             * path/to/cert/bundle.pem - A filename of the CA cert bundle to
-              uses.  You can specify this argument if you want to use a different
-              CA cert bundle than the one used by botocore.
+              uses.  You can specify this argument if you want to use a
+              different CA cert bundle than the one used by botocore.
 
         :type endpoint_url: string
-        :param endpoint_url: The complete URL to use for the constructed client.
-            Normally, botocore will automatically construct the appropriate URL
-            to use when communicating with a service.  You can specify a
-            complete URL (including the "http/https" scheme) to override this
-            behavior.  If this value is provided, then ``use_ssl`` is ignored.
+        :param endpoint_url: The complete URL to use for the constructed
+            client.  Normally, botocore will automatically construct the
+            appropriate URL to use when communicating with a service.  You can
+            specify a complete URL (including the "http/https" scheme) to
+            override this behavior.  If this value is provided, then
+            ``use_ssl`` is ignored.
 
         :type aws_access_key_id: string
         :param aws_access_key_id: The access key to use when creating

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -49,20 +49,6 @@ class Session(object):
     :ivar profile: The current profile.
     """
 
-    #: A dictionary where each key is an event name and the value
-    #: is the formatting string used to construct a new event.
-    ALL_EVENTS = {
-        'after-call': '.%s.%s',
-        'after-parsed': '.%s.%s.%s.%s',
-        'before-parameter-build': '.%s.%s',
-        'before-call': '.%s.%s',
-        'service-created': '',
-        'service-data-loaded': '.%s',
-        'creating-endpoint': '.%s',
-        'before-auth': '.%s',
-        'needs-retry': '.%s.%s',
-    }
-
     #: A default dictionary that maps the logical names for session variables
     #: to the specific environment variables and configuration file names
     #: that contain the values for these variables.
@@ -521,8 +507,8 @@ class Session(object):
             type_name='service-2',
             api_version=api_version
         )
-        event_name = self.create_event('service-data-loaded', service_name)
-        self._events.emit(event_name, service_data=service_data,
+        self._events.emit('service-data-loaded.%s' % service_name,
+                          service_data=service_data,
                           service_name=service_name, session=self)
         return service_data
 
@@ -678,44 +664,6 @@ class Session(object):
         self._events.unregister(event_name, handler=handler,
                                 unique_id=unique_id,
                                 unique_id_uses_count=unique_id_uses_count)
-
-    def register_event(self, event_name, fmtstr):
-        """
-        Register a new event.  The event will be added to ``ALL_EVENTS``
-        and will then be able to be created using ``create_event``.
-
-        :type event_name: str
-        :param event_name: The base name of the event.
-
-        :type fmtstr: str
-        :param fmtstr: The formatting string for the event.
-        """
-        if event_name not in self.ALL_EVENTS:
-            self.ALL_EVENTS[event_name] = fmtstr
-
-    def create_event(self, event_name, *fmtargs):
-        """
-        Creates a new event string that can then be emitted.
-        You could just create it manually, since it's just
-        a string but this helps to define the range of known events.
-
-        :type event_name: str
-        :param event_name: The base name of the new event.
-
-        :type fmtargs: tuple
-        :param fmtargs: A tuple of values that will be used as the
-            arguments pass to the string formatting operation.  The
-            actual values passed depend on the type of event you
-            are creating.
-        """
-        if event_name in self.ALL_EVENTS:
-            fmt_string = self.ALL_EVENTS[event_name]
-            if fmt_string:
-                event = event_name + (fmt_string % fmtargs)
-            else:
-                event = event_name
-            return event
-        raise EventNotFound(event_name=event_name)
 
     def emit(self, event_name, **kwargs):
         return self._events.emit(event_name, **kwargs)

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -49,6 +49,8 @@ class Session(object):
     :ivar profile: The current profile.
     """
 
+    #: A dictionary where each key is an event name and the value
+    #: is the formatting string used to construct a new event.
     ALL_EVENTS = {
         'after-call': '.%s.%s',
         'after-parsed': '.%s.%s.%s.%s',
@@ -60,11 +62,25 @@ class Session(object):
         'before-auth': '.%s',
         'needs-retry': '.%s.%s',
     }
-    """
-    A dictionary where each key is an event name and the value
-    is the formatting string used to construct a new event.
-    """
 
+    #: A default dictionary that maps the logical names for session variables
+    #: to the specific environment variables and configuration file names
+    #: that contain the values for these variables.
+    #: When creating a new Session object, you can pass in your own dictionary
+    #: to remap the logical names or to add new logical names.  You can then
+    #: get the current value for these variables by using the
+    #: ``get_config_variable`` method of the :class:`botocore.session.Session`
+    #: class.
+    #: These form the keys of the dictionary.  The values in the dictionary
+    #: are tuples of (<config_name>, <environment variable>, <default value).
+    #: The ``profile`` and ``config_file`` variables should always have a
+    #: None value for the first entry in the tuple because it doesn't make
+    #: sense to look inside the config file for the location of the config
+    #: file or for the default profile to use.
+    #: The ``config_name`` is the name to look for in the configuration file,
+    #: the ``env var`` is the OS environment variable (``os.environ``) to
+    #: use, and ``default_value`` is the value to use if no value is otherwise
+    #: found.
     SESSION_VARIABLES = {
         # logical:  config_file, env_var,        default_value
         'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None),
@@ -87,30 +103,9 @@ class Session(object):
         # up trying to retrieve data from the instance metadata service.
         'metadata_service_num_attempts': ('metadata_service_num_attempts',
                                           None, 1),
-        }
-    """
-    A default dictionary that maps the logical names for session variables
-    to the specific environment variables and configuration file names
-    that contain the values for these variables.
+    }
 
-    When creating a new Session object, you can pass in your own dictionary to
-    remap the logical names or to add new logical names.  You can then get the
-    current value for these variables by using the ``get_config_variable``
-    method of the :class:`botocore.session.Session` class.
-
-    These form the keys of the dictionary.  The values in the dictionary
-    are tuples of (<config_name>, <environment variable>, <default value).
-    The ``profile`` and ``config_file`` variables should always have a
-    None value for the first entry in the tuple because it doesn't make
-    sense to look inside the config file for the location of the config
-    file or for the default profile to use.
-
-    The ``config_name`` is the name to look for in the configuration file,
-    the ``env var`` is the OS environment variable (``os.environ``) to
-    use, and ``default_value`` is the value to use if no value is otherwise
-    found.
-    """
-
+    #: The default format string to use when configuring the botocore logger.
     LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
     def __init__(self, session_vars=None, event_hooks=None,

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -54,7 +54,7 @@ class Session(object):
     :ivar profile: The current profile.
     """
 
-    AllEvents = {
+    ALL_EVENTS = {
         'after-call': '.%s.%s',
         'after-parsed': '.%s.%s.%s.%s',
         'before-parameter-build': '.%s.%s',
@@ -116,7 +116,7 @@ class Session(object):
     found.
     """
 
-    FmtString = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
     def __init__(self, session_vars=None, event_hooks=None,
                  include_builtin_handlers=True, loader=None):
@@ -562,7 +562,7 @@ class Session(object):
         :type format_string: str
         :param format_string: The format string to use for the log
             formatter.  If none is provided this will default to
-            ``self.FmtString``.
+            ``self.LOG_FORMAT``.
 
         """
         log = logging.getLogger(logger_name)
@@ -573,7 +573,7 @@ class Session(object):
 
         # create formatter
         if format_string is None:
-            format_string = self.FmtString
+            format_string = self.LOG_FORMAT
         formatter = logging.Formatter(format_string)
 
         # add formatter to ch
@@ -602,7 +602,7 @@ class Session(object):
         ch.setLevel(log_level)
 
         # create formatter
-        formatter = logging.Formatter(self.FmtString)
+        formatter = logging.Formatter(self.LOG_FORMAT)
 
         # add formatter to ch
         ch.setFormatter(formatter)
@@ -683,7 +683,7 @@ class Session(object):
 
     def register_event(self, event_name, fmtstr):
         """
-        Register a new event.  The event will be added to ``AllEvents``
+        Register a new event.  The event will be added to ``ALL_EVENTS``
         and will then be able to be created using ``create_event``.
 
         :type event_name: str
@@ -692,8 +692,8 @@ class Session(object):
         :type fmtstr: str
         :param fmtstr: The formatting string for the event.
         """
-        if event_name not in self.AllEvents:
-            self.AllEvents[event_name] = fmtstr
+        if event_name not in self.ALL_EVENTS:
+            self.ALL_EVENTS[event_name] = fmtstr
 
     def create_event(self, event_name, *fmtargs):
         """
@@ -710,8 +710,8 @@ class Session(object):
             actual values passed depend on the type of event you
             are creating.
         """
-        if event_name in self.AllEvents:
-            fmt_string = self.AllEvents[event_name]
+        if event_name in self.ALL_EVENTS:
+            fmt_string = self.ALL_EVENTS[event_name]
             if fmt_string:
                 event = event_name + (fmt_string % fmtargs)
             else:

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -22,6 +22,7 @@ import os
 import platform
 import shlex
 import warnings
+from collections import namedtuple
 
 from botocore import __version__
 import botocore.config
@@ -248,8 +249,7 @@ class Session(object):
         self._reset_components()
 
     def get_config_variable(self, logical_name,
-                            methods=('instance', 'env', 'config'),
-                            default=None):
+                            methods=('instance', 'env', 'config')):
         """
         Retrieve the value associated with the specified logical_name
         from the environment or the config file.  Values found in the
@@ -269,20 +269,10 @@ class Session(object):
             by supplying a different value to this parameter.
             Valid choices are: instance|env|config
 
-        :param default: The default value to return if there is no
-            value associated with the config file.  This value will
-            override any default value specified in ``SessionVariables``.
-
-        :returns: str value of variable of None if not defined.
+        :returns: value of variable or None if not defined.
 
         """
         value = None
-        # There's two types of defaults here.  One if the
-        # default value specified in the SessionVariables.
-        # The second is an explicit default value passed into this
-        # function (the default parameter).
-        # config_default is tracking the default value specified
-        # in the SessionVariables.
         config_default = None
         if logical_name in self.session_var_map:
             # Short circuit case, check if the var has been explicitly
@@ -303,11 +293,6 @@ class Session(object):
                 if config_name:
                     config = self.get_scoped_config()
                     value = config.get(config_name)
-        # If we don't have a value at this point, we need to try to assign
-        # a default value.  An explicit default argument will win over the
-        # default value from SessionVariables.
-        if value is None and default is not None:
-            value = default
         if value is None and config_default is not None:
             value = config_default
         return value

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -25,7 +25,7 @@ from botocore import __version__
 import botocore.config
 import botocore.credentials
 import botocore.client
-from botocore.exceptions import EventNotFound, ConfigNotFound, ProfileNotFound
+from botocore.exceptions import ConfigNotFound, ProfileNotFound
 from botocore import handlers
 from botocore.hooks import HierarchicalEmitter, first_non_none_response
 from botocore.loaders import create_loader

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,14 @@ Contents:
 Upgrade Notes
 =============
 
+Upgrading to 1.0.0rc1
+---------------------
+
+* The ``default`` argument to ``session.get_config_variable()`` has been
+  removed.  If you need this functionality you can use::
+
+        value = session.get_config_variable() or 'default value'
+
 Upgrading to 0.104.0
 --------------------
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -55,8 +55,7 @@ class TestHandlers(BaseSessionTest):
 
     def test_quote_source_header(self):
         for op in ('UploadPartCopy', 'CopyObject'):
-            event = self.session.create_event(
-                'before-call', 's3', op)
+            event = 'before-call.s3.%s' % op
             params = {'headers': {'x-amz-copy-source': 'foo++bar.txt'}}
             m = mock.Mock()
             self.session.emit(event, params=params, model=m)
@@ -148,8 +147,7 @@ class TestHandlers(BaseSessionTest):
     def test_sse_params(self):
         for op in ('HeadObject', 'GetObject', 'PutObject', 'CopyObject',
                    'CreateMultipartUpload', 'UploadPart', 'UploadPartCopy'):
-            event = self.session.create_event(
-                'before-parameter-build', 's3', op)
+            event = 'before-parameter-build.s3.%s' % op
             params = {'SSECustomerKey': b'bar',
                       'SSECustomerAlgorithm': 'AES256'}
             self.session.emit(event, params=params, model=mock.Mock())
@@ -158,8 +156,7 @@ class TestHandlers(BaseSessionTest):
                              'N7UdGUp1E+RbVvZSTy1R8g==')
 
     def test_sse_params_as_str(self):
-        event = self.session.create_event(
-            'before-parameter-build', 's3', 'PutObject')
+        event = 'before-parameter-build.s3.PutObject'
         params = {'SSECustomerKey': 'bar',
                   'SSECustomerAlgorithm': 'AES256'}
         self.session.emit(event, params=params, model=mock.Mock())
@@ -168,8 +165,7 @@ class TestHandlers(BaseSessionTest):
                             'N7UdGUp1E+RbVvZSTy1R8g==')
 
     def test_route53_resource_id(self):
-        event = self.session.create_event(
-            'before-parameter-build', 'route53', 'GetHostedZone')
+        event = 'before-parameter-build.route53.GetHostedZone'
         params = {'Id': '/hostedzone/ABC123',
                   'HostedZoneId': '/hostedzone/ABC123',
                   'ResourceId': '/hostedzone/DEF456',
@@ -227,8 +223,7 @@ class TestHandlers(BaseSessionTest):
         self.assertEqual(params['Other'], '/hostedzone/foo')
 
     def test_route53_resource_id_missing_input_shape(self):
-        event = self.session.create_event(
-            'before-parameter-build', 'route53', 'GetHostedZone')
+        event = 'before-parameter-build.route53.GetHostedZone'
         params = {'HostedZoneId': '/hostedzone/ABC123',}
         operation_def = {
             'name': 'GetHostedZone'
@@ -245,8 +240,7 @@ class TestHandlers(BaseSessionTest):
     def test_run_instances_userdata(self):
         user_data = 'This is a test'
         b64_user_data = base64.b64encode(six.b(user_data)).decode('utf-8')
-        event = self.session.create_event(
-            'before-parameter-build', 'ec2', 'RunInstances')
+        event = 'before-parameter-build.ec2.RunInstances'
         params = dict(ImageId='img-12345678',
                       MinCount=1, MaxCount=5, UserData=user_data)
         self.session.emit(event, params=params)
@@ -262,8 +256,7 @@ class TestHandlers(BaseSessionTest):
         # user data.
         user_data = b'\xc7\xa9This is a test'
         b64_user_data = base64.b64encode(user_data).decode('utf-8')
-        event = self.session.create_event(
-            'before-parameter-build', 'ec2', 'RunInstances')
+        event = 'before-parameter-build.ec2.RunInstances'
         params = dict(ImageId='img-12345678',
                       MinCount=1, MaxCount=5, UserData=user_data)
         self.session.emit(event, params=params)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -20,6 +20,7 @@ import copy
 import botocore
 import botocore.session
 from botocore.compat import quote, six
+from botocore.awsrequest import AWSRequest
 from botocore.model import OperationModel, ServiceModel
 from botocore.signers import RequestSigner
 from botocore.credentials import Credentials

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -19,8 +19,6 @@ import copy
 
 import botocore
 import botocore.session
-from botocore.hooks import first_non_none_response
-from botocore.awsrequest import AWSRequest
 from botocore.compat import quote, six
 from botocore.model import OperationModel, ServiceModel
 from botocore.signers import RequestSigner
@@ -162,7 +160,7 @@ class TestHandlers(BaseSessionTest):
         self.session.emit(event, params=params, model=mock.Mock())
         self.assertEqual(params['SSECustomerKey'], 'YmFy')
         self.assertEqual(params['SSECustomerKeyMD5'],
-                            'N7UdGUp1E+RbVvZSTy1R8g==')
+                         'N7UdGUp1E+RbVvZSTy1R8g==')
 
     def test_route53_resource_id(self):
         event = 'before-parameter-build.route53.GetHostedZone'
@@ -224,7 +222,7 @@ class TestHandlers(BaseSessionTest):
 
     def test_route53_resource_id_missing_input_shape(self):
         event = 'before-parameter-build.route53.GetHostedZone'
-        params = {'HostedZoneId': '/hostedzone/ABC123',}
+        params = {'HostedZoneId': '/hostedzone/ABC123'}
         operation_def = {
             'name': 'GetHostedZone'
         }
@@ -462,7 +460,3 @@ class TestRetryHandlerOrder(BaseSessionTest):
         self.assertTrue(s3_200_handler < general_retry_handler,
                         "S3 200 error handler was supposed to be before "
                         "the general retry handler, but it was not.")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -35,11 +35,11 @@ class BaseSessionTest(unittest.TestCase):
 
     def setUp(self):
         self.env_vars = {
-            'profile': (None, 'FOO_PROFILE', None),
-            'region': ('foo_region', 'FOO_REGION', None),
-            'data_path': ('data_path', 'FOO_DATA_PATH', None),
-            'config_file': (None, 'FOO_CONFIG_FILE', None),
-            'credentials_file': (None, None, '/tmp/nowhere'),
+            'profile': (None, 'FOO_PROFILE', None, None),
+            'region': ('foo_region', 'FOO_REGION', None, None),
+            'data_path': ('data_path', 'FOO_DATA_PATH', None, None),
+            'config_file': (None, 'FOO_CONFIG_FILE', None, None),
+            'credentials_file': (None, None, '/tmp/nowhere', None),
         }
         self.environ = {}
         self.environ_patch = mock.patch('os.environ', self.environ)
@@ -78,7 +78,8 @@ class SessionTest(BaseSessionTest):
 
     def test_supports_multiple_env_vars_for_single_logical_name(self):
         env_vars = {
-            'profile': (None, ['BAR_DEFAULT_PROFILE', 'BAR_PROFILE'], None),
+            'profile': (None, ['BAR_DEFAULT_PROFILE', 'BAR_PROFILE'],
+                        None, None),
         }
         session = create_session(session_vars=env_vars)
         self.environ['BAR_DEFAULT_PROFILE'] = 'first'
@@ -87,7 +88,8 @@ class SessionTest(BaseSessionTest):
 
     def test_multiple_env_vars_uses_second_var(self):
         env_vars = {
-            'profile': (None, ['BAR_DEFAULT_PROFILE', 'BAR_PROFILE'], None),
+            'profile': (None, ['BAR_DEFAULT_PROFILE', 'BAR_PROFILE'],
+                        None, None),
         }
         session = create_session(session_vars=env_vars)
         self.environ.pop('BAR_DEFAULT_PROFILE', None)
@@ -132,6 +134,19 @@ class SessionTest(BaseSessionTest):
         # that foo_access_key which is defined in the config
         # file should be present in the loaded config dict.
         self.assertIn('aws_access_key_id', config)
+
+    def test_type_conversions_occur_when_specified(self):
+        # Specify that we can retrieve the var from the
+        # FOO_TIMEOUT env var, with a conversion function
+        # of int().
+        self.env_vars['metadata_service_timeout'] = (
+            None, 'FOO_TIMEOUT', None, int)
+        # Environment variables are always strings.
+        self.environ['FOO_TIMEOUT'] = '10'
+        session = create_session(session_vars=self.env_vars)
+        # But we should type convert this to a string.
+        self.assertEqual(
+            session.get_config_variable('metadata_service_timeout'), 10)
 
     def test_default_profile_specified_raises_exception(self):
         # If you explicity set the default profile and you don't
@@ -288,7 +303,8 @@ class TestBuiltinEventHandlers(BaseSessionTest):
 
 class TestSessionConfigurationVars(BaseSessionTest):
     def test_per_session_config_vars(self):
-        self.session.session_var_map['foobar'] = (None, 'FOOBAR', 'default')
+        self.session.session_var_map['foobar'] = (None, 'FOOBAR',
+                                                  'default', None)
         # Default value.
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
         # Retrieve from os environment variable.
@@ -306,7 +322,8 @@ class TestSessionConfigurationVars(BaseSessionTest):
             'foobar', methods=('env', 'config')), 'default')
 
     def test_default_value_can_be_overriden(self):
-        self.session.session_var_map['foobar'] = (None, 'FOOBAR', 'default')
+        self.session.session_var_map['foobar'] = (None, 'FOOBAR', 'default',
+                                                  None)
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -307,12 +307,7 @@ class TestSessionConfigurationVars(BaseSessionTest):
 
     def test_default_value_can_be_overriden(self):
         self.session.session_var_map['foobar'] = (None, 'FOOBAR', 'default')
-        # Default value.
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
-        self.assertEqual(
-            self.session.get_config_variable('foobar',
-                                             default='per-call-default'),
-            'per-call-default')
 
 
 class TestSessionUserAgent(BaseSessionTest):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -232,19 +232,6 @@ class SessionTest(BaseSessionTest):
         response = session.emit_first_non_none_response('foo')
         self.assertEqual(response, 'first')
 
-    def test_create_events(self):
-        event = self.session.create_event('before-call', 'foo', 'bar')
-        self.assertEqual(event, 'before-call.foo.bar')
-        event = self.session.create_event('after-call', 'foo', 'bar')
-        self.assertEqual(event, 'after-call.foo.bar')
-        event = self.session.create_event('after-parsed', 'foo',
-                                          'bar', 'fie', 'baz')
-        self.assertEqual(event, 'after-parsed.foo.bar.fie.baz')
-        event = self.session.create_event('service-created')
-        self.assertEqual(event, 'service-created')
-        self.assertRaises(botocore.exceptions.EventNotFound,
-                          self.session.create_event, 'foo-bar')
-
     @mock.patch('logging.getLogger')
     @mock.patch('logging.FileHandler')
     def test_logger_name_can_be_passed_in(self, file_handler, get_logger):


### PR DESCRIPTION
This is primarily to address #395, where the `metadata_*` variables need to be converted to integers.

To fix this, the session var mappings now have an additional field, which is a conversion function, which if provided, will be called before returning the value in `get_config_variable`.

The main change is provided in https://github.com/boto/botocore/commit/b0ea7bc62550665488a69ca0beeb9a240f249c50.  I've also included a number of commits for code cleanup to the session module.

Additionally, I've made one change to the signature of `get_config_variable` which is to remove the `default` argument.  This simplifies the code logic, and nothing in botocore, the cli, nor boto3 used this functionality.  I'd prefer to remove this until there's a strong case for adding this back.  It also simplifies the code logic.

This will also require a corresponding change to the CLI.

cc @kyleknap @mtdowling