### PR TITLE
Add paginators for CloudWatch Logs

### DIFF
--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -29,12 +29,6 @@
       "output_token": "nextToken",
       "limit_key": "Limit",
       "result_key": "Events"
-    },
-    "GetLogEvents": {
-      "input_token": "nextToken",
-      "output_token": "nextForwardToken",
-      "limit_key": "Limit",
-      "result_key": "Events"
     }
   }
 }

--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -3,32 +3,32 @@
     "DescribeLogGroups": {
       "input_token": "nextToken",
       "output_token": "nextToken",
-      "limit_key": "Limit",
-      "result_key": "LogGroups"
+      "limit_key": "limit",
+      "result_key": "logGroups"
     },
     "DescribeLogStreams": {
       "input_token": "nextToken",
       "output_token": "nextToken",
-      "limit_key": "Limit",
-      "result_key": "LogStreams"
+      "limit_key": "limit",
+      "result_key": "logStreams"
     },
     "DescribeMetricFilters": {
       "input_token": "nextToken",
       "output_token": "nextToken",
-      "limit_key": "Limit",
-      "result_key": "MetricFilters"
+      "limit_key": "limit",
+      "result_key": "metricFilters"
     },
     "DescribeSubscriptionFilters": {
       "input_token": "nextToken",
       "output_token": "nextToken",
-      "limit_key": "Limit",
-      "result_key": "SubscriptionFilters"
+      "limit_key": "limit",
+      "result_key": "subscriptionFilters"
     },
     "FilterLogEvents": {
       "input_token": "nextToken",
       "output_token": "nextToken",
-      "limit_key": "Limit",
-      "result_key": "Events"
+      "limit_key": "limit",
+      "result_key": "events"
     }
   }
 }

--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -1,0 +1,40 @@
+{
+  "pagination": {
+    "DescribeLogGroups": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "limit_key": "Limit",
+      "result_key": "LogGroups"
+    },
+    "DescribeLogStreams": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "limit_key": "Limit",
+      "result_key": "LogStreams"
+    },
+    "DescribeMetricFilters": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "limit_key": "Limit",
+      "result_key": "MetricFilters"
+    },
+    "DescribeSubscriptionFilters": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "limit_key": "Limit",
+      "result_key": "SubscriptionFilters"
+    },
+    "FilterLogEvents": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "limit_key": "Limit",
+      "result_key": "Events"
+    },
+    "GetLogEvents": {
+      "input_token": "nextToken",
+      "output_token": "nextForwardToken",
+      "limit_key": "Limit",
+      "result_key": "Events"
+    }
+  }
+}


### PR DESCRIPTION
This adds some paginators requested in https://github.com/boto/botocore/issues/613. I've verified them to the best of my ability with the services we use, but we don't have any subscription filters.

GetLogEvents is also strange because, it seems, that on the "last" page the `nextForwardToken` is intentially a self reference which causes botocore to raise `botocore.exceptions.PaginationError: Error during pagination: The same next token was received twice: [u'f/...']` exception.

Let me know what you think!