### PR TITLE
Move assume role provider from CLI to botocore

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -340,3 +340,11 @@ class InvalidS3AddressingStyleError(BotoCoreError):
         'S3 addressing style {s3_addressing_style} is invaild. Valid options '
         'are: \'auto\', \'virtual\', and \'path\''
     )
+
+
+class InvalidConfigError(BotoCoreError):
+    fmt = '{error_msg}'
+
+
+class RefreshWithMFAUnsupportedError(BotoCoreError):
+    fmt = 'Cannot refresh credentials: MFA token required.'


### PR DESCRIPTION
This is a direct port with these exceptions:

* The JSONFileCache was kept in the CLI.  You can still
  instantiate or attach a cache to the assume role provider
  if you're writing short lived scripts and want to avoid
  making unnecessary AssumeRole API calls, but you'll need
  to provide your own cache implementation.
* A get_provider() convenience method was added to the
  credential resolver.

This makes it straightforward to still use the JSONFileCache
in the CLI via:

```
c = session.get_component('credential_provider')
provider = c.get_provider('assume-role')
provide.cache = JSONFileCache()
```

Note: there will be a corresponding PR to CLI we'll need to sync up.
Supersedes and closes #721 

cc @kyleknap @mtdowling @rayluo @JordonPhillips 