### PR TITLE
Fix doc generation on python35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 sudo: false
 install:
   - python scripts/ci/install

--- a/botocore/docs/bcdoc/restdoc.py
+++ b/botocore/docs/bcdoc/restdoc.py
@@ -89,6 +89,7 @@ class ReSTDocument(object):
             try:
                 start = len(self._writes)
                 self.parser.feed(doc_string)
+                self.parser.close()
                 end = len(self._writes)
                 self._last_doc_string = (start, end)
             except Exception:


### PR DESCRIPTION
There's a regression on python35 where the final parts of the
document aren't parsed unless you call close.

Looks like there's a fix for this here:
https://bugs.python.org/issue23144 but this won't be available
until at least 3.5.1.

Either way, calling close() should work going forward even once
the original behavior is fixed.

I did verify that it's ok to re-use the parser after you call
close().

cc @kyleknap @mtdowling @rayluo @JordonPhillips 