### PR TITLE
Use more random random names

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,6 +19,7 @@ import random
 import shutil
 import contextlib
 import tempfile
+import binascii
 
 
 # The unittest module got a significant overhaul
@@ -33,6 +34,15 @@ else:
 import botocore.loaders
 import botocore.session
 _LOADER = botocore.loaders.Loader()
+
+
+def random_chars(num_chars):
+    """Returns random hex characters.
+
+    Useful for creating resources with random names.
+
+    """
+    return binascii.hexlify(os.urandom(int(num_chars / 2))).decode('ascii')
 
 
 def create_session(**kwargs):

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -11,10 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
-import random
 import logging
 import datetime
-from tests import unittest
+from tests import unittest, random_chars
 
 import botocore.session
 from botocore.client import ClientError
@@ -27,8 +26,7 @@ class TestBucketWithVersions(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
         self.client = self.session.create_client('s3', region_name='us-west-2')
-        self.bucket_name = 'botocoretest%s-%s' % (
-            int(time.time()), random.randint(1, 1000000))
+        self.bucket_name = 'botocoretest%s' % random_chars(50)
 
     def extract_version_ids(self, versions):
         version_ids = []

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
-import random
+from tests import unittest, random_chars
 
 import botocore.session
 from botocore.exceptions import ClientError
@@ -27,7 +26,7 @@ class TestCloudformation(unittest.TestCase):
         # it handles the case when a stack does not exist.
         with self.assertRaises(ClientError):
             self.client.get_template(
-                StackName='does-not-exist-%s' % random.randint(1, 10000))
+                StackName='does-not-exist-%s' % random_chars(10))
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_cognito_identity.py
+++ b/tests/integration/test_cognito_identity.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
-import random
+from tests import unittest, random_chars
 
 import botocore.session
 
@@ -22,7 +21,7 @@ class TestCognitoIdentity(unittest.TestCase):
         self.client = self.session.create_client('cognito-identity', 'us-east-1')
 
     def test_can_create_and_delete_identity_pool(self):
-        pool_name = 'botocoretest%s' % random.randint(1, 100000)
+        pool_name = 'test%s' % random_chars(10)
         response = self.client.create_identity_pool(
             IdentityPoolName=pool_name, AllowUnauthenticatedIdentities=True)
         self.client.delete_identity_pool(IdentityPoolId=response['IdentityPoolId'])

--- a/tests/integration/test_elastictranscoder.py
+++ b/tests/integration/test_elastictranscoder.py
@@ -11,9 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest
+from tests import unittest, random_chars
 import functools
-import random
 
 import botocore.session
 
@@ -39,14 +38,14 @@ class TestElasticTranscoder(unittest.TestCase):
         self.iam_client = self.session.create_client('iam', 'us-east-1')
 
     def create_bucket(self):
-        bucket_name = 'ets-bucket-1-%s' % random.randint(1, 1000000)
+        bucket_name = 'ets-bucket-1-%s' % random_chars(50)
         self.s3_client.create_bucket(Bucket=bucket_name)
         self.addCleanup(
             self.s3_client.delete_bucket, Bucket=bucket_name)
         return bucket_name
 
     def create_iam_role(self):
-        role_name = 'ets-role-name-1-%s' % random.randint(1, 1000000)
+        role_name = 'ets-role-name-1-%s' % random_chars(10)
         parsed = self.iam_client.create_role(
             RoleName=role_name,
             AssumeRolePolicyDocument=DEFAULT_ROLE_POLICY)
@@ -69,7 +68,7 @@ class TestElasticTranscoder(unittest.TestCase):
         input_bucket = self.create_bucket()
         output_bucket = self.create_bucket()
         role = self.create_iam_role()
-        pipeline_name = 'botocore-test-create-%s' % (random.randint(1, 1000000))
+        pipeline_name = 'botocore-test-create-%s' % random_chars(10)
 
         parsed = self.client.create_pipeline(
             InputBucket=input_bucket, OutputBucket=output_bucket,

--- a/tests/integration/test_glacier.py
+++ b/tests/integration/test_glacier.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from tests import unittest
-import random
 
 from botocore.exceptions import ClientError
 from botocore.vendored import six

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -11,8 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
-import random
-from tests import unittest
+from tests import unittest, random_chars
 
 from nose.plugins.attrib import attr
 
@@ -29,8 +28,7 @@ class TestKinesisListStreams(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.session = botocore.session.get_session()
-        cls.stream_name = 'botocore-test-%s-%s' % (int(time.time()),
-                                                   random.randint(1, 100))
+        cls.stream_name = 'botocore-test-%s' % random_chars(10)
         client = cls.session.create_client('kinesis', cls.REGION)
         client.create_stream(StreamName=cls.stream_name,
                              ShardCount=1)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 import os
 import time
-from tests import unittest, temporary_file
+from tests import unittest, temporary_file, random_chars
 from collections import defaultdict
 import tempfile
 import shutil
@@ -38,13 +38,9 @@ from botocore.client import Config
 
 
 def random_bucketname():
-    # Shooting for a max length of 63:
+    # 63 is the max bucket length.
     bucket_name = 'botocoretest'
-    # 1 byte -> 2 hex chars so we need to divide
-    # the remaining available length by 2.
-    bucket_name += binascii.hexlify(
-        os.urandom(int((63 - len(bucket_name)) / 2))).decode('ascii')
-    return bucket_name
+    return bucket_name + random_chars(63 - len(bucket_name))
 
 
 class BaseS3ClientTest(unittest.TestCase):

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
-import random
 from tests import unittest
 
 import botocore.session

--- a/tests/integration/test_waiters.py
+++ b/tests/integration/test_waiters.py
@@ -11,8 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
-import random
-from tests import unittest
+from tests import unittest, random_chars
 
 from nose.plugins.attrib import attr
 
@@ -28,7 +27,7 @@ class TestWaiterForDynamoDB(unittest.TestCase):
         self.client = self.session.create_client('dynamodb', 'us-west-2')
 
     def test_create_table_and_wait(self):
-        table_name = 'botocoretestddb-%s' % random.randint(1, 10000)
+        table_name = 'botocoretest-%s' % random_chars(10)
         self.client.create_table(
             TableName=table_name,
             ProvisionedThroughput={"ReadCapacityUnits": 5,


### PR DESCRIPTION
Fixes occasional integ test failures.

Removed all calls to `random.random` in integ tests.

cc @kyleknap @mtdowling