### PR TITLE
Skip convertion if the input is already unicode

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -112,7 +112,7 @@ else:
         return inspect.getargspec(func)[2]
 
     def ensure_unicode(s, encoding='utf-8', errors='strict'):
-        if type(s) == six.text_type:
+        if isinstance(s, six.text_type):
             return s
         return unicode(s, encoding, errors)
 

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -60,7 +60,7 @@ if six.PY3:
         # changes when using getargspec with functools.partials.
         return inspect.getfullargspec(func)[2]
 
-    def unicode(s, encoding=None, errors=None):
+    def ensure_unicode(s, encoding=None, errors=None):
         # NOOP in Python 3, because every string is already unicode
         return s
 
@@ -111,7 +111,10 @@ else:
     def accepts_kwargs(func):
         return inspect.getargspec(func)[2]
 
-    unicode = unicode
+    def ensure_unicode(s, encoding='utf-8', errors='strict'):
+        if type(s) == six.text_type:
+            return s
+        return unicode(s, encoding, errors)
 
 try:
     from collections import OrderedDict

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -133,8 +133,8 @@ class Credentials(object):
         #
         # Eventually the service will decide whether to accept the credential.
         # This also complies with the behavior in Python 3.
-        self.access_key = botocore.compat.unicode(self.access_key, 'utf-8')
-        self.secret_key = botocore.compat.unicode(self.secret_key, 'utf-8')
+        self.access_key = botocore.compat.ensure_unicode(self.access_key)
+        self.secret_key = botocore.compat.ensure_unicode(self.secret_key)
 
 
 class RefreshableCredentials(Credentials):
@@ -167,8 +167,8 @@ class RefreshableCredentials(Credentials):
         self._normalize()
 
     def _normalize(self):
-        self._access_key = botocore.compat.unicode(self._access_key, 'utf-8')
-        self._secret_key = botocore.compat.unicode(self._secret_key, 'utf-8')
+        self._access_key = botocore.compat.ensure_unicode(self._access_key)
+        self._secret_key = botocore.compat.ensure_unicode(self._secret_key)
 
     @classmethod
     def create_from_metadata(cls, metadata, refresh_using, method):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -58,15 +58,14 @@ class TestCredentials(BaseEnvVar):
         c = credentials.Credentials(access, secret)
         self.assertTrue(isinstance(c.access_key, type(u'u')))
         self.assertTrue(isinstance(c.secret_key, type(u'u')))
-        return True
 
     def test_detect_nonascii_character(self):
-        self.assertTrue(self._ensure_credential_is_normalized_as_unicode(
-            'foo\xe2\x80\x99', 'bar\xe2\x80\x99'))
+        self._ensure_credential_is_normalized_as_unicode(
+            'foo\xe2\x80\x99', 'bar\xe2\x80\x99')
 
     def test_unicode_input(self):
-        self.assertTrue(self._ensure_credential_is_normalized_as_unicode(
-            u'foo', u'bar'))
+        self._ensure_credential_is_normalized_as_unicode(
+            u'foo', u'bar')
 
 
 class TestRefreshableCredentials(TestCredentials):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -54,10 +54,19 @@ def path(filename):
 
 
 class TestCredentials(BaseEnvVar):
-    def test_detect_nonascii_character(self):
-        c = credentials.Credentials('foo\xe2\x80\x99', 'bar\xe2\x80\x99')
+    def _ensure_credential_is_normalized_as_unicode(self, access, secret):
+        c = credentials.Credentials(access, secret)
         self.assertTrue(isinstance(c.access_key, type(u'u')))
         self.assertTrue(isinstance(c.secret_key, type(u'u')))
+        return True
+
+    def test_detect_nonascii_character(self):
+        self.assertTrue(self._ensure_credential_is_normalized_as_unicode(
+            'foo\xe2\x80\x99', 'bar\xe2\x80\x99'))
+
+    def test_unicode_input(self):
+        self.assertTrue(self._ensure_credential_is_normalized_as_unicode(
+            u'foo', u'bar'))
 
 
 class TestRefreshableCredentials(TestCredentials):


### PR DESCRIPTION
It happens when the credential comes from iam-role.