### PR TITLE
Use HTTP POST to send Cloudsearchdomain search operation

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -472,6 +472,15 @@ def check_openssl_supports_tls_version_1_2(**kwargs):
         pass
 
 
+def change_get_to_post(request, **kwargs):
+    # This is useful when we need to change a potentially large GET request
+    # into a POST with x-www-form-urlencoded encoding.
+    if request.method == 'GET' and '?' in request.url:
+        request.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        request.method = 'POST'
+        request.url, request.data = request.url.split('?', 1)
+
+
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be
 # automatically registered with that Session.
@@ -539,6 +548,9 @@ BUILTIN_HANDLERS = [
     ('before-parameter-build.route53', fix_route53_ids),
     ('before-parameter-build.glacier', inject_account_id),
 
+    # Cloudsearchdomain search operation will be sent by HTTP POST
+    ('request-created.cloudsearchdomain.Search',
+     change_get_to_post),
     # Glacier documentation customizations
     ('docs.*.glacier.*.complete-section',
      AutoPopulatedParam('accountId', 'Note: this parameter is set to "-" by \

--- a/tests/functional/test_cloudsearchdomain.py
+++ b/tests/functional/test_cloudsearchdomain.py
@@ -1,0 +1,35 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+
+from tests import BaseSessionTest
+
+
+class TestCloudsearchdomain(BaseSessionTest):
+    def setUp(self):
+        super(TestCloudsearchdomain, self).setUp()
+        self.region = 'us-west-2'
+        self.client = self.session.create_client(
+            'cloudsearchdomain', self.region)
+
+    def test_search(self):
+        with mock.patch('botocore.endpoint.Session.send') as _send:
+            _send.return_value = mock.Mock(
+                status_code=200, headers={}, content=b'{}')
+            self.client.search(query='foo')
+            sent_request = _send.call_args[0][0]
+            self.assertEqual(sent_request.method, 'POST')
+            self.assertEqual(
+                sent_request.headers.get('Content-Type'),
+                b'application/x-www-form-urlencoded')
+            self.assertIn('q=foo', sent_request.body)


### PR DESCRIPTION
This can enable sending a potentially large request to Cloudsearchdomain.
This fixes boto/boto3#211