### PR TITLE
Add paginators for ssm

### DIFF
--- a/botocore/data/ssm/2014-11-06/paginators-1.json
+++ b/botocore/data/ssm/2014-11-06/paginators-1.json
@@ -1,0 +1,28 @@
+{
+  "pagination": {
+    "ListAssociations": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Associations"
+    },
+    "ListCommandInvocations": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "CommandInvocations"
+    },
+    "ListCommands": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Commands"
+    },
+    "ListDocuments": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "DocumentIdentifiers"
+    }
+  }
+}


### PR DESCRIPTION
We were missing paginators for ssm. Here are the API docs to double check: http://docs.aws.amazon.com/ssm/latest/APIReference/API_ListDocuments.html

cc @jamesls @mtdowling @rayluo @JordonPhillips 