### PR TITLE
Serialize Uri for no input shape

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -374,6 +374,7 @@ class BaseRestSerializer(Serializer):
                                                         self.DEFAULT_METHOD)
         shape = operation_model.input_shape
         if shape is None:
+            serialized['url_path'] = operation_model.http['requestUri']
             return serialized
         shape_members = shape.members
         # While the ``serialized`` key holds the final serialized request

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -1,5 +1,29 @@
 [
   {
+    "description": "No parameters",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {},
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/2014-01-01/jobs"
+          },
+          "name": "OperationName"
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/2014-01-01/jobs",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "URI parameter only with no location name",
     "metadata": {
       "protocol": "rest-json",

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -73,16 +73,16 @@
       {
         "given": {
           "http": {
-            "method": "PUT",
+            "method": "GET",
             "requestUri": "/2014-01-01/hostedzone"
           },
           "name": "OperationName"
         },
         "params": {},
         "serialized": {
-          "method": "PUT",
+          "method": "GET",
           "body": "",
-          "uri": "/",
+          "uri": "/2014-01-01/hostedzone",
           "headers": {}
         }
       }


### PR DESCRIPTION
There was an issue where if the operation had no input shape, we would not use the modeled URI and just use ``'/'`` because that is the default.

cc @jamesls @mtdowling @rayluo 