### PR TITLE
Add Kinesis stream-not-found waiter

### DIFF
--- a/botocore/data/kinesis/2013-12-02/waiters-2.json
+++ b/botocore/data/kinesis/2013-12-02/waiters-2.json
@@ -13,6 +13,18 @@
           "argument": "StreamDescription.StreamStatus"
         }
       ]
+    },
+    "StreamNotExists": {
+      "delay": 10,
+      "operation": "DescribeStream",
+      "maxAttempts": 18,
+      "acceptors": [
+        {
+          "expected": "ResourceNotFoundException",
+          "matcher": "error",
+          "state": "success"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
The `aws kinesis delete-stream` does not immediately
delete the stream. This adds a waiter so you can block
until the stream is unavailable(i.e.,
`aws kinesis describe-stream` returns `ResourceNotFoundException`).

## Usage

First, create a Kinesis stream

```
$ aws kinesis create-stream --stream-name Foo --shard-count 1
$ aws kinesis wait stream-exists --stream-name Foo
$ aws kinesis describe-stream --stream-name Foo
{
    "StreamDescription": {
        "RetentionPeriodHours": 24,
        "StreamStatus": "ACTIVE",
        "StreamName": "Foo",
        "StreamARN": "arn:aws:kinesis:ap-northeast-1:123456789012:stream/Foo",
        ..snip...
    }
}
```

Then delete the Kinesis stream `foo`.

```
$ aws kinesis delete-stream  --stream-name Foo
$ aws kinesis describe-stream --stream-name Foo
{
    "StreamDescription": {
        "RetentionPeriodHours": 24,
        "StreamStatus": "DELETING",
        "StreamName": "Foo",
        "StreamARN": "arn:aws:kinesis:ap-northeast-1:123456789012:stream/Foo",
        "Shards": []
    }
}
$ aws kinesis wait stream-not-exists --stream-name Foo
```