### PR TITLE
Add back paginator-1.json and waiters-2.json for cloudfront

### DIFF
--- a/botocore/data/cloudfront/2015-04-17/paginators-1.json
+++ b/botocore/data/cloudfront/2015-04-17/paginators-1.json
@@ -1,0 +1,32 @@
+{
+  "pagination": {
+    "ListCloudFrontOriginAccessIdentities": {
+      "input_token": "Marker",
+      "output_token": "CloudFrontOriginAccessIdentityList.NextMarker",
+      "limit_key": "MaxItems",
+      "more_results": "CloudFrontOriginAccessIdentityList.IsTruncated",
+      "result_key": "CloudFrontOriginAccessIdentityList.Items"
+    },
+    "ListDistributions": {
+      "input_token": "Marker",
+      "output_token": "DistributionList.NextMarker",
+      "limit_key": "MaxItems",
+      "more_results": "DistributionList.IsTruncated",
+      "result_key": "DistributionList.Items"
+    },
+    "ListInvalidations": {
+      "input_token": "Marker",
+      "output_token": "InvalidationList.NextMarker",
+      "limit_key": "MaxItems",
+      "more_results": "InvalidationList.IsTruncated",
+      "result_key": "InvalidationList.Items"
+    },
+    "ListStreamingDistributions": {
+      "input_token": "Marker",
+      "output_token": "StreamingDistributionList.NextMarker",
+      "limit_key": "MaxItems",
+      "more_results": "StreamingDistributionList.IsTruncated",
+      "result_key": "StreamingDistributionList.Items"
+    }
+  }
+}

--- a/botocore/data/cloudfront/2015-04-17/waiters-2.json
+++ b/botocore/data/cloudfront/2015-04-17/waiters-2.json
@@ -1,0 +1,47 @@
+{
+  "version": 2,
+  "waiters": {
+    "DistributionDeployed": {
+      "delay": 60,
+      "operation": "GetDistribution",
+      "maxAttempts": 25,
+      "description": "Wait until a distribution is deployed.",
+      "acceptors": [
+        {
+          "expected": "Deployed",
+          "matcher": "path",
+          "state": "success",
+          "argument": "Distribution.Status"
+        }
+      ]
+    },
+    "InvalidationCompleted": {
+      "delay": 20,
+      "operation": "GetInvalidation",
+      "maxAttempts": 60,
+      "description": "Wait until an invalidation has completed.",
+      "acceptors": [
+        {
+          "expected": "Completed",
+          "matcher": "path",
+          "state": "success",
+          "argument": "Invalidation.Status"
+        }
+      ]
+    },
+    "StreamingDistributionDeployed": {
+      "delay": 60,
+      "operation": "GetStreamingDistribution",
+      "maxAttempts": 25,
+      "description": "Wait until a streaming distribution is deployed.",
+      "acceptors": [
+        {
+          "expected": "Deployed",
+          "matcher": "path",
+          "state": "success",
+          "argument": "StreamingDistribution.Status"
+        }
+      ]
+    }
+  }
+}

--- a/tests/functional/test_model_completeness.py
+++ b/tests/functional/test_model_completeness.py
@@ -1,0 +1,42 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.session import Session
+from botocore.loaders import Loader
+from botocore.exceptions import DataNotFoundError
+
+
+def _test_model_is_not_lost(service_name, type_name,
+                            previous_version, latest_version):
+    # Make sure if a paginator and/or waiter exists in previous version,
+    # there will be a successor existing in latest version.
+    loader = Loader()
+    try:
+        previous = loader.load_service_model(
+            service_name, type_name, previous_version)
+    except DataNotFoundError:
+        pass
+    else:
+        try:
+            latest = loader.load_service_model(
+                service_name, type_name, latest_version)
+        except DataNotFoundError as e:
+            raise AssertionError(
+                "%s must exist for %s: %s" % (type_name, service_name, e))
+
+def test_paginators_and_waiters_are_not_lost_in_new_version():
+    for service_name in Session().get_available_services():
+        versions = Loader().list_api_versions(service_name, 'service-2')
+        if len(versions) > 1:
+            for type_name in ['paginators-1', 'waiters-2']:
+                yield (_test_model_is_not_lost, service_name,
+                       type_name, versions[-2], versions[-1])


### PR DESCRIPTION
These 2 files are now copied from previous version, the 2014-11-06 directory.

Also add a couple test cases to prevent this from happening in future.