### PR TITLE
Now can resume from an empty first page

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -189,14 +189,14 @@ class PageIterator(object):
 
     def _handle_first_request(self, parsed, primary_result_key,
                               starting_truncation):
-        # First we need to slice into the array and only return
+        # If the payload is an array, we need to slice into it and only return
         # the truncated amount.
         starting_truncation = self._parse_starting_token()[1]
-        all_data = primary_result_key.search(parsed)
+        data = primary_result_key.search(parsed)
         set_value_from_jmespath(
             parsed,
             primary_result_key.expression,
-            all_data[starting_truncation:]
+            data[starting_truncation:] if isinstance(data, list) else None
         )
         # We also need to truncate any secondary result keys
         # because they were not truncated in the previous last
@@ -204,7 +204,7 @@ class PageIterator(object):
         for token in self.result_keys:
             if token == primary_result_key:
                 continue
-            set_value_from_jmespath(parsed, token.expression, [])
+            set_value_from_jmespath(parsed, token.expression, None)
         return starting_truncation
 
     def _truncate_response(self, parsed, primary_result_key, truncate_amount,

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -189,14 +189,18 @@ class PageIterator(object):
 
     def _handle_first_request(self, parsed, primary_result_key,
                               starting_truncation):
-        # If the payload is an array, we need to slice into it and only return
-        # the truncated amount.
+        # If the payload is an array or string, we need to slice into it
+        # and only return the truncated amount.
         starting_truncation = self._parse_starting_token()[1]
-        data = primary_result_key.search(parsed)
+        all_data = primary_result_key.search(parsed)
+        if isinstance(all_data, (list, string_types)):
+            data = all_data[starting_truncation:]
+        else:
+            data = None
         set_value_from_jmespath(
             parsed,
             primary_result_key.expression,
-            data[starting_truncation:] if isinstance(data, list) else None
+            data
         )
         # We also need to truncate any secondary result keys
         # because they were not truncated in the previous last

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -208,7 +208,16 @@ class PageIterator(object):
         for token in self.result_keys:
             if token == primary_result_key:
                 continue
-            set_value_from_jmespath(parsed, token.expression, None)
+            sample = token.search(parsed)
+            if isinstance(sample, list):
+                empty_value = []
+            elif isinstance(sample, string_types):
+                empty_value = ''
+            elif isinstance(sample, (int, float)):
+                empty_value = 0
+            else:
+                empty_value = None
+            set_value_from_jmespath(parsed, token.expression, empty_value)
         return starting_truncation
 
     def _truncate_response(self, parsed, primary_result_key, truncate_amount,

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -567,7 +567,7 @@ class TestMultipleResultKeys(unittest.TestCase):
         # Note that the secondary keys ("Groups") are all truncated because
         # they were in the original (first) response.
         self.assertEqual(complete,
-                         {"Users": ["User2"],
+                         {"Users": ["User2"], "Groups": [],
                           "NextToken": "m1"})
 
 
@@ -613,6 +613,7 @@ class TestMultipleInputKeys(unittest.TestCase):
         complete = pages.build_full_result()
         self.assertEqual(complete,
                          {"Users": ['User4'],
+                          "Groups": [],
                           "NextToken": "m3___m4"})
         self.assertEqual(
             self.method.call_args_list,

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -570,6 +570,24 @@ class TestMultipleResultKeys(unittest.TestCase):
                          {"Users": ["User2"], "Groups": [],
                           "NextToken": "m1"})
 
+    def test_resume_with_secondary_result_as_string(self):
+        self.method.return_value = {"Users": ["User1", "User2"], "Groups": "a"}
+        pages = self.paginator.paginate(
+            PaginationConfig={'MaxItems': 1, 'StartingToken': "None___1"})
+        complete = pages.build_full_result()
+        # Note that the secondary keys ("Groups") becomes empty string because
+        # they were in the original (first) response.
+        self.assertEqual(complete, {"Users": ["User2"], "Groups": ""})
+
+    def test_resume_with_secondary_result_as_integer(self):
+        self.method.return_value = {"Users": ["User1", "User2"], "Groups": 123}
+        pages = self.paginator.paginate(
+            PaginationConfig={'MaxItems': 1, 'StartingToken': "None___1"})
+        complete = pages.build_full_result()
+        # Note that the secondary keys ("Groups") becomes zero because
+        # they were in the original (first) response.
+        self.assertEqual(complete, {"Users": ["User2"], "Groups": 0})
+
 
 class TestMultipleInputKeys(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -567,7 +567,7 @@ class TestMultipleResultKeys(unittest.TestCase):
         # Note that the secondary keys ("Groups") are all truncated because
         # they were in the original (first) response.
         self.assertEqual(complete,
-                         {"Users": ["User2"], "Groups": [],
+                         {"Users": ["User2"],
                           "NextToken": "m1"})
 
 
@@ -613,11 +613,17 @@ class TestMultipleInputKeys(unittest.TestCase):
         complete = pages.build_full_result()
         self.assertEqual(complete,
                          {"Users": ['User4'],
-                          "Groups": [],
                           "NextToken": "m3___m4"})
         self.assertEqual(
             self.method.call_args_list,
             [mock.call(InMarker1='m1', InMarker2='m2')])
+
+    def test_resume_encounters_an_empty_payload(self):
+        response = {"not_a_result_key": "it happens in some service"}
+        self.method.return_value = response
+        complete = self.paginator.paginate(
+            PaginationConfig={'StartingToken': 'None___1'}).build_full_result()
+        self.assertEqual(complete, {})
 
     def test_result_key_exposed_on_paginator(self):
         self.assertEqual(


### PR DESCRIPTION
This is built on top of PR #689, and fixes issue aws/aws-cli#1365

I also manually test it with this command line to make sure it solves the issue.

    aws rds download-db-log-file-portion --db-instance-identifier mydbinstance --log-file-name error/mysql-error-running.log --starting-token 1000

A couple previous test cases have also been adjusted a little bit. Their previous default value as list is no longer considered as proper anyway.