### PR TITLE
Use utf8 encoding to open model file

### DIFF
--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -94,6 +94,7 @@ version to use.
 
 """
 import os
+import io
 
 from botocore import BOTOCORE_ROOT
 from botocore.compat import json
@@ -153,7 +154,10 @@ class JSONFileLoader(object):
         full_path = file_path + '.json'
         if not os.path.isfile(full_path):
             return
-        with open(full_path) as fp:
+
+        # By default the file will be opened with locale encoding on Python 3.
+        # We specify "utf8" here to ensure the correct behavior.
+        with io.open(full_path, encoding='utf8') as fp:
             return json.load(fp, object_pairs_hook=OrderedDict)
 
 

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -94,7 +94,6 @@ version to use.
 
 """
 import os
-import io
 
 from botocore import BOTOCORE_ROOT
 from botocore.compat import json
@@ -157,8 +156,9 @@ class JSONFileLoader(object):
 
         # By default the file will be opened with locale encoding on Python 3.
         # We specify "utf8" here to ensure the correct behavior.
-        with io.open(full_path, encoding='utf8') as fp:
-            return json.load(fp, object_pairs_hook=OrderedDict)
+        with open(full_path, 'rb') as fp:
+            payload = fp.read().decode('utf-8')
+            return json.loads(payload, object_pairs_hook=OrderedDict)
 
 
 def create_loader(search_path_string=None):

--- a/tests/unit/data/non_ascii.json
+++ b/tests/unit/data/non_ascii.json
@@ -1,0 +1,11 @@
+{
+    "Note": "The following special characters show up in doc occasionally",
+
+    "dash_in_ascii": "-",
+    "dash_0x93": "–",
+    "dash_0x94": "—",
+
+    "quotation_mark_0x9d": "”",
+
+    "normal": "ascii"
+}

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -55,6 +55,13 @@ class TestJSONFileLoader(BaseEnvVar):
         self.assertFalse(self.file_loader.exists(
             os.path.join(self.data_path, 'does', 'not', 'exist')))
 
+    def test_file_with_non_ascii(self):
+        try:
+            filename = os.path.join(self.data_path, 'non_ascii')
+            self.assertTrue(self.file_loader.load_file(filename) is not None)
+        except UnicodeDecodeError:
+            self.fail('Fail to handle data file with non-ascii characters')
+
 
 class TestLoader(BaseEnvVar):
 


### PR DESCRIPTION
We encountered a test case failure on one of the test machine, when running Python 3.x.

    Traceback (most recent call last):
      File "C:\Python33\Lib\unittest\case.py", line 385, in _executeTestPart
        function()
      File "C:\Jenkins\shiningpanda\jobs\263e0464\virtualenvs\d41d8cd9\lib\site-packages\nose\failure.py", line 38, in runTest
        raise self.exc_val.with_traceback(self.tb)
      File "C:\Jenkins\shiningpanda\jobs\263e0464\virtualenvs\d41d8cd9\lib\site-packages\nose\loader.py", line 254, in generate
        for test in g():
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\tests\integration\test_utils.py", line 33, in test_can_generate_all_inputs
        service_model = session.get_service_model(service_name)
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\botocore\session.py", line 469, in get_service_model
        service_description = self.get_service_data(service_name, api_version)
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\botocore\session.py", line 492, in get_service_data
        api_version=api_version
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\botocore\loaders.py", line 119, in _wrapper
        data = func(self, *args, **kwargs)
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\botocore\loaders.py", line 343, in load_service_model
        return self.load_data(full_path)
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\botocore\loaders.py", line 119, in _wrapper
        data = func(self, *args, **kwargs)
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\botocore\loaders.py", line 363, in load_data
        found = self.file_loader.load_file(possible_path)
      File "C:\Jenkins\workspace\botocore-integ\PYTHON\CPython-3.3\botocore\loaders.py", line 157, in load_file
        return json.load(fp, object_pairs_hook=OrderedDict)
      File "C:\Python33\Lib\json\__init__.py", line 261, in load
        return loads(fp.read(),
      File "C:\Jenkins\shiningpanda\jobs\263e0464\virtualenvs\d41d8cd9\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 78208: character maps to <undefined>

It is because some non-ascii characters in one of our latest documentation model file can not be decoded by the locale encoding on our test machine. Note that you may or may not observe similar symptom on your own machine because your locale may be different.

This fix specifies utf8 encoding.