### PR TITLE
Respect locationName for JSON Protocols

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -308,6 +308,8 @@ class JSONSerializer(Serializer):
     def _serialize(self, serialized, value, shape, key=None):
         method = getattr(self, '_serialize_type_%s' % shape.type_name,
                          self._default_serialize)
+        if 'name' in shape.serialization:
+            key = shape.serialization['name']
         method(serialized, value, shape, key)
 
     def _serialize_type_structure(self, serialized, value, shape, key):

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -308,8 +308,6 @@ class JSONSerializer(Serializer):
     def _serialize(self, serialized, value, shape, key=None):
         method = getattr(self, '_serialize_type_%s' % shape.type_name,
                          self._default_serialize)
-        if 'name' in shape.serialization:
-            key = shape.serialization['name']
         method(serialized, value, shape, key)
 
     def _serialize_type_structure(self, serialized, value, shape, key):
@@ -325,6 +323,8 @@ class JSONSerializer(Serializer):
         members = shape.members
         for member_key, member_value in value.items():
             member_shape = members[member_key]
+            if 'name' in member_shape.serialization:
+                member_key = member_shape.serialization['name']
             self._serialize(serialized, member_value, member_shape, member_key)
 
     def _serialize_type_map(self, serialized, value, shape, key):

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1,0 +1,53 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+
+import botocore.session
+
+
+class TestApigateway(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client('apigateway', 'us-east-1')
+
+        # Create a resoruce to use with this client.
+        self.api_name = 'mytestapi'
+        self.api_id = self.client.create_rest_api(name=self.api_name)['id']
+
+    def tearDown(self):
+        self.client.delete_rest_api(restApiId=self.api_id)
+
+    def test_put_integration(self):
+        # The only resource on a brand new api is the path. So use that ID.
+        path_resource_id = self.client.get_resources(
+            restApiId=self.api_id)['items'][0]['id']
+
+        # Create a method for the resource.
+        self.client.put_method(
+            restApiId=self.api_id,
+            resourceId=path_resource_id,
+            httpMethod='GET',
+            authorizationType='None'
+        )
+
+        # Put an integration on the method.
+        response = self.client.put_integration(
+            restApiId=self.api_id,
+            resourceId=path_resource_id,
+            httpMethod='GET',
+            type='HTTP',
+            integrationHttpMethod='GET',
+            uri='https://api.endpoint.com'
+        )
+        # Assert the response was successful by checking the integration type
+        self.assertEqual(response['type'], 'HTTP')

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -28,6 +28,7 @@ from botocore.vendored.requests.exceptions import ConnectionError
 # Empty params means that the operation will be called with no params.  This is
 # used as a quick verification that we can successfully make calls to services.
 SMOKE_TESTS = {
+ 'apigateway': {'GetRestApis': {}},
  'autoscaling': {'DescribeAccountLimits': {},
                  'DescribeAdjustmentTypes': {}},
  'cloudformation': {'DescribeStacks': {},
@@ -99,6 +100,7 @@ SMOKE_TESTS = {
 # that we get an error response back from the server because
 # we've sent invalid params.
 ERROR_TESTS = {
+    'apigateway': {'GetRestApi': {'restApiId': 'fake-id'}},
     'autoscaling': {'CreateLaunchConfiguration': {
         'LaunchConfigurationName': 'foo',
         'ImageId': 'ami-12345678',

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -902,5 +902,48 @@
         }
       }
     ]
+  },
+  {
+    "description": "Named locations in JSON body",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType",
+            "locationName": "timestamp_location"
+          }
+        }
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "TimeArg": 1422172800
+        },
+        "serialized": {
+          "uri": "/path",
+          "headers": {},
+          "body": "{\"timestamp_location\": 1422172800}"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
We were not respecting ``locationName`` for JSON protocols, which caused issues with API Gateway's ``PutIntegration`` operation's [integrationHttpMethod](https://github.com/boto/botocore/blob/develop/botocore/data/apigateway/2015-07-09/service-2.json#L4133) which uses ``locationName``.

Fixes https://github.com/aws/aws-cli/issues/1605

cc @jamesls @mtdowling @rayluo @JordonPhillips 