### PR TITLE
Fix put_object when body is a bytes

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -242,7 +242,9 @@ class SigV4Auth(BaseSigner):
             request.body.seek(position)
             return hex_checksum
         elif request.body:
-            return sha256(request.body.encode('utf-8')).hexdigest()
+            # The request serialization has ensured that
+            # request.body is a bytes() type.
+            return sha256(request.body).hexdigest()
         else:
             return EMPTY_SHA256_HASH
 

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -383,7 +383,7 @@ def switch_host_machinelearning(request, **kwargs):
 
 
 def switch_host_with_param(request, param_name):
-    request_json = json.loads(request.data)
+    request_json = json.loads(request.data.decode('utf-8'))
     if request_json.get(param_name):
         new_endpoint = request_json[param_name]
         new_endpoint_components = urlsplit(new_endpoint)

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -302,7 +302,7 @@ class JSONSerializer(Serializer):
         input_shape = operation_model.input_shape
         if input_shape is not None:
             self._serialize(body, parameters, input_shape)
-        serialized['body'] = json.dumps(body).encode('utf-8')
+        serialized['body'] = json.dumps(body).encode(self.DEFAULT_ENCODING)
         return serialized
 
     def _serialize(self, serialized, value, shape, key=None):
@@ -513,7 +513,7 @@ class RestJSONSerializer(BaseRestSerializer, JSONSerializer):
     def _serialize_body_params(self, params, shape):
         serialized_body = self.MAP_TYPE()
         self._serialize(serialized_body, params, shape)
-        return json.dumps(serialized_body).encode('utf-8')
+        return json.dumps(serialized_body).encode(self.DEFAULT_ENCODING)
 
 
 class RestXMLSerializer(BaseRestSerializer):
@@ -524,8 +524,7 @@ class RestXMLSerializer(BaseRestSerializer):
         pseudo_root = ElementTree.Element('')
         self._serialize(shape, params, pseudo_root, root_name)
         real_root = list(pseudo_root)[0]
-        # TODO: double check on the utf-8 encoding bit.
-        return ElementTree.tostring(real_root, encoding='utf-8')
+        return ElementTree.tostring(real_root, encoding=self.DEFAULT_ENCODING)
 
     def _serialize(self, shape, params, xmlnode, name):
         method = getattr(self, '_serialize_type_%s' % shape.type_name,

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -119,8 +119,8 @@ class Serializer(object):
             'query_string': '',
             'method': self.DEFAULT_METHOD,
             'headers': {},
-            # An empty body is represented as an empty string.
-            'body': ''
+            # An empty body is represented as an empty byte string.
+            'body': b''
         }
         return serialized
 
@@ -302,7 +302,7 @@ class JSONSerializer(Serializer):
         input_shape = operation_model.input_shape
         if input_shape is not None:
             self._serialize(body, parameters, input_shape)
-        serialized['body'] = json.dumps(body)
+        serialized['body'] = json.dumps(body).encode('utf-8')
         return serialized
 
     def _serialize(self, serialized, value, shape, key=None):
@@ -513,7 +513,7 @@ class RestJSONSerializer(BaseRestSerializer, JSONSerializer):
     def _serialize_body_params(self, params, shape):
         serialized_body = self.MAP_TYPE()
         self._serialize(serialized_body, params, shape)
-        return json.dumps(serialized_body)
+        return json.dumps(serialized_body).encode('utf-8')
 
 
 class RestXMLSerializer(BaseRestSerializer):
@@ -525,7 +525,7 @@ class RestXMLSerializer(BaseRestSerializer):
         self._serialize(shape, params, pseudo_root, root_name)
         real_root = list(pseudo_root)[0]
         # TODO: double check on the utf-8 encoding bit.
-        return ElementTree.tostring(real_root).decode('utf-8')
+        return ElementTree.tostring(real_root, encoding='utf-8')
 
     def _serialize(self, shape, params, xmlnode, name):
         method = getattr(self, '_serialize_type_%s' % shape.type_name,

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -440,7 +440,9 @@ class BaseRestSerializer(Serializer):
                 shape_members[payload_member].type_name in ['blob', 'string']:
             # If it's streaming, then the body is just the
             # value of the payload.
-            serialized['body'] = parameters.get(payload_member, '')
+            body_payload = parameters.get(payload_member, b'')
+            body_payload = self._encode_payload(body_payload)
+            serialized['body'] = body_payload
         elif payload_member is not None:
             # If there's a payload member, we serialized that
             # member to they body.
@@ -452,6 +454,11 @@ class BaseRestSerializer(Serializer):
         elif partitioned['body_kwargs']:
             serialized['body'] = self._serialize_body_params(
                 partitioned['body_kwargs'], shape)
+
+    def _encode_payload(self, body):
+        if isinstance(body, six.text_type):
+            return body.encode(self.DEFAULT_ENCODING)
+        return body
 
     def _partition_parameters(self, partitioned, param_name,
                               param_value, shape_members):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -694,8 +694,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
         super(TestS3SigV4Client, self).tearDown()
         shutil.rmtree(self.tempdir)
         for key in self.keys:
-            response = self.delete_object(bucket_name=self.bucket_name,
-                                          key=key)
+            self.delete_object(bucket_name=self.bucket_name, key=key)
 
     def test_can_get_bucket_location(self):
         # Even though the bucket is in eu-central-1, we should still be able to

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -912,16 +912,6 @@ class TestSupportedPutObjectBodyTypes(BaseS3ClientTest):
         with open(filename, 'rb') as binary_file:
             self.assert_can_put_object(body=binary_file)
 
-    def test_can_put_unicode_file(self):
-        filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'wb') as f:
-            f.write(u'\u2713'.encode('utf-8'))
-        # Now, don't open the file as 'r', not 'rb'
-        # and verify we can upload this file like object
-        # appropriately.
-        with open(filename, 'r') as text_file:
-            self.assert_can_put_object(body=text_file)
-
 
 class TestSupportedPutObjectBodyTypesSigv4(TestSupportedPutObjectBodyTypes):
     def create_client(self):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -914,8 +914,8 @@ class TestSupportedPutObjectBodyTypes(BaseS3ClientTest):
 
     def test_can_put_unicode_file(self):
         filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'w') as f:
-            f.write(u'\u2713')
+        with open(filename, 'wb') as f:
+            f.write(u'\u2713'.encode('utf-8'))
         # Now, don't open the file as 'r', not 'rb'
         # and verify we can upload this file like object
         # appropriately.

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -11,25 +11,20 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from tests import unittest, temporary_file, random_chars
 import os
 import time
-from tests import unittest, temporary_file, random_chars
 from collections import defaultdict
 import tempfile
 import shutil
 import threading
 import mock
-import binascii
-try:
-    from itertools import izip_longest as zip_longest
-except ImportError:
-    from itertools import zip_longest
 
 from nose.plugins.attrib import attr
 
 from botocore.vendored.requests import adapters
 from botocore.vendored.requests.exceptions import ConnectionError
-from botocore.compat import six
+from botocore.compat import six, zip_longest
 import botocore.session
 import botocore.auth
 import botocore.credentials
@@ -43,12 +38,21 @@ def random_bucketname():
     return bucket_name + random_chars(63 - len(bucket_name))
 
 
+def recursive_delete(client, bucket_name):
+    # Recursively deletes a bucket and all of its contents.
+    objects = client.get_paginator('list_objects').paginate(
+        Bucket=bucket_name)
+    for key in objects.search('Contents[].Key'):
+        if key is not None:
+            client.delete_object(Bucket=bucket_name, Key=key)
+    client.delete_bucket(Bucket=bucket_name)
+
+
 class BaseS3ClientTest(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
         self.region = 'us-east-1'
         self.client = self.session.create_client('s3', region_name=self.region)
-        self.keys = []
 
     def assert_status_code(self, response, status_code):
         self.assertEqual(
@@ -56,22 +60,33 @@ class BaseS3ClientTest(unittest.TestCase):
             status_code
         )
 
-    def create_bucket(self, bucket_name=None):
+    def create_bucket(self, region_name, bucket_name=None):
         bucket_kwargs = {}
         if bucket_name is None:
             bucket_name = random_bucketname()
         bucket_kwargs = {'Bucket': bucket_name}
-        if self.region != 'us-east-1':
+        if region_name != 'us-east-1':
             bucket_kwargs['CreateBucketConfiguration'] = {
-                'LocationConstraint': self.region,
+                'LocationConstraint': region_name,
             }
         response = self.client.create_bucket(**bucket_kwargs)
         self.assert_status_code(response, 200)
-        self.addCleanup(self.delete_bucket, bucket_name)
+        self.addCleanup(recursive_delete, self.client, bucket_name)
         return bucket_name
 
+    def make_tempdir(self):
+        tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tempdir)
+        return tempdir
+
+
+class TestS3BaseWithBucket(BaseS3ClientTest):
+    def setUp(self):
+        super(TestS3BaseWithBucket, self).setUp()
+        self.bucket_name = self.create_bucket(self.region)
+        self.caught_exceptions = []
+
     def create_object(self, key_name, body='foo'):
-        self.keys.append(key_name)
         self.client.put_object(
             Bucket=self.bucket_name, Key=key_name,
             Body=body)
@@ -129,12 +144,6 @@ class BaseS3ClientTest(unittest.TestCase):
             num_uploads, amount_seen))
 
 
-class TestS3BaseWithBucket(BaseS3ClientTest):
-    def setUp(self):
-        super(TestS3BaseWithBucket, self).setUp()
-        self.bucket_name = self.create_bucket()
-
-
 class TestS3Buckets(TestS3BaseWithBucket):
     def setUp(self):
         super(TestS3Buckets, self).setUp()
@@ -155,11 +164,6 @@ class TestS3Buckets(TestS3BaseWithBucket):
 
 
 class TestS3Objects(TestS3BaseWithBucket):
-    def tearDown(self):
-        for key in self.keys:
-            self.client.delete_object(
-                Bucket=self.bucket_name, Key=key)
-        super(TestS3Objects, self).tearDown()
 
     def increment_auth(self, request, **kwargs):
         self.auth_paths.append(request.auth_path)
@@ -167,7 +171,6 @@ class TestS3Objects(TestS3BaseWithBucket):
     def test_can_delete_urlencoded_object(self):
         key_name = 'a+b/foo'
         self.create_object(key_name=key_name)
-        self.keys.pop()
         bucket_contents = self.client.list_objects(
             Bucket=self.bucket_name)['Contents']
         self.assertEqual(len(bucket_contents), 1)
@@ -330,7 +333,6 @@ class TestS3Objects(TestS3BaseWithBucket):
 
     def test_thread_safe_auth(self):
         self.auth_paths = []
-        self.caught_exceptions = []
         self.session.register('before-sign', self.increment_auth)
         self.client = self.session.create_client('s3', self.region)
         self.create_object(key_name='foo1')
@@ -363,26 +365,22 @@ class TestS3Objects(TestS3BaseWithBucket):
 
 class TestS3Regions(BaseS3ClientTest):
     def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-        self.region = 'us-west-2'
         super(TestS3Regions, self).setUp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
+        self.region = 'us-west-2'
+        self.client = self.session.create_client(
+            's3', region_name=self.region)
 
     def test_reset_stream_on_redirects(self):
         # Create a bucket in a non classic region.
-        bucket_name = self.create_bucket()
+        bucket_name = self.create_bucket(self.region)
         # Then try to put a file like object to this location.
-        filename = os.path.join(self.tempdir, 'foo')
+        tempdir = self.make_tempdir()
+        filename = os.path.join(tempdir, 'foo')
         with open(filename, 'wb') as f:
             f.write(b'foo' * 1024)
         with open(filename, 'rb') as f:
             self.client.put_object(
                 Bucket=bucket_name, Key='foo', Body=f)
-
-        self.addCleanup(self.delete_object, key='foo',
-                        bucket_name=bucket_name)
 
         data = self.client.get_object(
             Bucket=bucket_name, Key='foo')
@@ -391,25 +389,18 @@ class TestS3Regions(BaseS3ClientTest):
 
 class TestS3Copy(TestS3BaseWithBucket):
 
-    def tearDown(self):
-        for key in self.keys:
-            self.client.delete_object(
-                Bucket=self.bucket_name, Key=key)
-        super(TestS3Copy, self).tearDown()
-
     def test_copy_with_quoted_char(self):
         key_name = 'a+b/foo'
         self.create_object(key_name=key_name)
 
         key_name2 = key_name + 'bar'
         self.client.copy_object(
-            Bucket=self.bucket_name, Key=key_name + 'bar',
+            Bucket=self.bucket_name, Key=key_name2,
             CopySource='%s/%s' % (self.bucket_name, key_name))
-        self.keys.append(key_name2)
 
         # Now verify we can retrieve the copied object.
         data = self.client.get_object(
-            Bucket=self.bucket_name, Key=key_name + 'bar')
+            Bucket=self.bucket_name, Key=key_name2)
         self.assertEqual(data['Body'].read().decode('utf-8'), 'foo')
 
     def test_copy_with_s3_metadata(self):
@@ -421,22 +412,20 @@ class TestS3Copy(TestS3BaseWithBucket):
             CopySource='%s/%s' % (self.bucket_name, key_name),
             MetadataDirective='REPLACE',
             Metadata={"mykey": "myvalue", "mykey2": "myvalue2"})
-        self.keys.append(copied_key)
         self.assert_status_code(parsed, 200)
 
 
 class BaseS3PresignTest(BaseS3ClientTest):
 
-    def tearDown(self):
-        for key in self.keys:
-            self.client.delete_object(
-                Bucket=self.bucket_name, Key=key)
-        super(BaseS3PresignTest, self).tearDown()
-
     def setup_bucket(self):
         self.key = 'myobject'
-        self.bucket_name = self.create_bucket()
+        self.bucket_name = self.create_bucket(self.region)
         self.create_object(key_name=self.key)
+
+    def create_object(self, key_name, body='foo'):
+        self.client.put_object(
+            Bucket=self.bucket_name, Key=key_name,
+            Body=body)
 
 
 class TestS3PresignUsStandard(BaseS3PresignTest):
@@ -646,10 +635,6 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
 
 
 class TestCreateBucketInOtherRegion(TestS3BaseWithBucket):
-    def tearDown(self):
-        for key in self.keys:
-            self.client.delete_object(
-                Bucket=self.bucket_name, Key=key)
 
     def test_bucket_in_other_region(self):
         # This verifies expect 100-continue behavior.  We previously
@@ -665,7 +650,6 @@ class TestCreateBucketInOtherRegion(TestS3BaseWithBucket):
                     Bucket=self.bucket_name,
                     Key='foo.txt', Body=body_file)
             self.assert_status_code(response, 200)
-            self.keys.append('foo.txt')
 
     def test_bucket_in_other_region_using_http(self):
         client = self.session.create_client(
@@ -678,7 +662,6 @@ class TestCreateBucketInOtherRegion(TestS3BaseWithBucket):
                     Bucket=self.bucket_name,
                     Key='foo.txt', Body=body_file)
             self.assert_status_code(response, 200)
-            self.keys.append('foo.txt')
 
 
 class TestS3SigV4Client(BaseS3ClientTest):
@@ -686,15 +669,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
         super(TestS3SigV4Client, self).setUp()
         self.region = 'eu-central-1'
         self.client = self.session.create_client('s3', self.region)
-        self.bucket_name = self.create_bucket()
-        self.keys = []
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        super(TestS3SigV4Client, self).tearDown()
-        shutil.rmtree(self.tempdir)
-        for key in self.keys:
-            self.delete_object(bucket_name=self.bucket_name, key=key)
+        self.bucket_name = self.create_bucket(self.region)
 
     def test_can_get_bucket_location(self):
         # Even though the bucket is in eu-central-1, we should still be able to
@@ -724,7 +699,6 @@ class TestS3SigV4Client(BaseS3ClientTest):
             response = self.client.put_object(Bucket=self.bucket_name,
                                               Key='foo.txt', Body=body)
             self.assert_status_code(response, 200)
-            self.keys.append('foo.txt')
 
     @attr('slow')
     def test_paginate_list_objects_unicode(self):
@@ -738,7 +712,6 @@ class TestS3SigV4Client(BaseS3ClientTest):
             response = self.client.put_object(Bucket=self.bucket_name,
                                               Key=key, Body='')
             self.assert_status_code(response, 200)
-            self.keys.append(key)
 
         list_objs_paginator = self.client.get_paginator('list_objects')
         key_refs = []
@@ -762,7 +735,6 @@ class TestS3SigV4Client(BaseS3ClientTest):
             response = self.client.put_object(Bucket=self.bucket_name,
                                               Key=key, Body='')
             self.assert_status_code(response, 200)
-            self.keys.append(key)
 
         list_objs_paginator = self.client.get_paginator('list_objects')
         key_refs = []
@@ -782,8 +754,8 @@ class TestS3SigV4Client(BaseS3ClientTest):
         self.assert_status_code(response, 200)
         upload_id = response['UploadId']
         self.addCleanup(
-            self.abort_multipart_upload,
-            bucket_name=self.bucket_name, key=key, upload_id=upload_id
+            self.client.abort_multipart_upload,
+            Bucket=self.bucket_name, Key=key, UploadId=upload_id
         )
 
         response = self.client.list_multipart_uploads(
@@ -796,33 +768,11 @@ class TestS3SigV4Client(BaseS3ClientTest):
         self.assertEqual(response['Uploads'][0]['UploadId'], upload_id)
 
 
-class TestCanSwitchToSigV4(unittest.TestCase):
-    def setUp(self):
-        self.environ = {}
-        self.environ_patch = mock.patch('os.environ', self.environ)
-        self.environ_patch.start()
-        self.session = botocore.session.get_session()
-        self.tempdir = tempfile.mkdtemp()
-        self.config_filename = os.path.join(self.tempdir, 'config_file')
-        self.environ['AWS_CONFIG_FILE'] = self.config_filename
-
-    def tearDown(self):
-        self.environ_patch.stop()
-        shutil.rmtree(self.tempdir)
-
-
-class TestSSEKeyParamValidation(unittest.TestCase):
+class TestSSEKeyParamValidation(BaseS3ClientTest):
     def setUp(self):
         self.session = botocore.session.get_session()
         self.client = self.session.create_client('s3', 'us-west-2')
-        self.bucket_name = random_bucketname()
-        self.client.create_bucket(
-            Bucket=self.bucket_name,
-            CreateBucketConfiguration={
-                'LocationConstraint': 'us-west-2',
-            }
-        )
-        self.addCleanup(self.client.delete_bucket, Bucket=self.bucket_name)
+        self.bucket_name = self.create_bucket('us-west-2')
 
     def test_make_request_with_sse(self):
         key_bytes = os.urandom(32)
@@ -862,7 +812,7 @@ class TestSSEKeyParamValidation(unittest.TestCase):
 
 class TestS3UTF8Headers(BaseS3ClientTest):
     def test_can_set_utf_8_headers(self):
-        bucket_name = self.create_bucket()
+        bucket_name = self.create_bucket(self.region)
         body = six.BytesIO(b"Hello world!")
         response = self.client.put_object(
             Bucket=bucket_name, Key="foo.txt", Body=body,
@@ -872,17 +822,7 @@ class TestS3UTF8Headers(BaseS3ClientTest):
                         Bucket=bucket_name, Key="foo.txt")
 
 
-class TestSupportedPutObjectBodyTypes(BaseS3ClientTest):
-    def setUp(self):
-        super(TestSupportedPutObjectBodyTypes, self).setUp()
-        self.region = 'us-east-1'
-        self.client = self.create_client()
-        self.bucket_name = self.create_bucket()
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-        super(TestSupportedPutObjectBodyTypes, self).tearDown()
+class TestSupportedPutObjectBodyTypes(TestS3BaseWithBucket):
 
     def create_client(self):
         # Even though the default signature_version is s3,
@@ -892,11 +832,12 @@ class TestSupportedPutObjectBodyTypes(BaseS3ClientTest):
                                           config=client_config)
 
     def assert_can_put_object(self, body):
-        response = self.client.put_object(
+        client = self.create_client()
+        response = client.put_object(
             Bucket=self.bucket_name, Key='foo',
             Body=body)
         self.assert_status_code(response, 200)
-        self.addCleanup(self.client.delete_object, Bucket=self.bucket_name,
+        self.addCleanup(client.delete_object, Bucket=self.bucket_name,
                         Key='foo')
 
     def test_can_put_unicode_content(self):
@@ -906,7 +847,8 @@ class TestSupportedPutObjectBodyTypes(BaseS3ClientTest):
         self.assert_can_put_object(body=u'\u2713'.encode('utf-8'))
 
     def test_can_put_binary_file(self):
-        filename = os.path.join(self.tempdir, 'foo')
+        tempdir = self.make_tempdir()
+        filename = os.path.join(tempdir, 'foo')
         with open(filename, 'wb') as f:
             f.write(u'\u2713'.encode('utf-8'))
         with open(filename, 'rb') as binary_file:

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -126,7 +126,7 @@ def create_request_from_raw_request(raw_request):
     request.context['timestamp'] = datetime_now.strftime('%Y%m%dT%H%M%SZ')
     for key, val in raw.headers.items():
         request.headers[key] = val
-    request.data = raw.rfile.read().decode('utf-8')
+    request.data = raw.rfile.read()
     host = raw.headers.get('host', '')
     # For whatever reason, the BaseHTTPRequestHandler encodes
     # the first line of the response as 'iso-8859-1',

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -422,7 +422,7 @@ class TestHandlers(BaseSessionTest):
         url = 'https://machinelearning.us-east-1.amazonaws.com'
         new_endpoint = 'https://my-custom-endpoint.amazonaws.com'
         data = '{"PredictEndpoint":"%s"}' % new_endpoint
-        request.data = data
+        request.data = data.encode('utf-8')
         request.url = url
         handlers.switch_host_with_param(request, 'PredictEndpoint')
         self.assertEqual(request.url, new_endpoint)

--- a/tests/unit/test_protocols.py
+++ b/tests/unit/test_protocols.py
@@ -116,9 +116,16 @@ def _test_input(json_description, case, basename):
     request = serializer.serialize_to_request(case['params'], operation_model)
     _serialize_request_description(request)
     try:
+        _assert_request_body_is_bytes(request['body'])
         _assert_requests_equal(request, case['serialized'])
     except AssertionError as e:
         _input_failure_message(protocol_type, case, request, e)
+
+
+def _assert_request_body_is_bytes(body):
+    if not isinstance(body, bytes):
+        raise AssertionError("Expected body to be serialized as type "
+                             "bytes(), instead got: %s" % type(body))
 
 
 def _test_output(json_description, case, basename):

--- a/tests/unit/test_protocols.py
+++ b/tests/unit/test_protocols.py
@@ -258,7 +258,7 @@ def assert_equal(first, second, prefix):
 def _serialize_request_description(request_dict):
     if isinstance(request_dict.get('body'), dict):
         # urlencode the request body.
-        encoded = urlencode(request_dict['body'])
+        encoded = urlencode(request_dict['body']).encode('utf-8')
         request_dict['body'] = encoded
     if isinstance(request_dict.get('query_string'), dict):
         encoded = urlencode(request_dict.pop('query_string'))
@@ -273,7 +273,8 @@ def _serialize_request_description(request_dict):
 
 
 def _assert_requests_equal(actual, expected):
-    assert_equal(actual['body'], expected['body'], 'Body value')
+    assert_equal(actual['body'], expected['body'].encode('utf-8'),
+                 'Body value')
     actual_headers = dict(actual['headers'])
     expected_headers = expected.get('headers', {})
     assert_equal(actual_headers, expected_headers, "Header values")

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -100,7 +100,7 @@ class TestBinaryTypesJSON(BaseModelWithBlob):
     def test_blob_accepts_bytes_type(self):
         body = b'bytes body'
         request = self.serialize_to_request(input_params={'Blob': body})
-        serialized_blob = json.loads(request['body'])['Blob']
+        serialized_blob = json.loads(request['body'].decode('utf-8'))['Blob']
         self.assertEqual(
             base64.b64encode(body).decode('ascii'),
             serialized_blob)
@@ -239,19 +239,19 @@ class TestJSONTimestampSerialization(unittest.TestCase):
 
     def test_accepts_iso_8601_format(self):
         body = json.loads(self.serialize_to_request(
-            {'Timestamp': '1970-01-01T00:00:00'})['body'])
+            {'Timestamp': '1970-01-01T00:00:00'})['body'].decode('utf-8'))
         self.assertEqual(body['Timestamp'], 0)
 
     def test_accepts_epoch(self):
         body = json.loads(self.serialize_to_request(
-            {'Timestamp': '0'})['body'])
+            {'Timestamp': '0'})['body'].decode('utf-8'))
         self.assertEqual(body['Timestamp'], 0)
         # Can also be an integer 0.
         body = json.loads(self.serialize_to_request(
-            {'Timestamp': 0})['body'])
+            {'Timestamp': 0})['body'].decode('utf-8'))
         self.assertEqual(body['Timestamp'], 0)
 
     def test_accepts_partial_iso_format(self):
         body = json.loads(self.serialize_to_request(
-            {'Timestamp': '1970-01-01'})['body'])
+            {'Timestamp': '1970-01-01'})['body'].decode('utf-8'))
         self.assertEqual(body['Timestamp'], 0)

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -150,7 +150,7 @@ class TestSigner(BaseSignerTest):
         request_dict = {
             'headers': {},
             'url': 'https://foo.com',
-            'body': '',
+            'body': b'',
             'url_path': '/',
             'method': 'GET'
         }
@@ -169,7 +169,7 @@ class TestSigner(BaseSignerTest):
         request_dict = {
             'headers': {},
             'url': 'https://foo.com',
-            'body': '',
+            'body': b'',
             'url_path': '/',
             'method': 'GET'
         }
@@ -189,7 +189,7 @@ class TestSigner(BaseSignerTest):
         request_dict = {
             'headers': {},
             'url': 'https://foo.com',
-            'body': '',
+            'body': b'',
             'url_path': '/',
             'method': 'GET'
         }
@@ -213,7 +213,7 @@ class TestSigner(BaseSignerTest):
         request_dict = {
             'headers': {},
             'url': 'https://s3.amazonaws.com/mybucket/myobject',
-            'body': '',
+            'body': b'',
             'url_path': '/',
             'method': 'GET'
         }
@@ -245,7 +245,7 @@ class TestS3PostPresigner(BaseSignerTest):
         self.request_dict = {
             'headers': {},
             'url': 'https://s3.amazonaws.com/mybucket',
-            'body': '',
+            'body': b'',
             'url_path': '/',
             'method': 'POST'
         }
@@ -353,7 +353,7 @@ class TestGenerateUrl(unittest.TestCase):
             'get_object', Params={'Bucket': self.bucket, 'Key': self.key})
 
         ref_request_dict = {
-            'body': '',
+            'body': b'',
             'url': u'https://s3.amazonaws.com/mybucket/mykey',
             'headers': {},
             'query_string': {},
@@ -375,7 +375,7 @@ class TestGenerateUrl(unittest.TestCase):
             'get_object', Params={'Bucket': self.bucket, 'Key': self.key},
             ExpiresIn=20)
         ref_request_dict = {
-            'body': '',
+            'body': b'',
             'url': u'https://s3.amazonaws.com/mybucket/mykey',
             'headers': {},
             'query_string': {},
@@ -389,7 +389,7 @@ class TestGenerateUrl(unittest.TestCase):
             'get_object', Params={'Bucket': self.bucket, 'Key': self.key},
             HttpMethod='PUT')
         ref_request_dict = {
-            'body': '',
+            'body': b'',
             'url': u'https://s3.amazonaws.com/mybucket/mykey',
             'headers': {},
             'query_string': {},


### PR DESCRIPTION
This is more general change to handle how we handle blob types in general.

There's 4 possible types that a user could give us for a blob type that would pass validation:

* text type (str/unicode)
* bytes type (bytes())
* binary file obj
* text file obj

This PR updates botocore such that the first three cases are handled.  The fourth case could be something we support down the road, but it's easy enough for now to just open the file as binary.
It's also a somewhat difficult because we can't reliably tell if a file like object is opened as text.

To accomplish this, I picked up the work down a few months ago to standardize on the input types for serialization such that the *request dict body is always `bytes()`*.

cc @kyleknap @mtdowling