### PR TITLE
Content of .zip file bytestring needs not be base64-encoded

### DIFF
--- a/botocore/data/lambda/2015-03-31/service-2.json
+++ b/botocore/data/lambda/2015-03-31/service-2.json
@@ -2058,7 +2058,7 @@
         },
         "ZipFile":{
           "shape":"Blob",
-          "documentation":"<p>Based64-encoded .zip file containing your packaged source code.</p>"
+          "documentation":"<p>Bytestring of content of the .zip file containing your packaged source code.</p>"
         },
         "S3Bucket":{
           "shape":"S3Bucket",


### PR DESCRIPTION
There is a mistake in the documentation, there is no need to base64-encode the content of the zip file to be uploaded, botocore will take care of that. 