### PR TITLE
fixed parsers.BaseJSONParser error.

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -498,8 +498,11 @@ class BaseJSONParser(ResponseParser):
         return self._timestamp_parser(value)
 
     def _do_error_parse(self, response, shape):
-        body = json.loads(response['body'].decode(self.DEFAULT_ENCODING))
-        error = {"Error": {}, "ResponseMetadata": {}}
+        if response['body']:
+            body = json.loads(response['body'].decode(self.DEFAULT_ENCODING))
+        else:
+            body = {}
+        error = {"Error": {"Message": None, "Code": None}, "ResponseMetadata": {}}
         # Error responses can have slightly different structures for json.
         # The basic structure is:
         #

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -202,6 +202,24 @@ class TestResponseMetadataParsed(unittest.TestCase):
                                   'HostId': 'second-id',
                                   'HTTPStatusCode': 200}})
 
+
+    def test_error_response_with_no_body(self):
+        parser = parsers.RestJSONParser()
+        response = b''
+        headers = {'content-length': '0', 'connection': 'keep-alive'}
+        output_shape = None
+        parsed = parser.parse({'body': response, 'headers': headers,
+                               'status_code': 504}, output_shape)
+
+        self.assertIn('Error', parsed)
+        self.assertEqual(parsed['Error'], {
+            'Code': None,
+            'Message': ''
+        })
+        self.assertEqual(parsed['ResponseMetadata'], {
+            'HTTPStatusCode': 504,
+        })
+
     def test_s3_error_response(self):
         body = (
             '<Error>'


### PR DESCRIPTION
botocore authors.

First, thanks for the awesome tool.
I encountered errors such as the following.
This error seems to occur when  status  504 is returned from CloudSearch.

```
    parsed = self._do_error_parse(response, shape)
  File "/Users/tell_k/.virtualenvs/testproj-sns/lib/python3.4/site-packages/botocore/parsers.py", line 639, in _do_error_parse
    error = super(RestJSONParser, self)._do_error_parse(response, shape)
  File "/Users/tell_k/.virtualenvs/testproj-sns/lib/python3.4/site-packages/botocore/parsers.py", line 495, in _do_error_parse
    body = json.loads(response['body'].decode(self.DEFAULT_ENCODING))
  File "/usr/local/Cellar/python3/3.4.3/Frameworks/Python.framework/Versions/3.4/lib/python3.4/json/__init__.py", line 318, in loads
    return _default_decoder.decode(s)  
  File "/usr/local/Cellar/python3/3.4.3/Frameworks/Python.framework/Versions/3.4/lib/python3.4/json/decoder.py", line 343, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python3/3.4.3/Frameworks/Python.framework/Versions/3.4/lib/python3.4/json/decoder.py", line 361, in raw_decode
    raise ValueError(errmsg("Expecting value", s, err.value)) from None
ValueError: Expecting value: line 1 column 1 (char 0)
```

dump response object.

```
{'body': b'', 'status_code': 504, 'headers': {'connection': 'keep-alive', 'content-length': '0'}}
```

The cause of this error is because parsers.BaseJSONParser cannot handle empty response body well.
I have fixed so that botocore.exceptions.ClientError is raised. Please feel free to merge it.

see also http://docs.aws.amazon.com/cloudsearch/latest/developerguide/uploading-data.html#bulk-uploads

thx.