### PR TITLE
Make error parsing more robust

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -674,9 +674,14 @@ class RestXMLParser(BaseRestParser, BaseXMLResponseParser):
         #   <RequestId>request-id</RequestId>
         # </ErrorResponse>
         if response['body']:
-            return self._parse_error_from_body(response)
-        else:
-            return self._parse_error_from_http_status(response)
+            # If the body ends up being invalid xml, the xml parser should not
+            # blow up. It should at least try to pull information about the
+            # the error response from other sources like the HTTP status code.
+            try:
+                return self._parse_error_from_body(response)
+            except ResponseParserError:
+                pass
+        return self._parse_error_from_http_status(response)
 
     def _parse_error_from_http_status(self, response):
         return {

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -679,8 +679,10 @@ class RestXMLParser(BaseRestParser, BaseXMLResponseParser):
             # the error response from other sources like the HTTP status code.
             try:
                 return self._parse_error_from_body(response)
-            except ResponseParserError:
-                pass
+            except ResponseParserError as e:
+                LOG.debug(
+                    'Exception caught when parsing error response body:',
+                    exc_info=True)
         return self._parse_error_from_http_status(response)
 
     def _parse_error_from_http_status(self, response):

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -25,9 +25,9 @@ class TestS3BucketValidation(unittest.TestCase):
                           Key='foo', Body=b'asdf')
 
 
-class TestS3GetBucketLifecycle(BaseSessionTest):
+class BaseS3OperationTest(BaseSessionTest):
     def setUp(self):
-        super(TestS3GetBucketLifecycle, self).setUp()
+        super(BaseS3OperationTest, self).setUp()
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             's3', self.region)
@@ -35,9 +35,11 @@ class TestS3GetBucketLifecycle(BaseSessionTest):
         self.http_session_send_mock = self.session_send_patch.start()
 
     def tearDown(self):
-        super(TestS3GetBucketLifecycle, self).tearDown()
+        super(BaseSessionTest, self).tearDown()
         self.session_send_patch.stop()
 
+
+class TestS3GetBucketLifecycle(BaseS3OperationTest):
     def test_multiple_transitions_returns_one(self):
         http_response = mock.Mock()
         http_response.status_code = 200
@@ -87,3 +89,41 @@ class TestS3GetBucketLifecycle(BaseSessionTest):
             response['Rules'][1]['NoncurrentVersionTransition'],
             {'NoncurrentDays': 40, 'StorageClass': 'STANDARD_IA'}
         )
+
+
+class TestS3PutObject(BaseS3OperationTest):
+    def test_500_error_with_non_xml_body(self):
+        # This test was added because in some use cases, the response
+        # returned from S3 is a 500 response which should be retrieved even
+        # though the body of the response is in not valid xml such as
+        # headers being in the body. From what we can tell, the reason this
+        # happens is that the code of the response was probably mutated
+        # somewhere when the response was sent to the client, maybe was a
+        # proxy's doing and/or how expect 100's are treated,
+        # but a 200 response is mutated to have a 500 response code.
+        non_xml_content = (
+            'x-amz-id-2: foo\r\n'
+            'x-amz-request-id: bar\n'
+            'Date: Tue, 06 Oct 2015 03:20:38 GMT\r\n'
+            'ETag: "a6d856bc171fc6aa1b236680856094e2"\r\n'
+            'Content-Length: 0\r\n'
+            'Server: AmazonS3\r\n'
+        )
+        http_500_response = mock.Mock()
+        http_500_response.status_code = 500
+        http_500_response.content = non_xml_content
+        http_500_response.headers = {}
+
+        success_response = mock.Mock()
+        success_response.status_code = 200
+        success_response.content = b''
+        success_response.headers = {}
+
+        self.http_session_send_mock.side_effect = [
+            http_500_response, success_response
+        ]
+        s3 = self.session.create_client('s3')
+        response = s3.put_object(Bucket='mybucket', Key='mykey', Body=b'foo')
+        # The first response should have been retried even though the xml is
+        # invalid and eventually return the 200 response.
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)


### PR DESCRIPTION
For the rest-xml error parser, the body of the response had headers of a
200 response even though the http status code was 500. This blew up
of the error parser because it was invalid xml. For these situations, we should
at least respect the error code.

cc @jamesls @mtdowling @rayluo @JordonPhillips 