### PR TITLE
Empty response is now properly translated to list.

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -191,6 +191,8 @@ class PageIterator(object):
         # the truncated amount.
         starting_truncation = self._parse_starting_token()[1]
         all_data = primary_result_key.search(parsed)
+        if all_data is None:
+            all_data = []
         set_value_from_jmespath(
             parsed,
             primary_result_key.expression,

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -229,6 +229,13 @@ class TestPagination(unittest.TestCase):
         complete = pages.build_full_result()
         self.assertEqual(complete, {'Users': ['User1', 'User2', 'User3']})
 
+    def test_resume_encounters_an_empty_payload(self):
+        response = {"not_a_result_key": "it happens with large starting point"}
+        self.method.return_value = response
+        complete = self.paginator.paginate(
+            PaginationConfig={'StartingToken': 'None___1'}).build_full_result()
+        self.assertEqual(complete, {self.paginate_config['result_key']: []})
+
 
 class TestPaginatorPageSize(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This fixes issue aws/aws-cli#1365

I also manually test it with this command line to make sure it solves the issue.

    aws rds download-db-log-file-portion --db-instance-identifier mydbinstance --log-file-name error/mysql-error-running.log --starting-token 1000