### PR TITLE
Add append_lists option to merge_dicts()

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -220,8 +220,7 @@ def merge_dicts(dict1, dict2, append_lists=False):
             # The value in dict1 must be a list in order to append new
             # values onto it.
             if key in dict1 and isinstance(dict1[key], list):
-                for value in dict2[key]:
-                    dict1[key].append(value)
+                dict1[key].extend(dict2[key])
             else:
                 dict1[key] = dict2[key]
         else:

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -200,16 +200,28 @@ class InstanceMetadataFetcher(object):
         return final_data
 
 
-def merge_dicts(dict1, dict2):
+def merge_dicts(dict1, dict2, append_lists=False):
     """Given two dict, merge the second dict into the first.
 
     The dicts can have arbitrary nesting.
 
+    :param append_lists: If true, instead of clobbering a list with the new
+        value, append all of the new values onto the original list.
     """
     for key in dict2:
         if isinstance(dict2[key], dict):
             if key in dict1 and key in dict2:
                 merge_dicts(dict1[key], dict2[key])
+            else:
+                dict1[key] = dict2[key]
+        # If the value is a list and the ``append_lists`` flag is set,
+        # append the new values onto the original list
+        elif isinstance(dict2[key], list) and append_lists:
+            # The value in dict1 must be a list in order to append new
+            # values onto it.
+            if key in dict1 and isinstance(dict1[key], list):
+                for value in dict2[key]:
+                    dict1[key].append(value)
             else:
                 dict1[key] = dict2[key]
         else:

--- a/tests/unit/test_translate.py
+++ b/tests/unit/test_translate.py
@@ -687,52 +687,6 @@ class TestTranslateModel(unittest.TestCase):
         self.assertEqual(new_model['pagination'], extra['pagination'])
 
 
-class TestDictMerge(unittest.TestCase):
-    def test_merge_dicts_overrides(self):
-        first = {'foo': {'bar': {'baz': {'one': 'ORIGINAL', 'two': 'ORIGINAL'}}}}
-        second = {'foo': {'bar': {'baz': {'one': 'UPDATE'}}}}
-
-        merge_dicts(first, second)
-        # The value from the second dict wins.
-        self.assertEqual(first['foo']['bar']['baz']['one'], 'UPDATE')
-        # And we still preserve the other attributes.
-        self.assertEqual(first['foo']['bar']['baz']['two'], 'ORIGINAL')
-
-    def test_merge_dicts_new_keys(self):
-        first = {'foo': {'bar': {'baz': {'one': 'ORIGINAL', 'two': 'ORIGINAL'}}}}
-        second = {'foo': {'bar': {'baz': {'three': 'UPDATE'}}}}
-
-        merge_dicts(first, second)
-        self.assertEqual(first['foo']['bar']['baz']['one'], 'ORIGINAL')
-        self.assertEqual(first['foo']['bar']['baz']['two'], 'ORIGINAL')
-        self.assertEqual(first['foo']['bar']['baz']['three'], 'UPDATE')
-
-    def test_merge_empty_dict_does_nothing(self):
-        first = {'foo': {'bar': 'baz'}}
-        merge_dicts(first, {})
-        self.assertEqual(first, {'foo': {'bar': 'baz'}})
-
-    def test_more_than_one_sub_dict(self):
-        first = {'one': {'inner': 'ORIGINAL', 'inner2': 'ORIGINAL'},
-                 'two': {'inner': 'ORIGINAL', 'inner2': 'ORIGINAL'}}
-        second = {'one': {'inner': 'UPDATE'}, 'two': {'inner': 'UPDATE'}}
-
-        merge_dicts(first, second)
-        self.assertEqual(first['one']['inner'], 'UPDATE')
-        self.assertEqual(first['one']['inner2'], 'ORIGINAL')
-
-        self.assertEqual(first['two']['inner'], 'UPDATE')
-        self.assertEqual(first['two']['inner2'], 'ORIGINAL')
-
-    def test_new_keys(self):
-        first = {'one': {'inner': 'ORIGINAL'}, 'two': {'inner': 'ORIGINAL'}}
-        second = {'three': {'foo': {'bar': 'baz'}}}
-        # In this case, second has no keys in common, but we'd still expect
-        # this to get merged.
-        merge_dicts(first, second)
-        self.assertEqual(first['three']['foo']['bar'], 'baz')
-
-
 class TestBuildRetryConfig(unittest.TestCase):
     def setUp(self):
         self.retry = {


### PR DESCRIPTION
Allows user to append to lists as opposed to replace lists completely when
merging dictionaries.

This is needed for a subsequent PR to boto3 that fixes an issue in collections.

cc @jamesls @mtdowling 