### PR TITLE
Document streaming body

### DIFF
--- a/botocore/docs/example.py
+++ b/botocore/docs/example.py
@@ -16,8 +16,6 @@ from botocore.model import get_streaming_body
 
 
 class BaseExampleDocumenter(ShapeDocumenter):
-    streaming_shape = None
-
     def document_example(self, section, shape, prefix=None, include=None,
                          exclude=None):
         """Generates an example based on a shape
@@ -36,7 +34,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
         :param exclude: The names of the parameters to exclude from
             documentation.
         """
-        self.streaming_shape = get_streaming_body(shape)
+        self._context['streaming_shape'] = get_streaming_body(shape)
         history = []
         section.style.new_line()
         section.style.start_codeblock()
@@ -52,7 +50,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
     def document_shape_default(self, section, shape, history, include=None,
                                exclude=None, **kwargs):
         py_type = py_default(shape.type_name)
-        if self.streaming_shape == shape:
+        if self._context.get('streaming_shape') == shape:
             py_type = 'StreamingBody()'
         section.write(py_type)
 

--- a/botocore/docs/example.py
+++ b/botocore/docs/example.py
@@ -12,9 +12,12 @@
 # language governing permissions and limitations under the License.
 from botocore.docs.shape import ShapeDocumenter
 from botocore.docs.utils import py_default
+from botocore.model import get_streaming_body
 
 
 class BaseExampleDocumenter(ShapeDocumenter):
+    streaming_shape = None
+
     def document_example(self, section, shape, prefix=None, include=None,
                          exclude=None):
         """Generates an example based on a shape
@@ -33,6 +36,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
         :param exclude: The names of the parameters to exclude from
             documentation.
         """
+        self.streaming_shape = get_streaming_body(shape)
         history = []
         section.style.new_line()
         section.style.start_codeblock()
@@ -48,8 +52,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
     def document_shape_default(self, section, shape, history, include=None,
                                exclude=None, **kwargs):
         py_type = py_default(shape.type_name)
-        if (self._operation_model and
-                self._operation_model.streaming_output_shape == shape):
+        if self.streaming_shape == shape:
             py_type = 'StreamingBody()'
         section.write(py_type)
 

--- a/botocore/docs/example.py
+++ b/botocore/docs/example.py
@@ -50,7 +50,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
         py_type = py_default(shape.type_name)
         if (self._operation_model and
                 self._operation_model.streaming_output_shape == shape):
-            py_type = 'file_like_object'
+            py_type = 'StreamingBody'
         section.write(py_type)
 
     def document_shape_type_string(self, section, shape, history,

--- a/botocore/docs/example.py
+++ b/botocore/docs/example.py
@@ -48,6 +48,9 @@ class BaseExampleDocumenter(ShapeDocumenter):
     def document_shape_default(self, section, shape, history, include=None,
                                exclude=None, **kwargs):
         py_type = py_default(shape.type_name)
+        if (self._operation_model and
+                self._operation_model.streaming_output_shape == shape):
+            py_type = 'file_like_object'
         section.write(py_type)
 
     def document_shape_type_string(self, section, shape, history,

--- a/botocore/docs/example.py
+++ b/botocore/docs/example.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 from botocore.docs.shape import ShapeDocumenter
 from botocore.docs.utils import py_default
-from botocore.model import get_streaming_body
 
 
 class BaseExampleDocumenter(ShapeDocumenter):
@@ -34,7 +33,6 @@ class BaseExampleDocumenter(ShapeDocumenter):
         :param exclude: The names of the parameters to exclude from
             documentation.
         """
-        self._context['streaming_shape'] = get_streaming_body(shape)
         history = []
         section.style.new_line()
         section.style.start_codeblock()

--- a/botocore/docs/example.py
+++ b/botocore/docs/example.py
@@ -50,7 +50,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
         py_type = py_default(shape.type_name)
         if (self._operation_model and
                 self._operation_model.streaming_output_shape == shape):
-            py_type = 'StreamingBody'
+            py_type = 'StreamingBody()'
         section.write(py_type)
 
     def document_shape_type_string(self, section, shape, history,

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -209,6 +209,8 @@ def document_model_driven_method(section, method_name, operation_model,
         return_section.style.indent()
         return_section.style.new_line()
 
+        context = {'streaming_shape': operation_model.get_streaming_output()}
+
         # Add an example return value
         return_example_section = return_section.add_new_section('example')
         return_example_section.style.new_line()
@@ -217,7 +219,8 @@ def document_model_driven_method(section, method_name, operation_model,
         ResponseExampleDocumenter(
             service_name=operation_model.service_model.service_name,
             operation_name=operation_model.name,
-            event_emitter=event_emitter).document_example(
+            event_emitter=event_emitter,
+            context=context).document_example(
                 return_example_section, operation_model.output_shape,
                 include=include_output, exclude=exclude_output)
 
@@ -230,7 +233,8 @@ def document_model_driven_method(section, method_name, operation_model,
         ResponseParamsDocumenter(
             service_name=operation_model.service_model.service_name,
             operation_name=operation_model.name,
-            event_emitter=event_emitter).document_params(
+            event_emitter=event_emitter,
+            context=context).document_params(
                 return_description_section, operation_model.output_shape,
                 include=include_output, exclude=exclude_output)
     else:

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -217,8 +217,7 @@ def document_model_driven_method(section, method_name, operation_model,
         ResponseExampleDocumenter(
             service_name=operation_model.service_model.service_name,
             operation_name=operation_model.name,
-            event_emitter=event_emitter,
-            operation_model=operation_model).document_example(
+            event_emitter=event_emitter).document_example(
                 return_example_section, operation_model.output_shape,
                 include=include_output, exclude=exclude_output)
 
@@ -231,8 +230,7 @@ def document_model_driven_method(section, method_name, operation_model,
         ResponseParamsDocumenter(
             service_name=operation_model.service_model.service_name,
             operation_name=operation_model.name,
-            event_emitter=event_emitter,
-            operation_model=operation_model).document_params(
+            event_emitter=event_emitter).document_params(
                 return_description_section, operation_model.output_shape,
                 include=include_output, exclude=exclude_output)
     else:

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -217,7 +217,8 @@ def document_model_driven_method(section, method_name, operation_model,
         ResponseExampleDocumenter(
             service_name=operation_model.service_model.service_name,
             operation_name=operation_model.name,
-            event_emitter=event_emitter).document_example(
+            event_emitter=event_emitter,
+            operation_model=operation_model).document_example(
                 return_example_section, operation_model.output_shape,
                 include=include_output, exclude=exclude_output)
 
@@ -230,7 +231,8 @@ def document_model_driven_method(section, method_name, operation_model,
         ResponseParamsDocumenter(
             service_name=operation_model.service_model.service_name,
             operation_name=operation_model.name,
-            event_emitter=event_emitter).document_params(
+            event_emitter=event_emitter,
+            operation_model=operation_model).document_params(
                 return_description_section, operation_model.output_shape,
                 include=include_output, exclude=exclude_output)
     else:

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -126,6 +126,9 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
         if name is not None:
             name_section.style.bold('%s ' % name)
         type_section = section.add_new_section('param-type')
+        if (self._operation_model and
+                self._operation_model.streaming_output_shape == shape):
+            py_type = 'A file-like object with .read([size]) method'
         type_section.style.italics('(%s) -- ' % py_type)
 
         documentation_section = section.add_new_section('param-documentation')

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 from botocore.docs.shape import ShapeDocumenter
 from botocore.docs.utils import py_type_name
-from botocore.model import get_streaming_body
 
 
 class BaseParamsDocumenter(ShapeDocumenter):
@@ -31,7 +30,6 @@ class BaseParamsDocumenter(ShapeDocumenter):
         :param exclude: The names of the parameters to exclude from
             documentation.
         """
-        self._context['streaming_shape'] = get_streaming_body(shape)
         history = []
         self.traverse_and_document_shape(
             section=section, shape=shape, history=history,

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -16,8 +16,6 @@ from botocore.model import get_streaming_body
 
 
 class BaseParamsDocumenter(ShapeDocumenter):
-    streaming_shape = None
-
     def document_params(self, section, shape, include=None, exclude=None):
         """Fills out the documentation for a section given a model shape.
 
@@ -33,7 +31,7 @@ class BaseParamsDocumenter(ShapeDocumenter):
         :param exclude: The names of the parameters to exclude from
             documentation.
         """
-        self.streaming_shape = get_streaming_body(shape)
+        self._context['streaming_shape'] = get_streaming_body(shape)
         history = []
         self.traverse_and_document_shape(
             section=section, shape=shape, history=history,
@@ -130,7 +128,7 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
         if name is not None:
             name_section.style.bold('%s ' % name)
         type_section = section.add_new_section('param-type')
-        if self.streaming_shape == shape:
+        if self._context.get('streaming_shape') == shape:
             type_section.write('(:class:`.StreamingBody`) -- ')
         else:
             type_section.style.italics('(%s) -- ' % py_type)

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -12,9 +12,12 @@
 # language governing permissions and limitations under the License.
 from botocore.docs.shape import ShapeDocumenter
 from botocore.docs.utils import py_type_name
+from botocore.model import get_streaming_body
 
 
 class BaseParamsDocumenter(ShapeDocumenter):
+    streaming_shape = None
+
     def document_params(self, section, shape, include=None, exclude=None):
         """Fills out the documentation for a section given a model shape.
 
@@ -30,6 +33,7 @@ class BaseParamsDocumenter(ShapeDocumenter):
         :param exclude: The names of the parameters to exclude from
             documentation.
         """
+        self.streaming_shape = get_streaming_body(shape)
         history = []
         self.traverse_and_document_shape(
             section=section, shape=shape, history=history,
@@ -126,8 +130,7 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
         if name is not None:
             name_section.style.bold('%s ' % name)
         type_section = section.add_new_section('param-type')
-        if (self._operation_model and
-                self._operation_model.streaming_output_shape == shape):
+        if self.streaming_shape == shape:
             type_section.write('(:class:`.StreamingBody`) -- ')
         else:
             type_section.style.italics('(%s) -- ' % py_type)

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -128,8 +128,9 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
         type_section = section.add_new_section('param-type')
         if (self._operation_model and
                 self._operation_model.streaming_output_shape == shape):
-            py_type = 'A file-like object with .read([size]) method'
-        type_section.style.italics('(%s) -- ' % py_type)
+            type_section.write('(:class:`.StreamingBody`) -- ')
+        else:
+            type_section.style.italics('(%s) -- ' % py_type)
 
         documentation_section = section.add_new_section('param-documentation')
         if shape.documentation:

--- a/botocore/docs/shape.py
+++ b/botocore/docs/shape.py
@@ -19,10 +19,12 @@
 class ShapeDocumenter(object):
     EVENT_NAME = ''
 
-    def __init__(self, service_name, operation_name, event_emitter):
+    def __init__(self, service_name, operation_name, event_emitter,
+                 operation_model=None):
         self._service_name = service_name
         self._operation_name = operation_name
         self._event_emitter = event_emitter
+        self._operation_model = operation_model
 
     def traverse_and_document_shape(self, section, shape, history,
                                     include=None, exclude=None, name=None,

--- a/botocore/docs/shape.py
+++ b/botocore/docs/shape.py
@@ -19,12 +19,10 @@
 class ShapeDocumenter(object):
     EVENT_NAME = ''
 
-    def __init__(self, service_name, operation_name, event_emitter,
-                 operation_model=None):
+    def __init__(self, service_name, operation_name, event_emitter):
         self._service_name = service_name
         self._operation_name = operation_name
         self._event_emitter = event_emitter
-        self._operation_model = operation_model
 
     def traverse_and_document_shape(self, section, shape, history,
                                     include=None, exclude=None, name=None,

--- a/botocore/docs/shape.py
+++ b/botocore/docs/shape.py
@@ -23,6 +23,7 @@ class ShapeDocumenter(object):
         self._service_name = service_name
         self._operation_name = operation_name
         self._event_emitter = event_emitter
+        self._context = {}
 
     def traverse_and_document_shape(self, section, shape, history,
                                     include=None, exclude=None, name=None,

--- a/botocore/docs/shape.py
+++ b/botocore/docs/shape.py
@@ -19,11 +19,12 @@
 class ShapeDocumenter(object):
     EVENT_NAME = ''
 
-    def __init__(self, service_name, operation_name, event_emitter):
+    def __init__(self, service_name, operation_name, event_emitter,
+                 context=None):
         self._service_name = service_name
         self._operation_name = operation_name
         self._event_emitter = event_emitter
-        self._context = {}
+        self._context = {} if context is None else context
 
     def traverse_and_document_shape(self, section, shape, history,
                                     include=None, exclude=None, name=None,

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -321,6 +321,20 @@ class ServiceModel(object):
         self._signature_version = value
 
 
+def get_streaming_body(shape):
+    """Returns the streaming member's shape if any; or None otherwise."""
+    # Conceptually this works on output_shape only.
+    # But input_shape is also acceptable and the result will be None.
+    if shape is None:
+        return None
+    payload = shape.serialization.get('payload')
+    if payload is not None:
+        payload_shape = shape.members[payload]
+        if payload_shape.type_name == 'blob':
+            return payload_shape
+    return None
+
+
 class OperationModel(object):
     def __init__(self, operation_model, service_model, name=None):
         """
@@ -409,20 +423,7 @@ class OperationModel(object):
 
     @CachedProperty
     def has_streaming_output(self):
-        return self.streaming_output_shape is not None
-
-    @CachedProperty
-    def streaming_output_shape(self):
-        """Returns the streaming member's shape if any; or None otherwise"""
-        output_shape = self.output_shape
-        if output_shape is None:
-            return None
-        payload = output_shape.serialization.get('payload')
-        if payload is not None:
-            payload_shape = output_shape.members[payload]
-            if payload_shape.type_name == 'blob':
-                return payload_shape
-        return None
+        return get_streaming_body(self.output_shape) is not None
 
 
 class ShapeResolver(object):

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -409,15 +409,20 @@ class OperationModel(object):
 
     @CachedProperty
     def has_streaming_output(self):
+        return self.streaming_output_shape is not None
+
+    @CachedProperty
+    def streaming_output_shape(self):
+        """Returns the streaming member's shape if any; or None otherwise"""
         output_shape = self.output_shape
         if output_shape is None:
-            return False
+            return None
         payload = output_shape.serialization.get('payload')
         if payload is not None:
             payload_shape = output_shape.members[payload]
             if payload_shape.type_name == 'blob':
-                return True
-        return False
+                return payload_shape
+        return None
 
 
 class ShapeResolver(object):

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -321,20 +321,6 @@ class ServiceModel(object):
         self._signature_version = value
 
 
-def get_streaming_body(shape):
-    """Returns the streaming member's shape if any; or None otherwise."""
-    # Conceptually this works on output_shape only.
-    # But input_shape is also acceptable and the result will be None.
-    if shape is None:
-        return None
-    payload = shape.serialization.get('payload')
-    if payload is not None:
-        payload_shape = shape.members[payload]
-        if payload_shape.type_name == 'blob':
-            return payload_shape
-    return None
-
-
 class OperationModel(object):
     def __init__(self, operation_model, service_model, name=None):
         """
@@ -423,7 +409,19 @@ class OperationModel(object):
 
     @CachedProperty
     def has_streaming_output(self):
-        return get_streaming_body(self.output_shape) is not None
+        return self.get_streaming_output() is not None
+
+    def get_streaming_output(self):
+        """Returns the streaming member's shape if any; or None otherwise."""
+        shape = self.output_shape
+        if shape is None:
+            return None
+        payload = shape.serialization.get('payload')
+        if payload is not None:
+            payload_shape = shape.members[payload]
+            if payload_shape.type_name == 'blob':
+                return payload_shape
+        return None
 
 
 class ShapeResolver(object):

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -67,6 +67,11 @@ class StreamingBody(object):
             raise
 
     def read(self, amt=None):
+        """
+        Read at most amt bytes from the stream.
+
+        If the amt argument is omitted, read all data.
+        """
         chunk = self._raw_stream.read(amt)
         self._amount_read += len(chunk)
         if not chunk or amt is None:
@@ -84,6 +89,7 @@ class StreamingBody(object):
                 expected_bytes=int(self._content_length))
 
     def close(self):
+        """Close the underlying http response stream."""
         self._raw_stream.close()
 
 

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -67,8 +67,7 @@ class StreamingBody(object):
             raise
 
     def read(self, amt=None):
-        """
-        Read at most amt bytes from the stream.
+        """Read at most amt bytes from the stream.
 
         If the amt argument is omitted, read all data.
         """

--- a/docs/source/reference/response.rst
+++ b/docs/source/reference/response.rst
@@ -7,5 +7,5 @@ Response Reference
 botocore.response
 -----------------
 
-.. automodule:: botocore.response
+.. autoclass:: botocore.response.StreamingBody
    :members:

--- a/docs/source/reference/response.rst
+++ b/docs/source/reference/response.rst
@@ -1,0 +1,11 @@
+.. _ref-response:
+
+==================
+Response Reference
+==================
+
+botocore.response
+-----------------
+
+.. automodule:: botocore.response
+   :members:

--- a/tests/functional/docs/test_streaming_body.py
+++ b/tests/functional/docs/test_streaming_body.py
@@ -19,7 +19,9 @@ class TestStreamingBodyDocumentation(BaseDocsFunctionalTest):
 
     def test_all_streaming_body_are_properly_documented(self):
         for service in self._session.get_available_services():
-            client = self._session.create_client(service)
+            client = self._session.create_client(
+                service, region_name='us-east-1',
+                aws_access_key_id='foo', aws_secret_access_key='bar')
             service_model = client.meta.service_model
             for operation in service_model.operation_names:
                 operation_model = service_model.operation_model(operation)

--- a/tests/functional/docs/test_streaming_body.py
+++ b/tests/functional/docs/test_streaming_body.py
@@ -1,0 +1,34 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore import xform_name
+from tests.functional.docs import BaseDocsFunctionalTest
+from botocore.docs.service import ServiceDocumenter
+
+
+class TestStreamingBodyDocumentation(BaseDocsFunctionalTest):
+
+    def test_all_streaming_body_are_properly_documented(self):
+        for service in self._session.get_available_services():
+            client = self._session.create_client(service)
+            service_model = client.meta.service_model
+            for operation in service_model.operation_names:
+                operation_model = service_model.operation_model(operation)
+                if operation_model.has_streaming_output:
+                    self.assert_streaming_body_is_properly_documented(
+                        service, xform_name(operation))
+
+    def assert_streaming_body_is_properly_documented(self, service, operation):
+        service_docs = ServiceDocumenter(
+            service, self._session).document_service()
+        method_docs = self.get_method_document_block(operation, service_docs)
+        self.assert_contains_line('StreamingBody', method_docs)

--- a/tests/unit/docs/test_method.py
+++ b/tests/unit/docs/test_method.py
@@ -313,4 +313,4 @@ class TestDocumentModelDrivenMethod(BaseDocsTest):
             method_description='This describes the foo method.',
             example_prefix='response = client.foo'
         )
-        self.assert_contains_line('StreamingBody')
+        self.assert_contains_line('**Body** (:class:`.StreamingBody`)')

--- a/tests/unit/docs/test_method.py
+++ b/tests/unit/docs/test_method.py
@@ -301,3 +301,16 @@ class TestDocumentModelDrivenMethod(BaseDocsTest):
             '\'Bar\': \'string\'',
             '- **Bar** *(string) --*',
         ])
+
+    def test_streaming_body_in_output(self):
+        self.add_shape_to_params('Body', 'Blob')
+        self.json_model['shapes']['Blob'] = {'type': 'blob'}
+        self.json_model['shapes']['SampleOperationInputOutput']['payload'] = \
+            'Body'
+        document_model_driven_method(
+            self.doc_structure, 'foo', self.operation_model,
+            event_emitter=self.event_emitter,
+            method_description='This describes the foo method.',
+            example_prefix='response = client.foo'
+        )
+        self.assert_contains_line('StreamingBody')


### PR DESCRIPTION
Automatically document all operations with a streaming body. Previously they were incorrectly documented as bytes.

This fixes boto/boto3#330