### PR TITLE
Add the retry for Route53 when PriorRequestNotComplete happens

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -150,6 +150,20 @@
           }
         }
       }
+    },
+    "route53": {
+      "__default__": {
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "PriorRequestNotComplete",
+                "http_status_code": 400
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fix #91 accroding to the document (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html)