### PR TITLE
Profile should override env var creds

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -67,7 +67,7 @@ def create_credential_resolver(session):
     # We use ``session.profile`` for EnvProvider rather than
     # ``profile_name`` because it is ``None`` when unset.
     # TODO: Remove use of internal var.  We'll need to rethink this.
-    if session._profile is None:
+    if session.profile is None:
         # No profile has been explicitly set, so we prepend the environment
         # variable provider. That provider, in turn, may set a profile
         # or credentials.

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -47,7 +47,9 @@ def create_credential_resolver(session):
     metadata_timeout = session.get_config_variable('metadata_service_timeout')
     num_attempts = session.get_config_variable('metadata_service_num_attempts')
 
+    env_provider = EnvProvider()
     providers = [
+        env_provider,
         SharedCredentialProvider(
             creds_filename=credential_file,
             profile_name=profile_name
@@ -64,14 +66,25 @@ def create_credential_resolver(session):
         )
     ]
 
-    # We use ``session.profile`` for EnvProvider rather than
-    # ``profile_name`` because it is ``None`` when unset.
-    # TODO: Remove use of internal var.  We'll need to rethink this.
-    if session.profile is None:
-        # No profile has been explicitly set, so we prepend the environment
-        # variable provider. That provider, in turn, may set a profile
-        # or credentials.
-        providers.insert(0, EnvProvider())
+    explicit_profile = session.get_config_variable('profile',
+                                                   methods=('instance',))
+    if explicit_profile is not None:
+        # An explicitly provided profile will negate an EnvProvider.
+        # We will defer to providers that understand the "profile"
+        # concept to retrieve credentials.
+        # The one edge case if is all three values are provided via
+        # env vars:
+        # export AWS_ACCESS_KEY_ID=foo
+        # export AWS_SECRET_ACCESS_KEY=bar
+        # export AWS_PROFILE=baz
+        # Then, just like our client() calls, the explicit credentials
+        # will take precedence.
+        #
+        # This precedence is enforced by leaving the EnvProvider in the chain.
+        # This means that the only way a "profile" would win is if the
+        # EnvProvider does not return credentials, which is what we want
+        # in this scenario.
+        providers.remove(env_provider)
     else:
         logger.debug('Skipping environment variable credential check'
                      ' because profile name was explicitly set.')

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -138,13 +138,18 @@ class Session(object):
         self.user_agent_name = 'Botocore'
         self.user_agent_version = __version__
         self.user_agent_extra = ''
-        self._profile = profile
+        # The _profile attribute is just used to cache the value
+        # of the current profile to avoid going through the normal
+        # config lookup process each access time.
+        self._profile = None
         self._config = None
         self._credentials = None
         self._profile_map = None
         # This is a dict that stores per session specific config variable
         # overrides via set_config_variable().
         self._session_instance_vars = {}
+        if profile is not None:
+            self._session_instance_vars['profile'] = profile
         self._components = ComponentLocator()
         self._register_components()
 
@@ -235,9 +240,6 @@ class Session(object):
         # Handle all the short circuit special cases first.
         if logical_name not in self.session_var_map:
             return
-        if logical_name == 'profile' and self._profile:
-            return self._profile
-
         # Do the actual lookups.  We need to handle
         # 'instance', 'env', and 'config' locations, in that order.
         value = None

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -1,0 +1,91 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest, temporary_file
+
+import mock
+
+import botocore.session
+from botocore.exceptions import ProfileNotFound
+
+
+class TestSession(unittest.TestCase):
+    def setUp(self):
+        self.environ = {}
+        self.env_patch = mock.patch('os.environ', self.environ)
+        self.env_patch.start()
+        self.session = botocore.session.get_session()
+
+    def tearDown(self):
+        self.env_patch.stop()
+
+    def test_profile_precedence(self):
+        self.environ['AWS_PROFILE'] = 'from_env_var'
+        self.session.set_config_variable('profile',  'from_session_instance')
+        self.assertEqual(self.session.profile, 'from_session_instance')
+
+    def test_credentials_with_profile_precedence(self):
+        self.environ['AWS_PROFILE'] = 'from_env_var'
+        self.session.set_config_variable('profile',  'from_session_instance')
+        try:
+            creds = self.session.get_credentials()
+        except ProfileNotFound as e:
+            self.assertNotIn('from_env_var', str(e))
+            self.assertIn('from_session_instance', str(e))
+
+    def test_session_profile_overrides_env_vars(self):
+        # If the ".profile" attribute is set then the associated
+        # creds for that profile take precedence over the environment
+        # variables.
+        with temporary_file('w') as f:
+            # We test this by creating creds in two places,
+            # env vars and a fake shared creds file.  We ensure
+            # that if an explicit profile is set we pull creds
+            # from the shared creds file.
+            self.environ['AWS_ACCESS_KEY_ID'] = 'env_var_akid'
+            self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_var_sak'
+            self.environ['AWS_SHARED_CREDENTIALS_FILE'] = f.name
+            f.write(
+                '[from_session_instance]\n'
+                'aws_access_key_id=shared_creds_akid\n'
+                'aws_secret_access_key=shared_creds_sak\n'
+            )
+            f.flush()
+            self.session.set_config_variable('profile', 'from_session_instance')
+            creds = self.session.get_credentials()
+            self.assertEqual(creds.access_key, 'shared_creds_akid')
+            self.assertEqual(creds.secret_key, 'shared_creds_sak')
+
+    def test_profile_does_not_win_if_all_from_env_vars(self):
+        # Creds should be pulled from the env vars because
+        # if access_key/secret_key/profile are all specified on
+        # the same "level", then the explicit creds take
+        # precedence.
+        with temporary_file('w') as f:
+            self.environ['AWS_SHARED_CREDENTIALS_FILE'] = f.name
+            self.environ['AWS_PROFILE'] = 'myprofile'
+            # Even though we don't use the profile for credentials,
+            # if you have a profile configured in any way
+            # (env vars, set when creating a session, etc.) that profile
+            # must exist.  So we need to create an empty profile
+            # matching the value from AWS_PROFILE.
+            f.write(
+                '[myprofile]\n'
+            )
+            f.flush()
+            self.environ['AWS_ACCESS_KEY_ID'] = 'env_var_akid'
+            self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_var_sak'
+
+            creds = self.session.get_credentials()
+
+            self.assertEqual(creds.access_key, 'env_var_akid')
+            self.assertEqual(creds.secret_key, 'env_var_sak')

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -604,7 +604,7 @@ class TestCreateCredentialResolver(BaseEnvVar):
 
     def test_no_profile_checks_env_provider(self):
         self.config['profile'] = None
-        self.session._profile = None
+        self.session.profile = None
         resolver = credentials.create_credential_resolver(self.session)
 
         self.assertTrue(
@@ -612,7 +612,7 @@ class TestCreateCredentialResolver(BaseEnvVar):
 
     def test_no_profile_env_provider_is_first(self):
         self.config['profile'] = None
-        self.session._profile = None
+        self.session.profile = None
         resolver = credentials.create_credential_resolver(self.session)
 
         self.assertIsInstance(resolver.providers[0], credentials.EnvProvider)


### PR DESCRIPTION
Profile should override env var creds

Unless the profile and creds are both specified
as env vars.

In order to fix this regression, I had to make a
small change to session.  This makes the 'profile'
config var less special cased than it was previously.

Now, we always check the _session_instance_vars for
a profile, and simple use _profile as a placeholder
for the cached lookup value of 'profile'.

The only place this gets weird is we need to scope
down our call to ".get_config_variable" in the
credential provider creation to only check the
session instance variables for a profile to determine
whether or not we need to add the EnvProvider to our
lookup chain.

One of the reasons this regressed is we didn't have
sufficient functional tests to cover this behavior.
I've added functional tests that ensure that regardless
of internals, we won't regress on this in the future.

There will also be a pull request to the AWS CLI
to verify this behavior to ensure the CLI doesn't regress
on this behavior.

Fixes #663.


cc @kyleknap @mtdowling @rayluo @JordonPhillips 
