### PR TITLE
Automatically set EncodingType to url

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -22,10 +22,10 @@ import logging
 import xml.etree.cElementTree
 import copy
 import re
-import string
 import warnings
 
-from botocore.compat import urlsplit, urlunsplit, unquote, json, quote, six
+from botocore.compat import urlsplit, urlunsplit, unquote, \
+    json, quote, six, unquote_str
 from botocore.docs.utils import AutoPopulatedParam
 from botocore.docs.utils import HideParamFromOperations
 from botocore.docs.utils import AppendParamDocumentation
@@ -519,6 +519,20 @@ def change_get_to_post(request, **kwargs):
         request.url, request.data = request.url.split('?', 1)
 
 
+def set_list_objects_encoding_type_url(params, **kwargs):
+    if 'EncodingType' not in params:
+        params['EncodingType'] = 'url'
+
+
+def decode_list_object(parsed, **kwargs):
+    # This is needed because we are passing url as the encoding type. Since the
+    # paginator is based on the key, we need to handle it before it can be
+    # round tripped.
+    if 'Contents' in parsed and parsed.get('EncodingType') == 'url':
+        for content in parsed['Contents']:
+            content['Key'] = unquote_str(content['Key'])
+
+
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be
 # automatically registered with that Session.
@@ -535,6 +549,7 @@ BUILTIN_HANDLERS = [
 
     ('before-parameter-build.s3', validate_bucket_name),
 
+    ('before-parameter-build.s3.ListObjects', set_list_objects_encoding_type_url),
     ('before-call.s3.PutBucketTagging', calculate_md5),
     ('before-call.s3.PutBucketLifecycle', calculate_md5),
     ('before-call.s3.PutBucketLifecycleConfiguration', calculate_md5),
@@ -588,6 +603,7 @@ BUILTIN_HANDLERS = [
      base64_encode_user_data),
     ('before-parameter-build.route53', fix_route53_ids),
     ('before-parameter-build.glacier', inject_account_id),
+    ('after-call.s3.ListObjects', decode_list_object),
 
     # Cloudsearchdomain search operation will be sent by HTTP POST
     ('request-created.cloudsearchdomain.Search',

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -176,12 +176,12 @@ class TestS3Objects(TestS3BaseWithBucket):
         bucket_contents = self.client.list_objects(
             Bucket=self.bucket_name)['Contents']
         self.assertEqual(len(bucket_contents), 1)
-        self.assertEqual(bucket_contents[0]['Key'], 'a+b/foo')
+        self.assertEqual(bucket_contents[0]['Key'], u'a+b/foo')
 
         subdir_contents = self.client.list_objects(
             Bucket=self.bucket_name, Prefix='a+b')['Contents']
         self.assertEqual(len(subdir_contents), 1)
-        self.assertEqual(subdir_contents[0]['Key'], 'a+b/foo')
+        self.assertEqual(subdir_contents[0]['Key'], u'a+b/foo')
 
         response = self.client.delete_object(
             Bucket=self.bucket_name, Key=key_name)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -563,6 +563,26 @@ class TestHandlers(BaseSessionTest):
     def test_validation_is_noop_if_no_bucket_param_exists(self):
         self.assertIsNone(handlers.validate_bucket_name(params={}))
 
+    def test_set_encoding_type(self):
+        params = {}
+        handlers.set_list_objects_encoding_type_url(params)
+        self.assertEqual(params['EncodingType'], 'url')
+
+        params['EncodingType'] = 'new_value'
+        handlers.set_list_objects_encoding_type_url(params)
+        self.assertEqual(params['EncodingType'], 'new_value')
+
+    def test_decode_list_object(self):
+        parsed = {
+            'Contents': [
+                {
+                    'Key': "%C3%A7%C3%B6s%25asd"
+                }
+            ]
+        }
+        handlers.decode_list_object(parsed)
+        self.assertEqual(parsed['Contents'][0]['Key'], u'\xe7\xf6s%asd')
+
 
 class TestRetryHandlerOrder(BaseSessionTest):
     def get_handler_names(self, responses):

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -18,10 +18,8 @@ import os
 from tests import BaseSessionTest
 from mock import patch, Mock
 
-import botocore.session
-from botocore import auth
-from botocore import credentials
-from botocore.exceptions import ServiceNotInRegionError
+from botocore.compat import OrderedDict
+from botocore.handlers import set_list_objects_encoding_type_url
 
 
 class TestS3Addressing(BaseSessionTest):
@@ -35,6 +33,8 @@ class TestS3Addressing(BaseSessionTest):
         self.mock_response.content = ''
         self.mock_response.headers = {}
         self.mock_response.status_code = 200
+        self.session.unregister('before-parameter-build.s3.ListObjects',
+                                set_list_objects_encoding_type_url)
 
     def get_prepared_request(self, operation, params,
                              force_hmacv1=False):
@@ -76,7 +76,8 @@ class TestS3Addressing(BaseSessionTest):
 
     def test_list_objects_unicode_query_string_eu_central_1(self):
         self.region_name = 'eu-central-1'
-        params = {'Bucket': 'safename', 'Marker': u'\xe4\xf6\xfc-01.txt'}
+        params = OrderedDict([('Bucket', 'safename'),
+                             ('Marker', u'\xe4\xf6\xfc-01.txt')])
         prepared_request = self.get_prepared_request('list_objects', params)
         self.assertEqual(
             prepared_request.url,


### PR DESCRIPTION
Some unicode values can break the XML parser, so we have s3 url encode the keys and decode them on our end.