### PR TITLE
Detect non-ascii in credential

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -60,6 +60,9 @@ if six.PY3:
         # changes when using getargspec with functools.partials.
         return inspect.getfullargspec(func)[2]
 
+    def unicode(s, encoding=None, errors=None):
+        # NOOP in Python 3, because every string is already unicode
+        return s
 
 else:
     from urllib import quote
@@ -107,6 +110,8 @@ else:
 
     def accepts_kwargs(func):
         return inspect.getargspec(func)[2]
+
+    unicode = unicode
 
 try:
     from collections import OrderedDict

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -124,9 +124,9 @@ class Credentials(object):
             method = 'explicit'
         self.method = method
 
-        self.normalize()
+        self._normalize()
 
-    def normalize(self):
+    def _normalize(self):
         # Keys would sometimes (accidentally) contain non-ascii characters.
         # It would cause a confusing UnicodeDecodeError in Python 2.
         # We explicitly convert them into unicode to avoid such error.
@@ -164,9 +164,9 @@ class RefreshableCredentials(Credentials):
         self._expiry_time = expiry_time
         self._time_fetcher = time_fetcher
         self.method = method
-        self.normalize()
+        self._normalize()
 
-    def normalize(self):
+    def _normalize(self):
         self._access_key = botocore.compat.unicode(self._access_key, 'utf-8')
         self._secret_key = botocore.compat.unicode(self._secret_key, 'utf-8')
 
@@ -245,7 +245,7 @@ class RefreshableCredentials(Credentials):
         self.token = data['token']
         self._expiry_time = parse(data['expiry_time'])
         logger.debug("Retrieved credentials will expire at: %s", self._expiry_time)
-        self.normalize()
+        self._normalize()
 
 
 class CredentialProvider(object):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -115,9 +115,15 @@ class Credentials(object):
 
     def __init__(self, access_key, secret_key, token=None,
                  method=None):
-        self._assert_ascii(access_key)
-        self._assert_ascii(secret_key)
-
+        if six.PY2:
+            # Keys would sometimes (accidentally) contain non-ascii characters.
+            # It would cause a confusing UnicodeDecodeError in Python 2.
+            # We explicitly convert them into unicode to avoid such error.
+            #
+            # Eventually the service will decide whether to accept the
+            # credential. This also complies with the behavior in Python 3.
+            access_key = access_key.decode('utf-8')
+            secret_key = secret_key.decode('utf-8')
         self.access_key = access_key
         self.secret_key = secret_key
         self.token = token
@@ -125,15 +131,6 @@ class Credentials(object):
         if method is None:
             method = 'explicit'
         self.method = method
-
-    def _assert_ascii(self, s):
-        # Possible Non-ASCII in input, which presumably came from an incorrect
-        # copy-and-paste, would cause confusing UnicodeDecodeError later.
-        # We intercept it here, and provide a meaningful message to customer.
-        try:
-            s.decode('ascii')
-        except UnicodeDecodeError:
-            raise ValueError('Non-ASCII character found in credential: ' + s)
 
 
 class RefreshableCredentials(Credentials):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -115,6 +115,9 @@ class Credentials(object):
 
     def __init__(self, access_key, secret_key, token=None,
                  method=None):
+        self._assert_ascii(access_key)
+        self._assert_ascii(secret_key)
+
         self.access_key = access_key
         self.secret_key = secret_key
         self.token = token
@@ -122,6 +125,15 @@ class Credentials(object):
         if method is None:
             method = 'explicit'
         self.method = method
+
+    def _assert_ascii(self, s):
+        # Possible Non-ASCII in input, which presumably came from an incorrect
+        # copy-and-paste, would cause confusing UnicodeDecodeError later.
+        # We intercept it here, and provide a meaningful message to customer.
+        try:
+            s.decode('ascii')
+        except UnicodeDecodeError:
+            raise ValueError('Non-ASCII character found in credential: ' + s)
 
 
 class RefreshableCredentials(Credentials):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -164,6 +164,11 @@ class RefreshableCredentials(Credentials):
         self._expiry_time = expiry_time
         self._time_fetcher = time_fetcher
         self.method = method
+        self.normalize()
+
+    def normalize(self):
+        self._access_key = botocore.compat.unicode(self._access_key, 'utf-8')
+        self._secret_key = botocore.compat.unicode(self._secret_key, 'utf-8')
 
     @classmethod
     def create_from_metadata(cls, metadata, refresh_using, method):
@@ -240,6 +245,7 @@ class RefreshableCredentials(Credentials):
         self.token = data['token']
         self._expiry_time = parse(data['expiry_time'])
         logger.debug("Retrieved credentials will expire at: %s", self._expiry_time)
+        self.normalize()
 
 
 class CredentialProvider(object):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -55,8 +55,9 @@ def path(filename):
 
 class TestCredentials(BaseEnvVar):
     def test_detect_nonascii_character(self):
-        with self.assertRaises(ValueError):
-            credentials.Credentials('foo\xe2\x80\x99', 'bar')
+        c = credentials.Credentials('foo\xe2\x80\x99', 'bar\xe2\x80\x99')
+        self.assertTrue(isinstance(c.access_key, type(u'u')))
+        self.assertTrue(isinstance(c.secret_key, type(u'u')))
 
 
 class TestRefreshableCredentials(BaseEnvVar):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -60,7 +60,7 @@ class TestCredentials(BaseEnvVar):
         self.assertTrue(isinstance(c.secret_key, type(u'u')))
 
 
-class TestRefreshableCredentials(BaseEnvVar):
+class TestRefreshableCredentials(TestCredentials):
     def setUp(self):
         super(TestRefreshableCredentials, self).setUp()
         self.refresher = mock.Mock()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -53,6 +53,12 @@ def path(filename):
     return os.path.join(os.path.dirname(__file__), 'cfg', filename)
 
 
+class TestCredentials(BaseEnvVar):
+    def test_detect_nonascii_character(self):
+        with self.assertRaises(ValueError):
+            credentials.Credentials('foo\xe2\x80\x99', 'bar')
+
+
 class TestRefreshableCredentials(BaseEnvVar):
     def setUp(self):
         super(TestRefreshableCredentials, self).setUp()


### PR DESCRIPTION
Also provides better message to customer. This will resolve aws/aws-cli#708

Did not patch RefreshableCredentials, because it is less error-prone.