### PR TITLE
Parse xml attributes in XML responses

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -293,6 +293,15 @@ class BaseXMLResponseParser(ResponseParser):
             if member_node is not None:
                 parsed[member_name] = self._parse_shape(
                     member_shape, member_node)
+            elif member_shape.serialization.get('xmlAttribute'):
+                attribs = {}
+                location_name = member_shape.serialization['name']
+                for key, value in node.attrib.items():
+                    new_key = self._namespace_re.sub(
+                        location_name.split(':')[0] + ':', key)
+                    attribs[new_key] = value
+                if location_name in attribs:
+                    parsed[member_name] = attribs[location_name]
         return parsed
 
     def _member_key_name(self, shape, member_name):

--- a/tests/unit/protocols/output/rest-xml.json
+++ b/tests/unit/protocols/output/rest-xml.json
@@ -716,5 +716,73 @@
         }
       }
     ]
+  },
+  {
+    "description": "Parse XML Attributes",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Grants": {
+            "shape": "Grants",
+	    "locationName": "AccessControlList"
+          }
+        }
+      },
+      "Grants": {
+        "type": "list",
+	"member": {
+          "shape": "Grant"
+	}
+      },
+      "Grant": {
+        "type": "structure",
+	"members": {
+          "Grantee": {"shape": "Grantee"}
+	}
+      },
+      "Grantee": {
+        "type": "structure",
+	"members": {
+          "DisplayName": {"shape": "String"},
+          "ID": {"shape": "String"},
+          "Type": {
+            "shape": "String",
+	    "locationName": "xsi:type",
+	    "xmlAttribute": true
+	  }
+	}
+      },
+      "String": {"type": "string"}
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Grants": [
+            {
+              "Grantee": {
+                "DisplayName": "name",
+                "ID": "id",
+                "Type": "CanonicalUser"
+              }
+            }
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><AccessControlList><Grant><Grantee xmlns:xsi=\"http://foo/bar\"  xsi:type=\"CanonicalUser\"><ID>id</ID> <DisplayName>name</DisplayName></Grantee></Grant></AccessControlList></OperationNameResponse>"
+	}
+      }
+    ]
   }
 ]

--- a/tests/unit/response_parsing/xml/responses/s3-get-bucket-acl.json
+++ b/tests/unit/response_parsing/xml/responses/s3-get-bucket-acl.json
@@ -7,7 +7,8 @@
         {
             "Grantee": {
                 "DisplayName": "CustomersName@amazon.com", 
-                "ID": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
+                "ID": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a",
+                "Type": "CanonicalUser"
             }, 
             "Permission": "FULL_CONTROL"
         }

--- a/tests/unit/response_parsing/xml/responses/s3-get-bucket-logging.json
+++ b/tests/unit/response_parsing/xml/responses/s3-get-bucket-logging.json
@@ -5,7 +5,8 @@
         "TargetGrants": [
             {
                 "Grantee": {
-                    "EmailAddress": "user@company.com"
+                    "EmailAddress": "user@company.com",
+		    "Type": "AmazonCustomerByEmail"
                 }, 
                 "Permission": "READ"
             }


### PR DESCRIPTION
This fixes an issue where the "Type" field was not being
populated from S3 responses such as ``get_object_acl``.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 