### PR TITLE
add docs to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include LICENSE.txt
 include requirements.txt
 include botocore/vendored/requests/cacert.pem
 recursive-include botocore/data *.json
+recursive-include docs *
+prune docs/build


### PR DESCRIPTION
When packaging for distributions we sometimes want to include
documentation in the installation (especially on Gentoo).  This adds the
documentation to the sdist so we can use the PyPi distribution and build
the documentation for our users.