### PR TITLE
Always populate a 'Message' key in the errors dict

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -98,7 +98,7 @@ import logging
 
 from botocore.compat import six, XMLParseError
 
-from botocore.utils import parse_timestamp
+from botocore.utils import parse_timestamp, merge_dicts
 
 LOG = logging.getLogger(__name__)
 
@@ -705,7 +705,9 @@ class RestXMLParser(BaseRestParser, BaseXMLResponseParser):
         elif 'RequestId' in parsed:
             # Other rest-xml serivces:
             parsed['ResponseMetadata'] = {'RequestId': parsed.pop('RequestId')}
-        return parsed
+        default = {'Error': {'Message': '', 'Code': ''}}
+        merge_dicts(default, parsed)
+        return default
 
 
 PROTOCOL_PARSERS = {


### PR DESCRIPTION
Fixes #532.

The error message will now look like:

```
ClientError: An error occurred (InvalidInput) when calling the ListResourceRecordSets operation:
```

cc @kyleknap @mtdowling