### PR TITLE
Log traceback on ConnectionErrors

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -171,6 +171,8 @@ class Endpoint(object):
             # lookup issue, 99% of the time this is due to a misconfigured
             # region/endpoint so we'll raise a more specific error message
             # to help users.
+            logger.debug("ConnectionError received when sending HTTP request.",
+                         exc_info=True)
             if self._looks_like_dns_error(e):
                 endpoint_url = e.request.url
                 better_exception = EndpointConnectionError(


### PR DESCRIPTION
We log the traceback for the `except Exception` clause but not for `ConnectionError`s.  Even though the retry handler will reraise this exception, we miss the original stack trace so we can't see where in requests/urllib3 the ConnectionError originated from in python2.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 