### PR TITLE
Remove error message strings from tests

### DIFF
--- a/tests/acceptance/features/smoke/autoscaling/autoscaling.feature
+++ b/tests/acceptance/features/smoke/autoscaling/autoscaling.feature
@@ -12,7 +12,4 @@ Feature: Auto Scaling
     | ImageId                 | ami-12345678 |
     | InstanceType            | m1.small     |
     Then I expect the response error code to be "ValidationError"
-    And I expect the response error message to include:
-    """
-    AMI ami-12345678 is invalid: The image id '[ami-12345678]' does not exist
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cloudformation/cloudformation.feature
+++ b/tests/acceptance/features/smoke/cloudformation/cloudformation.feature
@@ -11,7 +11,4 @@ Feature: AWS CloudFormation
     | StackName   | fakestack                       |
     | TemplateURL | http://s3.amazonaws.com/foo/bar |
     Then I expect the response error code to be "ValidationError"
-    And I expect the response error message to include:
-    """
-    TemplateURL must reference a valid S3 object to which you have access.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cloudfront/cloudfront.feature
+++ b/tests/acceptance/features/smoke/cloudfront/cloudfront.feature
@@ -11,7 +11,4 @@ Feature: Amazon CloudFront
     When I attempt to call the "GetDistribution" API with:
     | Id | fake-id |
     Then I expect the response error code to be "NoSuchDistribution"
-    And I expect the response error message to include:
-    """
-    The specified distribution does not exist.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cloudhsm/cloudhsm.feature
+++ b/tests/acceptance/features/smoke/cloudhsm/cloudhsm.feature
@@ -10,7 +10,4 @@ Feature: Amazon CloudHSM
     When I attempt to call the "DescribeHapg" API with:
     | HapgArn | bogus-arn |
     Then I expect the response error code to be "ValidationException"
-    And I expect the response error message to include:
-    """
-    Value 'bogus-arn' at 'hapgArn' failed to satisfy constraint
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cloudsearch/cloudsearch.feature
+++ b/tests/acceptance/features/smoke/cloudsearch/cloudsearch.feature
@@ -10,7 +10,4 @@ Feature: Amazon CloudSearch
     When I attempt to call the "DescribeIndexFields" API with:
     | DomainName | fakedomain |
     Then I expect the response error code to be "ResourceNotFound"
-    And I expect the response error message to include:
-    """
-    Domain not found: fakedomain
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cloudtrail/cloudtrail.feature
+++ b/tests/acceptance/features/smoke/cloudtrail/cloudtrail.feature
@@ -10,7 +10,4 @@ Feature: AWS CloudTrail
     When I attempt to call the "DeleteTrail" API with:
     | Name | faketrail |
     Then I expect the response error code to be "TrailNotFoundException"
-    And I expect the response error message to include:
-    """
-    Unknown trail
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cloudwatch/cloudwatch.feature
+++ b/tests/acceptance/features/smoke/cloudwatch/cloudwatch.feature
@@ -13,7 +13,4 @@ Feature: Amazon CloudWatch
     | StateValue  | mno |
     | StateReason | xyz |
     Then I expect the response error code to be "ValidationError"
-    And I expect the response error message to include:
-    """
-    failed to satisfy constraint
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cloudwatchlogs/cloudwatchlogs.feature
+++ b/tests/acceptance/features/smoke/cloudwatchlogs/cloudwatchlogs.feature
@@ -11,7 +11,4 @@ Feature: Amazon CloudWatch Logs
     | logGroupName  | fakegroup  |
     | logStreamName | fakestream |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    The specified log group does not exist.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/codecommit/codecommit.feature
+++ b/tests/acceptance/features/smoke/codecommit/codecommit.feature
@@ -10,7 +10,4 @@ Feature: Amazon CodeCommit
     When I attempt to call the "ListBranches" API with:
     | repositoryName | fake-repo |
     Then I expect the response error code to be "RepositoryDoesNotExistException"
-    And I expect the response error message to include:
-    """
-    fake-repo does not exist
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/codedeploy/codedeploy.feature
+++ b/tests/acceptance/features/smoke/codedeploy/codedeploy.feature
@@ -10,7 +10,4 @@ Feature: Amazon CodeDeploy
     When I attempt to call the "GetDeployment" API with:
       | deploymentId | d-USUAELQEX |
     Then I expect the response error code to be "DeploymentDoesNotExistException"
-    And I expect the response error message to include:
-    """
-    The deployment d-USUAELQEX could not be found
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/codepipeline/codepipeline.feature
+++ b/tests/acceptance/features/smoke/codepipeline/codepipeline.feature
@@ -10,7 +10,4 @@ Feature: Amazon CodePipeline
     When I attempt to call the "GetPipeline" API with:
     | name | fake-pipeline |
     Then I expect the response error code to be "PipelineNotFoundException"
-    And I expect the response error message to include:
-    """
-    does not have a pipeline with name 'fake-pipeline'
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cognitoidentity/cognitoidentity.feature
+++ b/tests/acceptance/features/smoke/cognitoidentity/cognitoidentity.feature
@@ -13,7 +13,4 @@ Feature: Amazon Cognito Idenity
     When I attempt to call the "DescribeIdentityPool" API with:
     | IdentityPoolId | us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    IdentityPool 'us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' not found
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/cognitosync/cognitosync.feature
+++ b/tests/acceptance/features/smoke/cognitosync/cognitosync.feature
@@ -10,7 +10,4 @@ Feature: Amazon Cognito Sync
     When I attempt to call the "DescribeIdentityPoolUsage" API with:
     | IdentityPoolId | us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    IdentityPool 'us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' not found
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/configservice/configservice.feature
+++ b/tests/acceptance/features/smoke/configservice/configservice.feature
@@ -12,7 +12,4 @@ Feature: AWS Config
     | resourceType | fake-type |
     | resourceId   | fake-id   |
     Then I expect the response error code to be "ValidationException"
-    And I expect the response error message to include:
-    """
-    failed to satisfy constraint
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/datapipeline/datapipeline.feature
+++ b/tests/acceptance/features/smoke/datapipeline/datapipeline.feature
@@ -10,7 +10,4 @@ Feature: AWS Data Pipeline
     When I attempt to call the "GetPipelineDefinition" API with:
     | pipelineId | fake-id |
     Then I expect the response error code to be "PipelineNotFoundException"
-    And I expect the response error message to include:
-    """
-    does not exist
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/devicefarm/devicefarm.feature
+++ b/tests/acceptance/features/smoke/devicefarm/devicefarm.feature
@@ -10,7 +10,4 @@ Feature: AWS Device Farm
     When I attempt to call the "GetDevice" API with:
     | arn | arn:aws:devicefarm:us-west-2::device:000000000000000000000000fake-arn |
     Then I expect the response error code to be "NotFoundException"
-    And I expect the response error message to include:
-    """
-    No device was found for arn
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/directconnect/directconnect.feature
+++ b/tests/acceptance/features/smoke/directconnect/directconnect.feature
@@ -10,7 +10,4 @@ Feature: AWS Direct Connect
     When I attempt to call the "DescribeConnections" API with:
     | connectionId | fake-connection |
     Then I expect the response error code to be "DirectConnectClientException"
-    And I expect the response error message to include:
-    """
-    Connection ID fake-connection has an invalid format
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/dynamodb/dynamodb.feature
+++ b/tests/acceptance/features/smoke/dynamodb/dynamodb.feature
@@ -13,7 +13,4 @@ Feature: Amazon DynamoDB
     When I attempt to call the "DescribeTable" API with:
     | TableName | fake-table |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    Requested resource not found: Table: fake-table not found
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/dynamodbstreams/dynamodbstreams.feature
+++ b/tests/acceptance/features/smoke/dynamodbstreams/dynamodbstreams.feature
@@ -10,7 +10,4 @@ Feature: Amazon DynamoDB Streams
     When I attempt to call the "DescribeStream" API with:
     | StreamArn | arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T20:51:10.252 |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    Stream: arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T20:51:10.252 not found
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/ec2/ec2.feature
+++ b/tests/acceptance/features/smoke/ec2/ec2.feature
@@ -12,7 +12,4 @@ Feature: Amazon Elastic Compute Cloud
     {"InstanceIds": ["i-12345678"]}
     """
     Then I expect the response error code to be "InvalidInstanceID.NotFound"
-    And I expect the response error message to include:
-    """
-    The instance ID 'i-12345678' does not exist
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/elasticache/elasticache.feature
+++ b/tests/acceptance/features/smoke/elasticache/elasticache.feature
@@ -10,7 +10,4 @@ Feature: ElastiCache
     When I attempt to call the "DescribeCacheClusters" API with:
     | CacheClusterId | fake_cluster |
     Then I expect the response error code to be "InvalidParameterValue"
-    And I expect the response error message to include:
-    """
-    The parameter CacheClusterIdentifier is not a valid identifier.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/elasticbeanstalk/elasticbeanstalk.feature
+++ b/tests/acceptance/features/smoke/elasticbeanstalk/elasticbeanstalk.feature
@@ -10,7 +10,4 @@ Feature: AWS Elastic Beanstalk
     When I attempt to call the "DescribeEnvironmentResources" API with:
     | EnvironmentId | fake_environment |
     Then I expect the response error code to be "InvalidParameterValue"
-    And I expect the response error message to include:
-    """
-    No Environment found for EnvironmentId = 'fake_environment'.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/elasticloadbalancing/elasticloadbalancing.feature
+++ b/tests/acceptance/features/smoke/elasticloadbalancing/elasticloadbalancing.feature
@@ -12,7 +12,4 @@ Feature: Elastic Load Balancing
     {"LoadBalancerNames": ["fake_load_balancer"]}
     """
     Then I expect the response error code to be "ValidationError"
-    And I expect the response error message to include:
-    """
-    LoadBalancer name cannot contain characters that are not letters, or digits or the dash.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/elastictranscoder/elastictranscoder.feature
+++ b/tests/acceptance/features/smoke/elastictranscoder/elastictranscoder.feature
@@ -10,7 +10,4 @@ Feature: Amazon Elastic Transcoder
     When I attempt to call the "ReadJob" API with:
     | Id | fake_job |
     Then I expect the response error code to be "ValidationException"
-    And I expect the response error message to include:
-    """
-    Value 'fake_job' at 'id' failed to satisfy constraint
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/emr/emr.feature
+++ b/tests/acceptance/features/smoke/emr/emr.feature
@@ -10,7 +10,4 @@ Feature: Amazon EMR
     When I attempt to call the "DescribeCluster" API with:
     | ClusterId | fake_cluster |
     Then I expect the response error code to be "InvalidRequestException"
-    And I expect the response error message to include:
-    """
-    Cluster id 'fake_cluster' is not valid.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/es/es.feature
+++ b/tests/acceptance/features/smoke/es/es.feature
@@ -10,7 +10,4 @@ Feature: Amazon ElasticsearchService
     When I attempt to call the "DescribeElasticsearchDomain" API with:
       | DomainName      | not-a-domain |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-      """
-      Domain not found: not-a-domain
-      """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/glacier/glacier.feature
+++ b/tests/acceptance/features/smoke/glacier/glacier.feature
@@ -10,7 +10,4 @@ Feature: Amazon Glacier
     When I attempt to call the "ListVaults" API with:
     | accountId | abcmnoxyz |
     Then I expect the response error code to be "UnrecognizedClientException"
-    And I expect the response error message to include:
-    """
-    No account found for the given parameters
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/iam/iam.feature
+++ b/tests/acceptance/features/smoke/iam/iam.feature
@@ -10,7 +10,4 @@ Feature: AWS Identity and Access Management
     When I attempt to call the "GetUser" API with:
     | UserName | fake_user |
     Then I expect the response error code to be "NoSuchEntity"
-    And I expect the response error message to include:
-    """
-    The user with name fake_user cannot be found.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/importexport/importexport.feature
+++ b/tests/acceptance/features/smoke/importexport/importexport.feature
@@ -12,7 +12,4 @@ Feature: AWS Import Export
     {"JobType": "Import", "ValidateOnly": false, "Manifest": "invalid-manifest"}
     """
     Then I expect the response error code to be "MalformedManifestException"
-    And I expect the response error message to include:
-    """
-    Your manifest is not well-formed
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/kinesis/kinesis.feature
+++ b/tests/acceptance/features/smoke/kinesis/kinesis.feature
@@ -10,7 +10,4 @@ Feature: AWS Kinesis
     When I attempt to call the "DescribeStream" API with:
     | StreamName | bogus-stream-name |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    Stream bogus-stream-name under account
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/kms/kms.feature
+++ b/tests/acceptance/features/smoke/kms/kms.feature
@@ -11,7 +11,4 @@ Feature: Amazon Key Management Service
     | KeyId      | 12345678-1234-1234-1234-123456789012 |
     | PolicyName | fake-policy                          |
     Then I expect the response error code to be "NotFoundException"
-    And I expect the response error message to include:
-    """
-    does not exist
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/lambda/lambda.feature
+++ b/tests/acceptance/features/smoke/lambda/lambda.feature
@@ -10,7 +10,4 @@ Feature: Amazon Lambda
     When I attempt to call the "Invoke" API with:
     | FunctionName | bogus-function |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    Function not found
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/machinelearning/machinelearning.feature
+++ b/tests/acceptance/features/smoke/machinelearning/machinelearning.feature
@@ -12,7 +12,4 @@ Feature: Amazon Machine Learning
     When I attempt to call the "GetBatchPrediction" API with:
     | BatchPredictionId | fake-id |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    No BatchPrediction with id fake-id exists
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/opsworks/opsworks.feature
+++ b/tests/acceptance/features/smoke/opsworks/opsworks.feature
@@ -10,7 +10,4 @@ Feature: AWS OpsWorks
     When I attempt to call the "DescribeLayers" API with:
     | StackId | fake_stack |
     Then I expect the response error code to be "ResourceNotFoundException"
-    And I expect the response error message to include:
-    """
-    Unable to find stack with ID fake_stack
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/rds/rds.feature
+++ b/tests/acceptance/features/smoke/rds/rds.feature
@@ -10,7 +10,4 @@ Feature: Amazon RDS
     When I attempt to call the "DescribeDBInstances" API with:
     | DBInstanceIdentifier | fake-id |
     Then I expect the response error code to be "DBInstanceNotFound"
-    And I expect the response error message to include:
-    """
-    DBInstance fake-id not found.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/redshift/redshift.feature
+++ b/tests/acceptance/features/smoke/redshift/redshift.feature
@@ -10,7 +10,4 @@ Feature: Amazon Redshift
     When I attempt to call the "DescribeClusters" API with:
     | ClusterIdentifier | fake-cluster |
     Then I expect the response error code to be "ClusterNotFound"
-    And I expect the response error message to include:
-    """
-    Cluster fake-cluster not found.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/route53/route53.feature
+++ b/tests/acceptance/features/smoke/route53/route53.feature
@@ -10,7 +10,4 @@ Feature: Amazon Route 53
     When I attempt to call the "GetHostedZone" API with:
     | Id | fake-zone |
     Then I expect the response error code to be "NoSuchHostedZone"
-    And I expect the response error message to include:
-    """
-    No hosted zone found with ID: fake-zone
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/route53domains/route53domains.feature
+++ b/tests/acceptance/features/smoke/route53domains/route53domains.feature
@@ -10,7 +10,4 @@ Feature: Amazon Route53 Domains
     When I attempt to call the "GetDomainDetail" API with:
     | DomainName | fake-domain-name |
     Then I expect the response error code to be "InvalidInput"
-    And I expect the response error message to include:
-    """
-    domain name must contain more than 1 label
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/ses/ses.feature
+++ b/tests/acceptance/features/smoke/ses/ses.feature
@@ -10,7 +10,4 @@ Feature: Amazon Simple Email Service
     When I attempt to call the "VerifyEmailIdentity" API with:
     | EmailAddress | fake_email |
     Then I expect the response error code to be "InvalidParameterValue"
-    And I expect the response error message to include:
-    """
-    Invalid email address<fake_email>.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/sns/sns.feature
+++ b/tests/acceptance/features/smoke/sns/sns.feature
@@ -11,7 +11,4 @@ Feature: Amazon Simple Notification Service
     | Message  | hello      |
     | TopicArn | fake_topic |
     Then I expect the response error code to be "InvalidParameter"
-    And I expect the response error message to include:
-    """
-    Invalid parameter: TopicArn Reason: fake_topic does not start with arn
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/sqs/sqs.feature
+++ b/tests/acceptance/features/smoke/sqs/sqs.feature
@@ -10,7 +10,4 @@ Feature: Amazon Simple Queue Service
     When I attempt to call the "GetQueueUrl" API with:
     | QueueName | fake_queue |
     Then I expect the response error code to be "AWS.SimpleQueueService.NonExistentQueue"
-    And I expect the response error message to include:
-    """
-    The specified queue does not exist for this wsdl version.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/ssm/ssm.feature
+++ b/tests/acceptance/features/smoke/ssm/ssm.feature
@@ -10,7 +10,4 @@ Feature: Amazon SSM
     When I attempt to call the "GetDocument" API with:
     | Name | 'fake-name' |
     Then I expect the response error code to be "ValidationException"
-    And I expect the response error message to include:
-    """
-    validation error detected
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/storagegateway/storagegateway.feature
+++ b/tests/acceptance/features/smoke/storagegateway/storagegateway.feature
@@ -10,7 +10,4 @@ Feature: AWS Storage Gateway
     When I attempt to call the "ListVolumes" API with:
     | GatewayARN | fake_gateway_that_meets_the_minimum_length_restriction |
     Then I expect the response error code to be "InvalidGatewayRequestException"
-    And I expect the response error message to include:
-    """
-    Invalid resource fake_gateway_that_meets_the_minimum_length_restriction
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/sts/sts.feature
+++ b/tests/acceptance/features/smoke/sts/sts.feature
@@ -11,7 +11,4 @@ Feature: AWS STS
     | Name   | temp            |
     | Policy | {\"temp\":true} |
     Then I expect the response error code to be "MalformedPolicyDocument"
-    And I expect the response error message to include:
-    """
-    Syntax errors in policy.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/support/support.feature
+++ b/tests/acceptance/features/smoke/support/support.feature
@@ -16,7 +16,4 @@ Feature: AWS Support
     | serviceCode       | amazon-dynamodb |
     | severityCode      | low             |
     Then I expect the response error code to be "InvalidParameterValueException"
-    And the error message should contain:
-    """
-    Invalid category code
-    """
+    And the response error contains a message

--- a/tests/acceptance/features/smoke/swf/swf.feature
+++ b/tests/acceptance/features/smoke/swf/swf.feature
@@ -11,7 +11,4 @@ Feature: Amazon Simple Workflow Service
     When I attempt to call the "DescribeDomain" API with:
     | name | fake_domain |
     Then I expect the response error code to be "UnknownResourceFault"
-    And I expect the response error message to include:
-    """
-    Unknown domain: fake_domain
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/waf/waf.feature
+++ b/tests/acceptance/features/smoke/waf/waf.feature
@@ -14,7 +14,4 @@ Feature: AWS WAF
     | Name        | fake_name   |
     | ChangeToken | fake_token  |
     Then I expect the response error code to be "WAFStaleDataException"
-    And I expect the response error message to include:
-    """
-    The input token is no longer current
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/smoke/workspaces/workspaces.feature
+++ b/tests/acceptance/features/smoke/workspaces/workspaces.feature
@@ -12,7 +12,4 @@ Feature: Amazon WorkSpaces
     When I attempt to call the "DescribeWorkspaces" API with:
     | DirectoryId | fake-id |
     Then I expect the response error code to be "ValidationException"
-    And I expect the response error message to include:
-    """
-    The Directory ID fake-id in the request is invalid.
-    """
+    And I expect the response error to contain a message

--- a/tests/acceptance/features/steps/base.py
+++ b/tests/acceptance/features/steps/base.py
@@ -99,13 +99,8 @@ def then_should_contain_key(context, key):
         raise AssertionError("Response is not a dict: %s" % context.response)
 
 
-@then(u'the error message should contain')
-def then_ignore_me(context, msg):
-    # TODO: These steps will be removed.
-    pass
-
-
-@then(u'I expect the response error message to include')
-def step_impl(context):
-    # TODO: These steps will be removed.
-    pass
+@then(u'I expect the response error to contain a message')
+def then_error_has_message(context):
+    if 'Message' not in context.error_response.response['Error']:
+        raise AssertionError("Message key missing from error response: %s" %
+                             context.error_response.response)


### PR DESCRIPTION
This fixes one of the TODOs in the acceptance test runner.

We just need to check that the error response contains
a message.  We don't need to check the contents of that error message.

Relevant lines: https://github.com/boto/botocore/pull/725/files#diff-82cf6007372edb07a2f866f77827bbe3R102

cc @kyleknap @mtdowling @rayluo @JordonPhillips 