### PR TITLE
Remove coveralls.io badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,6 @@ botocore
 .. image:: https://secure.travis-ci.org/boto/botocore.png?branch=develop
    :target: http://travis-ci.org/boto/botocore
 
-.. image:: https://coveralls.io/repos/boto/botocore/badge.png?branch=develop
-   :target: https://coveralls.io/r/boto/botocore?branch=master
 
 A low-level interface to a growing number of Amazon Web Services. The
 botocore package is the foundation for the


### PR DESCRIPTION
1) It's reporting wrong coverage numbers
2) We've already removed it in boto3

For reference: https://github.com/boto/boto3/pull/284

cc @kyleknap @mtdowling @rayluo @JordonPhillips 