### PR TITLE
Use env vars to set metadata service config

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -89,11 +89,11 @@ class Session(object):
         # This is the number of seconds until we time out a request to
         # the instance metadata service.
         'metadata_service_timeout': ('metadata_service_timeout',
-                                     None, 1, int),
+                                     'AWS_METADATA_SERVICE_TIMEOUT', 1, int),
         # This is the number of request attempts we make until we give
         # up trying to retrieve data from the instance metadata service.
         'metadata_service_num_attempts': ('metadata_service_num_attempts',
-                                          None, 1, int),
+                                          'AWS_METADATA_SERVICE_NUM_ATTEMPTS', 1, int),
     }
 
     #: The default format string to use when configuring the botocore logger.


### PR DESCRIPTION
I think there's no reason to limit the users from setting `metadata_service_timeout` and `metadata_service_num_attempts` config from  environment variables.