### PR TITLE
[WIP] Conditionally add Content-MD5 in S3 when not sigv4

### DIFF
--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -19,7 +19,6 @@ import copy
 
 import botocore
 import botocore.session
-from botocore.hooks import first_non_none_response
 from botocore.awsrequest import AWSRequest
 from botocore.compat import quote, six
 from botocore.model import OperationModel, ServiceModel
@@ -434,6 +433,30 @@ class TestHandlers(BaseSessionTest):
         request.url = url
         handlers.switch_host_with_param(request, 'PredictEndpoint')
         self.assertEqual(request.url, new_endpoint)
+
+    def test_does_not_add_md5_when_v4(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 'v4', credentials, None)
+        request_dict = {'body': 'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+        handlers.conditionally_calculate_md5(request_dict,
+                                             request_signer=request_signer)
+        self.assertTrue('Content-MD5' not in request_dict['headers'])
+
+    def test_adds_md5_when_not_v4(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 's3', credentials, None)
+        request_dict = {'body': 'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+        handlers.conditionally_calculate_md5(request_dict,
+                                             request_signer=request_signer)
+        self.assertTrue('Content-MD5' in request_dict['headers'])
 
 
 class TestRetryHandlerOrder(BaseSessionTest):


### PR DESCRIPTION
This PR conditionally adds a Content-MD5 to several S3 operations when the following constraints are met:

1. Not using signature version 4 (because a Content-SHA256 header is already used).
2. When a Content-MD5 is not already present.

I ran into a few issues with this commit because a file is being passed into the "body" parameter of a request dict, but `six.b` requires a buffer or string: `md5.update(six.b(params['body']))`
