### PR TITLE
Remove hardcoded uris in endpoint heuristics

### DIFF
--- a/botocore/data/_endpoints.json
+++ b/botocore/data/_endpoints.json
@@ -18,7 +18,7 @@
   ],
   "iam":[
     {
-      "uri":"https://{service}.cn-north-1.amazonaws.com.cn",
+      "uri":"https://{service}.{region}.amazonaws.com.cn",
       "constraints":[
         ["region", "startsWith", "cn-"]
       ]
@@ -48,7 +48,7 @@
   ],
   "sts":[
     {
-      "uri":"{scheme}://{service}.cn-north-1.amazonaws.com.cn",
+      "uri":"{scheme}://{service}.{region}.amazonaws.com.cn",
       "constraints":[
         ["region", "startsWith", "cn-"]
       ]
@@ -126,7 +126,7 @@
   ],
   "elasticmapreduce":[
     {
-      "uri":"https://elasticmapreduce.cn-north-1.amazonaws.com.cn",
+      "uri":"https://elasticmapreduce.{region}.amazonaws.com.cn",
       "constraints":[
         ["region", "startsWith", "cn-"]
       ]


### PR DESCRIPTION
As a general principle, anything that has a startsWith
constraint should not have a hard coded region name.

Note that there's already existing tests for this: https://github.com/boto/botocore/blob/develop/tests/unit/test_regions.py#L27

cc @kyleknap @mtdowling @rayluo 