### PR TITLE
Append signature to HmacV1Query querystring instead of replace

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -685,6 +685,8 @@ class HmacV1QueryAuth(HmacV1Auth):
 
         # Create a new url with the presigned url.
         p = urlsplit(request.url)
+        if p[3]:
+            new_query_string = p[3] + "&" + new_query_string
         new_url_parts = (p[0], p[1], p[2], new_query_string, p[4])
         request.url = urlunsplit(new_url_parts)
 


### PR DESCRIPTION
This pull request fixes an issue with presigned URLs for S3 where the request has extra parameters in the query string (such as response-content-disposition):

This problem is evident in the following code
```
import boto3
s3 = boto3.resource('s3')
f = s3.Object('foo-bucket', 'image.jpg')
f.meta.client.generate_presigned_url(
    'get_object',
    Params={'Bucket': f.bucket_name, 'Key': f.key, 'ResponseContentDisposition': 'attachment; filename="download.jpg"'})
```

The URL returned does not contain the response-content-disposition argument in the query string, and the resulting URL does not work because it has signed a string containing the response-content-disposition header but the URL lacks it.

This comes down to the s3-query auth (implemented by HmacV1QueryAuth) dropping all other query string headers when it reassembles the URL. This pull request appends the signature to any pre-existing querystring, instead of replacing it. I've verified that the signature does work in the case where response content disposition is provided as a parameter, and I assume it will work for other such query string values.