### PR TITLE
Allow profile to be provided when session is created

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -102,7 +102,7 @@ class Session(object):
     LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
     def __init__(self, session_vars=None, event_hooks=None,
-                 include_builtin_handlers=True, loader=None):
+                 include_builtin_handlers=True, profile=None):
         """
         Create a new Session object.
 
@@ -120,6 +120,12 @@ class Session(object):
         :type include_builtin_handlers: bool
         :param include_builtin_handlers: Indicates whether or not to
             automatically register builtin handlers.
+
+        :type profile: str
+        :param profile: The name of the profile to use for this
+            session.  Note that the profile can only be set when
+            the session is created.
+
         """
         self.session_var_map = copy.copy(self.SESSION_VARIABLES)
         if session_vars:
@@ -133,7 +139,7 @@ class Session(object):
         self.user_agent_name = 'Botocore'
         self.user_agent_version = __version__
         self.user_agent_extra = ''
-        self._profile = None
+        self._profile = profile
         self._config = None
         self._credentials = None
         self._profile_map = None

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -177,9 +177,6 @@ class Session(object):
         self._components.register_component('response_parser_factory',
                                             ResponseParserFactory())
 
-    def _reset_components(self):
-        self._register_components()
-
     def _register_builtin_handlers(self, events):
         for spec in handlers.BUILTIN_HANDLERS:
             if len(spec) == 2:
@@ -214,15 +211,6 @@ class Session(object):
     @property
     def profile(self):
         return self._profile
-
-    @profile.setter
-    def profile(self, profile):
-        # Since provider can be specified in profile, changing the
-        # profile should reset the provider.
-        self._provider = None
-        self._profile = profile
-        # Need to potentially reload the config file/creds.
-        self._reset_components()
 
     def get_config_variable(self, logical_name,
                             methods=('instance', 'env', 'config')):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -186,7 +186,7 @@ class SessionTest(BaseSessionTest):
             f.write('aws_secret_access_key=FROM_CREDS_FILE_2\n')
             f.flush()
 
-            self.session.profile = 'newprofile'
+            self.session.set_config_variable('profile', 'newprofile')
             full_config = self.session.full_config
             self.assertEqual(full_config['profiles']['newprofile'],
                              {'aws_access_key_id': 'FROM_CREDS_FILE_1',
@@ -336,7 +336,7 @@ class TestConfigLoaderObject(BaseSessionTest):
             f.write('aws_secret_access_key=b\n')
             f.flush()
             self.session.set_config_variable('credentials_file', f.name)
-            self.session.profile = 'credfile-profile'
+            self.session.set_config_variable('profile', 'credfile-profile')
             # Now trying to retrieve the scoped config should pull in
             # values from the shared credentials file.
             self.assertEqual(self.session.get_scoped_config(),


### PR DESCRIPTION
This also makes the profile property read only.

This will require changes in the CLI to account for this, as it currently has this code: https://github.com/aws/aws-cli/blob/develop/awscli/clidriver.py#L221-L222

Same deal with boto3.

The only other thing that might need to be updated is whether or not we should allow `set_config_variable` to support `profile`.  You can technically still do this:

```
s = Session(...)
s.set_config_variable('profile', 'myprofile')
s.create_client(...)
```

thoughts?  cc @kyleknap @mtdowling