### PR TITLE
Remove GetLogEvents paginator

### DIFF
--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -38,12 +38,6 @@
         "events",
         "searchedLogStreams"
       ]
-    },
-    "GetLogEvents": {
-      "input_token": "nextToken",
-      "output_token": "nextForwardToken",
-      "limit_key": "limit",
-      "result_key": "events"
     }
   }
 }


### PR DESCRIPTION
This paginator returns the same token twice to indicate pagination is
done. Botocore treats this as an error, but really we should stop paginating.
So remove this paginator for now until support is added in botocore.

cc @jamesls @mtdowling @rayluo 