### PR TITLE
Fix custom method documentation

### DIFF
--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -13,7 +13,7 @@
 import inspect
 
 from botocore.docs.utils import get_official_service_name
-from botocore.docs.method import document_custom_signature
+from botocore.docs.method import document_custom_method
 from botocore.docs.method import document_model_driven_method
 from botocore.docs.method import get_instance_public_methods
 
@@ -83,12 +83,7 @@ class ClientDocumenter(object):
         return method_name not in self._client.meta.method_to_api_mapping
 
     def _add_custom_method(self, section, method_name, method):
-        document_custom_signature(
-            section, method_name, method)
-        method_intro_section = section.add_new_section('method-intro')
-        doc_string = inspect.getdoc(method)
-        if doc_string is not None:
-            method_intro_section.style.write_py_doc_string(doc_string)
+        document_custom_method(section, method_name, method)
 
     def _add_model_driven_method(self, section, method_name):
         service_model = self._client.meta.service_model

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -108,6 +108,24 @@ def document_custom_signature(section, name, method,
     section.style.start_sphinx_py_method(name, signature_params)
 
 
+def document_custom_method(section, method_name, method):
+    """Documents a non-data driven method
+
+    :param section: The section to write the documentation to.
+
+    :param method_name: The name of the method
+
+    :param method: The handle to the method being documented
+    """
+    document_custom_signature(
+        section, method_name, method)
+    method_intro_section = section.add_new_section('method-intro')
+    method_intro_section.writeln('')
+    doc_string = inspect.getdoc(method)
+    if doc_string is not None:
+        method_intro_section.style.write_py_doc_string(doc_string)
+
+
 def document_model_driven_method(section, method_name, operation_model,
                                  event_emitter, method_description=None,
                                  example_prefix=None, include_input=None,

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -164,7 +164,7 @@ class RequestSigner(object):
         :type region_name: string
         :param region_name: The region name to sign the presigned url.
 
-        returns: The presigned url
+        :returns: The presigned url
         """
         if region_name is None:
             region_name = self._region_name
@@ -318,7 +318,7 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     :param HttpMethod: The http method to use on the generated url. By
         default, the http method is whatever is used in the method's model.
 
-    returns: The presigned url
+    :returns: The presigned url
     """
     client_method = ClientMethod
     params = Params

--- a/tests/unit/docs/test_method.py
+++ b/tests/unit/docs/test_method.py
@@ -15,6 +15,7 @@ from tests.unit.docs import BaseDocsTest
 from botocore.hooks import HierarchicalEmitter
 from botocore.docs.method import document_model_driven_signature
 from botocore.docs.method import document_custom_signature
+from botocore.docs.method import document_custom_method
 from botocore.docs.method import document_model_driven_method
 from botocore.docs.method import get_instance_public_methods
 from botocore.docs.utils import DocumentedShape
@@ -79,6 +80,26 @@ class TestDocumentCustomSignature(BaseDocsTest):
             self.doc_structure, 'my_method', self.sample_method)
         self.assert_contains_line(
             '.. py:method:: my_method(foo, bar=\'bar\', baz=None)')
+
+
+class TestDocumentCustomMethod(BaseDocsTest):
+    def custom_method(self, foo):
+        """This is a custom method
+
+        :type foo: string
+        :param foo: The foo parameter
+        """
+        pass
+
+    def test_document_custom_signature(self):
+        document_custom_method(
+            self.doc_structure, 'my_method', self.custom_method)
+        self.assert_contains_lines_in_order([
+            '.. py:method:: my_method(foo)',
+            '  This is a custom method',
+            '  :type foo: string',
+            '  :param foo: The foo parameter'
+        ])
 
 
 class TestDocumentModelDrivenMethod(BaseDocsTest):


### PR DESCRIPTION
Also, extracted logic to new method and fixed a doc string in the presigner methods.

The old documentation looked like this:
![screen shot 2015-06-17 at 2 53 41 pm](https://cloud.githubusercontent.com/assets/4605355/8219761/28667798-1501-11e5-84c1-da4b02389ba4.png)

The new documentation looks like this:
![screen shot 2015-06-17 at 2 56 41 pm](https://cloud.githubusercontent.com/assets/4605355/8219766/350e76c6-1501-11e5-8127-05f3c3695041.png)

The main difference being the docstring is fixed on the returns and there is no more paragraph block surrounding the summary of the doc string.

cc @jamesls @mtdowling 
