### PR TITLE
Update tox to use the ci scripts

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,9 @@
 [tox]
 envlist = py26,py27,py33,py34
 
-[testenv]
-commands = nosetests tests/unit
-deps =
-    nose
-    mock
+skipsdist = True
 
-[testenv:py26]
-commands = nosetests tests/unit
-deps =
-    nose
-    mock
-    unittest2
+[testenv]
+commands =
+    {toxinidir}/scripts/ci/install
+    {toxinidir}/scripts/ci/run-tests


### PR DESCRIPTION
It now matches boto3: https://github.com/boto/boto3/pull/353 where the ci scripts are used instead of some separate logic.

cc @jamesls @mtdowling @rayluo @JordonPhillips 