### PR TITLE
Conditionally add Content-MD5 in S3 when not sigv4

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -139,6 +139,14 @@
                 "service_error_code": "RequestTimeout"
               }
             }
+          },
+          "contentmd5": {
+            "applies_when": {
+              "response": {
+                "http_status_code": 400,
+                "service_error_code": "BadDigest"
+              }
+            }
           }
         }
       }

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -116,6 +116,13 @@ def calculate_md5(params, **kwargs):
         params['headers']['Content-MD5'] = value
 
 
+def conditionally_calculate_md5(params, **kwargs):
+    """Only add a Content-MD5 when not using sigv4"""
+    signer = kwargs['request_signer']
+    if signer.signature_version != 'v4':
+        calculate_md5(params, **kwargs)
+
+
 def sse_md5(params, **kwargs):
     """
     S3 server-side encryption requires the encryption key to be sent to the
@@ -423,6 +430,17 @@ BUILTIN_HANDLERS = [
     ('before-call.s3.PutBucketCors', calculate_md5),
     ('before-call.s3.DeleteObjects', calculate_md5),
     ('before-call.s3.PutBucketReplication', calculate_md5),
+    ('before-call.s3.PutObject', conditionally_calculate_md5),
+    ('before-call.s3.UploadPart', conditionally_calculate_md5),
+    ('before-call.s3.PutBucketAcl', conditionally_calculate_md5),
+    ('before-call.s3.PutBucketLogging', conditionally_calculate_md5),
+    ('before-call.s3.PutBucketNotification', conditionally_calculate_md5),
+    ('before-call.s3.PutBucketPolicy', conditionally_calculate_md5),
+    ('before-call.s3.PutBucketRequestPayment', conditionally_calculate_md5),
+    ('before-call.s3.PutBucketVersioning', conditionally_calculate_md5),
+    ('before-call.s3.PutBucketWebsite', conditionally_calculate_md5),
+    ('before-call.s3.PutObjectAcl', conditionally_calculate_md5),
+
     ('before-call.s3.UploadPartCopy', quote_source_header),
     ('before-call.s3.CopyObject', quote_source_header),
     ('before-call.s3', add_expect_header),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -112,15 +112,16 @@ def calculate_md5(params, **kwargs):
     if request_dict['body'] and 'Content-MD5' not in params['headers']:
         body = request_dict['body']
         if isinstance(body, bytes):
-            hex_md5 = _calculate_md5_from_bytes(body)
+            binary_md5 = _calculate_md5_from_bytes(body)
         else:
-            hex_md5 = _calculate_md5_from_file(body)
-        params['headers']['Content-MD5'] = hex_md5
+            binary_md5 = _calculate_md5_from_file(body)
+        base64_md5 = base64.b64encode(binary_md5).decode('ascii')
+        params['headers']['Content-MD5'] = base64_md5
 
 
 def _calculate_md5_from_bytes(body_bytes):
     md5 = hashlib.md5(body_bytes)
-    return md5.hexdigest()
+    return md5.digest()
 
 
 def _calculate_md5_from_file(fileobj):
@@ -129,7 +130,7 @@ def _calculate_md5_from_file(fileobj):
     for chunk in iter(lambda: fileobj.read(1024 * 1024), b''):
         md5.update(chunk)
     fileobj.seek(start_position)
-    return md5.hexdigest()
+    return md5.digest()
 
 
 def conditionally_calculate_md5(params, **kwargs):


### PR DESCRIPTION
This fleshes out the rest of https://github.com/boto/botocore/pull/564 and adds support for calculating content md5 headers when the body is a file like object.


cc @kyleknap @mtdowling