### PR TITLE
Added error code and message to unexpected WaiterError

### DIFF
--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -272,8 +272,9 @@ class Waiter(object):
                 if 'Error' in response:
                     # Transition to the failure state, which we can
                     # just handle here by raising an exception.
-                    raise WaiterError(name=self.name,
-                                      reason='Unexpected error encountered.')
+                    raise WaiterError(
+                        name=self.name,
+                        reason=response['Error'].get('Message', 'Unknown'))
             if current_state == 'success':
                 logger.debug("Waiting complete, waiter matched the "
                              "success state.")

--- a/tests/unit/test_waiters.py
+++ b/tests/unit/test_waiters.py
@@ -342,6 +342,26 @@ class TestWaitersObjects(unittest.TestCase):
         with self.assertRaises(WaiterError):
             waiter.wait()
 
+    def test_unspecified_errors_propagate_error_code(self):
+        # If a waiter receives an error response, then the
+        # waiter should pass along the error code
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        error_code = 'error_message'
+        error_message = 'error_message'
+        self.client_responses_are(
+            # This is an unknown error that's not called out
+            # in any of the waiter config, so when the
+            # waiter encounters this response it will transition
+            # to the failure state.
+            {'Error': {'Code': error_code, 'Message': error_message}},
+            for_operation=operation_method
+        )
+        waiter = Waiter('MyWaiter', config, operation_method)
+
+        with self.assertRaisesRegexp(WaiterError, error_message):
+            waiter.wait()
+
     def test_waiter_transitions_to_failure_state(self):
         acceptors = [
             # A success state that will never be hit.


### PR DESCRIPTION
Fixes boto/boto3#233

In that specific case, the result now looks like:

    WaiterError: Waiter InstanceStopped failed: Request would have succeeded, but DryRun flag is set.