### PR TITLE
Retrieve refreshable credentials as a set to avoid auth failures when refresh happens in the middle of auth signing process.

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -289,6 +289,10 @@ class RefreshableCredentials(Credentials):
         logger.debug("Retrieved credentials will expire at: %s", self._expiry_time)
         self._normalize()
 
+    def get_credential_set(self):
+        self._refresh()
+        return Credentials(self._access_key, self._secret_key, token=self._token)
+
 
 class CredentialProvider(object):
 

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -148,7 +148,12 @@ class RequestSigner(object):
         if cls is None:
             raise UnknownSignatureVersionError(
                 signature_version=signature_version)
-        kwargs['credentials'] = self._credentials
+        # Get consistent set of credentials and don't cache RefreshableCredentials
+        if hasattr(self._credentials, 'get_credential_set'):
+            kwargs['credentials'] = self._credentials.get_credential_set()
+            cache_key = None
+        else:
+            kwargs['credentials'] = self._credentials
         if cls.REQUIRES_REGION:
             if self._region_name is None:
                 raise botocore.exceptions.NoRegionError()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -112,6 +112,16 @@ class TestRefreshableCredentials(TestCredentials):
         self.assertEqual(self.creds.secret_key, 'ORIGINAL-SECRET')
         self.assertEqual(self.creds.token, 'ORIGINAL-TOKEN')
 
+    def test_get_credentials_set(self):
+        # We need to return a consistent set of credentials to use during the signing process
+        self.mock_time.return_value = (
+            datetime.now(tzlocal()) - timedelta(minutes=60))
+        self.assertTrue(not self.creds.refresh_needed())
+        credential_set = self.creds.get_credential_set()
+        self.assertEqual(credential_set.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(credential_set.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(credential_set.token, 'ORIGINAL-TOKEN')
+
 
 class TestEnvVar(BaseEnvVar):
 

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -19,7 +19,7 @@ import botocore
 import botocore.auth
 from botocore.compat import six, urlparse, parse_qs
 
-from botocore.credentials import Credentials
+from botocore.credentials import Credentials, RefreshableCredentials
 from botocore.exceptions import NoRegionError, UnknownSignatureVersionError
 from botocore.exceptions import UnknownClientMethodError, ParamValidationError
 from botocore.exceptions import UnsupportedSignatureVersionError
@@ -251,6 +251,44 @@ class TestSigner(BaseSignerTest):
         with self.assertRaises(UnsupportedSignatureVersionError):
             self.signer.generate_presigned_url({})
 
+    def test_signer_with_refreshable_credentials_gets_credential_set(self):
+        self.credentials = mock.Mock()
+        credential_set = Credentials('r_access', 'r_secret', 'r_token')
+        self.credentials.get_credential_set.return_value = credential_set
+
+        self.signer = RequestSigner(
+            'service_name', 'region_name', 'signing_name',
+            'v4', self.credentials, self.emitter)
+
+        auth_cls = mock.Mock()
+        with mock.patch.dict(botocore.auth.AUTH_TYPE_MAPS,
+                             {'v4': auth_cls}):
+            auth = self.signer.get_auth('service_name', 'region_name')
+
+            self.assertEqual(auth, auth_cls.return_value)
+            auth_cls.assert_called_with(
+                credentials=credential_set, service_name='service_name',
+                region_name='region_name')
+
+    def test_signer_with_refreshable_credentials_is_not_cached(self):
+
+        self.credentials = mock.Mock()
+        credential_set = Credentials('r_access', 'r_secret', 'r_token')
+        self.credentials.get_credential_set.return_value = credential_set
+
+        self.signer = RequestSigner(
+            'service_name', 'region_name', 'signing_name',
+            'v4', self.credentials, self.emitter)
+
+        def side_effect(*args, **kwargs):
+            return mock.Mock()
+        auth_cls = mock.Mock(side_effect=side_effect)
+        with mock.patch.dict(botocore.auth.AUTH_TYPE_MAPS,
+                             {'v4': auth_cls}):
+            auth1 = self.signer.get_auth('service_name', 'region_name')
+            auth2 = self.signer.get_auth('service_name', 'region_name')
+
+            self.assertNotEqual(auth1, auth2)
 
 class TestCloudfrontSigner(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
There is currently a problem that can be triggered during refresh time using refreshable credentials. 

Because multiple properties (access key/secret key/token) of the credentials are accessed independently for the signing process and each access can trigger a refresh for that property we can end up signing our request with inconsistent values. IE an access key from the previous set and a secret and/or token from the refreshed set. 

This addresses that issue by retrieving the credentials as a set (and triggering a refresh if necessary) and using that consistent set during the signing process.