### PR TITLE
Implement CloudFormation waiters

### DIFF
--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -1,0 +1,197 @@
+{
+    "version": 2,
+    "waiters": {
+        "StackAvailable": {
+            "delay": 30,
+            "maxAttempts": 120,
+            "operation": "DescribeStacks",
+            "acceptors": [
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "CREATE_COMPLETE",
+                    "matcher": "pathAll",
+                    "state": "success"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "CREATE_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "DELETE_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "DELETE_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "DELETE_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "ROLLBACK_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "ROLLBACK_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "ROLLBACK_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_COMPLETE",
+                    "matcher": "pathAll",
+                    "state": "success"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "expected": "ValidationError",
+                    "matcher": "error",
+                    "state": "failure"
+                }
+            ]
+        },
+        "StackDeleted": {
+            "delay": 30,
+            "maxAttempts": 120,
+            "operation": "DescribeStacks",
+            "acceptors": [
+                {
+                    "expected": "ValidationError",
+                    "matcher": "error",
+                    "state": "success"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "CREATE_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "CREATE_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "CREATE_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "DELETE_COMPLETE",
+                    "matcher": "pathAll",
+                    "state": "success"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "DELETE_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "ROLLBACK_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "ROLLBACK_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "ROLLBACK_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                }
+            ]
+        }
+    }
+}

--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -1,7 +1,24 @@
 {
     "version": 2,
     "waiters": {
-        "StackAvailable": {
+        "StackExists": {
+            "delay": 5,
+            "operation": "DescribeStacks",
+            "maxAttempts": 20,
+            "acceptors": [
+                {
+                    "matcher": "status",
+                    "expected": 200,
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "ValidationError",
+                    "state": "retry"
+                }
+            ]
+        },
+        "StackCreateComplete": {
             "delay": 30,
             "maxAttempts": 120,
             "operation": "DescribeStacks",
@@ -55,43 +72,13 @@
                     "state": "failure"
                 },
                 {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_COMPLETE",
-                    "matcher": "pathAll",
-                    "state": "success"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
                     "expected": "ValidationError",
                     "matcher": "error",
                     "state": "failure"
                 }
             ]
         },
-        "StackDeleted": {
+        "StackDeleteComplete": {
             "delay": 30,
             "maxAttempts": 120,
             "operation": "DescribeStacks",
@@ -189,6 +176,48 @@
                     "argument": "Stacks[].StackStatus",
                     "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
                     "matcher": "pathAny",
+                    "state": "failure"
+                }
+            ]
+        },
+        "StackUpdateComplete": {
+            "delay": 30,
+            "maxAttempts": 120,
+            "operation": "DescribeStacks",
+            "acceptors": [
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_COMPLETE",
+                    "matcher": "pathAll",
+                    "state": "success"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_COMPLETE",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "argument": "Stacks[].StackStatus",
+                    "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
+                    "matcher": "pathAny",
+                    "state": "failure"
+                },
+                {
+                    "expected": "ValidationError",
+                    "matcher": "error",
                     "state": "failure"
                 }
             ]

--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -1,226 +1,226 @@
 {
-    "version": 2,
-    "waiters": {
-        "StackExists": {
-            "delay": 5,
-            "operation": "DescribeStacks",
-            "maxAttempts": 20,
-            "acceptors": [
-                {
-                    "matcher": "status",
-                    "expected": 200,
-                    "state": "success"
-                },
-                {
-                    "matcher": "error",
-                    "expected": "ValidationError",
-                    "state": "retry"
-                }
-            ]
+  "version": 2,
+  "waiters": {
+    "StackExists": {
+      "delay": 5,
+      "operation": "DescribeStacks",
+      "maxAttempts": 20,
+      "acceptors": [
+        {
+          "matcher": "status",
+          "expected": 200,
+          "state": "success"
         },
-        "StackCreateComplete": {
-            "delay": 30,
-            "maxAttempts": 120,
-            "operation": "DescribeStacks",
-            "acceptors": [
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "CREATE_COMPLETE",
-                    "matcher": "pathAll",
-                    "state": "success"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "CREATE_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "DELETE_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "DELETE_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "DELETE_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "ROLLBACK_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "ROLLBACK_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "ROLLBACK_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "expected": "ValidationError",
-                    "matcher": "error",
-                    "state": "failure"
-                }
-            ]
-        },
-        "StackDeleteComplete": {
-            "delay": 30,
-            "maxAttempts": 120,
-            "operation": "DescribeStacks",
-            "acceptors": [
-                {
-                    "expected": "ValidationError",
-                    "matcher": "error",
-                    "state": "success"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "CREATE_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "CREATE_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "CREATE_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "DELETE_COMPLETE",
-                    "matcher": "pathAll",
-                    "state": "success"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "DELETE_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "ROLLBACK_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "ROLLBACK_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "ROLLBACK_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                }
-            ]
-        },
-        "StackUpdateComplete": {
-            "delay": 30,
-            "maxAttempts": 120,
-            "operation": "DescribeStacks",
-            "acceptors": [
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_COMPLETE",
-                    "matcher": "pathAll",
-                    "state": "success"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_COMPLETE",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_FAILED",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "argument": "Stacks[].StackStatus",
-                    "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
-                    "matcher": "pathAny",
-                    "state": "failure"
-                },
-                {
-                    "expected": "ValidationError",
-                    "matcher": "error",
-                    "state": "failure"
-                }
-            ]
+        {
+          "matcher": "error",
+          "expected": "ValidationError",
+          "state": "retry"
         }
+      ]
+    },
+    "StackCreateComplete": {
+      "delay": 30,
+      "maxAttempts": 120,
+      "operation": "DescribeStacks",
+      "acceptors": [
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "CREATE_COMPLETE",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "CREATE_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "DELETE_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "DELETE_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "DELETE_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "ROLLBACK_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "ROLLBACK_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "ROLLBACK_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "expected": "ValidationError",
+          "matcher": "error",
+          "state": "failure"
+        }
+      ]
+    },
+    "StackDeleteComplete": {
+      "delay": 30,
+      "maxAttempts": 120,
+      "operation": "DescribeStacks",
+      "acceptors": [
+        {
+          "expected": "ValidationError",
+          "matcher": "error",
+          "state": "success"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "CREATE_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "CREATE_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "CREATE_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "DELETE_COMPLETE",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "DELETE_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "ROLLBACK_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "ROLLBACK_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "ROLLBACK_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        }
+      ]
+    },
+    "StackUpdateComplete": {
+      "delay": 30,
+      "maxAttempts": 120,
+      "operation": "DescribeStacks",
+      "acceptors": [
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_COMPLETE",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "argument": "Stacks[].StackStatus",
+          "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
+          "expected": "ValidationError",
+          "matcher": "error",
+          "state": "failure"
+        }
+      ]
     }
+  }
 }


### PR DESCRIPTION
# Cloudformation Waiters

Two sub-commands are added with this PR

## wait stack-available

to be used with `create-stack`/`update-stack`

    $ aws cloudformation create-stack --stack-name foo --template-body file://foo.template.json
    $ aws cloudformation wait stack-available --stack-name foo

o success status

* CREATE_COMPLETE
* UPDATE_COMPLETE

o retry status

* CREATE_IN_PROGRESS
* UPDATE_IN_PROGRESS
* UPDATE_COMPLETE_CLEANUP_IN_PROGRESS

o failure status

* other statuses

## wait stack-deleted

to be used with `delete-stack`

    $ aws cloudformation delete-stack --stack-name foo
    $ aws cloudformation wait stack-deleted --stack-name foo

o success status

* DELETE_COMPLETE (when queried with stack-id)
* ValidationError (when queried with stack-name)

o retry status

* DELETE_IN_PROGRESS

o failure status

* other statuses


## retry handling

Poll every 30 seconds for 120 times(60 minutes) with `describe-stacks` API and query the response with `Stacks[].StackStatus`.

When provisioning services like cloudformation or DB(RDS, RedShift, etc) or Elastic BeanStalk or changing magnetic device to SSD,  CFn takes a long time, so I set threshold times(60 mins) longer than other wait commands.

# StackStatus

## List of StackStatus

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html

* CREATE_COMPLETE
* CREATE_IN_PROGRESS
* CREATE_FAILED
* DELETE_COMPLETE
* DELETE_FAILED
* DELETE_IN_PROGRESS
* ROLLBACK_COMPLETE
* ROLLBACK_FAILED
* ROLLBACK_IN_PROGRESS
* UPDATE_COMPLETE
* UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
* UPDATE_IN_PROGRESS
* UPDATE_ROLLBACK_COMPLETE
* UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS
* UPDATE_ROLLBACK_FAILED
* UPDATE_ROLLBACK_IN_PROGRESS

## StackStatus state diagram

Based on the document and playing with CFn and advices from my colleagues, I created a StackStatus state diagram.
This diagram does *not* cover every single flow, but will cover most of the state changes(I think).

* Blue-filled statuses are success
* Green-filled statuses are retry
* Other statuses are failure

### create-stack 

![create-stack](https://cloud.githubusercontent.com/assets/266641/9308707/804b53e2-4540-11e5-9b95-0b14c9e43254.png)

* If you pass `--disable-rollback`, rollback won't occur.
* `CREATE_IN_PROGRESS` stack can be deleted with `DeleteStack` API

### update-stack

![update-stack](https://cloud.githubusercontent.com/assets/266641/9308712/856fc308-4540-11e5-9656-6c5faef11ec3.png)

* `UPDATE_IN_PROGRESS` stack can be canceled(rollback) with `CancelUpdateStack` API
* There's no `--disable-rollback` option for update stack

### delete-stack
![delete-stack](https://cloud.githubusercontent.com/assets/266641/9308723/8bce5020-4540-11e5-81a8-4fde233c40b8.png)

* There's no rollback or abort flow for `DeleteStack` API 
* `DescribeStacks`'s `StackName` parameter can take either `StackName` or `StackID`.
  For `DELETE_COMPLETE`-state stacks, `DescribeStacks`
  * returns `ValidationError` when queried with `StackName`
  * returns `DELETE_COMPLETE` status when queried with `StackID`

Original graphviz gist files can be found here https://gist.github.com/quiver/e5496a91deda73bc9f84

# Solves

* aws/aws-cli#895
* boto/boto3#84