### PR TITLE
Removing "max" trait validation.

### DIFF
--- a/botocore/validate.py
+++ b/botocore/validate.py
@@ -73,10 +73,6 @@ def range_check(name, value, shape, error_type, errors):
         min_allowed = shape.metadata['min']
         if value < min_allowed:
             failed = True
-    if 'max' in shape.metadata:
-        max_allowed = shape.metadata['max']
-        if value > max_allowed:
-            failed = True
     if failed:
         errors.report(name, error_type, param=value,
                       valid_range=[min_allowed, max_allowed])

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -234,18 +234,16 @@ class TestValidateRanges(BaseTestValidate):
             ]
         )
 
-    def test_greater_than_range(self):
-        self.assert_has_validation_errors(
+    def test_does_not_validate_greater_than_range(self):
+        errors = self.get_validation_error_message(
             given_shapes=self.shapes,
             input_params={
                 'Int': 100000000,
                 'Long': 100000000,
             },
-            errors=[
-                'Invalid range for parameter Int',
-                'Invalid range for parameter Long',
-            ]
         )
+        error_msg = errors.generate_report()
+        self.assertEqual(error_msg, '')
 
     def test_within_range(self):
         errors = self.get_validation_error_message(
@@ -265,16 +263,15 @@ class TestValidateRanges(BaseTestValidate):
             ]
         )
 
-    def test_string_max_length_contraint(self):
-        self.assert_has_validation_errors(
+    def test_does_not_validate_string_max_length_contraint(self):
+        errors = self.get_validation_error_message(
             given_shapes=self.shapes,
             input_params={
                 'String': 'more than ten characters',
             },
-            errors=[
-                'Invalid length for parameter String',
-            ]
         )
+        error_msg = errors.generate_report()
+        self.assertEqual(error_msg, '')
 
     def test_list_min_length_constraint(self):
         self.assert_has_validation_errors(
@@ -287,16 +284,15 @@ class TestValidateRanges(BaseTestValidate):
             ]
         )
 
-    def test_list_max_length_constraint(self):
-        self.assert_has_validation_errors(
+    def test_does_not_validate_list_max_length_constraint(self):
+        errors = self.get_validation_error_message(
             given_shapes=self.shapes,
             input_params={
                 'List': ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
             },
-            errors=[
-                'Invalid length for parameter List',
-            ]
         )
+        error_msg = errors.generate_report()
+        self.assertEqual(error_msg, '')
 
     def test_only_min_value_specified(self):
         # min anx max don't have to both be provided.
@@ -312,16 +308,16 @@ class TestValidateRanges(BaseTestValidate):
             ]
         )
 
-    def test_only_max_value_specified(self):
-        self.assert_has_validation_errors(
+    def test_does_not_validate_max_when_only_max_value_specified(self):
+        errors = self.get_validation_error_message(
             given_shapes=self.shapes,
             input_params={
                 'OnlyMax': 'more than ten characters',
             },
-            errors=[
-                'Invalid length for parameter OnlyMax',
-            ]
         )
+        error_msg = errors.generate_report()
+        self.assertEqual(error_msg, '')
+
 
 class TestValidateMapType(BaseTestValidate):
     def setUp(self):


### PR DESCRIPTION
This commit updates Botocore to no longer validate the "max" constraint.
This allows customers to use older versions of Botocore/CLI even if the
service relaxes the "max" constraint in a subsequent release.

@jamesls @kyleknap @rayluo @JordonPhillips 