### PR TITLE
Adding RetentionPeriodHours to Kinesis non_aggregate_keys

### DIFF
--- a/botocore/data/kinesis/2013-12-02/paginators-1.json
+++ b/botocore/data/kinesis/2013-12-02/paginators-1.json
@@ -9,7 +9,8 @@
       "non_aggregate_keys": [
         "StreamDescription.StreamARN",
         "StreamDescription.StreamName",
-        "StreamDescription.StreamStatus"
+        "StreamDescription.StreamStatus",
+        "StreamDescription.RetentionPeriodHours"
       ]
     },
     "ListStreams": {


### PR DESCRIPTION
This PR updates the `DescribeStream` paginator for Kinesis to include `StreamDescription.RetentionPeriodHours` in the non aggregate keys. I've verified that this works with the CLI.

@kyleknap @jamesls @rayluo @JordonPhillips 