### PR TITLE
Autopopulate CopySourceSSECustomerKeyMD5 for s3

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -198,9 +198,9 @@ def _sse_md5(params, sse_member_prefix='SSECustomer'):
     params[sse_md5_member] = key_md5_str
 
 
-def _needs_s3_sse_customization(params, sse_member_prefix='SSECustomer'):
-    return (params.get(sse_member_prefix+'Key') is not None and
-            sse_member_prefix+'KeyMD5' not in params)
+def _needs_s3_sse_customization(params, sse_member_prefix):
+    return (params.get(sse_member_prefix + 'Key') is not None and
+            sse_member_prefix + 'KeyMD5' not in params)
 
 
 def register_retries_for_service(service_data, session,

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -21,6 +21,12 @@ class TestS3Docs(BaseDocsFunctionalTest):
             method_name='put_object',
             param_name='SSECustomerKeyMD5')
 
+    def test_auto_populates_copy_source_sse_customer_key_md5(self):
+        self.assert_is_documented_as_autopopulated_param(
+            service_name='s3',
+            method_name='copy_object',
+            param_name='CopySourceSSECustomerKeyMD5')
+
     def test_hides_content_md5_when_impossible_to_provide(self):
         modified_methods = ['delete_objects', 'put_bucket_acl',
                             'put_bucket_cors', 'put_bucket_lifecycle',

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -189,6 +189,25 @@ class TestHandlers(BaseSessionTest):
         self.assertEqual(params['SSECustomerKeyMD5'],
                          'N7UdGUp1E+RbVvZSTy1R8g==')
 
+    def test_copy_source_sse_params(self):
+        for op in ['CopyObject', 'UploadPartCopy']:
+            event = 'before-parameter-build.s3.%s' % op
+            params = {'CopySourceSSECustomerKey': b'bar',
+                      'CopySourceSSECustomerAlgorithm': 'AES256'}
+            self.session.emit(event, params=params, model=mock.Mock())
+            self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
+            self.assertEqual(params['CopySourceSSECustomerKeyMD5'],
+                             'N7UdGUp1E+RbVvZSTy1R8g==')
+
+    def test_copy_source_sse_params_as_str(self):
+        event = 'before-parameter-build.s3.CopyObject'
+        params = {'CopySourceSSECustomerKey': 'bar',
+                  'CopySourceSSECustomerAlgorithm': 'AES256'}
+        self.session.emit(event, params=params, model=mock.Mock())
+        self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
+        self.assertEqual(params['CopySourceSSECustomerKeyMD5'],
+                         'N7UdGUp1E+RbVvZSTy1R8g==')
+
     def test_route53_resource_id(self):
         event = 'before-parameter-build.route53.GetHostedZone'
         params = {'Id': '/hostedzone/ABC123',


### PR DESCRIPTION
This is implementing logic used for this PR: https://github.com/aws/aws-cli/pull/1487. We have it for SSECustomer members but not the copy source one which may be needed when calling CopyObject.

cc @jamesls @mtdowling @rayluo @JordonPhillips 