### PR TITLE
Tolerate missing code or message in error response

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -296,8 +296,8 @@ class ClientError(Exception):
 
     def __init__(self, error_response, operation_name):
         msg = self.MSG_TEMPLATE.format(
-            error_code=error_response['Error']['Code'],
-            error_message=error_response['Error']['Message'],
+            error_code=error_response['Error'].get('Code', 'Unknown'),
+            error_message=error_response['Error'].get('Message', 'Unknown'),
             operation_name=operation_name)
         super(ClientError, self).__init__(msg)
         self.response = error_response

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from nose.tools import assert_equals
+
+from botocore import exceptions
+
+
+def test_client_error_can_handle_missing_code_or_message():
+    response = {'Error': {}}
+    expect = 'An error occurred (Unknown) when calling the blackhole operation: Unknown'
+    assert_equals(str(exceptions.ClientError(response, 'blackhole')), expect)


### PR DESCRIPTION
Since we don't have control to field names in upstream services, let's play safe by not assuming any field's existence.

PS: This is a successor of the closed PR https://github.com/boto/botocore/pull/610.
That one was originally developed to address another issue with similar symptom, but then we used another approach to solve the root cause for that one.
Now this one seems still useful as part of the fix for boto/boto3#249. (Similar fix can be found here too. borrows the concept in https://github.com/boto/botocore/pull/647)