### PR TITLE
Remove all beta/dev preview warnings

### DIFF
--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -3,16 +3,6 @@ Getting Started With botocore
 *****************************
 
 
-.. warning::
-
-  Botocore is currently under a developer preview, and its API is subject
-  to change prior to a GA (1.0) release.  Until botocore reaches a 1.0 release,
-  backwards compatibility is not guaranteed.
-
-  If you need a stable interface, please consider using
-  `boto <https://github.com/boto/boto>`__.
-
-
 The ``botocore`` package provides a low-level interface to Amazon
 services.  It is responsible for:
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     },
     license="Apache License 2.0",
     classifiers=(
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Natural Language :: English',


### PR DESCRIPTION
There's a few additional things we need to change:

* Change trove classifiers to stable
* Remove dev preview warning from tutorial.


The tutorial/getting started guide could use some sprucing up, but we can address that in a separate PR.

cc @kyleknap @mtdowling