### PR TITLE
Update serializers/parsers with latest protocol tests

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -465,6 +465,11 @@ class BaseJSONParser(ResponseParser):
 
     def _handle_structure(self, shape, value):
         member_shapes = shape.members
+        if value is None:
+            # If the comes across the wire as "null" (None in python),
+            # we should be returning this unchanged, instead of as an
+            # empty dict.
+            return None
         final_parsed = {}
         for member_name in member_shapes:
             member_shape = member_shapes[member_name]

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -212,7 +212,8 @@ class QuerySerializer(Serializer):
                 # Replace '.Original' with '.{name}'.
                 list_prefix = '.'.join(prefix.split('.')[:-1] + [name])
         else:
-            list_prefix = '%s.member' % prefix
+            list_name = shape.member.serialization.get('name', 'member')
+            list_prefix = '%s.%s' % (prefix, list_name)
         for i, element in enumerate(value, 1):
             element_prefix = '%s.%s' % (list_prefix, i)
             element_shape = shape.member
@@ -472,7 +473,10 @@ class BaseRestSerializer(Serializer):
         if location == 'uri':
             partitioned['uri_path_kwargs'][key_name] = param_value
         elif location == 'querystring':
-            partitioned['query_string_kwargs'][key_name] = param_value
+            if isinstance(param_value, dict):
+                partitioned['query_string_kwargs'].update(param_value)
+            else:
+                partitioned['query_string_kwargs'][key_name] = param_value
         elif location == 'header':
             shape = shape_members[param_name]
             value = self._convert_header_value(shape, param_value)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -277,6 +277,10 @@ def percent_encode_sequence(mapping, safe=SAFE_CHARS):
     * It has a default list of safe chars that don't need
       to be encoded, which matches what AWS services expect.
 
+    If any value in the input ``mapping`` is a list type,
+    then each list element wil be serialized.  This is the equivalent
+    to ``urlencode``'s ``doseq=True`` argument.
+
     This function should be preferred over the stdlib
     ``urlencode()`` function.
 
@@ -290,8 +294,13 @@ def percent_encode_sequence(mapping, safe=SAFE_CHARS):
     else:
         pairs = mapping
     for key, value in pairs:
-        encoded_pairs.append('%s=%s' % (percent_encode(key),
-                                        percent_encode(value)))
+        if isinstance(value, list):
+            for element in value:
+                encoded_pairs.append('%s=%s' % (percent_encode(key),
+                                                percent_encode(element)))
+        else:
+            encoded_pairs.append('%s=%s' % (percent_encode(key),
+                                            percent_encode(value)))
     return '&'.join(encoded_pairs)
 
 

--- a/tests/unit/protocols/input/json.json
+++ b/tests/unit/protocols/input/json.json
@@ -3,7 +3,7 @@
     "description": "Scalar members",
     "metadata": {
       "protocol": "json",
-      "jsonVersion": 1.1,
+      "jsonVersion": "1.1",
       "targetPrefix": "com.amazonaws.foo"
     },
     "shapes": {
@@ -48,7 +48,7 @@
     "description": "Timestamp values",
     "metadata": {
       "protocol": "json",
-      "jsonVersion": 1.1,
+      "jsonVersion": "1.1",
       "targetPrefix": "com.amazonaws.foo"
     },
     "shapes": {
@@ -90,7 +90,7 @@
     "description": "Base64 encoded Blobs",
     "metadata": {
       "protocol": "json",
-      "jsonVersion": 1.1,
+      "jsonVersion": "1.1",
       "targetPrefix": "com.amazonaws.foo"
     },
     "shapes": {
@@ -165,7 +165,7 @@
     "description": "Nested blobs",
     "metadata": {
       "protocol": "json",
-      "jsonVersion": 1.1,
+      "jsonVersion": "1.1",
       "targetPrefix": "com.amazonaws.foo"
     },
     "shapes": {
@@ -214,7 +214,7 @@
     "description": "Recursive shapes",
     "metadata": {
       "protocol": "json",
-      "jsonVersion": 1.1,
+      "jsonVersion": "1.1",
       "targetPrefix": "com.amazonaws.foo"
     },
     "shapes": {
@@ -418,6 +418,60 @@
             "Content-Type": "application/x-amz-json-1.1"
           },
           "body": "{\"RecursiveStruct\": {\"RecursiveMap\": {\"foo\": {\"NoRecurse\": \"foo\"}, \"bar\": {\"NoRecurse\": \"bar\"}}}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Empty maps",
+    "metadata": {
+      "protocol": "json",
+      "jsonVersion": 1.1,
+      "targetPrefix": "com.amazonaws.foo"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "MapType"
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "Map": {}
+        },
+        "serialized": {
+          "body": "{\"Map\": {}}",
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/"
         }
       }
     ]

--- a/tests/unit/protocols/input/query.json
+++ b/tests/unit/protocols/input/query.json
@@ -316,6 +316,107 @@
     ]
   },
   {
+    "description": "Non flattened list with LocationName",
+    "metadata": {
+      "protocol": "query",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "ListArg": {
+            "shape": "ListType"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType",
+          "locationName": "item"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ListArg": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "serialized": {
+          "uri": "/",
+          "body": "Action=OperationName&Version=2014-01-01&ListArg.item.1=a&ListArg.item.2=b&ListArg.item.3=c"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened list with LocationName",
+    "metadata": {
+      "protocol": "query",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "ScalarArg": {
+            "shape": "StringType"
+          },
+          "ListArg": {
+            "shape": "ListType"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType",
+          "locationName": "ListArgLocation"
+        },
+        "flattened": true
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ScalarArg": "foo",
+          "ListArg": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "serialized": {
+          "uri": "/",
+          "body": "Action=OperationName&Version=2014-01-01&ScalarArg=foo&ListArgLocation.1=a&ListArgLocation.2=b&ListArgLocation.3=c"
+        }
+      }
+    ]
+  },
+  {
     "description": "Serialize map type",
     "metadata": {
       "protocol": "query",
@@ -360,6 +461,57 @@
         "serialized": {
           "uri": "/",
           "body": "Action=OperationName&Version=2014-01-01&MapArg.entry.1.key=key1&MapArg.entry.1.value=val1&MapArg.entry.2.key=key2&MapArg.entry.2.value=val2"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serialize map type with locationName",
+    "metadata": {
+      "protocol": "query",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "MapArg": {
+            "shape": "StringMap"
+          }
+        }
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType",
+          "locationName": "TheKey"
+        },
+        "value": {
+          "shape": "StringType",
+          "locationName": "TheValue"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "MapArg": {
+            "key1": "val1",
+            "key2": "val2"
+          }
+        },
+        "serialized": {
+          "uri": "/",
+          "body": "Action=OperationName&Version=2014-01-01&MapArg.entry.1.TheKey=key1&MapArg.entry.1.TheValue=val1&MapArg.entry.2.TheKey=key2&MapArg.entry.2.TheValue=val2"
         }
       }
     ]

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -111,6 +111,132 @@
     ]
   },
   {
+    "description": "String to string maps in querystring",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "PipelineId": {
+            "shape": "StringType",
+            "location": "uri"
+          },
+          "QueryDoc": {
+            "shape": "MapStringStringType",
+            "location": "querystring"
+          }
+        }
+      },
+      "MapStringStringType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/2014-01-01/jobsByPipeline/{PipelineId}"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "PipelineId": "foo",
+          "QueryDoc": {
+            "bar": "baz",
+            "fizz": "buzz"
+          }
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/2014-01-01/jobsByPipeline/foo?bar=baz&fizz=buzz",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "String to string list maps in querystring",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "PipelineId": {
+            "shape": "StringType",
+            "location": "uri"
+          },
+          "QueryDoc": {
+            "shape": "MapStringStringListType",
+            "location": "querystring"
+          }
+        }
+      },
+      "MapStringStringListType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringListType"
+        }
+      },
+      "StringListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/2014-01-01/jobsByPipeline/{PipelineId}"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "PipelineId": "id",
+          "QueryDoc": {
+            "foo": ["bar", "baz"],
+            "fizz": ["buzz", "pop"]
+          }
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/2014-01-01/jobsByPipeline/id?foo=bar&foo=baz&fizz=buzz&fizz=pop",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "URI parameter and querystring params",
     "metadata": {
       "protocol": "rest-json",
@@ -215,7 +341,7 @@
       {
         "given": {
           "http": {
-            "method": "GET",
+            "method": "POST",
             "requestUri": "/2014-01-01/jobsByPipeline/{PipelineId}"
           },
           "input": {
@@ -294,7 +420,7 @@
       {
         "given": {
           "http": {
-            "method": "GET",
+            "method": "POST",
             "requestUri": "/2014-01-01/jobsByPipeline/{PipelineId}"
           },
           "input": {
@@ -363,7 +489,7 @@
       {
         "given": {
           "http": {
-            "method": "GET",
+            "method": "POST",
             "requestUri": "/2014-01-01/vaults/{vaultName}/archives"
           },
           "input": {

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -723,6 +723,133 @@
     ]
   },
   {
+    "description": "String to string maps in querystring",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "PipelineId": {
+            "shape": "StringType",
+            "location": "uri"
+          },
+          "QueryDoc": {
+            "shape": "MapStringStringType",
+            "location": "querystring"
+          }
+        }
+      },
+      "MapStringStringType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/2014-01-01/jobsByPipeline/{PipelineId}"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "PipelineId": "foo",
+          "QueryDoc": {
+            "bar": "baz",
+            "fizz": "buzz"
+          }
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/2014-01-01/jobsByPipeline/foo?bar=baz&fizz=buzz",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "String to string list maps in querystring",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "PipelineId": {
+            "shape": "StringType",
+            "location": "uri"
+          },
+          "QueryDoc": {
+            "shape": "MapStringStringListType",
+            "location": "querystring"
+          }
+        }
+      },
+      "MapStringStringListType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringListType"
+        }
+      },
+      "StringListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/2014-01-01/jobsByPipeline/{PipelineId}"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "PipelineId": "id",
+          "QueryDoc": {
+            "foo": ["bar", "baz"],
+            "fizz": ["buzz", "pop"]
+          }
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/2014-01-01/jobsByPipeline/id?foo=bar&foo=baz&fizz=buzz&fizz=pop",
+          "headers": {}
+        }
+      }
+    ]
+  },
+
+  {
     "description": "String payload",
     "metadata": {
       "protocol": "rest-xml",
@@ -1007,8 +1134,8 @@
         "params": {
           "Grant": {
             "Grantee": {
-              "Type": "CanonicalUser",
-              "EmailAddress": "foo@example.com"
+              "EmailAddress": "foo@example.com",
+              "Type": "CanonicalUser"
             }
           }
         },

--- a/tests/unit/protocols/output/json.json
+++ b/tests/unit/protocols/output/json.json
@@ -195,6 +195,12 @@
         "members": {
           "ListMember": {
             "shape": "ListType"
+          },
+          "ListMemberMap": {
+            "shape": "ListTypeMap"
+          },
+          "ListMemberStruct": {
+            "shape": "ListTypeStruct"
           }
         }
       },
@@ -204,8 +210,30 @@
           "shape": "StringType"
         }
       },
+      "ListTypeMap": {
+        "type": "list",
+        "member": {
+          "shape": "MapType"
+        }
+      },
+      "ListTypeStruct": {
+        "type": "list",
+        "member": {
+          "shape": "StructType"
+        }
+      },
       "StringType": {
         "type": "string"
+      },
+      "StructType": {
+        "type": "structure",
+        "members": {
+        }
+      },
+      "MapType": {
+        "type": "string",
+        "key": { "shape": "StringType" },
+        "value": { "shape": "StringType" }
       }
     },
     "cases": [
@@ -223,6 +251,24 @@
           "status_code": 200,
           "headers": {},
           "body": "{\"ListMember\": [\"a\", \"b\"]}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["a", null],
+          "ListMemberMap": [{}, null, null, {}],
+          "ListMemberStruct": [{}, null, null, {}]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"ListMember\": [\"a\", null], \"ListMemberMap\": [{}, null, null, {}], \"ListMemberStruct\": [{}, null, null, {}]}"
         }
       }
     ]

--- a/tests/unit/protocols/output/query.json
+++ b/tests/unit/protocols/output/query.json
@@ -7,7 +7,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "Str": {
             "shape": "StringType"
@@ -68,6 +67,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -99,7 +99,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "Str": {
             "shape": "StringType"
@@ -120,6 +119,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -136,51 +136,12 @@
     ]
   },
   {
-    "description": "Custom result wrapper",
-    "metadata": {
-      "protocol": "query"
-    },
-    "shapes": {
-      "OutputShape": {
-        "type": "structure",
-        "resultWrapper": "Wrapper",
-        "members": {
-          "Str": {
-            "shape": "StringType"
-          }
-        }
-      },
-      "StringType": {
-        "type": "string"
-      }
-    },
-    "cases": [
-      {
-        "given": {
-          "output": {
-            "shape": "OutputShape"
-          },
-          "name": "OperationName"
-        },
-        "result": {
-          "Str": "myname"
-        },
-        "response": {
-          "status_code": 200,
-          "headers": {},
-          "body": "<OperationNameResponse><Wrapper><Str>myname</Str></Wrapper><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
-        }
-      }
-    ]
-  },
-  {
     "description": "Blob",
     "metadata": {
       "protocol": "query"
     },
     "shapes": {
       "OutputShape": {
-        "resultWrapper": "OperationNameResult",
         "type": "structure",
         "members": {
           "Blob": {
@@ -196,6 +157,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -219,7 +181,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "ListMember": {
             "shape": "ListShape"
@@ -240,6 +201,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -263,7 +225,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "ListMember": {
             "shape": "ListShape"
@@ -285,6 +246,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -308,7 +270,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "ListMember": {
             "shape": "ListType"
@@ -330,6 +291,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -353,7 +315,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "ListMember": {
             "shape": "ListType"
@@ -375,6 +336,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -398,7 +360,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "List": {
             "shape": "ListOfStructs"
@@ -433,6 +394,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -515,7 +477,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "List": {
             "shape": "ListType"
@@ -538,6 +499,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -561,7 +523,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "Map": {
             "shape": "StringMap"
@@ -593,6 +554,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -728,7 +690,6 @@
     "shapes": {
       "OutputShape": {
         "type": "structure",
-        "resultWrapper": "OperationNameResult",
         "members": {
           "Map": {
             "shape": "MapType"
@@ -755,6 +716,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"

--- a/tests/unit/protocols/output/rest-json.json
+++ b/tests/unit/protocols/output/rest-json.json
@@ -490,7 +490,7 @@
         },
         "result": {
           "AllHeaders": {
-            "Content-Length": 10,
+            "Content-Length": "10",
             "x-Foo": "bar",
             "X-bam": "boo"
           },
@@ -502,7 +502,7 @@
         "response": {
           "status_code": 200,
           "headers": {
-            "Content-Length": 10,
+            "Content-Length": "10",
             "x-Foo": "bar",
             "X-bam": "boo"
           },

--- a/tests/unit/protocols/output/rest-xml.json
+++ b/tests/unit/protocols/output/rest-xml.json
@@ -673,7 +673,7 @@
             "x-double": "1.5",
             "x-long": "100",
             "x-char": "a",
-            "x-timestamp": "Sun, 25 Jan 2015 08:00:00 -0000"
+            "x-timestamp": "Sun, 25 Jan 2015 08:00:00 GMT"
           },
           "body": ""
         }

--- a/tests/unit/test_protocols.py
+++ b/tests/unit/test_protocols.py
@@ -62,7 +62,7 @@ from botocore.serialize import EC2Serializer, QuerySerializer, \
         JSONSerializer, RestJSONSerializer, RestXMLSerializer
 from botocore.parsers import QueryParser, JSONParser, \
         RestJSONParser, RestXMLParser
-from botocore.utils import parse_timestamp
+from botocore.utils import parse_timestamp, percent_encode_sequence
 from calendar import timegm
 from botocore.compat import urlencode
 
@@ -265,10 +265,10 @@ def assert_equal(first, second, prefix):
 def _serialize_request_description(request_dict):
     if isinstance(request_dict.get('body'), dict):
         # urlencode the request body.
-        encoded = urlencode(request_dict['body']).encode('utf-8')
+        encoded = percent_encode_sequence(request_dict['body']).encode('utf-8')
         request_dict['body'] = encoded
     if isinstance(request_dict.get('query_string'), dict):
-        encoded = urlencode(request_dict.pop('query_string'))
+        encoded = percent_encode_sequence(request_dict.pop('query_string'))
         if encoded:
             # 'requests' automatically handle this, but we in the
             # test runner we need to handle the case where the url_path


### PR DESCRIPTION
This fixed three issues with protocol serialization/parsing:

1. If a struct is returned as `null` across the wire in `json` we should parse that as `None`, not `{}`.
2. If we're serializing to a query string and the value is a map we need to ignore the top level key and pull the map keys up to top level query string params.
3. If a query string *value* is a sequence, we need to serialize it as: `{"a": ["b", "c"]}` -> `a=b&a=c`.
4. Honor locationName in query protocol for non flattened lists.


See commit messages for more details.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 