### PR TITLE
Support stubbing out operations.

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -193,8 +193,8 @@ class Endpoint(object):
                                                  operation_model)
         parser = self._response_parser_factory.create_parser(
             operation_model.metadata['protocol'])
-        return ((http_response, parser.parse(response_dict,
-                                             operation_model.output_shape)),
+        return ((http_response,
+                 parser.parse(response_dict, operation_model.output_shape)),
                 None)
 
     def _looks_like_dns_error(self, e):

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -353,6 +353,10 @@ class InvalidS3AddressingStyleError(BotoCoreError):
     )
 
 
+class StubResponseError(BotoCoreError):
+    fmt = 'Error getting response stub for operation {operation_name}: {reason}'
+
+
 class InvalidConfigError(BotoCoreError):
     fmt = '{error_msg}'
 

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -1,0 +1,201 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import copy
+from collections import deque
+from botocore.validate import validate_parameters
+from botocore.exceptions import ParamValidationError, StubResponseError
+from botocore.vendored.requests.models import Response
+
+
+class Stubber(object):
+    """
+    This class will allow you to stub out requests so you don't have to hit
+    an endpoint to write tests. Responses are returned first in, first out.
+    If operations are called out of order, or are called with no remaining
+    queued responses, an error will be raised.
+
+    Example::
+        import datetime
+        import botocore.session
+        from botocore.stub import Stubber
+
+
+        s3 = botocore.session.get_session().create_client('s3')
+        stubber = Stubber(s3)
+
+        response = {
+            'IsTruncated': False,
+            'Name': 'test-bucket',
+            'MaxKeys': 1000, 'Prefix': '',
+            'Contents': [{
+                'Key': 'test.txt',
+                'ETag': '"abc123"',
+                'StorageClass': 'STANDARD',
+                'LastModified': datetime.datetime(2016, 1, 20, 22, 9),
+                'Owner': {'ID': 'abc123', 'DisplayName': 'myname'},
+                'Size': 14814
+            }],
+            'EncodingType': 'url',
+            'ResponseMetadata': {
+                'RequestId': 'abc123',
+                'HTTPStatusCode': 200,
+                'HostId': 'abc123'
+            },
+            'Marker': ''
+        }
+
+        stubber.add_response('list_objects', response)
+        stubber.activate()
+
+        service_response = s3.list_objects(Bucket='test-bucket')
+        assert service_response == response
+    """
+    def __init__(self, client):
+        """
+        :param client: The client to add your stubs to.
+        """
+        self.client = client
+        self._event_id = 'boto_stubber'
+        self._queue = deque()
+
+    def activate(self):
+        """
+        Activates the stubber on the client
+        """
+        self.client.meta.events.register(
+                'before-call.*.*',
+                self._get_response_handler,
+                unique_id=self._event_id)
+
+    def deactivate(self):
+        """
+        Deactivates the stubber on the client
+        """
+        self.client.meta.events.unregister(
+                'before-call.*.*',
+                self._get_response_handler,
+                unique_id=self._event_id)
+
+    def add_response(self, method, service_response):
+        """
+        Adds a service response to the response queue. This will be validated
+        against the service model to ensure correctness. It should be noted,
+        however, that while missing attributes are often considered correct,
+        your code may not function properly if you leave them out. Therefore
+        you should always fill in every value you see in a typical response for
+        your particular request.
+
+        :param method: The name of the client method to stub.
+        :type method: str
+
+        :param service_response: A dict response stub. Provided parameters will
+            be validated against the service model.
+        :type service_response: dict
+        """
+        self._add_response(method, service_response)
+
+    def _add_response(self, method, service_response, http_response=None):
+        if not hasattr(self.client, method):
+            raise ValueError(
+                "Client %s does not have method: %s"
+                % (self.client.meta.service_model.service_name, method))
+
+        if http_response is None:
+            http_response = Response()
+            http_response.status_code = 200
+            http_response.reason = 'OK'
+
+        operation_name = self.client.meta.method_to_api_mapping.get(method)
+        self._validate_response(operation_name, service_response)
+
+        response = (operation_name, (http_response, service_response))
+        self._queue.append(response)
+
+    def add_client_error(self, method, service_error_code='',
+                         service_message='', http_status_code=400):
+        """
+        Adds a ClientError to the response queue.
+
+        :param method: The name of the service method to return the error on.
+        :type method: str
+
+        :param service_error_code: The service error code to return,
+                                   e.g. NoSuchBucket
+        :type service_error_code: str
+
+        :param service_message: The service message to return, e.g.
+                        'The specified bucket does not exist.'
+        :type service_message: str
+
+        :param http_status_code: The HTTP status code to return, e.g. 404, etc
+        :type http_status_code: int
+        """
+        http_response = Response()
+        http_response.status_code = http_status_code
+
+        # We don't look to the model to build this because the caller would need
+        # to know the details of what the HTTP body would need to look like.
+        parsed_response = {
+            'ResponseMetadata': {'HTTPStatusCode': http_status_code},
+            'Error': {
+                'Message': service_message,
+                'Code': service_error_code
+            }
+        }
+
+        operation_name = self.client.meta.method_to_api_mapping.get(method)
+        response = (operation_name, (http_response, parsed_response))
+        self._queue.append(response)
+
+    def assert_no_pending_responses(self):
+        """
+        Asserts that all expected calls were made.
+        """
+        remaining = len(self._queue)
+        if remaining != 0:
+            raise AssertionError("%d responses remaining in queue." % remaining)
+
+    def _get_response_handler(self, model, params, **kwargs):
+        if not self._queue:
+            raise StubResponseError(
+                operation_name=model.name,
+                reason='Unexpected API Call: called with parameters %s' %
+                       params)
+
+        name, response = self._queue.popleft()
+        if name != model.name:
+            raise StubResponseError(
+                operation_name=model.name,
+                reason='Operation mismatch: found response for %s.' % name)
+
+        return response
+
+    def _validate_response(self, operation_name, service_response):
+        service_model = self.client.meta.service_model
+        operation_model = service_model.operation_model(operation_name)
+        output_shape = operation_model.output_shape
+
+        # Remove ResponseMetadata so that the validator doesn't attempt to
+        # perform validation on it.
+        response = service_response
+        if 'ResponseMetadata' in response:
+            response = copy.copy(service_response)
+            del response['ResponseMetadata']
+
+        if output_shape is not None:
+            validate_parameters(response, output_shape)
+        elif response:
+            # If the output shape is None, that means the response should be
+            # empty apart from ResponseMetadata
+            raise ParamValidationError(
+                report="Service response should only contain ResponseMetadata.")

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -1,0 +1,60 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from tests import unittest
+
+import botocore
+import botocore.session
+from botocore.stub import Stubber
+from botocore.exceptions import StubResponseError, ClientError
+import botocore.client
+import botocore.retryhandler
+import botocore.translate
+
+
+class TestStubber(unittest.TestCase):
+    def setUp(self):
+        session = botocore.session.get_session()
+        config = botocore.client.Config(signature_version=botocore.UNSIGNED)
+        self.client = session.create_client('s3', config=config)
+
+        self.stubber = Stubber(self.client)
+
+    def test_stubber_returns_response(self):
+        service_response = {'ResponseMetadata': {'foo': 'bar'}}
+        self.stubber.add_response('list_objects', service_response)
+        self.stubber.activate()
+        response = self.client.list_objects(Bucket='foo')
+        self.assertEqual(response, service_response)
+
+    def test_activated_stubber_errors_with_no_registered_stubs(self):
+        self.stubber.activate()
+        with self.assertRaises(StubResponseError):
+            self.client.list_objects(Bucket='foo')
+
+    def test_stubber_errors_when_stubs_are_used_up(self):
+        self.stubber.add_response('list_objects', {})
+        self.stubber.activate()
+        self.client.list_objects(Bucket='foo')
+
+        with self.assertRaises(StubResponseError):
+            self.client.list_objects(Bucket='foo')
+
+    def test_client_error_response(self):
+        error_code = "AccessDenied"
+        error_message = "Access Denied"
+        self.stubber.add_client_error('list_objects', error_code, error_message)
+        self.stubber.activate()
+
+        with self.assertRaises(ClientError):
+            self.client.list_objects(Bucket='foo')

--- a/tests/unit/test_stub.py
+++ b/tests/unit/test_stub.py
@@ -1,0 +1,144 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from tests import unittest
+import mock
+
+from botocore.stub import Stubber
+from botocore.exceptions import ParamValidationError, StubResponseError
+from botocore.model import ServiceModel
+from botocore import hooks
+
+
+class TestStubber(unittest.TestCase):
+    def setUp(self):
+        self.event_emitter = hooks.HierarchicalEmitter()
+        self.client = mock.Mock()
+        self.client.meta.events = self.event_emitter
+        self.client.meta.method_to_api_mapping.get.return_value = 'foo'
+        self.stubber = Stubber(self.client)
+        self.validate_parameters_mock = mock.Mock()
+        self.validate_parameters_patch = mock.patch(
+            'botocore.stub.validate_parameters', self.validate_parameters_mock)
+        self.validate_parameters_patch.start()
+
+    def tearDown(self):
+        self.validate_parameters_patch.stop()
+
+    def emit_get_response_event(self, model=None, request_dict=None,
+                                signer=None, context=None):
+        if model is None:
+            model = mock.Mock()
+            model.name = 'foo'
+
+        handler, response = self.event_emitter.emit_until_response(
+            event_name='before-call.myservice.foo', model=model,
+            params=request_dict, request_signer=signer, context=context)
+
+        return response
+
+    def test_stubber_registers_events(self):
+        self.event_emitter = mock.Mock()
+        self.client.meta.events = self.event_emitter
+        self.stubber.activate()
+        self.assertTrue(self.event_emitter.register.called)
+
+    def test_stubber_unregisters_events(self):
+        self.event_emitter = mock.Mock()
+        self.client.meta.events = self.event_emitter
+        self.stubber.activate()
+        self.stubber.deactivate()
+        self.assertTrue(self.event_emitter.unregister.called)
+
+    def test_add_response(self):
+        response = {'foo': 'bar'}
+        self.stubber.add_response('foo', response)
+
+        with self.assertRaises(AssertionError):
+            self.stubber.assert_no_pending_responses()
+
+    def test_add_response_fails_when_missing_client_method(self):
+        del self.client.foo
+        with self.assertRaises(ValueError):
+            self.stubber.add_response('foo', {})
+
+    def test_validates_service_response(self):
+        self.stubber.add_response('foo', {})
+        self.assertTrue(self.validate_parameters_mock.called)
+
+    def test_validate_ignores_response_metadata(self):
+        service_response = {'ResponseMetadata': {'foo': 'bar'}}
+        service_model = ServiceModel({
+            'documentation': '',
+            'operations': {
+                'foo': {
+                    'name': 'foo',
+                    'input': {'shape': 'StringShape'},
+                    'output': {'shape': 'StringShape'}
+                }
+            },
+            'shapes': {
+                'StringShape': {'type': 'string'}
+            }
+        })
+        op_name = service_model.operation_names[0]
+        output_shape = service_model.operation_model(op_name).output_shape
+
+        self.client.meta.service_model = service_model
+        self.stubber.add_response('TestOperation', service_response)
+        self.validate_parameters_mock.assert_called_with(
+            {}, output_shape)
+
+        # Make sure service response hasn't been mutated
+        self.assertEqual(service_response, {'ResponseMetadata': {'foo': 'bar'}})
+
+    def test_validates_on_empty_output_shape(self):
+        service_model = ServiceModel({
+            'documentation': '',
+            'operations': {
+                'foo': {
+                    'name': 'foo'
+                }
+            }
+        })
+        self.client.meta.service_model = service_model
+
+        with self.assertRaises(ParamValidationError):
+            self.stubber.add_response('TestOperation', {'foo': 'bar'})
+
+    def test_get_response(self):
+        service_response = {'bar': 'baz'}
+        self.stubber.add_response('foo', service_response)
+        self.stubber.activate()
+        response = self.emit_get_response_event()
+        self.assertEqual(response[1], service_response)
+        self.assertEqual(response[0].status_code, 200)
+
+    def test_get_client_error_response(self):
+        error_code = "foo"
+        service_message = "bar"
+        self.stubber.add_client_error('foo', error_code, service_message)
+        self.stubber.activate()
+        response = self.emit_get_response_event()
+        self.assertEqual(response[1]['Error']['Message'], service_message)
+        self.assertEqual(response[1]['Error']['Code'], error_code)
+
+    def test_get_response_errors_with_no_stubs(self):
+        self.stubber.activate()
+        with self.assertRaises(StubResponseError):
+            self.emit_get_response_event()
+
+    def test_assert_no_responses_remaining(self):
+        self.stubber.add_response('foo', {})
+        with self.assertRaises(AssertionError):
+            self.stubber.assert_no_pending_responses()


### PR DESCRIPTION
This will allow customers to stub out operations, providing their own responses so that they don't have to hit an endpoint to test their code. The interface for this is the `Stubber` class, which will manage the response queue and and handle validating the provided response stubs.

Usage example:

```python
import botocore.session
import botocore.stub
import datetime


s3_client = botocore.session.get_session().create_client('s3')
stubber = botocore.stub.Stubber(s3_client)
list_objects_response = {
   'IsTruncated': False,
   'EncodingType': 'url',
   'Marker': '',
   'Prefix': '',
   'Name': 'test-bucket',
   'Contents': [
      {
         'Size': 123,
         'Owner': {
            'DisplayName': 'display_name',
            'ID': '123abc'
         },
         'Key': 'file.txt',
         'StorageClass': 'STANDARD',
         'ETag': '"abc123"',
         'LastModified': datetime.datetime(2015, 12, 7, 18, 5, 52)
      },
      {
         'Size': 456,
         'Owner': {
            'DisplayName': 'display_name',
            'ID': '123abc'
         },
         'Key': 'file.py',
         'StorageClass': 'STANDARD',
         'ETag': '"abc123"',
         'LastModified': datetime.datetime(2015, 12, 7, 17, 38, 49)
      }
   ],
   'MaxKeys': 1000
}
stubber.add_response('list_objects', list_objects_response)
stubber.activate()
response = s3_client.list_objects(Bucket='test-bucket')
assert(response == list_objects_response)
```

cc @rayluo @kyleknap @mtdowling @jamesls 