### PR TITLE
Add content length for seekable files

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -77,6 +77,7 @@ class AWSHTTPConnection(HTTPConnection):
         # body in _send_request, as opposed to endheaders(), which is where the
         # body is sent in all versions > 2.6.
         self._response_received = False
+        self._expect_header_set = False
 
     def _tunnel(self):
         # Works around a bug in py26 which is fixed in later versions of
@@ -414,6 +415,25 @@ class AWSPreparedRequest(models.PreparedRequest):
             logger.debug("Unable to rewind stream: %s", e)
             raise UnseekableStreamError(stream_object=self.body)
 
+    def prepare_body(self, data, files, json=None):
+        """Prepares the given HTTP body data."""
+        super(AWSPreparedRequest, self).prepare_body(data, files, json)
+
+        # Transfer-Encoding is not supported for AWS Services so remove it
+        # if it is added.
+        if 'Transfer-Encoding' in self.headers:
+            self.headers.pop('Transfer-Encoding')
+
+        # Calculate the Content-Length by trying to seek the file as
+        # requests cannot determine content length for some seekable file-like
+        # objects.
+        if 'Content-Length' not in self.headers:
+            if hasattr(data, 'seek') and hasattr(data, 'tell'):
+                orig_pos = data.tell()
+                data.seek(0, 2)
+                end_file_pos = data.tell()
+                self.headers['Content-Length'] = str(end_file_pos - orig_pos)
+                data.seek(orig_pos)
 
 HTTPSConnectionPool.ConnectionCls = AWSHTTPSConnection
 HTTPConnectionPool.ConnectionCls = AWSHTTPConnection

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -85,7 +85,7 @@ class Seekable(object):
         self._stream = stream
 
     def __iter__(self):
-        yield self._stream.__iter__()
+        return iter(self._stream)
 
     def read(self):
         return self._stream.read()

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -23,7 +23,7 @@ import sys
 from mock import Mock, patch
 
 from botocore.exceptions import UnseekableStreamError
-from botocore.awsrequest import AWSRequest
+from botocore.awsrequest import AWSRequest, AWSPreparedRequest
 from botocore.awsrequest import AWSHTTPConnection
 from botocore.awsrequest import prepare_request_dict, create_request_object
 from botocore.compat import file_type, six
@@ -70,6 +70,31 @@ class Unseekable(file_type):
         # but it doesn't actually work (for example socket.makefile(), which
         # will raise an io.* error on python3).
         raise ValueError("Underlying stream does not support seeking.")
+
+
+class Seekable(object):
+    """This class represents a bare-bones,seekable file-like object
+
+    Note it does not include some of the other attributes of other
+    file-like objects such as StringIO's getvalue() and file object's fileno
+    property. If the file-like object does not have either of these attributes
+    requests will not calculate the content length even though it is still
+    possible to calculate it.
+    """
+    def __init__(self, stream):
+        self._stream = stream
+
+    def __iter__(self):
+        yield self._stream.__iter__()
+
+    def read(self):
+        return self._stream.read()
+
+    def seek(self, offset, whence=0):
+        self._stream.seek(offset, whence)
+
+    def tell(self):
+        return self._stream.tell()
 
 
 class TestAWSRequest(unittest.TestCase):
@@ -147,6 +172,39 @@ class TestAWSRequest(unittest.TestCase):
 
         # The stream should now be reset.
         self.assertTrue(looks_like_file.seek_called)
+
+
+class TestAWSPreparedRequest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'foo')
+        self.request = AWSRequest(url='http://example.com')
+        self.prepared_request = AWSPreparedRequest(self.request)
+        self.prepared_request.prepare_headers(self.request.headers)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_prepare_body_content_adds_content_length(self):
+        content = b'foobarbaz'
+        with open(self.filename, 'wb') as f:
+            f.write(content)
+        with open(self.filename, 'rb') as f:
+            data = Seekable(f)
+            self.prepared_request.prepare_body(data=data, files=None)
+        self.assertEqual(
+            self.prepared_request.headers['Content-Length'],
+            str(len(content)))
+
+    def test_prepare_body_removes_transfer_encoding(self):
+        self.prepared_request.headers['Transfer-Encoding'] = 'chunked'
+        content = b'foobarbaz'
+        with open(self.filename, 'wb') as f:
+            f.write(content)
+        with open(self.filename, 'rb') as f:
+            data = Seekable(f)
+            self.prepared_request.prepare_body(data=data, files=None)
+        self.assertNotIn('Transfer-Encoding', self.prepared_request.headers)
 
 
 class TestAWSHTTPConnection(unittest.TestCase):


### PR DESCRIPTION
For some cases like an extracted file from a tar file were not able to
be uploaded because requests did not calculate the content-length despite
the fact that it was seekable. Added logic to calculate and add the content
length header for these types of files.

cc @jamesls @mtdowling @rayluo 