### PR TITLE
Add bucket name validation to S3 calls

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -21,6 +21,7 @@ import hashlib
 import logging
 import xml.etree.cElementTree
 import copy
+import string
 
 from botocore.compat import urlsplit, urlunsplit, unquote, json, quote, six
 from botocore.docs.utils import AutoPopulatedParam
@@ -28,6 +29,7 @@ from botocore.docs.utils import HideParamFromOperations
 from botocore.docs.utils import AppendParamDocumentation
 from botocore.signers import add_generate_presigned_url
 from botocore.signers import add_generate_presigned_post
+from botocore.exceptions import ParamValidationError
 
 from botocore import retryhandler
 from botocore import utils
@@ -40,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 REGISTER_FIRST = object()
 REGISTER_LAST = object()
+VALID_BUCKET_CHARS = string.ascii_letters + string.digits + '.-_'
 
 
 def check_for_200_error(response, **kwargs):
@@ -138,6 +141,28 @@ def conditionally_calculate_md5(params, **kwargs):
     signer = kwargs['request_signer']
     if signer.signature_version != 'v4':
         calculate_md5(params, **kwargs)
+
+
+def validate_bucket_name(params, **kwargs):
+    # The rules for bucket names in the US Standard region allow bucket names
+    # to be as long as 255 characters, and bucket names can contain any
+    # combination of uppercase letters, lowercase letters, numbers, periods
+    # (.), hyphens (-), and underscores (_).
+    if 'Bucket' not in params:
+        return
+    bucket = params['Bucket']
+    if len(bucket) > 255:
+        error_msg = (
+            'Invalid bucket name "%s": Bucket name cannot be '
+            'longer than 255 characters.' % bucket)
+        raise ParamValidationError(report=error_msg)
+    for char in bucket:
+        if char not in VALID_BUCKET_CHARS:
+            error_msg = (
+                'Invalid bucket name "%s", can only contain '
+                'uppercase letters, lowercase letters, numbers, periods, '
+                'hyphens, and underscores.' % bucket)
+            raise ParamValidationError(report=error_msg)
 
 
 def sse_md5(params, **kwargs):
@@ -443,6 +468,8 @@ BUILTIN_HANDLERS = [
     ('after-call.ec2.GetConsoleOutput', decode_console_output),
     ('after-call.cloudformation.GetTemplate', json_decode_template_body),
     ('after-call.s3.GetBucketLocation', parse_get_bucket_location),
+
+    ('before-parameter-build.s3', validate_bucket_name),
 
     ('before-call.s3.PutBucketTagging', calculate_md5),
     ('before-call.s3.PutBucketLifecycle', calculate_md5),

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+
+import botocore.session
+from botocore.exceptions import ParamValidationError
+
+
+class TestS3BucketValidation(unittest.TestCase):
+    def test_invalid_bucket_name_raises_error(self):
+        session = botocore.session.get_session()
+        s3 = session.create_client('s3')
+        with self.assertRaises(ParamValidationError):
+            s3.put_object(Bucket='adfgasdfadfs/bucket/name',
+                          Key='foo', Body=b'asdf')

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -513,6 +513,18 @@ class TestHandlers(BaseSessionTest):
         }
         self.assertIsNone(handlers.validate_bucket_name(params))
 
+    def test_valid_bucket_name_hyphen(self):
+        self.assertIsNone(
+            handlers.validate_bucket_name({'Bucket': 'my-bucket-name'}))
+
+    def test_valid_bucket_name_underscore(self):
+        self.assertIsNone(
+            handlers.validate_bucket_name({'Bucket': 'my_bucket_name'}))
+
+    def test_valid_bucket_name_period(self):
+        self.assertIsNone(
+            handlers.validate_bucket_name({'Bucket': 'my.bucket.name'}))
+
     def test_validation_is_noop_if_no_bucket_param_exists(self):
         self.assertIsNone(handlers.validate_bucket_name(params={}))
 


### PR DESCRIPTION
Fixes boto/boto3#181

Based on:

http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#non-dns-compliant-bucketname-challenges


cc @kyleknap @mtdowling @rayluo 