### PR TITLE
Signature cache fix

### DIFF
--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -83,8 +83,10 @@ class TestSigner(BaseSignerTest):
         auth_cls = mock.Mock(side_effect=side_effect)
         with mock.patch.dict(botocore.auth.AUTH_TYPE_MAPS,
                              {'v4': auth_cls}):
-            auth1 = self.signer.get_auth('service_name', 'region_name', expires=60)
-            auth2 = self.signer.get_auth('service_name', 'region_name', expires=90)
+            auth1 = self.signer.get_auth('service_name', 'region_name',
+                                         expires=60)
+            auth2 = self.signer.get_auth('service_name', 'region_name',
+                                         expires=90)
 
         self.assertNotEqual(auth1, auth2)
 


### PR DESCRIPTION
Do not cache signers that have an expires value. This commit supersedes #699
    
This commit updates the signer cache to not cache signers that have an
expires value because the cache hit ratio for these signers will be
virtually 0 as the key would have to be derived from a timestamp.
    
This change should address several existing issues:
- Closes #699
- Closes #698
- Probably fixes https://github.com/boto/boto3/issues/309

@jamesls @kyleknap @rayluo @JordonPhillips 