### PR TITLE
Add resource leak tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -176,7 +176,7 @@ class ClientRunner(object):
 
     def start(self):
         """Start up the command runner process."""
-        self._popen = Popen(['python', self.CLIENT_SERVER],
+        self._popen = Popen([sys.executable, self.CLIENT_SERVER],
                             stdout=PIPE, stdin=PIPE)
 
     def stop(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -203,7 +203,8 @@ class ClientRunner(object):
 
         """
         cmd_str = ' '.join(cmd) + '\n'
-        self._popen.stdin.write(cmd_str)
+        cmd_bytes = cmd_str.encode('utf-8')
+        self._popen.stdin.write(cmd_bytes)
         self._popen.stdin.flush()
 
     def is_cmd_finished(self):

--- a/tests/cmd-runner
+++ b/tests/cmd-runner
@@ -17,7 +17,7 @@ How it Works
 ============
 
 This script is part of the infrastructure used for resource leak tests.
-At a high level, we're trying to varify that specific types of operations
+At a high level, we're trying to verify that specific types of operations
 don't leak memory.  For example:
 
 * Creating 100 clients in a loop doesn't leak memory within reason
@@ -111,11 +111,6 @@ class CommandRunner(object):
     def _do_free_clients(self, args):
         # Frees the memory associated with all clients.
         self._clients = []
-
-    def _do_gc_collect(self, args):
-        # Run a gc collection to clean up cyclic references.
-        import gc
-        gc.collect()
 
     def _do_make_aws_request(self, args):
         # Create a client and make a number of AWS requests.

--- a/tests/cmd-runner
+++ b/tests/cmd-runner
@@ -145,7 +145,8 @@ class CommandRunner(object):
         # * filename - The name of the local filename to upload
         bucket, key, local_filename = args
         client = self._session.create_client('s3')
-        client.put_object(Bucket=bucket, Key=key, Body=open(local_filename))
+        with open(local_filename, 'rb') as f:
+            client.put_object(Bucket=bucket, Key=key, Body=f)
 
     def _do_stream_s3_download(self, args):
         # Stream a download to S3 from a local file.

--- a/tests/cmd-runner
+++ b/tests/cmd-runner
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Driver for client scripts.
+
+How it Works
+============
+
+This script is part of the infrastructure used for resource leak tests.
+At a high level, we're trying to varify that specific types of operations
+don't leak memory.  For example:
+
+* Creating 100 clients in a loop doesn't leak memory within reason
+* Making 100 API calls doesn't leak memory
+* Streaming uploads/downloads to/from S3 have O(1) memory usage.
+
+In order to do this, these tests are written to utilize two separate
+processes: a driver and a runner.  The driver sends commands to the
+runner which performs the actual commands.  While the runner is
+running commands the driver can record various attributes about
+the runner process.  So far this is just memory usage.
+
+There's a BaseClientDriverTest test that implements the driver part
+of the tests.  These should read like normal functional/integration tests.
+
+This script (cmd-runner) implements the runner.  It listens for commands
+from the driver and runs the commands.
+
+The driver and runner communicate via a basic text protocol.  Commands
+are line separated with arguments separated by spaces.  Commands
+are sent to the runner via stdin.
+
+On success, the runner response through stdout with "OK".
+
+Here's an example::
+
+    +--------+                                     +-------+
+    | Driver |                                     |Runner |
+    +--------+                                     +-------+
+
+         create_client s3
+         -------------------------------------------->
+               OK
+         <-------------------------------------------
+
+         make_aws_request 100 ec2 describe_instances
+         -------------------------------------------->
+               OK
+         <-------------------------------------------
+
+         stream_s3_upload bucket key /tmp/foo.txt
+         -------------------------------------------->
+               OK
+         <-------------------------------------------
+
+         exit
+         -------------------------------------------->
+               OK
+         <-------------------------------------------
+
+"""
+import botocore.session
+import sys
+
+
+class CommandRunner(object):
+    def __init__(self):
+        self._session = botocore.session.get_session()
+        self._clients = []
+
+    def run(self):
+        while True:
+            line = sys.stdin.readline()
+            parts = line.strip().split()
+            if not parts:
+                break
+            elif parts[0] == 'exit':
+                sys.stdout.write('OK\n')
+                sys.stdout.flush()
+                break
+            else:
+                getattr(self, '_do_%s' % parts[0])(parts[1:])
+                sys.stdout.write('OK\n')
+                sys.stdout.flush()
+
+    def _do_create_client(self, args):
+        # The args provided by the user map directly to the args
+        # passed to create_client.  At the least you need
+        # to provide the service name.
+        self._clients.append(self._session.create_client(*args))
+
+    def _do_create_multiple_clients(self, args):
+        # Args:
+        # * num_clients - Number of clients to create in a loop
+        # * client_args - Variable number of args to pass to create_client
+        num_clients = args[0]
+        client_args = args[1:]
+        for _ in range(int(num_clients)):
+            self._clients.append(self._session.create_client(*client_args))
+
+    def _do_free_clients(self, args):
+        # Frees the memory associated with all clients.
+        self._clients = []
+
+    def _do_gc_collect(self, args):
+        # Run a gc collection to clean up cyclic references.
+        import gc
+        gc.collect()
+
+    def _do_make_aws_request(self, args):
+        # Create a client and make a number of AWS requests.
+        # Args:
+        # * num_requests   - The number of requests to create in a loop
+        # * service_name   - The name of the AWS service
+        # * operation_name - The name of the service, snake_cased
+        # * oepration_args - Variable args, kwargs to pass to the API call,
+        #                    in the format Kwarg1:Val1 Kwarg2:Val2
+        num_requests = int(args[0])
+        service_name = args[1]
+        operation_name = args[2]
+        kwargs = dict([v.split(':', 1) for v in args[3:]])
+        client = self._session.create_client(service_name)
+        method = getattr(client, operation_name)
+        for _ in range(num_requests):
+            method(**kwargs)
+
+    def _do_stream_s3_upload(self, args):
+        # Stream an upload to S3 from a local file.
+        # This does *not* create an S3 bucket.  You need to create this
+        # before running this command.  You will also need to create
+        # the local file to upload before calling this command.
+        # Args:
+        # * bucket   - The name of the S3 bucket
+        # * key      - The name of the S3 key
+        # * filename - The name of the local filename to upload
+        bucket, key, local_filename = args
+        client = self._session.create_client('s3')
+        client.put_object(Bucket=bucket, Key=key, Body=open(local_filename))
+
+    def _do_stream_s3_download(self, args):
+        # Stream a download to S3 from a local file.
+        # Before calling this command you'll need to create the S3 bucket
+        # as well as the S3 object.  Also, the directory where the
+        # file will be downloaded must already exist.
+        # Args:
+        # * bucket   - The name of the S3 bucket
+        # * key      - The name of the S3 key
+        # * filename - The local filename where the object will be downloaded
+        bucket, key, local_filename = args
+        client = self._session.create_client('s3')
+        response = client.get_object(Bucket=bucket, Key=key)
+        body_stream = response['Body']
+        with open(local_filename, 'wb') as f:
+            for chunk in iter(lambda: body_stream.read(64 * 1024), b''):
+                f.write(chunk)
+
+
+def run():
+    CommandRunner().run()
+
+
+run()

--- a/tests/functional/leak/__init__.py
+++ b/tests/functional/leak/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/leak/test_resource_leaks.py
+++ b/tests/functional/leak/test_resource_leaks.py
@@ -1,0 +1,42 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import BaseClientDriverTest
+
+
+class TestDoesNotLeakMemory(BaseClientDriverTest):
+    # We're making up numbers here, but let's say arbitrarily
+    # that the memory can't increase by more than 10MB.
+    MAX_GROWTH_BYTES = 10 * 1024 * 1024
+
+    def test_create_single_client_memory_constant(self):
+        self.cmd('create_client', 's3')
+        self.cmd('free_clients')
+        self.record_memory()
+        for _ in range(100):
+            self.cmd('create_client', 's3')
+            self.cmd('free_clients')
+        self.record_memory()
+        start, end = self.runner.memory_samples
+        self.assertTrue((end - start) < self.MAX_GROWTH_BYTES, (end - start))
+
+    def test_create_memory_clients_in_loop(self):
+        self.cmd('create_multiple_clients', '200', 's3')
+        self.cmd('free_clients')
+        self.record_memory()
+        # 500 clients in batches of 50.
+        for _ in range(10):
+            self.cmd('create_multiple_clients', '50', 's3')
+            self.cmd('free_clients')
+        self.record_memory()
+        start, end = self.runner.memory_samples
+        self.assertTrue((end - start) < self.MAX_GROWTH_BYTES, (end - start))


### PR DESCRIPTION
This adds several functional and integration tests for verifying that we don't leak memory when performing various botocore operations.  This includes:

* Creating multiple clients.  Verify creating/deleting multiple clients does not cause undesired memory growth.
* Performing various AWS operation does not have undesired memory growth.
* Performing streaming S3 uploads/downloads has constant memory utilization during (and after) the transfers.

The best description of how this works is in the tests/cmd-runner module docstring.

cc @kyleknap @mtdowling @rayluo 