### PR TITLE
Special case versionId query param in urlencoding

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -419,6 +419,20 @@ class TestS3Copy(TestS3BaseWithBucket):
             Bucket=self.bucket_name, Key=key_name2)
         self.assertEqual(data['Body'].read().decode('utf-8'), 'foo')
 
+    def test_copy_with_query_string(self):
+        key_name = 'a+b/foo?notVersionid=bar'
+        self.create_object(key_name=key_name)
+
+        key_name2 = key_name + 'bar'
+        self.client.copy_object(
+            Bucket=self.bucket_name, Key=key_name2,
+            CopySource='%s/%s' % (self.bucket_name, key_name))
+
+        # Now verify we can retrieve the copied object.
+        data = self.client.get_object(
+            Bucket=self.bucket_name, Key=key_name2)
+        self.assertEqual(data['Body'].read().decode('utf-8'), 'foo')
+
     def test_copy_with_s3_metadata(self):
         key_name = 'foo.txt'
         self.create_object(key_name=key_name)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -71,13 +71,30 @@ class TestHandlers(BaseSessionTest):
             self.assertEqual(
                 params['headers']['x-amz-copy-source'], 'foo%2B%2Bbar.txt')
 
-    def test_only_quote_url_path_not_query_string(self):
+    def test_only_quote_url_path_not_version_id(self):
         request = {
             'headers': {'x-amz-copy-source': '/foo/bar++baz?versionId=123'}
         }
         handlers.quote_source_header(request)
         self.assertEqual(request['headers']['x-amz-copy-source'],
                          '/foo/bar%2B%2Bbaz?versionId=123')
+
+    def test_only_version_id_is_special_cased(self):
+        request = {
+            'headers': {'x-amz-copy-source': '/foo/bar++baz?notVersion=foo+'}
+        }
+        handlers.quote_source_header(request)
+        self.assertEqual(request['headers']['x-amz-copy-source'],
+                         '/foo/bar%2B%2Bbaz%3FnotVersion%3Dfoo%2B')
+
+    def test_copy_source_with_multiple_questions(self):
+        request = {
+            'headers': {
+                'x-amz-copy-source': '/foo/bar+baz?a=baz+?versionId=a+'}
+        }
+        handlers.quote_source_header(request)
+        self.assertEqual(request['headers']['x-amz-copy-source'],
+                         '/foo/bar%2Bbaz%3Fa%3Dbaz%2B?versionId=a+')
 
     def test_quote_source_header_needs_no_changes(self):
         request = {


### PR DESCRIPTION
A while back there was a bug fix that did not url encode
the query string.  This was so customers could provide
a ?versionId to indicate they wanted a specific version
copied (https://github.com/boto/botocore/issues/509).

However, it's possible that a customer's key name ends
with something that looks like a query string, e.g.
"foo?a=b&c=d".

This modifies this code to only skip the uri encoding
if there's a query string with versionId.

There's still one edge case.  It's ambiguous for a key
such as 'foo?versionId=bar' whether you meant the entire
string to be the key name or whether you meant
key=foo, versionId=bar.  In this case, we assume you meant
the latter, so it's not possible to copy a key with
'?versionId=...'.

In order to fix this edge case we'd need to support some
explicit way of the customer specifying the bucket, key,
and versionId.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 