### PR TITLE
Add support for alternate form of CopySource

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -268,6 +268,35 @@ def add_expect_header(model, params, **kwargs):
             params['headers']['Expect'] = '100-continue'
 
 
+def document_copy_source_form(section, event_name, **kwargs):
+    if 'request-example' in event_name:
+        parent = section.get_section('structure-value')
+        param_line = parent.get_section('CopySource')
+        value_portion = param_line.get_section('member-value')
+        value_portion.clear_text()
+        value_portion.write("'string' or {'Bucket': 'string', "
+                            "'Key': 'string', 'VersionId': 'string'}")
+    elif 'request-params' in event_name:
+        param_section = section.get_section('CopySource')
+        type_section = param_section.get_section('param-type')
+        type_section.clear_text()
+        type_section.write(':type CopySource: str or dict')
+        doc_section = param_section.get_section('param-documentation')
+        doc_section.clear_text()
+        doc_section.write(
+            "The name of the source bucket, key name of the source object, "
+            "and optional version ID of the source object.  You can either "
+            "provide this value as a string or a dictionary.  The "
+            "string form is {bucket}/{key} or "
+            "{bucket}/{key}?versionId={versionId} if you want to copy a "
+            "specific version.  You can also provide this value as a "
+            "dictionary.  The dictionary format is recommended over "
+            "the string format because it is more explicit.  The dictionary "
+            "format is: {'Bucket': 'bucket', 'Key': 'key', 'VersionId': 'id'}."
+            "  Note that the VersionId key is optional and may be omitted."
+        )
+
+
 def support_dict_copy_source(params, context, **kwargs):
     source = params.get('CopySource')
     if source is None or not isinstance(source, dict):
@@ -602,8 +631,7 @@ BUILTIN_HANDLERS = [
      support_dict_copy_source),
     ('before-parameter-build.s3.UploadPartCopy',
      support_dict_copy_source),
-
-
+    ('docs.*.s3.CopyObject.complete-section', document_copy_source_form),
 
     ('before-call.s3', add_expect_header),
     ('before-call.glacier', add_glacier_version),

--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -69,11 +69,17 @@ class BaseDocsFunctionalTest(unittest.TestCase):
         return self.get_parameter_document_block(
             param_name, method_contents)
 
+    def get_docstring_for_method(self, service_name, method_name):
+        contents = ServiceDocumenter(
+            service_name, self._session).document_service()
+        method_contents = self.get_method_document_block(
+            method_name, contents)
+        return method_contents
+
     def assert_is_documented_as_autopopulated_param(
             self, service_name, method_name, param_name, doc_string=None):
         contents = ServiceDocumenter(
             service_name, self._session).document_service()
-        # Pick an arbitrary method that uses AccountId.
         method_contents = self.get_method_document_block(
             method_name, contents)
 

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -42,3 +42,18 @@ class TestS3Docs(BaseDocsFunctionalTest):
                 method_name, service_contents)
             self.assertNotIn('ContentMD5=\'string\'',
                              method_contents.decode('utf-8'))
+
+    def test_copy_source_documented_as_union_type(self):
+        content  = self.get_docstring_for_method('s3', 'copy_object')
+        dict_form = (
+            "{'Bucket': 'string', 'Key': 'string', 'VersionId': 'string'}")
+        self.assert_contains_line(
+            "CopySource='string' or %s" % dict_form, content)
+
+    def test_copy_source_param_docs_also_modified(self):
+        content  = self.get_docstring_for_method('s3', 'copy_object')
+        param_docs = self.get_parameter_document_block('CopySource', content)
+        # We don't want to overspecify the test, so I've picked
+        # an arbitrary line from the customized docs.
+        self.assert_contains_line(
+            "You can also provide this value as a dictionary", param_docs)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -419,6 +419,20 @@ class TestS3Copy(TestS3BaseWithBucket):
             Bucket=self.bucket_name, Key=key_name2)
         self.assertEqual(data['Body'].read().decode('utf-8'), 'foo')
 
+    def test_copy_with_query_string(self):
+        key_name = 'a+b/foo?notVersionid=bar'
+        self.create_object(key_name=key_name)
+
+        key_name2 = key_name + 'bar'
+        self.client.copy_object(
+            Bucket=self.bucket_name, Key=key_name2,
+            CopySource='%s/%s' % (self.bucket_name, key_name))
+
+        # Now verify we can retrieve the copied object.
+        data = self.client.get_object(
+            Bucket=self.bucket_name, Key=key_name2)
+        self.assertEqual(data['Body'].read().decode('utf-8'), 'foo')
+
     def test_copy_with_s3_metadata(self):
         key_name = 'foo.txt'
         self.create_object(key_name=key_name)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -433,6 +433,21 @@ class TestS3Copy(TestS3BaseWithBucket):
             Bucket=self.bucket_name, Key=key_name2)
         self.assertEqual(data['Body'].read().decode('utf-8'), 'foo')
 
+    def test_can_copy_with_dict_form(self):
+        key_name = 'a+b/foo?versionId=abcd'
+        self.create_object(key_name=key_name)
+
+        key_name2 = key_name + 'bar'
+        self.client.copy_object(
+            Bucket=self.bucket_name, Key=key_name2,
+            CopySource={'Bucket': self.bucket_name,
+                        'Key': key_name})
+
+        # Now verify we can retrieve the copied object.
+        data = self.client.get_object(
+            Bucket=self.bucket_name, Key=key_name2)
+        self.assertEqual(data['Body'].read().decode('utf-8'), 'foo')
+
     def test_copy_with_s3_metadata(self):
         key_name = 'foo.txt'
         self.create_object(key_name=key_name)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -71,13 +71,30 @@ class TestHandlers(BaseSessionTest):
             self.assertEqual(
                 params['headers']['x-amz-copy-source'], 'foo%2B%2Bbar.txt')
 
-    def test_only_quote_url_path_not_query_string(self):
+    def test_only_quote_url_path_not_version_id(self):
         request = {
             'headers': {'x-amz-copy-source': '/foo/bar++baz?versionId=123'}
         }
         handlers.quote_source_header(request)
         self.assertEqual(request['headers']['x-amz-copy-source'],
                          '/foo/bar%2B%2Bbaz?versionId=123')
+
+    def test_only_version_id_is_special_cased(self):
+        request = {
+            'headers': {'x-amz-copy-source': '/foo/bar++baz?notVersion=foo+'}
+        }
+        handlers.quote_source_header(request)
+        self.assertEqual(request['headers']['x-amz-copy-source'],
+                         '/foo/bar%2B%2Bbaz%3FnotVersion%3Dfoo%2B')
+
+    def test_copy_source_with_multiple_questions(self):
+        request = {
+            'headers': {
+                'x-amz-copy-source': '/foo/bar+baz?a=baz+?versionId=a+'}
+        }
+        handlers.quote_source_header(request)
+        self.assertEqual(request['headers']['x-amz-copy-source'],
+                         '/foo/bar%2Bbaz%3Fa%3Dbaz%2B?versionId=a+')
 
     def test_quote_source_header_needs_no_changes(self):
         request = {

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -62,96 +62,58 @@ class TestHandlers(BaseSessionTest):
     def test_disable_signing(self):
         self.assertEqual(handlers.disable_signing(), botocore.UNSIGNED)
 
-    def test_quote_source_header(self):
-        for op in ('UploadPartCopy', 'CopyObject'):
-            event = 'before-call.s3.%s' % op
-            params = {'headers': {'x-amz-copy-source': 'foo++bar.txt'}}
-            m = mock.Mock()
-            self.session.emit(event, params=params, context={},
-                              model=m)
-            self.assertEqual(
-                params['headers']['x-amz-copy-source'], 'foo%2B%2Bbar.txt')
-
     def test_only_quote_url_path_not_version_id(self):
-        request = {
-            'headers': {'x-amz-copy-source': '/foo/bar++baz?versionId=123'}
-        }
-        handlers.quote_source_header(request, {})
-        self.assertEqual(request['headers']['x-amz-copy-source'],
+        params = {'CopySource': '/foo/bar++baz?versionId=123'}
+        handlers.handle_copy_source_param(params)
+        self.assertEqual(params['CopySource'],
                          '/foo/bar%2B%2Bbaz?versionId=123')
 
     def test_only_version_id_is_special_cased(self):
-        request = {
-            'headers': {'x-amz-copy-source': '/foo/bar++baz?notVersion=foo+'}
-        }
-        handlers.quote_source_header(request, {})
-        self.assertEqual(request['headers']['x-amz-copy-source'],
+        params = {'CopySource': '/foo/bar++baz?notVersion=foo+'}
+        handlers.handle_copy_source_param(params)
+        self.assertEqual(params['CopySource'],
                          '/foo/bar%2B%2Bbaz%3FnotVersion%3Dfoo%2B')
 
     def test_copy_source_with_multiple_questions(self):
-        request = {
-            'headers': {
-                'x-amz-copy-source': '/foo/bar+baz?a=baz+?versionId=a+'}
-        }
-        handlers.quote_source_header(request, {})
-        self.assertEqual(request['headers']['x-amz-copy-source'],
+        params = {'CopySource': '/foo/bar+baz?a=baz+?versionId=a+'}
+        handlers.handle_copy_source_param(params)
+        self.assertEqual(params['CopySource'],
                          '/foo/bar%2Bbaz%3Fa%3Dbaz%2B?versionId=a+')
 
     def test_copy_source_supports_dict(self):
-        context = {}
         params = {
             'CopySource': {'Bucket': 'foo', 'Key': 'keyname+'}
         }
-        handlers.support_dict_copy_source(params, context)
-
-        self.assertTrue(context['CopySourceEncoded'])
+        handlers.handle_copy_source_param(params)
         self.assertEqual(params['CopySource'], 'foo/keyname%2B')
 
     def test_copy_source_ignored_if_not_dict(self):
-        context = {}
         params = {
             'CopySource': 'stringvalue'
         }
-        handlers.support_dict_copy_source(params, context)
-
-        self.assertNotIn('CopySourceEncoded', context)
+        handlers.handle_copy_source_param(params)
         self.assertEqual(params['CopySource'], 'stringvalue')
 
     def test_copy_source_supports_optional_version_id(self):
-        context = {}
         params = {
             'CopySource': {'Bucket': 'foo',
                            'Key': 'keyname+',
                            'VersionId': 'asdf+'}
         }
-        handlers.support_dict_copy_source(params, context)
-
-        self.assertTrue(context['CopySourceEncoded'])
+        handlers.handle_copy_source_param(params)
         self.assertEqual(params['CopySource'],
                          # Note, versionId is not url encoded.
                          'foo/keyname%2B?versionId=asdf+')
 
     def test_copy_source_has_validation_failure(self):
-        context = {}
         with self.assertRaisesRegexp(ParamValidationError, 'Key'):
-            handlers.support_dict_copy_source(
-                {'CopySource': {'Bucket': 'foo'}}, context)
-
-    def test_quote_header_noop_when_already_encoded(self):
-        context = {'CopySourceEncoded': True}
-        request = {
-            'headers': {'x-amz-copy-source': '/foo/bar++'},
-        }
-        handlers.quote_source_header(request, context)
-        self.assertEqual(request['headers']['x-amz-copy-source'],
-                         '/foo/bar++')
+            handlers.handle_copy_source_param(
+                {'CopySource': {'Bucket': 'foo'}})
 
     def test_quote_source_header_needs_no_changes(self):
-        request = {
-            'headers': {'x-amz-copy-source': '/foo/bar?versionId=123'}
-        }
-        handlers.quote_source_header(request, {})
-        self.assertEqual(request['headers']['x-amz-copy-source'],
+        params = {'CopySource': '/foo/bar?versionId=123'}
+        handlers.handle_copy_source_param(params)
+        self.assertEqual(params['CopySource'],
                          '/foo/bar?versionId=123')
 
     def test_presigned_url_already_present(self):
@@ -242,9 +204,7 @@ class TestHandlers(BaseSessionTest):
             event = 'before-parameter-build.s3.%s' % op
             params = {'SSECustomerKey': b'bar',
                       'SSECustomerAlgorithm': 'AES256'}
-            self.session.emit(event, params=params,
-                              context={},
-                              model=mock.Mock())
+            self.session.emit(event, params=params, model=mock.Mock())
             self.assertEqual(params['SSECustomerKey'], 'YmFy')
             self.assertEqual(params['SSECustomerKeyMD5'],
                              'N7UdGUp1E+RbVvZSTy1R8g==')
@@ -263,9 +223,7 @@ class TestHandlers(BaseSessionTest):
             event = 'before-parameter-build.s3.%s' % op
             params = {'CopySourceSSECustomerKey': b'bar',
                       'CopySourceSSECustomerAlgorithm': 'AES256'}
-            self.session.emit(event, params=params,
-                              context={},
-                              model=mock.Mock())
+            self.session.emit(event, params=params, model=mock.Mock())
             self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
             self.assertEqual(params['CopySourceSSECustomerKeyMD5'],
                              'N7UdGUp1E+RbVvZSTy1R8g==')
@@ -274,9 +232,7 @@ class TestHandlers(BaseSessionTest):
         event = 'before-parameter-build.s3.CopyObject'
         params = {'CopySourceSSECustomerKey': 'bar',
                   'CopySourceSSECustomerAlgorithm': 'AES256'}
-        self.session.emit(event, params=params,
-                          context={},
-                          model=mock.Mock())
+        self.session.emit(event, params=params, model=mock.Mock())
         self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
         self.assertEqual(params['CopySourceSSECustomerKeyMD5'],
                          'N7UdGUp1E+RbVvZSTy1R8g==')


### PR DESCRIPTION
Follow up from https://github.com/boto/botocore/pull/757, this adds support for a dict value for `CopySource`.  This ensures we automatically handle all cases correctly for the customer because they're explicitly telling us the bucket, key, and optional version id.

```
s3.copy_object(CopySource={'Bucket': 'sourcebucket', 'Key': 'sourcekey'})
```

I've also handed a handler to update the documentation for this new format.

I'll add a handwritten example to boto3 shortly as well.

NOTE: I've branched this off of #757 because I had to modify the existing handler for the string value of `CopySource` so you'll see the diff of both in this PR.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 