### PR TITLE
add tests to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include LICENSE.txt
 include requirements.txt
 include botocore/vendored/requests/cacert.pem
 recursive-include botocore/data *.json
-recursive-include docs *
+graft docs
 prune docs/build
+graft tests


### PR DESCRIPTION
When packaging botocore it's nice to be able to run the tests from the
source distribution to ensure that the packaging has been done
correctly.  This includes the tests directoy in the sdist without
installing it to the system.  Piggy-backed is a change to the docs
inclusion that uses graft rather than recursive-include.