### PR TITLE
Add console-output-available waiter

### DIFF
--- a/botocore/data/ec2/2015-10-01/waiters-2.json
+++ b/botocore/data/ec2/2015-10-01/waiters-2.json
@@ -37,6 +37,19 @@
         }
       ]
     },
+    "ConsoleOutputAvailable": {
+      "operation": "GetConsoleOutput",
+      "maxAttempts": 40,
+      "delay": 15,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "path",
+          "argument": "length(Output || '') > `0`",
+          "expected": true
+        }
+      ]
+    },
     "ConversionTaskCancelled": {
       "delay": 15,
       "operation": "DescribeConversionTasks",


### PR DESCRIPTION
The "aws ec2 get-console-output" does not immediately
return the console output when you launch a new
EC2 instance.  This adds a waiter so you can block
until this data is available.

This is similar to the PasswordDataAvailable, with the
exception that in this API call, the "Output" element
isn't in the response when there is no output.  So
the JMESPath expression needed to be "Output || ''" to avoid
type errors when calling length().

cc @kyleknap @mtdowling @rayluo @JordonPhillips 