### PR TITLE
Refactored paginators to use a dict rather than a custom seperator.

### DIFF
--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -322,11 +322,11 @@ class TestMultipleTokens(unittest.TestCase):
     def test_s3_list_multipart_uploads(self):
         responses = [
             {"Foo": [1], "ListBucketResults": {"NextKeyMarker": "key1",
-             "NextUploadIdMarker": "up1"}},
+                                               "NextUploadIdMarker": "up1"}},
             {"Foo": [2], "ListBucketResults": {"NextKeyMarker": "key2",
-             "NextUploadIdMarker": "up2"}},
+                                               "NextUploadIdMarker": "up2"}},
             {"Foo": [3], "ListBucketResults": {"NextKeyMarker": "key3",
-             "NextUploadIdMarker": "up3"}},
+                                               "NextUploadIdMarker": "up3"}},
             {}
         ]
         self.method.side_effect = responses
@@ -431,7 +431,8 @@ class TestKeyIterators(unittest.TestCase):
             {"Users": ["User7"]},
         ]
         self.method.side_effect = responses
-        expected_token = encode_token({"Marker": "m1", "truncate_amount": 1})
+        expected_token = encode_token(
+            {"Marker": "m1", "boto_truncate_amount": 1})
         self.assertEqual(
             paginator.paginate(
                 PaginationConfig={'MaxItems': 4}).build_full_result(),
@@ -449,7 +450,8 @@ class TestKeyIterators(unittest.TestCase):
             {"Users": ["User7"]},
         ]
         self.method.side_effect = responses
-        starting_token = encode_token({"Marker": "m1", "truncate_amount": 1})
+        starting_token = encode_token(
+            {"Marker": "m1", "boto_truncate_amount": 1})
         pagination_config = {'StartingToken': starting_token}
         self.assertEqual(
             paginator.paginate(
@@ -554,7 +556,8 @@ class TestMultipleResultKeys(unittest.TestCase):
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1})
         complete = pages.build_full_result()
-        expected_token = encode_token({"Marker": None, "truncate_amount": 1})
+        expected_token = encode_token(
+            {"Marker": None, "boto_truncate_amount": 1})
         self.assertEqual(complete,
                          {"Users": ["User1"], "Groups": ["Group1", "Group2"],
                           "NextToken": expected_token})
@@ -572,7 +575,8 @@ class TestMultipleResultKeys(unittest.TestCase):
             {"Users": ["User4"], "Groups": ["Group4"]},
         ]
         self.method.side_effect = responses
-        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
+        starting_token = encode_token(
+            {"Marker": None, "boto_truncate_amount": 1})
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1,
                               'StartingToken': starting_token})
@@ -586,7 +590,8 @@ class TestMultipleResultKeys(unittest.TestCase):
 
     def test_resume_with_secondary_result_as_string(self):
         self.method.return_value = {"Users": ["User1", "User2"], "Groups": "a"}
-        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
+        starting_token = encode_token(
+            {"Marker": None, "boto_truncate_amount": 1})
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1, 'StartingToken': starting_token})
         complete = pages.build_full_result()
@@ -596,7 +601,8 @@ class TestMultipleResultKeys(unittest.TestCase):
 
     def test_resume_with_secondary_result_as_integer(self):
         self.method.return_value = {"Users": ["User1", "User2"], "Groups": 123}
-        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
+        starting_token = encode_token(
+            {"Marker": None, "boto_truncate_amount": 1})
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1, 'StartingToken': starting_token})
         complete = pages.build_full_result()
@@ -630,7 +636,7 @@ class TestMultipleInputKeys(unittest.TestCase):
             PaginationConfig={'MaxItems': 3})
         complete = pages.build_full_result()
         expected_token = encode_token(
-                {"InMarker1": "m1", "InMarker2": "m2", "truncate_amount": 1})
+            {"InMarker1": "m1", "InMarker2": "m2", "boto_truncate_amount": 1})
         self.assertEqual(complete,
                          {"Users": ['User1', 'User2', 'User3'],
                           "Groups": ['Group1', 'Group2'],
@@ -644,13 +650,13 @@ class TestMultipleInputKeys(unittest.TestCase):
         ]
         self.method.side_effect = responses
         starting_token = encode_token(
-                {"InMarker1": "m1", "InMarker2": "m2", "truncate_amount": 1})
+            {"InMarker1": "m1", "InMarker2": "m2", "boto_truncate_amount": 1})
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1,
                               'StartingToken': starting_token})
         complete = pages.build_full_result()
         expected_token = encode_token(
-                {"InMarker1": "m3", "InMarker2": "m4"})
+            {"InMarker1": "m3", "InMarker2": "m4"})
         self.assertEqual(complete,
                          {"Users": ['User4'],
                           "Groups": [],
@@ -662,9 +668,10 @@ class TestMultipleInputKeys(unittest.TestCase):
     def test_resume_encounters_an_empty_payload(self):
         response = {"not_a_result_key": "it happens in some service"}
         self.method.return_value = response
-        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
-        complete = self.paginator\
-            .paginate(PaginationConfig={'StartingToken': starting_token})\
+        starting_token = encode_token(
+            {"Marker": None, "boto_truncate_amount": 1})
+        complete = self.paginator \
+            .paginate(PaginationConfig={'StartingToken': starting_token}) \
             .build_full_result()
         self.assertEqual(complete, {})
 

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -17,6 +17,12 @@ from botocore.paginate import PaginatorModel
 from botocore.exceptions import PaginationError
 
 import mock
+import base64
+import json
+
+
+def encode_token(token):
+    return base64.b64encode(json.dumps(token).encode('utf-8'))
 
 
 class TestPaginatorModel(unittest.TestCase):
@@ -377,10 +383,11 @@ class TestKeyIterators(unittest.TestCase):
             {"Users": ["User3"]},
         ]
         self.method.side_effect = responses
+        expected_token = encode_token({"Marker": "m1"})
         self.assertEqual(
             paginator.paginate(
                 PaginationConfig={'MaxItems': 1}).build_full_result(),
-            {'Users': ['User1'], 'NextToken': 'm1'})
+            {'Users': ['User1'], 'NextToken': expected_token})
 
     def test_max_items_as_strings(self):
         # Some services (route53) model MaxItems as a string type.
@@ -392,11 +399,12 @@ class TestKeyIterators(unittest.TestCase):
             {"Users": ["User3"]},
         ]
         self.method.side_effect = responses
+        expected_token = encode_token({"Marker": "m1"})
         self.assertEqual(
             # Note MaxItems is a string here.
             paginator.paginate(
                 PaginationConfig={'MaxItems': '1'}).build_full_result(),
-            {'Users': ['User1'], 'NextToken': 'm1'})
+            {'Users': ['User1'], 'NextToken': expected_token})
 
     def test_next_token_on_page_boundary(self):
         paginator = Paginator(self.method, self.paginate_config)
@@ -406,10 +414,11 @@ class TestKeyIterators(unittest.TestCase):
             {"Users": ["User3"]},
         ]
         self.method.side_effect = responses
+        expected_token = encode_token({"Marker": "m2"})
         self.assertEqual(
             paginator.paginate(
                 PaginationConfig={'MaxItems': 2}).build_full_result(),
-            {'Users': ['User1', 'User2'], 'NextToken': 'm2'})
+            {'Users': ['User1', 'User2'], 'NextToken': expected_token})
 
     def test_max_items_can_be_specified_truncates_response(self):
         # We're saying we only want 4 items, but notice that the second
@@ -422,11 +431,12 @@ class TestKeyIterators(unittest.TestCase):
             {"Users": ["User7"]},
         ]
         self.method.side_effect = responses
+        expected_token = encode_token({"Marker": "m1", "truncate_amount": 1})
         self.assertEqual(
             paginator.paginate(
                 PaginationConfig={'MaxItems': 4}).build_full_result(),
             {'Users': ['User1', 'User2', 'User3', 'User4'],
-             'NextToken': 'm1___1'})
+             'NextToken': expected_token})
 
     def test_resume_next_marker_mid_page(self):
         # This is a simulation of picking up from the response
@@ -439,7 +449,8 @@ class TestKeyIterators(unittest.TestCase):
             {"Users": ["User7"]},
         ]
         self.method.side_effect = responses
-        pagination_config = {'StartingToken': 'm1___1'}
+        starting_token = encode_token({"Marker": "m1", "truncate_amount": 1})
+        pagination_config = {'StartingToken': starting_token}
         self.assertEqual(
             paginator.paginate(
                 PaginationConfig=pagination_config).build_full_result(),
@@ -472,7 +483,7 @@ class TestKeyIterators(unittest.TestCase):
         ]
         self.method.side_effect = responses
         with self.assertRaisesRegexp(ValueError, 'Bad starting token'):
-            pagination_config = {'StartingToken': 'bad___notanint'}
+            pagination_config = {'StartingToken': 'doesnotdecode'}
             self.paginator.paginate(
                 PaginationConfig=pagination_config).build_full_result()
 
@@ -543,9 +554,10 @@ class TestMultipleResultKeys(unittest.TestCase):
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1})
         complete = pages.build_full_result()
+        expected_token = encode_token({"Marker": None, "truncate_amount": 1})
         self.assertEqual(complete,
                          {"Users": ["User1"], "Groups": ["Group1", "Group2"],
-                          "NextToken": "None___1"})
+                          "NextToken": expected_token})
 
     def test_resume_with_secondary_keys(self):
         # This is simulating a continutation of the previous test,
@@ -560,20 +572,23 @@ class TestMultipleResultKeys(unittest.TestCase):
             {"Users": ["User4"], "Groups": ["Group4"]},
         ]
         self.method.side_effect = responses
+        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1,
-                              'StartingToken': "None___1"})
+                              'StartingToken': starting_token})
         complete = pages.build_full_result()
         # Note that the secondary keys ("Groups") are all truncated because
         # they were in the original (first) response.
+        expected_token = encode_token({"Marker": "m1"})
         self.assertEqual(complete,
                          {"Users": ["User2"], "Groups": [],
-                          "NextToken": "m1"})
+                          "NextToken": expected_token})
 
     def test_resume_with_secondary_result_as_string(self):
         self.method.return_value = {"Users": ["User1", "User2"], "Groups": "a"}
+        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
         pages = self.paginator.paginate(
-            PaginationConfig={'MaxItems': 1, 'StartingToken': "None___1"})
+            PaginationConfig={'MaxItems': 1, 'StartingToken': starting_token})
         complete = pages.build_full_result()
         # Note that the secondary keys ("Groups") becomes empty string because
         # they were in the original (first) response.
@@ -581,8 +596,9 @@ class TestMultipleResultKeys(unittest.TestCase):
 
     def test_resume_with_secondary_result_as_integer(self):
         self.method.return_value = {"Users": ["User1", "User2"], "Groups": 123}
+        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
         pages = self.paginator.paginate(
-            PaginationConfig={'MaxItems': 1, 'StartingToken': "None___1"})
+            PaginationConfig={'MaxItems': 1, 'StartingToken': starting_token})
         complete = pages.build_full_result()
         # Note that the secondary keys ("Groups") becomes zero because
         # they were in the original (first) response.
@@ -613,10 +629,12 @@ class TestMultipleInputKeys(unittest.TestCase):
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 3})
         complete = pages.build_full_result()
+        expected_token = encode_token(
+                {"InMarker1": "m1", "InMarker2": "m2", "truncate_amount": 1})
         self.assertEqual(complete,
                          {"Users": ['User1', 'User2', 'User3'],
                           "Groups": ['Group1', 'Group2'],
-                          "NextToken": "m1___m2___1"})
+                          "NextToken": expected_token})
 
     def test_resume_with_multiple_input_keys(self):
         responses = [
@@ -625,14 +643,18 @@ class TestMultipleInputKeys(unittest.TestCase):
             {"Users": ["User5"], "Groups": ["Group3"]},
         ]
         self.method.side_effect = responses
+        starting_token = encode_token(
+                {"InMarker1": "m1", "InMarker2": "m2", "truncate_amount": 1})
         pages = self.paginator.paginate(
             PaginationConfig={'MaxItems': 1,
-                              'StartingToken': 'm1___m2___1'})
+                              'StartingToken': starting_token})
         complete = pages.build_full_result()
+        expected_token = encode_token(
+                {"InMarker1": "m3", "InMarker2": "m4"})
         self.assertEqual(complete,
                          {"Users": ['User4'],
                           "Groups": [],
-                          "NextToken": "m3___m4"})
+                          "NextToken": expected_token})
         self.assertEqual(
             self.method.call_args_list,
             [mock.call(InMarker1='m1', InMarker2='m2')])
@@ -640,8 +662,10 @@ class TestMultipleInputKeys(unittest.TestCase):
     def test_resume_encounters_an_empty_payload(self):
         response = {"not_a_result_key": "it happens in some service"}
         self.method.return_value = response
-        complete = self.paginator.paginate(
-            PaginationConfig={'StartingToken': 'None___1'}).build_full_result()
+        starting_token = encode_token({"Marker": None, "truncate_amount": 1})
+        complete = self.paginator\
+            .paginate(PaginationConfig={'StartingToken': starting_token})\
+            .build_full_result()
         self.assertEqual(complete, {})
 
     def test_result_key_exposed_on_paginator(self):


### PR DESCRIPTION
Previously, our custom pagination token came in the form: `serviceToken___5000` where serviceToken represented the service's pagination token(s) and the number at the end represented where in the array we should slice the response. The problem is that a token for dynamodb or s3 can include a triple underscore. So instead of seeing one token and an index, we see two tokens and an index. This causes the paginator to fall on its face.

The solution is to use a list as a token instead. So our token will now look like `"['serviceToken', '5000']"`. We then use ast to evaluate that back into a list that we can easily use. The service token won't cause any issues because python will see that it's a string and leave it at that. Additionally, if the service token is not a string (such as in the case of dynamodb), we will get the original object back. This fixes issues we had previously where we were trying to pass the dynamodb `ExclusiveStartKey` back as a string when it's actually a dict.

I would also like to discuss another addition: base64 encoding this new token. This would obfuscate it much like the service tokens. Since this isn't something the customer is supposed to be generating on their own, encoding it would discourage such behavior.

Fixes aws/aws-cli#1601