### PR TITLE
Support AWS_SHARED_CREDENTIALS_FILE

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -82,7 +82,7 @@ class Session(object):
         # These variables are intended for internal use so don't have any
         # user settable values.
         # This is the shared credentials file amongst sdks.
-        'credentials_file': (None, None, '~/.aws/credentials', None),
+        'credentials_file': (None, 'AWS_CREDENTIALS_FILE', '~/.aws/credentials', None),
 
         # These variables only exist in the config file.
 

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -82,7 +82,8 @@ class Session(object):
         # These variables are intended for internal use so don't have any
         # user settable values.
         # This is the shared credentials file amongst sdks.
-        'credentials_file': (None, 'AWS_CREDENTIALS_FILE', '~/.aws/credentials', None),
+        'credentials_file': (None, 'AWS_SHARED_CREDENTIALS_FILE',
+                             '~/.aws/credentials', None),
 
         # These variables only exist in the config file.
 


### PR DESCRIPTION
This pulls in https://github.com/boto/botocore/pull/600, and renames the env var to `AWS_SHARED_CREDENTIALS_FILE`.  It also adds an integration test to verify behavior.

Note that there's no actual new code.  It's just changing a config value from None to `AWS_SHARED_CREDENTIALS_FILE`, and that mechanism for the env var->config file->default lookup is already tested.  So it seems reasonable to add an integration test to verify that this specific value was being picked up.


cc @kyleknap @mtdowling @rayluo 