### PR TITLE
Generate RoleSessionName before creating assume_role refresher

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -770,9 +770,6 @@ class AssumeRoleProvider(CredentialProvider):
         client = self._create_client_from_config(config)
 
         assume_role_kwargs = self._assume_role_base_kwargs(config)
-        if assume_role_kwargs.get('RoleSessionName') is None:
-            role_session_name = 'AWS-CLI-session-%s' % (int(time.time()))
-            assume_role_kwargs['RoleSessionName'] = role_session_name
 
         response = client.assume_role(**assume_role_kwargs)
         creds = self._create_creds_from_response(response)
@@ -788,6 +785,9 @@ class AssumeRoleProvider(CredentialProvider):
             assume_role_kwargs['TokenCode'] = token_code
         if config['role_session_name'] is not None:
             assume_role_kwargs['RoleSessionName'] = config['role_session_name']
+        else:
+            role_session_name = 'AWS-CLI-session-%s' % (int(time.time()))
+            assume_role_kwargs['RoleSessionName'] = role_session_name
         return assume_role_kwargs
 
 


### PR DESCRIPTION
When using a session profile that assumes a role, and when the profile config has no "role_session_name" attribute, the RoleSessionName argument to assume_role is generated the first time, but then never provided to the refresher function.  As a result, the refresher fails to assume the role and raises an exception.  It's not possible to recover from.

I moved the RoleSessionName creation into _assume_role_base_kwargs so that's it's available before the refresher is created, as well as to anything else that may need to generate assume_role args from profile configs.