### PR TITLE
Making UserData docs more clear about base64

### DIFF
--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -102,8 +102,8 @@ class AutoPopulatedParam(object):
         self.param_description = param_description
         if param_description is None:
             self.param_description = (
-                'Please note that this parameter is automatically populated if'
-                'it is not provided. Including this parameter is not '
+                'Please note that this parameter is automatically populated '
+                'if it is not provided. Including this parameter is not '
                 'required\n')
 
     def document_auto_populated_param(self, event_name, section, **kwargs):

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -334,7 +334,9 @@ def base64_encode_user_data(params, **kwargs):
 
 
 def document_base64_encoding():
-    description = 'UserData will be automatically base64 encoded if necessary.'
+    description = ('**This value will be base64 encoded automatically. Do '
+                   'not base64 encode this value prior to performing the '
+                   'operation.**')
     append = AppendParamDocumentation('UserData', description)
     return append.append_documentation
 

--- a/tests/functional/docs/test_autoscaling.py
+++ b/tests/functional/docs/test_autoscaling.py
@@ -17,4 +17,4 @@ class TestAutoscalingDocs(BaseDocsFunctionalTest):
     def test_documents_encoding_of_user_data(self):
         docs = self.get_parameter_documentation_from_service(
             'autoscaling', 'create_launch_configuration', 'UserData')
-        self.assertIn('automatically base64', docs.decode('utf-8'))
+        self.assertIn('base64 encoded automatically', docs.decode('utf-8'))

--- a/tests/functional/docs/test_ec2.py
+++ b/tests/functional/docs/test_ec2.py
@@ -17,7 +17,7 @@ class TestEc2Docs(BaseDocsFunctionalTest):
     def test_documents_encoding_of_user_data(self):
         docs = self.get_parameter_documentation_from_service(
             'ec2', 'run_instances', 'UserData')
-        self.assertIn('automatically base64', docs.decode('utf-8'))
+        self.assertIn('base64 encoded automatically', docs.decode('utf-8'))
 
     def test_copy_snapshot_presigned_url_is_autopopulated(self):
         self.assert_is_documented_as_autopopulated_param(


### PR DESCRIPTION
This commit updates the UserData docs to be more clear that you should not base64 encode the value when providing the parameter. The text is now bold to make it more pronounced.

Also added a minor typo fix for the default AutoPopulatedParam description.

Closes #585 

@jamesls @kyleknap 