### PR TITLE
Add dummy credentials to functional leak tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -134,9 +134,15 @@ class BaseSessionTest(BaseEnvVar):
 
 @skip_unless_has_memory_collection
 class BaseClientDriverTest(unittest.TestCase):
+    INJECT_DUMMY_CREDS = False
+
     def setUp(self):
         self.driver = ClientDriver()
-        self.driver.start()
+        env = None
+        if self.INJECT_DUMMY_CREDS:
+            env = {'AWS_ACCESS_KEY_ID': 'foo',
+                   'AWS_SECRET_ACCESS_KEY': 'bar'}
+        self.driver.start(env=env)
 
     def cmd(self, *args):
         self.driver.cmd(*args)
@@ -184,10 +190,10 @@ class ClientDriver(object):
         mem = self._get_memory_with_ps(self._popen.pid)
         self.memory_samples.append(mem)
 
-    def start(self):
+    def start(self, env=None):
         """Start up the command runner process."""
         self._popen = Popen([sys.executable, self.CLIENT_SERVER],
-                            stdout=PIPE, stdin=PIPE)
+                            stdout=PIPE, stdin=PIPE, env=env)
 
     def stop(self):
         """Shutdown the command runner process."""

--- a/tests/functional/leak/test_resource_leaks.py
+++ b/tests/functional/leak/test_resource_leaks.py
@@ -14,6 +14,13 @@ from tests import BaseClientDriverTest
 
 
 class TestDoesNotLeakMemory(BaseClientDriverTest):
+    # The user doesn't need to have credentials configured
+    # in order to run the functional tests for resource leaks.
+    # If we don't set this value and a user doesn't have creds
+    # configured, each create_client() call will have to go through
+    # the EC2 Instance Metadata provider's timeout, which can add
+    # a substantial amount of time to the total test run time.
+    INJECT_DUMMY_CREDS = True
     # We're making up numbers here, but let's say arbitrarily
     # that the memory can't increase by more than 10MB.
     MAX_GROWTH_BYTES = 10 * 1024 * 1024


### PR DESCRIPTION
Avoids the instance metadata timeout during credential lookup.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 