### PR TITLE
Update Bucket Lifecycle Rule Transition shape

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.json
+++ b/botocore/data/s3/2006-03-01/service-2.json
@@ -4511,7 +4511,7 @@
           "shape":"ExpirationStatus",
           "documentation":"If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied."
         },
-        "Transition":{"shape":"Transition"},
+        "Transition":{"shape":"TransitionList"},
         "NoncurrentVersionTransition":{"shape":"NoncurrentVersionTransition"},
         "NoncurrentVersionExpiration":{"shape":"NoncurrentVersionExpiration"}
       }


### PR DESCRIPTION
A bucket with multiple transitions in a single lifecycle rule was not correctly returning. Instead it was only returning the first transition.

Eg. Before
`[{u'Status': 'Enabled', u'Prefix': '', u'Transition': {u'Days': 30, u'StorageClass': 'STANDARD_IA'}, u'Expiration': {u'Days': 365}, u'ID': 'test'}]`

After
`[{u'Status': 'Enabled', u'Prefix': '', u'Transition': [{u'Days': 30, u'StorageClass': 'STANDARD_IA'}, {u'Days': 90, u'StorageClass': 'GLACIER'}], u'Expiration': {u'Days': 365}, u'ID': 'test'}]`