### PR TITLE
RestJSONParser now parses "code" from "__type" field

### DIFF
--- a/tests/unit/response_parsing/json/expected/elastictranscoder-delete-pipeline.json
+++ b/tests/unit/response_parsing/json/expected/elastictranscoder-delete-pipeline.json
@@ -1,5 +1,5 @@
 {
-    "ResponseMetadata": {},
+    "ResponseMetadata": {"RequestId": "1234"},
     "Error": {
         "Message": "1 validation error detected: Value 'foobar' at 'id' failed to satisfy constraint: Member must satisfy regular expression pattern: ^\\d{13}-\\w{6}$",
         "Code": "ValidationException"

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -294,6 +294,23 @@ class TestResponseMetadataParsed(unittest.TestCase):
         self.assertEqual(parsed['Error'], {'Message': 'Access denied',
                                            'Code': 'AccessDeniedException'})
 
+    def test_can_parse_restjson_error_code(self):
+        body = b'''{
+            "status": "error",
+            "errors": [{"message": "[*Deprecated*: blah"}],
+            "adds": 0,
+            "__type": "#WasUnableToParseThis",
+            "message": "blah",
+            "deletes": 0}'''
+        headers = {
+             'x-amzn-requestid': 'request-id'
+        }
+        parser = parsers.RestJSONParser()
+        parsed = parser.parse(
+            {'body': body, 'headers': headers, 'status_code': 400}, None)
+        self.assertEqual(parsed['Error'], {'Message': 'blah',
+                                           'Code': 'WasUnableToParseThis'})
+
     def test_can_parse_with_case_insensitive_keys(self):
         body = (b'{"Code":"AccessDeniedException","type":"Client","Message":'
                 b'"Access denied"}')


### PR DESCRIPTION
According to issue boto/boto3#186, this happens in cloudsearchdomain service and some other services too. This fix is generic for all RestJSON responses.