### PR TITLE
Account for Output not in response

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -92,11 +92,12 @@ def _looks_like_special_case_error(http_response):
 
 
 def decode_console_output(parsed, **kwargs):
-    try:
-        value = base64.b64decode(six.b(parsed['Output'])).decode('utf-8')
-        parsed['Output'] = value
-    except (ValueError, TypeError, AttributeError):
-        logger.debug('Error decoding base64', exc_info=True)
+    if 'Output' in parsed:
+        try:
+            value = base64.b64decode(six.b(parsed['Output'])).decode('utf-8')
+            parsed['Output'] = value
+        except (ValueError, TypeError, AttributeError):
+            logger.debug('Error decoding base64', exc_info=True)
 
 
 def decode_quoted_jsondoc(value):

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -16,6 +16,7 @@ import itertools
 from nose.plugins.attrib import attr
 
 import botocore.session
+from botocore.exceptions import ClientError
 
 
 class TestEC2(unittest.TestCase):
@@ -29,6 +30,12 @@ class TestEC2(unittest.TestCase):
         result = self.client.describe_availability_zones()
         zones = list(sorted(a['ZoneName'] for a in result['AvailabilityZones']))
         self.assertEqual(zones, ['us-west-2a', 'us-west-2b', 'us-west-2c'])
+
+    def test_get_console_output_handles_error(self):
+        # Want to ensure the underlying ClientError is propogated
+        # on error.
+        with self.assertRaises(ClientError):
+            self.client.get_console_output(InstanceId='i-12345')
 
 
 class TestEC2Pagination(unittest.TestCase):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -40,6 +40,15 @@ class TestHandlers(BaseSessionTest):
         handlers.decode_console_output(parsed)
         self.assertEqual(parsed['Output'], 1)
 
+    def test_noop_if_output_key_does_not_exist(self):
+        original = {'foo': 'bar'}
+        parsed = original.copy()
+
+        handlers.decode_console_output(parsed)
+        # Should be unchanged because the 'Output'
+        # key is not in the output.
+        self.assertEqual(parsed, original)
+
     def test_decode_quoted_jsondoc(self):
         value = quote('{"foo":"bar"}')
         converted_value = handlers.decode_quoted_jsondoc(value)


### PR DESCRIPTION
This can happen in the case of an error.

Fixes boto/boto3#262.

cc @kyleknap @mtdowling @rayluo 