### PR TITLE
(Updated) Append signature to HmacV1Query querystring instead of replace

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -685,6 +685,8 @@ class HmacV1QueryAuth(HmacV1Auth):
 
         # Create a new url with the presigned url.
         p = urlsplit(request.url)
+        if p[3]:
+            new_query_string = p[3] + "&" + new_query_string
         new_url_parts = (p[0], p[1], p[2], new_query_string, p[4])
         request.url = urlunsplit(new_url_parts)
 

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -686,7 +686,9 @@ class HmacV1QueryAuth(HmacV1Auth):
         # Create a new url with the presigned url.
         p = urlsplit(request.url)
         if p[3]:
-            new_query_string = p[3] + "&" + new_query_string
+            # If there was a pre-existing query string, we should
+            # add that back before injecting the new query string.
+            new_query_string ='%s&%s' % (p[3], new_query_string)
         new_url_parts = (p[0], p[1], p[2], new_query_string, p[4])
         request.url = urlunsplit(new_url_parts)
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -450,6 +450,17 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
         # Try to retrieve the object using the presigned url.
         self.assertEqual(requests.get(presigned_url).content, b'foo')
 
+    def test_presign_with_existing_query_string_values(self):
+        content_disposition = 'attachment; filename=foo.txt;'
+        presigned_url = self.client.generate_presigned_url(
+            'get_object', Params={
+                'Bucket': self.bucket_name, 'Key': self.key,
+                'ResponseContentDisposition': content_disposition})
+        response = requests.get(presigned_url)
+        self.assertEqual(response.headers['Content-Disposition'],
+                         content_disposition)
+        self.assertEqual(response.content, b'foo')
+
     def test_presign_sigv4(self):
         self.client_config.signature_version = 's3v4'
         self.client = self.session.create_client(

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -362,6 +362,25 @@ class TestGenerateUrl(unittest.TestCase):
         self.generate_url_mock.assert_called_with(
             request_dict=ref_request_dict, expires_in=3600)
 
+    def test_generate_presigned_url_with_query_string(self):
+        disposition = 'attachment; filename="download.jpg"'
+        self.client.generate_presigned_url(
+            'get_object', Params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'ResponseContentDisposition': disposition})
+        ref_request_dict = {
+            'body': b'',
+            'url': (u'https://s3.amazonaws.com/mybucket/mykey'
+                    '?response-content-disposition='
+                    'attachment%3B%20filename%3D%22download.jpg%22'),
+            'headers': {},
+            'query_string': {u'response-content-disposition': disposition},
+            'url_path': u'/mybucket/mykey',
+            'method': u'GET'}
+        self.generate_url_mock.assert_called_with(
+            request_dict=ref_request_dict, expires_in=3600)
+
     def test_generate_presigned_url_unknown_method_name(self):
         with self.assertRaises(UnknownClientMethodError):
             self.client.generate_presigned_url('getobject')


### PR DESCRIPTION
This pulls in https://github.com/boto/botocore/pull/597 and adds a few unit tests and an integration test.


cc @kyleknap @mtdowling @rayluo 