### PR TITLE
Sets PolicyDocument return type to dict in generated documentation.

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -29,6 +29,7 @@ from botocore.compat import urlsplit, urlunsplit, unquote, json, quote, six
 from botocore.docs.utils import AutoPopulatedParam
 from botocore.docs.utils import HideParamFromOperations
 from botocore.docs.utils import AppendParamDocumentation
+from botocore.docs.utils import DocumentModifiedShape
 from botocore.signers import add_generate_presigned_url
 from botocore.signers import add_generate_presigned_post
 from botocore.exceptions import ParamValidationError
@@ -555,6 +556,13 @@ BUILTIN_HANDLERS = [
      AutoPopulatedParam('PresignedUrl').document_auto_populated_param),
     ('docs.*.ec2.CopySnapshot.complete-section',
      AutoPopulatedParam('DestinationRegion').document_auto_populated_param),
+    # IAM PolicyDocument documentation customizations
+    ('docs.*.iam.*.complete-section',
+     DocumentModifiedShape(
+         shape_name='policyDocumentType',
+         new_type='dict',
+         new_example_value='{}')
+        .replace_documentation_for_matching_shape),
     # S3 SSE documentation modifications
     ('docs.*.s3.*.complete-section',
      AutoPopulatedParam('SSECustomerKeyMD5').document_auto_populated_param),

--- a/tests/functional/docs/test_iam.py
+++ b/tests/functional/docs/test_iam.py
@@ -1,0 +1,49 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.functional.docs import BaseDocsFunctionalTest
+from botocore.docs.service import ServiceDocumenter
+
+
+class TestIAMDocs(BaseDocsFunctionalTest):
+    def test_changes_policy_doc_to_dict(self):
+        modified_methods = ['create_policy', 'get_role_policy']
+        service_contents = ServiceDocumenter('iam', self._session)\
+            .document_service()
+        for method_name in modified_methods:
+            method_contents = self.get_method_document_block(
+                method_name, service_contents)
+            self.assertNotIn(b"Document': 'string'", method_contents)
+            self.assertNotIn(b"Document='string", method_contents)
+            self.assertTrue(
+                (b"Document': {}" in method_contents) or
+                (b"Document={}" in method_contents))
+            self.assertNotIn(b"Document** *(string)", method_contents)
+            self.assertNotIn(b"Document: string", method_contents)
+            self.assertTrue(
+                (b"Document** *(dict)" in method_contents) or
+                (b"Document: dict" in method_contents))
+
+    def test_changes_policy_doc_list_to_dict(self):
+        modified_methods = ['get_context_keys_for_custom_policy',
+                            'simulate_custom_policy']
+        service_contents = ServiceDocumenter('iam', self._session)\
+            .document_service()
+        for method_name in modified_methods:
+            method_contents = self.get_method_document_block(
+                method_name, service_contents)
+            lines = [
+                "PolicyInputList=[",
+                "              {},",
+                "          ]"
+            ]
+            self.assert_contains_lines_in_order(lines, method_contents)


### PR DESCRIPTION
Addresses boto/boto3#229
Accepting the dict for put is beyond the scope of this commit.