### PR TITLE
Add ability to set location of credentials file with AWS_CREDENTIALS_…

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -82,7 +82,7 @@ class Session(object):
         # These variables are intended for internal use so don't have any
         # user settable values.
         # This is the shared credentials file amongst sdks.
-        'credentials_file': (None, None, '~/.aws/credentials', None),
+        'credentials_file': (None, 'AWS_CREDENTIALS_FILE', '~/.aws/credentials', None),
 
         # These variables only exist in the config file.
 


### PR DESCRIPTION
…FILE environment variable

Sorry, I don't know how to add to the unit tests...

Signed-off-by: Fred Reimer <Fred.Reimer@jmfamily.com>