### PR TITLE
Updating theme version

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,2 @@
 Sphinx>=1.1.3,<1.3
-guzzle_sphinx_theme>=0.7.9,<0.8
+guzzle_sphinx_theme>=0.7.10,<0.8


### PR DESCRIPTION
This commit updates to the latest version of the Guzzle sphinx theme.

Theme changes:

1. Removed some kerning rules that were not noticeable but caused a significant rendering penalty. This change reduces the time to finish rendering the EC2 page from about 4.6 seconds to about 1.7 seconds.
2. Lightened the left nav border.
3. Added a border between each method and class to better visually distinguish them.

This commit is only really necessary to get readthedocs to update their local package cache.

@kyleknap 