### PR TITLE
Remove usage of nonexistent assert_called_once method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tox==1.4
 python-dateutil>=2.1,<3.0.0
 nose==1.3.0
-mock==1.0.1
+mock==1.3.0
 wheel==0.24.0
 docutils>=0.10
 behave==1.2.5

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -363,7 +363,7 @@ class TestS3PostPresigner(BaseSignerTest):
         self.auth.assert_called_with(
             credentials=self.credentials, region_name='region_name',
             service_name='signing_name')
-        self.add_auth.assert_called_once()
+        self.assertEqual(self.add_auth.call_count, 1)
         ref_request = self.add_auth.call_args[0][0]
         ref_policy = ref_request.context['s3-presign-post-policy']
         self.assertEqual(ref_policy['expiration'], '2014-03-10T18:02:55Z')
@@ -385,7 +385,7 @@ class TestS3PostPresigner(BaseSignerTest):
         self.auth.assert_called_with(
             credentials=self.credentials, region_name='region_name',
             service_name='signing_name')
-        self.add_auth.assert_called_once()
+        self.assertEqual(self.add_auth.call_count, 1)
         ref_request = self.add_auth.call_args[0][0]
         ref_policy = ref_request.context['s3-presign-post-policy']
         self.assertEqual(ref_policy['conditions'], conditions)


### PR DESCRIPTION
This properly fails in mock 1.3.0.

Rather than use assert_called_once_with() I've just used
assertEqual(call_count, 1) which works with older versions
of Mock.

I've bumped the test dependency to mock=1.3.0, which catches
more error cases (such as the one here).

Fixes #738.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 