### PR TITLE
Adds the count ability to paginator

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -13,6 +13,8 @@
 
 from itertools import tee
 
+from six import string_types
+
 import jmespath
 from botocore.exceptions import PaginationError
 from botocore.compat import zip
@@ -286,12 +288,11 @@ class PageIterator(object):
                 # Now both result_value and existing_value contain something
                 if isinstance(result_value, list):
                     existing_value.extend(result_value)
-                elif isinstance(result_value, (int, float)):
-                    # Modify the existing result with the sum
+                elif isinstance(result_value, (int, float, string_types)):
+                    # Modify the existing result with the sum or concatenation
                     set_value_from_jmespath(
                         complete_result, result_expression.expression,
                         existing_value + result_value)
-
         merge_dicts(complete_result, self.non_aggregate_part)
         if self.resume_token is not None:
             complete_result['NextToken'] = self.resume_token

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -671,7 +671,7 @@ class TestExpressionKeyIterators(unittest.TestCase):
         })
 
 
-class TestIncludeResultKeysOtherThanList(unittest.TestCase):
+class TestIncludeResultKeys(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
         self.paginate_config = {
@@ -681,9 +681,10 @@ class TestIncludeResultKeysOtherThanList(unittest.TestCase):
         }
         self.paginator = Paginator(self.method, self.paginate_config)
 
-    def test_include_counter_keys(self):
+    def test_different_kinds_of_result_key(self):
         self.method.side_effect = [
             {'ResultKey': ['a'], 'Count': 1, 'Log': 'x', 'Marker': 'a'},
+            {'not_a_result_key': 'this page will be ignored', 'Marker': '_'},
             {'ResultKey': ['b', 'c'], 'Count': 2, 'Log': 'y', 'Marker': 'b'},
             {'ResultKey': ['d', 'e', 'f'], 'Count': 3, 'Log': 'z'},
         ]
@@ -693,6 +694,15 @@ class TestIncludeResultKeysOtherThanList(unittest.TestCase):
             'Count': 6,
             'Log': 'xyz',
         }
+        self.assertEqual(pages.build_full_result(), expected)
+
+    def test_result_key_is_missing(self):
+        self.method.side_effect = [
+            {'not_a_result_key': 'this page will be ignored', 'Marker': '_'},
+            {'neither_this_one': 'this page will be ignored, too'},
+        ]
+        pages = self.paginator.paginate()
+        expected = {}
         self.assertEqual(pages.build_full_result(), expected)
 
 

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -671,6 +671,30 @@ class TestExpressionKeyIterators(unittest.TestCase):
         })
 
 
+class TestIncludeResultKeysOtherThanList(unittest.TestCase):
+    def setUp(self):
+        self.method = mock.Mock()
+        self.paginate_config = {
+            'output_token': 'Marker',
+            'input_token': 'Marker',
+            'result_key': ['ResultKey', 'Count'],
+        }
+        self.paginator = Paginator(self.method, self.paginate_config)
+
+    def test_include_counter_keys(self):
+        self.method.side_effect = [
+            {'ResultKey': ['a'], 'Count': 1, 'Marker': 'a'},
+            {'ResultKey': ['b', 'c'], 'Count': 2, 'Marker': 'b'},
+            {'ResultKey': ['d', 'e', 'f'], 'Count': 3},
+        ]
+        pages = self.paginator.paginate()
+        expected = {
+            'ResultKey': ['a', 'b', 'c', 'd', 'e', 'f'],
+            'Count': 6,
+        }
+        self.assertEqual(pages.build_full_result(), expected)
+
+
 class TestIncludeNonResultKeys(unittest.TestCase):
     maxDiff = None
 

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -677,20 +677,21 @@ class TestIncludeResultKeysOtherThanList(unittest.TestCase):
         self.paginate_config = {
             'output_token': 'Marker',
             'input_token': 'Marker',
-            'result_key': ['ResultKey', 'Count'],
+            'result_key': ['ResultKey', 'Count', 'Log'],
         }
         self.paginator = Paginator(self.method, self.paginate_config)
 
     def test_include_counter_keys(self):
         self.method.side_effect = [
-            {'ResultKey': ['a'], 'Count': 1, 'Marker': 'a'},
-            {'ResultKey': ['b', 'c'], 'Count': 2, 'Marker': 'b'},
-            {'ResultKey': ['d', 'e', 'f'], 'Count': 3},
+            {'ResultKey': ['a'], 'Count': 1, 'Log': 'x', 'Marker': 'a'},
+            {'ResultKey': ['b', 'c'], 'Count': 2, 'Log': 'y', 'Marker': 'b'},
+            {'ResultKey': ['d', 'e', 'f'], 'Count': 3, 'Log': 'z'},
         ]
         pages = self.paginator.paginate()
         expected = {
             'ResultKey': ['a', 'b', 'c', 'd', 'e', 'f'],
             'Count': 6,
+            'Log': 'xyz',
         }
         self.assertEqual(pages.build_full_result(), expected)
 


### PR DESCRIPTION
Paginator's result_key used to expect list value only.
Now, if a result_key's value is an integer (or a float),
paginator can aggregate them.