### PR TITLE
Added GLOBAL_ENDPOINT for private S3 endpoints

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -40,6 +40,7 @@ RESTRICTED_REGIONS = [
     'us-gov-west-1',
     'fips-us-gov-west-1',
 ]
+GLOBAL_ENDPOINT = 's3.amazonaws.com'
 
 
 class _RetriesExceededError(Exception):
@@ -649,8 +650,7 @@ def fix_s3_host(request, signature_version, region_name, **kwargs):
                 if request.auth_path[-1] != '/':
                     request.auth_path += '/'
             path_parts.remove(bucket_name)
-            global_endpoint = 's3.amazonaws.com'
-            host = bucket_name + '.' + global_endpoint
+            host = bucket_name + '.' + GLOBAL_ENDPOINT
             new_tuple = (parts.scheme, host, '/'.join(path_parts),
                          parts.query, '')
             new_uri = urlunsplit(new_tuple)


### PR DESCRIPTION
Exposed `global_endpoint` value within **fix_s3_host()** as `GLOBAL_ENDPOINT`, for use with private S3 clouds.
Sample usage with override for signature type follows (`HmacV1QueryAuth` signer for `s3-query` on `http://mydomain.com`):
```
import boto3
import botocore

# botocore / boto3 require explicit config and credentials files,
# in order to manually override the default values for signature version
AWS_CONFIG_FILE = '~/.aws/config'

HTTP_PROTOCOL = 'http'
ENDPOINT = 'mydomain.com'
SIGNATURE_TYPE = 's3-query'

# boto S3 session setup
connection_data = {
    'config_file': (None, 'AWS_CONFIG_FILE', None, None),
}
s3_session = botocore.session.get_session(connection_data)

# overrides values from AWS_CONFIG_FILE at '~/.aws/config'
config = botocore.client.Config(signature_version=SIGNATURE_TYPE)

# overrides GLOBAL_ENDPOINT value
botocore.utils.GLOBAL_ENDPOINT = ENDPOINT

# create the client
conn_client = s3_session.create_client(
    's3',
    endpoint_url=HTTP_PROTOCOL + '://' + ENDPOINT,
    config=config)
```
If DNS-compatible buckets are used, the calling format will be re-mapped to `subdomain` for all requests except `GET Service (List Buckets)` and `GET Bucket ?location`.

Make sure to run **aws configure** beforehand, which generates the `~/.aws/config` and `~/.aws/credentials` files required to override the default signature type (sample config shown):
```
[default]
s3 =
    signature_version = s3v4
```

