### PR TITLE
Make the StreamingBody wrapper more file-like with a close() method

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -83,6 +83,9 @@ class StreamingBody(object):
                 actual_bytes=self._amount_read,
                 expected_bytes=int(self._content_length))
 
+    def close(self):
+        self._raw_stream.close()
+
 
 def _validate_content_length(expected_content_length, body_length):
     # See: https://github.com/kennethreitz/requests/issues/1855

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -61,6 +61,14 @@ class TestStreamWrapper(unittest.TestCase):
         with self.assertRaises(IncompleteReadError):
             stream.read()
 
+    def test_streaming_body_closes(self):
+        body = six.BytesIO(b'1234567890')
+        stream = response.StreamingBody(body, content_length=10)
+        self.assertFalse(body.closed)
+        stream.close()
+        self.assertTrue(body.closed)
+
+
 class TestGetResponse(unittest.TestCase):
     maxDiff = None
 


### PR DESCRIPTION
This will solve pypa/warehouse#676 which is essentially caused by trying to treat the StreamingBody like a file-like object.