### PR TITLE
Reset HTTP connection state when connection is closed

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -79,6 +79,13 @@ class AWSHTTPConnection(HTTPConnection):
         self._response_received = False
         self._expect_header_set = False
 
+    def close(self):
+        super(AWSHTTPConnection, self).close()
+        # Reset all of our instance state we were tracking.
+        self._response_received = False
+        self._expect_header_set = False
+        self.response_class = self._original_response_cls
+
     def _tunnel(self):
         # Works around a bug in py26 which is fixed in later versions of
         # python. Bug involves hitting an infinite loop if readline() returns


### PR DESCRIPTION
A connection instance can be reused even if the server
has closed the associated socket.

When this happens, urllib3 will ".close()" the connection
which also closes and deletes the socket associated with
the connection.

However, the AWSHTTPConnection *object* is still reused
in the underlying connection pool.  The HTTP client will
notice that associated socket is None and will create
a new socket thereby establishing a new connection to the
AWS endpoint.

The bug on our end was that we were not properly resetting
our own instance state variables we use to keep track of
if we've sent the expect header, if we've seen a response,
etc.  We were assuming that a connection instance is removed
from the connection pool when the connection and underlying
socket is closed.

As a result, state from the previous (and generally unrelated)
response was leaking into the current response, specifically
in the scenario when the service responds with some other
status besides the "100 continue" response (i.e a fast fail).
This ended up with two things happening:

* We were reusing the status code of the previous response
* Because we thought we've already seen a response, we were
  not reading the HTTP response headers.

Consequently, the HTTP headers were being sent to our
response parser, which would throw exceptions because it
was not receiving data in the format it was expecting.

We now ensure that we also reset our own state when the
parent class resets its state, which happens in the
".close()" method.

In addition to the associated test, I've also manually
verified this fix by writing a small http server that
returns the same sequence of HTTP responses that trigger
this error.


cc @kyleknap @mtdowling @rayluo @JordonPhillips 