### PR TITLE
Updating to latest version of theme.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,10 +136,10 @@ html_static_path = ['_static']
 # Custom sidebar templates, maps document names to template names.
 html_show_sourcelink = False
 html_sidebars = {
-    '**': [
-        'globaltoc.html',
-        'localtoc.html',
-        'searchbox.html']
+    '**': ['logo-text.html',
+           'globaltoc.html',
+           'localtoc.html',
+           'searchbox.html']
 }
 
 # Additional templates that should be rendered to pages, maps page names to

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,2 @@
 Sphinx>=1.1.3,<1.3
-guzzle_sphinx_theme>=0.7.7,<0.8
+guzzle_sphinx_theme>=0.7.9,<0.8


### PR DESCRIPTION
Also adding logo-text.html to left nav.

The latest version of the theme has a ton of style fixes, including:

- Breadcrumbs are no longer hidden on a small device.
- Left nav elements are smaller.
- Left nav headers are smaller.
- text logo is now styled to better call it out.
- reduced padding in the main content section.
- admonitions are more subtle.
- p tags no longer have a top margin of 1.2 em (making them act like normal p tags you see everywhere else)
- h1's are more subtle

And most importantly, parameters inside of field-lists are now rendered in html as dt and dl tags. This makes long nested documentation no longer overflow due to table styling issues, and reduces the time render large pages significantly because the dom size is not having to be recalculated for ever table.

![screen shot 2015-06-24 at 6 02 34 pm](https://cloud.githubusercontent.com/assets/190930/8344861/e339a460-1a9b-11e5-9ec4-79bcd07b6fff.png)

![screen shot 2015-06-24 at 6 02 11 pm](https://cloud.githubusercontent.com/assets/190930/8344862/e34723ba-1a9b-11e5-81c2-932ed4f579c5.png)

![screen shot 2015-06-24 at 6 01 35 pm](https://cloud.githubusercontent.com/assets/190930/8344863/e348a9ce-1a9b-11e5-89f0-a39238018672.png)

@kyleknap @jamesls 