### PR TITLE
Wrap string bodies as StringIO

### DIFF
--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -259,7 +259,6 @@ class HierarchicalEmitter(BaseEventHooks):
         self._register_section(event_name, handler, unique_id,
                                unique_id_uses_count, section=_LAST)
 
-
     def _register_section(self, event_name, handler, unique_id,
                           unique_id_uses_count, section):
         if unique_id is not None:

--- a/tests/functional/test_cloudsearchdomain.py
+++ b/tests/functional/test_cloudsearchdomain.py
@@ -32,4 +32,4 @@ class TestCloudsearchdomain(BaseSessionTest):
             self.assertEqual(
                 sent_request.headers.get('Content-Type'),
                 b'application/x-www-form-urlencoded')
-            self.assertIn('q=foo', sent_request.body)
+            self.assertIn('q=foo', sent_request.body.getvalue())

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1016,6 +1016,14 @@ class TestS3VirtualAddressing(TestAutoS3Addressing):
         self.addressing_style = 'virtual'
         self.client = self.create_client()
 
+    def test_can_make_bucket_and_put_large_object(self):
+        bucket_name = self.create_bucket(self.region)
+        body = "*" * (5 * (1024 ** 2))
+        response = self.client.put_object(
+            Bucket=bucket_name, Key='foo', Body=body)
+        self.assertEqual(
+            response['ResponseMetadata']['HTTPStatusCode'], 200)
+
 
 class TestS3PathAddressing(TestAutoS3Addressing):
     def setUp(self):


### PR DESCRIPTION
There was an issue where young buckets would fail to PUT  when virtual host addressing was used and when the body was a string of a few MB. This was because urllib3 will send the body as a separate request on file-like objects, but not on strings. S3 sends back a redirect after the initial request. When we're using two requests, we see the redirect before sending the body. When using small strings, S3 will redirect it for us. But when using long strings, we will continue sending data until S3 closes the connection on us, resulting in an exception.

This commit fixes the issue by wrapping string bodies in a StringIO object, which is a file-like object.