### PR TITLE
Don't remove lazy component from deferred until success

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -770,8 +770,12 @@ class ComponentLocator(object):
 
     def get_component(self, name):
         if name in self._deferred:
-            factory = self._deferred.pop(name)
+            factory = self._deferred[name]
             self._components[name] = factory()
+            # Only delete the component from the deferred dict after
+            # successfully creating the object from the factory as well as
+            # injecting the instantiated value into the _components dict.
+            del self._deferred[name]
         try:
             return self._components[name]
         except KeyError:


### PR DESCRIPTION
Only delete the component from the deferred dict after
successfully creating the object from the factory as well as
injecting the instantiated value into the _components dict.

The bug is that is the factory object raises an exception,
we've already removed it from the deferred list (via the
.pop() call), but we haven't added anything to the _components
dict.

Because of this, the next time you try to make a call you'll
get an error message about an unknown component.

It also looks like there were no unit tests for this class.
It was only tested transitively before.  I've added a set
of unit tests covering this behavior.

This was found while looking into https://github.com/aws/aws-cli/pull/1515

cc @kyleknap @mtdowling @rayluo 