### PR TITLE
Generate shared examples for API documentation

### DIFF
--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -19,8 +19,11 @@ from botocore.docs.method import get_instance_public_methods
 
 
 class ClientDocumenter(object):
-    def __init__(self, client):
+    def __init__(self, client, shared_examples=None):
         self._client = client
+        self._shared_examples = shared_examples
+        if self._shared_examples is None:
+            self._shared_examples = {}
         self._service_name = self._client.meta.service_model.service_name
 
     def document_client(self, section):
@@ -96,5 +99,6 @@ class ClientDocumenter(object):
             section, method_name, operation_model,
             event_emitter=self._client.meta.events,
             method_description=operation_model.documentation,
-            example_prefix='response = client.%s' % method_name
+            example_prefix='response = client.%s' % method_name,
+            shared_examples=self._shared_examples.get(operation_name)
         )

--- a/botocore/docs/service.py
+++ b/botocore/docs/service.py
@@ -57,7 +57,8 @@ class ServiceDocumenter(object):
         section.style.table_of_contents(title='Table of Contents', depth=2)
 
     def client_api(self, section):
-        ClientDocumenter(self._client).document_client(section)
+        examples = self._session.get_examples(self._service_name)
+        ClientDocumenter(self._client, examples).document_client(section)
 
     def paginator_api(self, section):
         try:

--- a/botocore/docs/sharedexample.py
+++ b/botocore/docs/sharedexample.py
@@ -1,0 +1,82 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import re
+
+class SharedExampleBuilder(object):
+    def __init__(self, params, operation_name, comments, is_input=True):
+        self._params = params
+        self._operation_name = operation_name
+        self._comments = comments
+        self._is_input = is_input
+
+    def example_code(self, prefix=''):
+        if self._is_input:
+            return prefix + self._visit(self._params, '', [], is_param=True)
+        else:
+            return self._visit(self._params, '', [], is_param=False)
+
+    def _visit(self, value, indent, path, is_param=False):
+        if is_param:
+            return self._visit_param(value, indent, path)
+        if isinstance(value, dict):
+            return self._visit_struct(value, indent, path)
+        elif isinstance(value, list):
+            return self._visit_list(value, indent, path)
+        elif isinstance(value, basestring):
+            return "'%s'" % value
+        else:
+            return value
+
+    def _visit_param(self, value, indent, path):
+        lines = ['(']
+        for key, val in value.items():
+            path.append('.%s' % key)
+            comment = self._apply_comment(path)
+            shape_val = self._visit(val, '    ' + indent, path)
+            lines.append("%s    %s=%s, %s" %
+                (indent, key, shape_val, comment))
+            path.pop()
+        lines.append('%s)' % indent)
+        return '\n'.join(lines)
+
+
+    def _visit_struct(self, value, indent, path):
+        lines = ['{']
+        for key, val in value.items():
+            path.append('.%s' % key)
+            comment = self._apply_comment(path)
+            shape_val = self._visit(val, '    ' + indent, path)
+            lines.append("%s    '%s': %s, %s" %
+                (indent, key, shape_val, comment))
+            path.pop()
+        lines.append('%s}' % indent)
+        return '\n'.join(lines)
+
+    def _visit_list(self, value, indent, path):
+        lines = ['[']
+        for ind, val in enumerate(value):
+            path.append('[%s]' % ind)
+            comment = self._apply_comment(path)
+            shape_val = self._visit(val, '    ' + indent, path)
+            lines.append('%s    %s, %s' %
+                (indent, shape_val, comment))
+            path.pop()
+        lines.append('%s]' % indent)
+        return '\n'.join(lines)
+
+    def _apply_comment(self, path):
+        key = re.sub('^\.', '', ''.join(path))
+        if self._comments and key in self._comments:
+            return '# ' + self._comments[key]
+        else:
+            return ''

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -94,6 +94,7 @@ version to use.
 
 """
 import os
+import glob
 
 from botocore import BOTOCORE_ROOT
 from botocore.compat import json
@@ -362,6 +363,35 @@ class Loader(object):
                 return found
         # We didn't find anything that matched on any path.
         raise DataNotFoundError(data_path=name)
+
+    @instance_cache
+    def load_examples(self, service_name, api_version=None):
+        """Load example JSON.
+
+        This method loads the example JSON models given a service name
+        and optionally, an API version.
+
+        :type service_name: str
+        :param service_name: The name of the service (e.g ``ec2``, ``s3``).
+
+        :type api_version: str
+        :param api_version: The API version to load.  If this is not
+            provided, then the latest API version will be used.
+
+        :return: The loaded examples or None if no examples found.
+        """
+        if api_version is not None:
+            name = os.path.join(self.BUILTIN_DATA_PATH, service_name,
+                                api_version, 'examples-1.json')
+            path = os.path.splitext(name)[0]
+            return self.file_loader.load_file(path)
+        else:
+            name = os.path.join(self.BUILTIN_DATA_PATH, service_name,
+                                '**/examples-1.json')
+            paths = glob.glob(name)
+            if paths:
+                example_path = os.path.splitext(max(paths))[0]
+                return self.file_loader.load_file(example_path)
 
     def _potential_locations(self, name=None, must_exist=False,
                              is_dir=False):

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -480,6 +480,11 @@ class Session(object):
             service_name, 'paginators-1', api_version)
         return paginate.PaginatorModel(paginator_config)
 
+    def get_examples(self, service_name, api_version=None):
+        loader = self.get_component('data_loader')
+        examples = loader.load_examples(service_name, api_version)
+        return examples['examples'] if examples else {}
+
     def get_service_data(self, service_name, api_version=None):
         """
         Retrieve the fully merged data associated with a service.


### PR DESCRIPTION
Adds functionality for generating shared documentation examples from the language-agnostic JSON format. These new examples will live alongside the JSON model files.

The code in this PR creates a new loader for loading examples and passes them through to the session, service and client until they are documented in the document_model_driven_method function. From there, the SharedExampleBuilder class parses the dict and creates Python examples at the end of each operation in the client documentation.

Unit tests to be added in a separate PR.