### PR TITLE
Adding a StringShape and enum attribute

### DIFF
--- a/botocore/model.py
+++ b/botocore/model.py
@@ -191,18 +191,18 @@ class MapShape(Shape):
         return self._resolve_shape_ref(self._shape_model['value'])
 
 
+class StringShape(Shape):
+    @CachedProperty
+    def enum(self):
+        return self.metadata.get('enum', [])
+
+
 class ServiceModel(object):
     """
 
     :ivar service_description: The parsed service description dictionary.
 
     """
-    # Any type not in this mapping will default to the Shape class.
-    SHAPE_CLASSES = {
-        'structure': StructureShape,
-        'list': ListShape,
-        'map': MapShape,
-    }
 
     def __init__(self, service_description, service_name=None):
         """
@@ -428,6 +428,7 @@ class ShapeResolver(object):
         'structure': StructureShape,
         'list': ListShape,
         'map': MapShape,
+        'string': StringShape
     }
 
     def __init__(self, shape_map):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -588,17 +588,20 @@ class TestBuilders(unittest.TestCase):
         self.assertEqual(
             shape.members['A'].members['B'].members['C'].type_name, 'string')
 
-    def test_enum_values_on_scalar_used(self):
+    def test_enum_values_on_string_used(self):
         b = model.DenormalizedStructureBuilder()
+        enum_values = ['foo', 'bar', 'baz']
         shape = b.with_members({
             'A': {
                 'type': 'string',
-                'enum': ['foo', 'bar', 'baz'],
+                'enum': enum_values,
             },
         }).build_model()
         self.assertIsInstance(shape, model.StructureShape)
-        self.assertEqual(shape.members['A'].metadata['enum'],
-                         ['foo', 'bar', 'baz'])
+        string_shape = shape.members['A']
+        self.assertIsInstance(string_shape, model.StringShape)
+        self.assertEqual(string_shape.metadata['enum'], enum_values)
+        self.assertEqual(string_shape.enum, enum_values)
 
     def test_documentation_on_shape_used(self):
         b = model.DenormalizedStructureBuilder()


### PR DESCRIPTION
This commit updates the shape builders to utilize a new concrete shape
type, StringShape. StringShape exposes a property that makes it easier
to inspect the enum attribute of a string shape. StringShape is the only
concrete shape type to expose this property because, at present, the only
shapes that have the `enum` property are string shapes.

In addition to this feature, the unused `SHAPE_CLASSES` constant has been
deleted from ServiceModel. If removing this constant is not acceptable, I can
put it back and rebase.