### PR TITLE
Skip sts/importexport acceptance tests

### DIFF
--- a/tests/acceptance/features/environment.py
+++ b/tests/acceptance/features/environment.py
@@ -19,9 +19,15 @@ REGION_OVERRIDES = {
     'devicefarm': 'us-west-2',
     'efs': 'us-west-2',
 }
-# These services require subscriptions and
-# may not work on every machine.
-SKIP_SERVICES = set(['efs', 'support'])
+SKIP_SERVICES = set([
+    # efs/support require subscriptions and may not work on every machine.
+    'efs',
+    'support',
+    # sts and importexport are skipped because they do not
+    # work when using temporary credentials.
+    'sts',
+    'importexport',
+])
 
 
 def before_feature(context, feature):


### PR DESCRIPTION
We have the same behavior in our integration smoke tests.

See: https://github.com/boto/botocore/blob/develop/tests/integration/test_smoke.py#L86-L90


cc @kyleknap @mtdowling @rayluo @JordonPhillips 