### PR TITLE
Fix issue with machinelearning predict

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -24,7 +24,7 @@ import re
 import xml.etree.cElementTree
 import copy
 
-from botocore.compat import unquote, json, quote, six
+from botocore.compat import urlsplit, urlunsplit, unquote, json, quote, six
 from botocore.docs.utils import AutoPopulatedParam
 from botocore.signers import add_generate_presigned_url
 from botocore.signers import add_generate_presigned_post

--- a/tests/functional/test_machinelearning.py
+++ b/tests/functional/test_machinelearning.py
@@ -27,7 +27,7 @@ class TestMachineLearning(BaseSessionTest):
                 http_session_send_patch:
             http_response = mock.Mock()
             http_response.status_code = 200
-            http_response.content = '{}'
+            http_response.content = b'{}'
             http_response.headers = {}
             http_session_send_patch.return_value = http_response
             custom_endpoint = 'https://myendpoint.amazonaws.com/'

--- a/tests/functional/test_machinelearning.py
+++ b/tests/functional/test_machinelearning.py
@@ -1,0 +1,40 @@
+# Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+
+from tests import BaseSessionTest
+
+
+class TestMachineLearning(BaseSessionTest):
+    def setUp(self):
+        super(TestMachineLearning, self).setUp()
+        self.region = 'us-west-2'
+        self.client = self.session.create_client(
+            'machinelearning', self.region)
+
+    def test_predict(self):
+        with mock.patch('botocore.endpoint.Session.send') as \
+                http_session_send_patch:
+            http_response = mock.Mock()
+            http_response.status_code = 200
+            http_response.content = '{}'
+            http_response.headers = {}
+            http_session_send_patch.return_value = http_response
+            custom_endpoint = 'https://myendpoint.amazonaws.com/'
+            self.client.predict(
+                MLModelId='ml-foo',
+                Record={'Foo': 'Bar'},
+                PredictEndpoint=custom_endpoint
+            )
+            sent_request = http_session_send_patch.call_args[0][0]
+            self.assertEqual(sent_request.url, custom_endpoint)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -425,6 +425,16 @@ class TestHandlers(BaseSessionTest):
             request_dict['headers']['x-amz-sha256-tree-hash'],
             'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9')
 
+    def test_switch_host_with_param(self):
+        request = AWSRequest()
+        url = 'https://machinelearning.us-east-1.amazonaws.com'
+        new_endpoint = 'https://my-custom-endpoint.amazonaws.com'
+        data = '{"PredictEndpoint":"%s"}' % new_endpoint
+        request.data = data
+        request.url = url
+        handlers.switch_host_with_param(request, 'PredictEndpoint')
+        self.assertEqual(request.url, new_endpoint)
+
 
 class TestRetryHandlerOrder(BaseSessionTest):
     def get_handler_names(self, responses):


### PR DESCRIPTION
Fixes the issue brought up in the forums:
https://forums.aws.amazon.com/thread.jspa?threadID=182689&tstart=0 

We have tests for machinelearning in the CLI but that mocks out the ``make_request`` method of the endpoint so the handler for machine learning was never called.

cc @jamesls @mtdowling 