### PR TITLE
Some moderate refactoring for boto3 docstrings

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -26,6 +26,7 @@ from botocore.model import ServiceModel
 from botocore.paginate import Paginator
 from botocore.signers import RequestSigner
 from botocore.utils import CachedProperty
+from botocore.utils import get_service_module_name
 from botocore.docs.method import LazyLoadedDocstring
 
 
@@ -69,7 +70,7 @@ class ClientCreator(object):
         self._event_emitter.emit('creating-client-class.%s' % service_name,
                                  class_attributes=class_attributes,
                                  base_classes=bases)
-        class_name = self._get_client_class_name(service_model, service_name)
+        class_name = get_service_module_name(service_model)
         cls = type(str(class_name), tuple(bases), class_attributes)
         return cls
 
@@ -79,15 +80,6 @@ class ClientCreator(object):
         service_model = ServiceModel(json_model, service_name=service_name)
         self._register_retries(service_model)
         return service_model
-
-    def _get_client_class_name(self, service_model, service_name):
-        name = service_model.metadata.get(
-            'serviceAbbreviation',
-            service_model.metadata.get('serviceFullName', service_name))
-        name = name.replace('Amazon', '')
-        name = name.replace('AWS', '')
-        name = re.sub('\W+', '', name)
-        return name
 
     def _register_retries(self, service_model):
         endpoint_prefix = service_model.endpoint_prefix

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -255,6 +255,7 @@ class LazyLoadedDocstring(str):
         self._gen_args = args
         self._gen_kwargs = kwargs
         self._docstring = None
+        self._docstring_writer = document_model_driven_method
 
     def __new__(cls, *args, **kwargs):
         # Needed in order to sub class from str with args and kwargs
@@ -290,7 +291,7 @@ class LazyLoadedDocstring(str):
         docstring_structure = DocumentStructure('docstring')
         # Call the document method function with the args and kwargs
         # passed to the class.
-        document_model_driven_method(
+        self._docstring_writer(
             docstring_structure, *self._gen_args,
             **self._gen_kwargs)
         return docstring_structure.flush_structure().decode('utf-8')

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -47,6 +47,21 @@ class _RetriesExceededError(Exception):
     pass
 
 
+def get_service_module_name(service_model):
+    """Returns the module name for a service
+
+    This is the value used in both the documentation and client class name
+    """
+    name = service_model.metadata.get(
+        'serviceAbbreviation',
+        service_model.metadata.get(
+            'serviceFullName', service_model.service_name))
+    name = name.replace('Amazon', '')
+    name = name.replace('AWS', '')
+    name = re.sub('\W+', '', name)
+    return name
+
+
 def normalize_url_path(path):
     if not path:
         return '/'


### PR DESCRIPTION
Includes extracting out the logic that creates the client classes into a public function. This is needed because resource factories in boto3 do not have access to the client's class, and thus its name, when creating the resource class.

There was also some moving around some of the internals of the docstring class to make it easier to inherit from for example:
```py
class ActionDocstring(LazyLoadedDocstring):
    def __init__(self, *args, **kwargs):
        super(ActionDocstring, self).__init__(*args, **kwargs)
        self._docstring_writer = document_action
```

cc @jamesls @mtdowling @rayluo 