### PR TITLE
Making the use of session sound less optional

### DIFF
--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -27,8 +27,8 @@ of these services, it's much easier to keep ``botocore`` current.
 Using Botocore
 ==============
 
-The main way to use botocore is to first create a ``Session`` object, and
-from the ``Session`` object you can create individual clients::
+The first step in using botocore is to create a ``Session`` object.
+``Session`` objects then allow you to create individual clients::
 
     import botocore.session
     session = botocore.session.get_session()


### PR DESCRIPTION
The current wording of getting started with botocore makes it seem like there are other ways that developers could use when interacting with botocore. While it's possible to use botocore by creating clients manually without a session, I think we should update the documentation to be more clear that using a session is needed for almost every use case, and using a session is the public API of botocore.