### PR TITLE
Fix decode_list_object handler to urldecode all values that can contain S3 key strings

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -531,11 +531,22 @@ def decode_list_object(parsed, context, **kwargs):
     # This is needed because we are passing url as the encoding type. Since the
     # paginator is based on the key, we need to handle it before it can be
     # round tripped.
-    if 'Contents' in parsed and parsed.get('EncodingType') == 'url' and \
-                    context.get('EncodingTypeAutoSet'):
-        for content in parsed['Contents']:
-            content['Key'] = unquote_str(content['Key'])
+    if (parsed.get('EncodingType') == 'url' and
+        context.get('EncodingTypeAutoSet')):
 
+        if 'Contents' in parsed:
+            for content in parsed['Contents']:
+                content['Key'] = unquote_str(content['Key'])
+
+        if 'CommonPrefixes' in parsed:
+            for common_prefix in parsed['CommonPrefixes']:
+                common_prefix['Prefix'] = unquote_str(common_prefix['Prefix'])
+
+        for key in ('Marker', 'NextMarker', 'Prefix', 'Delimiter'):
+            try:
+                parsed[key] = unquote_str(parsed[key])
+            except KeyError:
+                pass
 
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -591,6 +591,50 @@ class TestHandlers(BaseSessionTest):
         handlers.decode_list_object(parsed, context={})
         self.assertEqual(parsed['Contents'][0]['Key'], u'%C3%A7%C3%B6s%25asd')
 
+    def test_decode_list_objects_with_common_prefixes(self):
+        parsed = {
+            'CommonPrefixes': [{'Prefix': "%C3%A7%C3%B6s%25%20asd%08+c"}],
+            'EncodingType': 'url',
+        }
+        context = {'EncodingTypeAutoSet': True}
+        handlers.decode_list_object(parsed, context=context)
+        self.assertEqual(parsed['CommonPrefixes'][0]['Prefix'], u'\xe7\xf6s% asd\x08 c')
+
+    def test_decode_list_objects_with_marker(self):
+        parsed = {
+            'Marker': "%C3%A7%C3%B6s%25%20asd%08+c",
+            'EncodingType': 'url',
+        }
+        context = {'EncodingTypeAutoSet': True}
+        handlers.decode_list_object(parsed, context=context)
+        self.assertEqual(parsed['Marker'], u'\xe7\xf6s% asd\x08 c')
+
+    def test_decode_list_objects_with_nextmarker(self):
+        parsed = {
+            'NextMarker': "%C3%A7%C3%B6s%25%20asd%08+c",
+            'EncodingType': 'url',
+        }
+        context = {'EncodingTypeAutoSet': True}
+        handlers.decode_list_object(parsed, context=context)
+        self.assertEqual(parsed['NextMarker'], u'\xe7\xf6s% asd\x08 c')
+
+    def test_decode_list_objects_with_prefix(self):
+        parsed = {
+            'Prefix': "%C3%A7%C3%B6s%25%20asd%08+c",
+            'EncodingType': 'url',
+        }
+        context = {'EncodingTypeAutoSet': True}
+        handlers.decode_list_object(parsed, context=context)
+        self.assertEqual(parsed['Prefix'], u'\xe7\xf6s% asd\x08 c')
+
+    def test_decode_list_objects_with_delimiter(self):
+        parsed = {
+            'Delimiter': "%C3%A7%C3%B6s%25%20asd%08+c",
+            'EncodingType': 'url',
+        }
+        context = {'EncodingTypeAutoSet': True}
+        handlers.decode_list_object(parsed, context=context)
+        self.assertEqual(parsed['Delimiter'], u'\xe7\xf6s% asd\x08 c')
 
 class TestRetryHandlerOrder(BaseSessionTest):
     def get_handler_names(self, responses):


### PR DESCRIPTION
Hi,

I've noticed that botocore.handlers.decode_list_object() only addresses url-decoding of the 'Contents' key of the response dict.

This leaves undecoded values of response keys that can contain S3 object names:
CommonPrefixes
Marker
NextMarker
Prefix
Delimiter

I've been able to track back the problem until version 1.3.9 (last working version).
This PR should address the issue.
Please let me know if it's ok.

Thanks!