### PR TITLE
AWS_DATA_PATH should override customer/builtin data paths

### DIFF
--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -207,13 +207,13 @@ class Loader(object):
         if file_loader is None:
             file_loader = self.FILE_LOADER_CLASS()
         self.file_loader = file_loader
-        if include_default_search_paths:
-            self._search_paths = [self.CUSTOMER_DATA_PATH,
-                                  self.BUILTIN_DATA_PATH]
+        if extra_search_paths is not None:
+            self._search_paths = extra_search_paths
         else:
             self._search_paths = []
-        if extra_search_paths is not None:
-            self._search_paths.extend(extra_search_paths)
+        if include_default_search_paths:
+            self._search_paths.extend([self.CUSTOMER_DATA_PATH,
+                                       self.BUILTIN_DATA_PATH])
 
     @property
     def search_paths(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -66,8 +66,6 @@ def create_session(**kwargs):
     # the _LOADER object is used as the loader
     # so that we reused the same models across tests.
     session = botocore.session.Session(**kwargs)
-    data_path = session.get_config_variable('data_path')
-    _LOADER.data_path = data_path or ''
     session.register_component('data_loader', _LOADER)
     session.set_config_variable('credentials_file', 'noexist/foo/botocore')
     return session

--- a/tests/functional/test_loaders.py
+++ b/tests/functional/test_loaders.py
@@ -1,0 +1,40 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import shutil
+
+from botocore import loaders
+from tests import unittest, temporary_file
+
+
+class TestLoaderAllowsDataPathOverride(unittest.TestCase):
+    def create_file(self, f, contents, name):
+        f.write(contents)
+        f.flush()
+        dirname = os.path.dirname(os.path.abspath(f.name))
+        override_name = os.path.join(dirname, name)
+        shutil.copy(f.name, override_name)
+        return override_name
+
+    def test_can_override_session(self):
+        with temporary_file('w') as f:
+            # We're going to override _retry.json in 
+            # botocore/data by setting our own data directory.
+            override_name = self.create_file(
+                f, contents='{"foo": "bar"}', name='_retry.json')
+            new_data_path = os.path.dirname(override_name)
+            loader = loaders.create_loader(search_path_string=new_data_path)
+
+            new_content = loader.load_data('_retry')
+            # This should contain the content we just created.
+            self.assertEqual(new_content, {"foo": "bar"})

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -84,12 +84,12 @@ class TestLoader(BaseEnvVar):
 
     def test_can_initialize_with_search_paths(self):
         loader = Loader(extra_search_paths=['foo', 'bar'])
-        self.assertIn('foo', loader.search_paths)
-        self.assertIn('bar', loader.search_paths)
-        # We should also always add the default search
-        # paths even if the loader is initialized with
-        # additional search paths.
-        self.assertEqual(len(loader.search_paths), 4)
+        # Note that the extra search paths are before
+        # the customer/builtin data paths.
+        self.assertEqual(
+            loader.search_paths,
+            ['foo', 'bar', loader.CUSTOMER_DATA_PATH,
+             loader.BUILTIN_DATA_PATH])
 
     # The file loader isn't consulted unless the current
     # search path exists, so we're patching isdir to always

--- a/tests/unit/test_waiters.py
+++ b/tests/unit/test_waiters.py
@@ -580,8 +580,8 @@ class ServiceWaiterFunctionalTest(BaseEnvVar):
         super(ServiceWaiterFunctionalTest, self).setUp()
         self.data_path = os.path.join(
             os.path.dirname(botocore.__file__), 'data')
-        self.environ['BOTO_DATA_PATH'] = self.data_path
-        self.loader = Loader(self.data_path)
+        self.environ['AWS_DATA_PATH'] = self.data_path
+        self.loader = Loader([self.data_path])
 
     def get_waiter_model(self, service, api_version=None):
         """Get the waiter model for the service."""


### PR DESCRIPTION
This was a regression introduced in
1225dc7ed2246461166b27822323d61543ae0550.  This was
originally fixed in 0.68.0 of botocore.

At this point, I think a functional test in warranted,
as this did functionality did not surivive a refactoring,
so I've added a basic functional test to ensure we don't
regress on this in the future.

There were also a few tests that need to be updated with this change.
These tests were previously wrong but were not being caught
because of this bug.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 