### PR TITLE
A small typo fix in the event docs

### DIFF
--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -43,7 +43,7 @@ example ``s3.ListObjects.bar``.
      - Ignored.
    * - **after-call.<service>.<operation>**
      - After an operation has been called, but before the response is parsed.
-     - ``response`` - The HTTP response, ``parsed`` - The parsed data.
+     - ``http_response`` - The HTTP response, ``parsed`` - The parsed data.
      - Ignored.
 
 


### PR DESCRIPTION
The arguments to the after-call event handler are ``http_response`` and ``parsed``, not ``response`` and ``parsed``.