### PR TITLE
Decode JSON pagination tokens.

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -484,9 +484,11 @@ class BaseClient(object):
             documented_paginator_cls = type(
                 paginator_class_name, (Paginator,), {'paginate': paginate})
 
+            operation_model = \
+                self._service_model.operation_model(actual_operation_name)
             paginator = documented_paginator_cls(
                 getattr(self, operation_name),
-                paginator_config)
+                paginator_config, operation_model)
             return paginator
 
     def can_paginate(self, operation_name):

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import ast
+import logging
 from itertools import tee
 
 from six import string_types
@@ -20,6 +21,9 @@ import jmespath
 from botocore.exceptions import PaginationError
 from botocore.compat import zip
 from botocore.utils import set_value_from_jmespath, merge_dicts
+
+
+logger = logging.getLogger(__name__)
 
 
 class PaginatorModel(object):
@@ -335,6 +339,8 @@ class PageIterator(object):
                     # converted to their proper type.
                     next_token.append(ast.literal_eval(part))
                 except ValueError:
+                    logger.debug(
+                        "Dict pagination token failed to parse as dict.")
                     next_token.append(part)
             else:
                 next_token.append(part)

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import ast
 from itertools import tee
 
 from six import string_types
@@ -327,7 +328,13 @@ class PageIterator(object):
             if part == 'None':
                 next_token.append(None)
             else:
-                next_token.append(part)
+                try:
+                    # Some services (such as dynamodb) non-string pagination
+                    # tokens, which will fail validation if they aren't
+                    # converted to their proper type.
+                    next_token.append(ast.literal_eval(part))
+                except ValueError:
+                    next_token.append(part)
         return next_token, index
 
 

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -15,9 +15,13 @@ from tests import unittest
 from botocore.paginate import Paginator
 from botocore.paginate import PaginatorModel
 from botocore.exceptions import PaginationError
-import botocore.session
+from botocore.model import ServiceModel
 
 import mock
+
+
+def create_paginator(method, config, model=mock.Mock()):
+    return Paginator(method, config, model)
 
 
 class TestPaginatorModel(unittest.TestCase):
@@ -53,8 +57,7 @@ class TestPagination(unittest.TestCase):
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_result_key_available(self):
         self.assertEqual(
@@ -103,13 +106,12 @@ class TestPagination(unittest.TestCase):
             list(self.paginator.paginate())
 
     def test_next_token_with_or_expression(self):
-        self.pagination_config = {
+        self.paginate_config = {
             'output_token': 'NextToken || NextToken2',
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(
-            self.method, self.pagination_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         # Verify that despite varying between NextToken and NextToken2
         # we still can extract the right next tokens.
         responses = [
@@ -139,8 +141,7 @@ class TestPagination(unittest.TestCase):
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {'Foo': [1], 'IsTruncated': True, 'NextToken': 'token1'},
             {'Foo': [2], 'IsTruncated': True, 'NextToken': 'token2'},
@@ -162,8 +163,7 @@ class TestPagination(unittest.TestCase):
             'input_token': 'NextToken',
             'result_key': 'Bar',
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {'Foo': {'IsTruncated': True}, 'NextToken': 'token1'},
             {'Foo': {'IsTruncated': False}, 'NextToken': 'token2'},
@@ -182,8 +182,7 @@ class TestPagination(unittest.TestCase):
             "result_key": "Users",
             "limit_key": "MaxKeys",
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -224,8 +223,7 @@ class TestPagination(unittest.TestCase):
             "result_key": "Users",
             "limit_key": "MaxKeys",
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -246,8 +244,7 @@ class TestPaginatorPageSize(unittest.TestCase):
             "result_key": ["Users", "Groups"],
             'limit_key': 'MaxKeys',
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         self.endpoint = mock.Mock()
 
     def test_no_page_size(self):
@@ -279,8 +276,7 @@ class TestPaginatorWithPathExpressions(unittest.TestCase):
             'input_token': 'next_marker',
             'result_key': 'Contents',
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_s3_list_objects(self):
         responses = [
@@ -320,8 +316,7 @@ class TestMultipleTokens(unittest.TestCase):
             "input_token": ["key_marker", "upload_id_marker"],
             "result_key": 'Foo',
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_s3_list_multipart_uploads(self):
         responses = [
@@ -347,16 +342,39 @@ class TestMultipleTokens(unittest.TestCase):
 class TestNonStringTokens(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
-        # This is something we'd see in s3 pagination.
+        # This is something we'd see in dynamodb pagination.
         self.paginate_config = {
             "input_token": ["ExclusiveStartKey"],
             "output_token": ["LastEvaluatedKey"],
             "result_key": 'Items',
         }
-        session = botocore.session.get_session()
-        service_model = session.get_service_model('dynamodb')
+        model = {
+            'operations': {
+                'Scan': {
+                    'name': 'Scan',
+                    'input': {'shape': 'ScanInput'}
+                }
+            },
+            'shapes': {
+                'ScanInput': {
+                    'type': 'structure',
+                    'members': {
+                        'ExclusiveStartKey': {
+                            'shape': 'Key'
+                        }
+                    }
+                },
+                'Key': {
+                    'type': 'map',
+                    'key': {'shape': 'StringShape'},
+                    'value': {'shape': 'StringShape'}
+                },
+                'StringShape': {'type': 'string'}
+            }
+        }
+        service_model = ServiceModel(model)
         operation_model = service_model.operation_model('Scan')
-        self.paginator = Paginator(
+        self.paginator = create_paginator(
             self.method, self.paginate_config, operation_model)
 
     def test_dynamo_scan(self):
@@ -382,8 +400,7 @@ class TestKeyIterators(unittest.TestCase):
             "input_token": "Marker",
             "result_key": "Users"
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_result_key_iters(self):
         responses = [
@@ -410,7 +427,7 @@ class TestKeyIterators(unittest.TestCase):
         self.assertEqual(complete, {'Users': ['User1', 'User2', 'User3']})
 
     def test_max_items_can_be_specified(self):
-        paginator = Paginator(self.method, self.paginate_config, mock.Mock())
+        paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -425,7 +442,7 @@ class TestKeyIterators(unittest.TestCase):
     def test_max_items_as_strings(self):
         # Some services (route53) model MaxItems as a string type.
         # We need to be able to handle this case.
-        paginator = Paginator(self.method, self.paginate_config, mock.Mock())
+        paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -439,7 +456,7 @@ class TestKeyIterators(unittest.TestCase):
             {'Users': ['User1'], 'NextToken': 'm1'})
 
     def test_next_token_on_page_boundary(self):
-        paginator = Paginator(self.method, self.paginate_config, mock.Mock())
+        paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -455,7 +472,7 @@ class TestKeyIterators(unittest.TestCase):
         # We're saying we only want 4 items, but notice that the second
         # page of results returns users 4-6 so we have to truncated
         # part of that second page.
-        paginator = Paginator(self.method, self.paginate_config, mock.Mock())
+        paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User1", "User2", "User3"], "Marker": "m1"},
             {"Users": ["User4", "User5", "User6"], "Marker": "m2"},
@@ -473,7 +490,7 @@ class TestKeyIterators(unittest.TestCase):
         # from test_MaxItems_can_be_specified_truncates_response
         # We got the first 4 users, when we pick up we should get
         # User5 - User7.
-        paginator = Paginator(self.method, self.paginate_config, mock.Mock())
+        paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User4", "User5", "User6"], "Marker": "m2"},
             {"Users": ["User7"]},
@@ -492,7 +509,7 @@ class TestKeyIterators(unittest.TestCase):
     def test_max_items_exceeds_actual_amount(self):
         # Because MaxItems=10 > number of users (3), we should just return
         # all of the users.
-        paginator = Paginator(self.method, self.paginate_config, mock.Mock())
+        paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -526,8 +543,7 @@ class TestMultipleResultKeys(unittest.TestCase):
             "input_token": "Marker",
             "result_key": ["Users", "Groups"],
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_build_full_result_with_multiple_result_keys(self):
         responses = [
@@ -640,8 +656,7 @@ class TestMultipleInputKeys(unittest.TestCase):
             "input_token": ["InMarker1", "InMarker2"],
             "result_key": ["Users", "Groups"],
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_build_full_result_with_multiple_input_keys(self):
         responses = [
@@ -710,8 +725,7 @@ class TestExpressionKeyIterators(unittest.TestCase):
             "limit_key": "MaxRecords",
             "result_key": "EngineDefaults.Parameters"
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         self.responses = [
             {"EngineDefaults": {"Parameters": ["One", "Two"]},
              "Marker": "m1"},
@@ -747,8 +761,7 @@ class TestIncludeResultKeys(unittest.TestCase):
             'input_token': 'Marker',
             'result_key': ['ResultKey', 'Count', 'Log'],
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_different_kinds_of_result_key(self):
         self.method.side_effect = [
@@ -786,8 +799,7 @@ class TestIncludeNonResultKeys(unittest.TestCase):
             'result_key': 'ResultKey',
             'non_aggregate_keys': ['NotResultKey'],
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
 
     def test_include_non_aggregate_keys(self):
         self.method.side_effect = [
@@ -806,8 +818,7 @@ class TestIncludeNonResultKeys(unittest.TestCase):
 
     def test_include_with_multiple_result_keys(self):
         self.paginate_config['result_key'] = ['ResultKey1', 'ResultKey2']
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         self.method.side_effect = [
             {'ResultKey1': ['a', 'b'], 'ResultKey2': ['u', 'v'],
              'NotResultKey': 'a', 'NextToken': 'token1'},
@@ -830,8 +841,7 @@ class TestIncludeNonResultKeys(unittest.TestCase):
         self.paginate_config['non_aggregate_keys'] = [
             'Outer', 'Result.Inner',
         ]
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         self.method.side_effect = [
             # The non result keys shows hypothetical
             # example.  This doesn't actually happen,
@@ -865,8 +875,7 @@ class TestSearchOverResults(unittest.TestCase):
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(
-            self.method, self.paginate_config, mock.Mock())
+        self.paginator = create_paginator(self.method, self.paginate_config)
         responses = [
             {'Foo': [{'a': 1}, {'b': 2}],
              'IsTruncated': True, 'NextToken': '1'},


### PR DESCRIPTION
Fixes aws/aws-cli#1601

The issue was that dynamodb sends back dicts for pagination tokens rather than strings like other services do. When you hit a boundary, the `NextToken` we return would look something like this:

`{'foo': 'bar'}___1234`

When you pass that back in as the `StartingToken` for the next request we take the bits before `___`  and pass them into the request. The issue is that we take that as the string `"{'foo': 'bar'}"` instead  of the dict `{'foo': 'bar'}`. So when we pass that in, parameter validation would fail.

This PR will attempt to parse the prefix into a dict before passing it along. If it fails, it will fall back to previous behavior. 

cc @kyleknap @mtdowling @rayluo @jamesls 