### PR TITLE
SAML forms-based authentication

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -42,6 +42,7 @@ if six.PY3:
     from itertools import zip_longest
     file_type = _IOBase
     zip = zip
+    raw_input = input
 
     # In python3, unquote takes a str() object, url decodes it,
     # then takes the bytestring and decodes it to utf-8.
@@ -90,6 +91,8 @@ else:
     from itertools import izip_longest as zip_longest
     from httplib import HTTPResponse
     from base64 import encodestring as encodebytes
+
+    raw_input = raw_input
 
     class HTTPHeaders(Message):
 

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -35,6 +35,7 @@ if six.PY3:
     from urllib.parse import urljoin
     from urllib.parse import parse_qsl
     from urllib.parse import parse_qs
+    from html import escape
     from http.client import HTTPResponse
     from io import IOBase as _IOBase
     from base64 import encodebytes
@@ -83,6 +84,7 @@ else:
     from urlparse import urljoin
     from urlparse import parse_qsl
     from urlparse import parse_qs
+    from cgi import escape
     from email.message import Message
     from email.Utils import formatdate
     file_type = file

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -42,7 +42,6 @@ if six.PY3:
     from itertools import zip_longest
     file_type = _IOBase
     zip = zip
-    raw_input = input
 
     # In python3, unquote takes a str() object, url decodes it,
     # then takes the bytestring and decodes it to utf-8.
@@ -91,8 +90,6 @@ else:
     from itertools import izip_longest as zip_longest
     from httplib import HTTPResponse
     from base64 import encodestring as encodebytes
-
-    raw_input = raw_input
 
     class HTTPHeaders(Message):
 

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1106,7 +1106,7 @@ class SamlGenericFormsBasedAuthenticator(SamlAuthenticator):
         return config.get('saml_authentication_type') == 'form'
 
     def authenticate(self, config, username_prompter, password_prompter):
-        verify = config.get('saml_verify_ssl') != 'false'
+        verify = True
         if not config.get('saml_username'):
             config['saml_username'] = username_prompter("Username: ")
         endpoint = config['saml_endpoint']

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -35,7 +35,7 @@ from botocore.exceptions import PartialCredentialsError
 from botocore.exceptions import ConfigNotFound
 from botocore.exceptions import InvalidConfigError
 from botocore.exceptions import RefreshWithMFAUnsupportedError
-from botocore.exceptions import RefreshUnsupportedError, SamlError
+from botocore.exceptions import RefreshUnsupportedError, SAMLError
 from botocore.utils import InstanceMetadataFetcher, parse_key_val_file
 import botocore.vendored.requests as requests
 from botocore.client import Config
@@ -1052,12 +1052,12 @@ class AssumeRoleWithSAMLProvider(AssumeRoleProvider):
             raise ValueError("Unsupported saml_authentication_type: %s"
                              % config.get('saml_authentication_type'))
         if not assertion:
-            raise SamlError(
+            raise SAMLError(
                 detail='Failed to login at %s' % config['saml_endpoint'])
         idp_roles = self._parse_roles(assertion)
         role = self.role_selector(config.get('role_arn'), idp_roles)
         if not role:
-            raise SamlError(detail='Unable to choose role "%s" from %s' % (
+            raise SAMLError(detail='Unable to choose role "%s" from %s' % (
                 config.get('role_arn'), [r['RoleArn'] for r in idp_roles]))
         role['SAMLAssertion'] = assertion
         return role
@@ -1108,7 +1108,7 @@ class SAMLGenericFormsBasedAuthenticator(SAMLAuthenticator):
         endpoint = config['saml_endpoint']
         login_form = self._get_form(requests.get(endpoint, verify=verify).text)
         if login_form is None:
-            raise SamlError(detail='Login form is not found in %s' % endpoint)
+            raise SAMLError(detail='Login form is not found in %s' % endpoint)
         form_action = urljoin(endpoint, login_form.attrib.get('action', ''))
         remind = ''
         if not form_action.lower().startswith('https://'):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -966,7 +966,20 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
                  password_prompter=getpass.getpass,
                  username_prompter=raw_input,
                  authenticators=None):
-        """
+        """To initiate an AssumeRoleWithSamlProvider.
+
+        :type role_selector: callable
+        :param role_selector: A function to choose a role based on both
+            user configuration and the roles allowed by IdP.
+
+        :type password_prompter: callable
+        :param password_prompter: A callable that receives a prompt for user,
+            and then returns a password provided by the user, such as getpass()
+
+        :type username_prompter: callable
+        :param username_prompter: A callable that receives a prompt for user,
+            and then returns the username provided by the user, such as input()
+
         :type authenticators: list
         :param authenticators: A list of authenticators, which are instances
             with an is_suitable() method and an authenticate() method.

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -38,6 +38,7 @@ from botocore.exceptions import RefreshWithMFAUnsupportedError
 from botocore.exceptions import RefreshUnsupportedError, SamlError
 from botocore.utils import InstanceMetadataFetcher, parse_key_val_file
 import botocore.vendored.requests as requests
+from botocore.client import Config
 
 
 logger = logging.getLogger(__name__)
@@ -1029,10 +1030,8 @@ class AssumeRoleWithSAMLProvider(AssumeRoleProvider):
             refresh_using=refresh_func)
 
     def _create_client(self):
-        # sts.assume_role_with_saml() requires no access keys,
-        # but we still need a pair of dummy values here to break recursion.
         return self._client_creator(
-            'sts', aws_access_key_id='dummy', aws_secret_access_key='dummy')
+            'sts', config=Config(signature_version='unsigned'))
 
     def _retrieve_temp_credentials(self):
         logger.debug("Retrieving credentials via AssumeRoleWithSaml.")

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -972,7 +972,9 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
         self.role_selector = role_selector
 
     def _create_cache_key(self):
-        return self._profile_name.replace(':', '_')
+        role_arn = self._get_role_config_values().get('role_arn')
+        cache_key = "%s--%s" % (self._profile_name, role_arn)
+        return cache_key.replace(':', '_').replace('/', '-')
 
     def _get_role_config_values(self):
         return self._loaded_config.get('profiles', {}).get(
@@ -1013,7 +1015,7 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
         return creds, response
 
     def _assume_role_base_kwargs(self, config):
-        if config.get('saml_authentication_type')=='form':
+        if config.get('saml_authentication_type') == 'form':
             if not config.get('saml_username'):
                 config['saml_username'] = self.username_prompter("Username: ")
             mapping = {

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1111,20 +1111,16 @@ class SAMLGenericFormsBasedAuthenticator(SAMLAuthenticator):
         if login_form is None:
             raise SAMLError(detail='Login form is not found in %s' % endpoint)
         form_action = urljoin(endpoint, login_form.attrib.get('action', ''))
-        remind = ''
         if not form_action.lower().startswith('https://'):
-            remind = ("Your IdP is not using secure HTTPS connection. "
-                      "Abort if you don't want to proceed.\n")
-            logger.warn(remind)
+            raise SAMLError(detail='Your SAML IdP must use HTTPS connection')
         if not config.get('saml_username'):
-            config['saml_username'] = username_prompter(remind + "Username: ")
+            config['saml_username'] = username_prompter("Username: ")
         payload = dict((tag.attrib['name'], tag.attrib.get('value', ''))
                        for tag in login_form.findall(".//input"))
         if self.username_field in payload:
             payload[self.username_field] = config['saml_username']
         if self.password_field in payload:
-            payload[self.password_field] = password_prompter(
-                remind + "Password: ")
+            payload[self.password_field] = password_prompter("Password: ")
         response_form = self._get_form(requests.post(
             form_action, data=payload, verify=verify).text)
         if response_form is not None:

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1113,12 +1113,13 @@ class SAMLGenericFormsBasedAuthenticator(SAMLAuthenticator):
         form_action = urljoin(endpoint, login_form.attrib.get('action', ''))
         if not form_action.lower().startswith('https://'):
             raise SAMLError(detail='Your SAML IdP must use HTTPS connection')
-        if not config.get('saml_username'):
-            config['saml_username'] = username_prompter("Username: ")
+        username = config.get('saml_username')
+        if username is None:
+            username = username_prompter("Username: ")
         payload = dict((tag.attrib['name'], tag.attrib.get('value', ''))
                        for tag in login_form.findall(".//input"))
         if self.username_field in payload:
-            payload[self.username_field] = config['saml_username']
+            payload[self.username_field] = username
         if self.password_field in payload:
             payload[self.password_field] = password_prompter("Password: ")
         response_form = self._get_form(requests.post(

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -26,6 +26,7 @@ from dateutil.parser import parse
 from dateutil.tz import tzlocal
 from six.moves import input as raw_input
 
+import botocore
 import botocore.config
 import botocore.compat
 from botocore.compat import total_seconds
@@ -1031,7 +1032,7 @@ class AssumeRoleWithSAMLProvider(AssumeRoleProvider):
 
     def _create_client(self):
         return self._client_creator(
-            'sts', config=Config(signature_version='unsigned'))
+            'sts', config=Config(signature_version=botocore.UNSIGNED))
 
     def _retrieve_temp_credentials(self):
         logger.debug("Retrieving credentials via AssumeRoleWithSaml.")

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1053,10 +1053,9 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
             raise ValueError("Unsupported saml_authentication_type: %s"
                              % config.get('saml_authentication_type'))
         if not assertion:
-            raise SamlError(detail='Login failed: SAML assertion not found')
+            raise SamlError(
+                detail='Failed to login at %s' % config['saml_endpoint'])
         idp_roles = self._parse_roles(assertion)
-        if not idp_roles:
-            raise SamlError(detail='Identity provider provides no role.')
         role = self.role_selector(config.get('role_arn'), idp_roles)
         if not role:
             raise SamlError(detail='Unable to choose role "%s" from %s' % (
@@ -1125,7 +1124,8 @@ class SamlGenericFormsBasedAuthenticator(SamlAuthenticator):
         if response_form is not None:
             return self._get_value_of_first_tag(
                 response_form, 'input', 'name', 'SAMLResponse')
-        # Login failed, typically caused by incorrect username and/or password
+        # Login failed, typically caused by incorrect username and/or password.
+        # The error page format is not defined in SAML.
         return None
 
     def _get_value_of_first_tag(self, root, tag, attr, trait):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1064,6 +1064,15 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
 
 class SamlFormsBasedAuthenticator(object):
     def authenticate(self, endpoint, params, verify=True):
+        """Handle the forms-based authentication.
+
+        :param endpoint: The url of the web page containing the login form
+        :param params: A dictionary containing user input to be filled in form.
+                       Such as {"username": "joe", "password": "secret"}
+                       Its key names would need to match those fields in form,
+                       and the values are from user input.
+        :param verify: Turn on/off SSL verification. Keep it True when on prod.
+        """
         login_form = self._get_form(requests.get(endpoint, verify=verify).text)
         if login_form is None:
             raise ValueError('Login form is not found in %s' % endpoint)
@@ -1086,7 +1095,7 @@ class SamlFormsBasedAuthenticator(object):
         # found = root.findall(".//tag[@attr='trait']")
         # return found[0].attrib.get('value') if found else None
         for element in root.findall(tag):
-            if element.attrib.get(attr)==trait:
+            if element.attrib.get(attr) == trait:
                 return element.attrib.get('value')
 
     def _get_form(self, html):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -62,7 +62,7 @@ def create_credential_resolver(session):
     env_provider = EnvProvider()
     providers = [
         env_provider,
-        AssumeRoleWithSamlProvider(
+        AssumeRoleWithSAMLProvider(
             load_config=lambda: session.full_config,
             client_creator=session.create_client,
             cache={},
@@ -958,7 +958,7 @@ class AssumeRoleProvider(CredentialProvider):
         return assume_role_kwargs
 
 
-class AssumeRoleWithSamlProvider(AssumeRoleProvider):
+class AssumeRoleWithSAMLProvider(AssumeRoleProvider):
     METHOD = 'assume-role-with-saml'
     DISTINCTION_VAR = 'saml_endpoint'
 
@@ -967,7 +967,7 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
                  password_prompter=getpass.getpass,
                  username_prompter=raw_input,
                  authenticators=None):
-        """To initiate an AssumeRoleWithSamlProvider.
+        """To initiate an AssumeRoleWithSAMLProvider.
 
         :type role_selector: callable
         :param role_selector: A function to choose a role based on both
@@ -986,7 +986,7 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
             with an is_suitable() method and an authenticate() method.
             You can use it to add your own implementation for 3rd party IdP.
         """
-        super(AssumeRoleWithSamlProvider, self).__init__(
+        super(AssumeRoleWithSAMLProvider, self).__init__(
             load_config, client_creator, cache, profile_name)
         self.username_prompter = username_prompter
         self.password_prompter = password_prompter
@@ -995,8 +995,8 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
             self.authenticators = authenticators
         else:
             self.authenticators = [
-                SamlAdfsFormsBasedAuthenticator(),
-                SamlGenericFormsBasedAuthenticator()]
+                SAMLAdfsFormsBasedAuthenticator(),
+                SAMLGenericFormsBasedAuthenticator()]
 
     def _create_cache_key(self):
         role_arn = self._get_role_config_values().get('role_arn')
@@ -1082,7 +1082,7 @@ class AssumeRoleWithSamlProvider(AssumeRoleProvider):
         return awsroles
 
 
-class SamlAuthenticator(object):
+class SAMLAuthenticator(object):
     def is_suitable(self, config):
         """Return True if this instance intends to perform authentication.
 
@@ -1097,7 +1097,7 @@ class SamlAuthenticator(object):
         raise NotImplemented()
 
 
-class SamlGenericFormsBasedAuthenticator(SamlAuthenticator):
+class SAMLGenericFormsBasedAuthenticator(SAMLAuthenticator):
     username_field = 'username'
     password_field = 'password'
 
@@ -1151,7 +1151,7 @@ class SamlGenericFormsBasedAuthenticator(SamlAuthenticator):
                 ]>''' + form_snippet.group(0))
 
 
-class SamlAdfsFormsBasedAuthenticator(SamlGenericFormsBasedAuthenticator):
+class SAMLAdfsFormsBasedAuthenticator(SAMLGenericFormsBasedAuthenticator):
     username_field = 'ctl00$ContentPlaceHolder1$UsernameTextBox'
     password_field = 'ctl00$ContentPlaceHolder1$PasswordTextBox'
 

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -371,3 +371,7 @@ class RefreshUnsupportedError(BotoCoreError):
 
 class RefreshWithMFAUnsupportedError(BotoCoreError):
     fmt = 'Cannot refresh credentials: MFA token required.'
+
+
+class SamlError(BotoCoreError):
+    fmt = 'A SAML error occurred: {detail}'

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -365,5 +365,9 @@ class InvalidConfigError(BotoCoreError):
     fmt = '{error_msg}'
 
 
+class RefreshUnsupportedError(BotoCoreError):
+    fmt = 'Cannot refresh credentials: human interaction required.'
+
+
 class RefreshWithMFAUnsupportedError(BotoCoreError):
     fmt = 'Cannot refresh credentials: MFA token required.'

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -373,5 +373,5 @@ class RefreshWithMFAUnsupportedError(BotoCoreError):
     fmt = 'Cannot refresh credentials: MFA token required.'
 
 
-class SamlError(BotoCoreError):
+class SAMLError(BotoCoreError):
     fmt = 'A SAML error occurred: {detail}'

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -787,7 +787,9 @@ class Session(object):
         event_emitter = self.get_component('event_emitter')
         response_parser_factory = self.get_component(
             'response_parser_factory')
-        if aws_secret_access_key is not None:
+        if config and config.signature_version == 'unsigned':
+            credentials = None
+        elif aws_secret_access_key is not None:
             credentials = botocore.credentials.Credentials(
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -21,7 +21,7 @@ import logging
 import os
 import platform
 
-from botocore import __version__
+from botocore import __version__, UNSIGNED
 import botocore.config
 import botocore.credentials
 import botocore.client
@@ -787,7 +787,7 @@ class Session(object):
         event_emitter = self.get_component('event_emitter')
         response_parser_factory = self.get_component(
             'response_parser_factory')
-        if config and config.signature_version == 'unsigned':
+        if config and config.signature_version == UNSIGNED:
             credentials = None
         elif aws_secret_access_key is not None:
             credentials = botocore.credentials.Credentials(

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -787,7 +787,7 @@ class Session(object):
         event_emitter = self.get_component('event_emitter')
         response_parser_factory = self.get_component(
             'response_parser_factory')
-        if config and config.signature_version == UNSIGNED:
+        if config and config.signature_version is UNSIGNED:
             credentials = None
         elif aws_secret_access_key is not None:
             credentials = botocore.credentials.Credentials(

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1008,10 +1008,10 @@ class TestSamlGenericFormsBasedAuthenticator(unittest.TestCase):
 
     @mock.patch(GET, return_value=mock.Mock(text='<html>wrong way</html>'))
     def test_login_form_not_exist(self, patched_get):
-        with self.assertRaises(botocore.exceptions.SamlError):
-            if self.authenticator.is_suitable(self.profile):
-                self.authenticator.authenticate(
-                    self.profile, lambda prompt: 'foo', lambda prompt: 'bar')
+        self.assertTrue(self.authenticator.is_suitable(self.profile))
+        with self.assertRaisesRegexp(botocore.exceptions.SamlError, 'form'):
+            self.authenticator.authenticate(
+                self.profile, lambda prompt: 'foo', lambda prompt: 'bar')
 
     @mock.patch(POST, return_value=mock.Mock(text='<html>login failed</html>'))
     @mock.patch(GET, return_value=mock.Mock(text=login_form))
@@ -1121,7 +1121,8 @@ class TestAssumeRoleWithSamlProvider(unittest.TestCase):
             'saml_username': 'joe',
             'role_arn': 'arn:aws:iam::123456789012:role/does_not_match',
         }
-        with self.assertRaises(botocore.exceptions.SamlError):
+        with self.assertRaisesRegexp(botocore.exceptions.SamlError,
+                                     'Unable to choose role'):
             self.load_cred(profile)
 
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -14,6 +14,7 @@
 from datetime import datetime, timedelta
 import mock
 import os
+import base64
 
 from dateutil.tz import tzlocal
 
@@ -988,6 +989,131 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         # source_profile is required, we shoudl get an error.
         with self.assertRaises(botocore.exceptions.InvalidConfigError):
             provider.load()
+
+
+class TestSamlFormsBasedAuthenticator(unittest.TestCase):
+    authenticator = credentials.SamlFormsBasedAuthenticator()
+    login_form = '''<html><form action="login">
+        <div>The &nbsp; in the form will not confuse our parser.</div>
+        <input name="foo" value="bar"/><input name="user"/><input name="pass"/>
+        </form></html>'''
+    GET = 'botocore.credentials.requests.get'
+    POST = 'botocore.credentials.requests.post'
+
+    @mock.patch(GET, return_value=mock.Mock(text='<html>wrong way</html>'))
+    def test_login_form_not_exist(self, _get):
+        with self.assertRaises(ValueError):
+            self.authenticator.authenticate('http://notexist.com', {})
+
+    @mock.patch(POST, return_value=mock.Mock(text='<html>login failed</html>'))
+    @mock.patch(GET, return_value=mock.Mock(text=login_form))
+    def test_no_saml_assertion(self, _get, _post):
+        self.assertIsNone(self.authenticator.authenticate(
+            'http://example.com', {"user": "joe", "pass": "secret"}))
+        _post.assert_called_with(
+            "http://example.com/login",
+            data={'foo': 'bar', 'user': 'joe', 'pass': 'secret'}, verify=True)
+
+    @mock.patch(POST, return_value=mock.Mock(
+        text='<form><input name="SAMLResponse" value="assertion"/></form>'))
+    @mock.patch(GET, return_value=mock.Mock(text=login_form))
+    def test_got_saml_assertion(self, _get, _post):
+        self.assertEqual("assertion", self.authenticator.authenticate(
+            'http://example.com', {"user": "joe", "pass": "secret"}))
+
+
+class TestAssumeRoleWithSamlProvider(unittest.TestCase):
+    GET = 'botocore.credentials.requests.get'
+    POST = 'botocore.credentials.requests.post'
+    assertion = base64.b64encode("""<?xml version="1.0" encoding="UTF-8"?>
+        <saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
+        <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+                <saml2:AttributeValue>arn:aws:iam::123456789012:saml-provider/Example,arn:aws:iam::123456789012:role/joe</saml2:AttributeValue>
+                <saml2:AttributeValue>arn:aws:iam::123456789012:saml-provider/Example,arn:aws:iam::123456789012:role/ray</saml2:AttributeValue>
+            </saml2:Attribute>
+        </saml2:Assertion>
+        </saml2p:Response>""")
+    adfs_login_form = '''<form>
+        <input name="ctl00$ContentPlaceHolder1$UsernameTextBox"/>
+        <input name="ctl00$ContentPlaceHolder1$PasswordTextBox"/></form>'''
+
+    def setUp(self):
+        patcher = mock.patch(
+            'botocore.credentials.requests.post',
+            return_value=mock.Mock(
+                text='<form><input name="SAMLResponse" value="%s"/></form>'
+                    % self.assertion))
+        self._post = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def create_client_creator(self, with_response=None):
+        # Create a mock sts client that returns a specific response
+        # for assume_role_with_saml.
+        client = mock.Mock()
+        client.assume_role_with_saml.return_value = with_response or {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': datetime.now(tzlocal()).isoformat(),
+            },
+        }
+        return mock.Mock(return_value=client)
+
+    def load_cred(self, profile):
+        provider = credentials.AssumeRoleWithSamlProvider(
+            lambda: {'profiles': {'saml': profile}},
+            self.create_client_creator(), cache={}, profile_name='saml',
+            username_prompter=lambda prompt: 'joe',
+            password_prompter=lambda prompt: 'secret')
+        creds = provider.load()
+        with self.assertRaises(credentials.RefreshUnsupportedError):
+            # access_key is a property that will refresh credentials.
+            # Forms-based SAML authentication will currently raise an exception
+            creds.access_key
+
+    @mock.patch(GET, return_value=mock.Mock(
+        text='<form><input name="username"/><input name="password"/></form>'))
+    def test_assume_role_with_okta(self, _get):
+        profile = {
+            'saml_endpoint': 'http://example.com/login.asp',
+            'saml_authentication_type': 'form',
+            'saml_provider': 'okta',
+            'saml_username': 'joe',
+            'role_arn': 'arn:aws:iam::123456789012:role/joe',
+        }
+        self.load_cred(profile)
+        self._post.assert_called_with(
+            'http://example.com/login.asp',
+            data={'username': 'joe', 'password': 'secret'}, verify=True)
+
+    @mock.patch(GET, return_value=mock.Mock(text=adfs_login_form))
+    def test_assume_role_with_adfs(self, _get):
+        profile = {
+            'saml_endpoint': 'http://example.com/login.asp',
+            'saml_authentication_type': 'form',
+            'saml_provider': 'adfs',
+            'saml_username': 'joe',
+            'role_arn': 'arn:aws:iam::123456789012:role/joe',
+        }
+        self.load_cred(profile)
+        self._post.assert_called_with(
+            'http://example.com/login.asp', verify=True,
+            data={'ctl00$ContentPlaceHolder1$UsernameTextBox': 'joe',
+                  'ctl00$ContentPlaceHolder1$PasswordTextBox': 'secret'})
+
+    @mock.patch(GET, return_value=mock.Mock(text=adfs_login_form))
+    def test_unmatch_role(self, _get):
+        profile = {
+            'saml_endpoint': 'http://example.com/login.asp',
+            'saml_authentication_type': 'form',
+            'saml_provider': 'adfs',
+            'saml_username': 'joe',
+            'role_arn': 'arn:aws:iam::123456789012:role/does_not_match',
+        }
+        with self.assertRaises(ValueError):
+            self.load_cred(profile)
 
 
 class TestRefreshLogic(unittest.TestCase):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1000,7 +1000,7 @@ class TestSAMLGenericFormsBasedAuthenticator(unittest.TestCase):
     GET = 'botocore.credentials.requests.get'
     POST = 'botocore.credentials.requests.post'
     profile = {
-        'saml_endpoint': 'http://notexist.com',
+        'saml_endpoint': 'https://notexist.com',
         'saml_authentication_type': 'form',}
 
     def setUp(self):
@@ -1020,7 +1020,7 @@ class TestSAMLGenericFormsBasedAuthenticator(unittest.TestCase):
         self.assertIsNone(self.authenticator.authenticate(
             self.profile, lambda prompt: 'joe', lambda prompt: 'secret'))
         patched_post.assert_called_with(
-            "http://notexist.com/login", verify=True,
+            "https://notexist.com/login", verify=True,
             data={'foo': 'bar', 'username': 'joe', 'password': 'secret'})
 
     @mock.patch(POST, return_value=mock.Mock(
@@ -1086,7 +1086,7 @@ class TestAssumeRoleWithSAMLProvider(unittest.TestCase):
         text='<form><input name="username"/><input name="password"/></form>'))
     def test_assume_role_with_okta(self, patched_get):
         profile = {
-            'saml_endpoint': 'http://example.com/login.asp',
+            'saml_endpoint': 'https://example.com/login.asp',
             'saml_authentication_type': 'form',
             'saml_provider': 'okta',
             'saml_username': 'joe',
@@ -1094,13 +1094,13 @@ class TestAssumeRoleWithSAMLProvider(unittest.TestCase):
         }
         self.load_cred(profile)
         self.patched_post.assert_called_with(
-            'http://example.com/login.asp',
+            'https://example.com/login.asp',
             data={'username': 'joe', 'password': 'secret'}, verify=True)
 
     @mock.patch(GET, return_value=mock.Mock(text=adfs_login_form))
     def test_assume_role_with_adfs(self, patched_get):
         profile = {
-            'saml_endpoint': 'http://example.com/login.asp',
+            'saml_endpoint': 'https://example.com/login.asp',
             'saml_authentication_type': 'form',
             'saml_provider': 'adfs',
             'saml_username': 'joe',
@@ -1108,14 +1108,14 @@ class TestAssumeRoleWithSAMLProvider(unittest.TestCase):
         }
         self.load_cred(profile)
         self.patched_post.assert_called_with(
-            'http://example.com/login.asp', verify=True,
+            'https://example.com/login.asp', verify=True,
             data={'ctl00$ContentPlaceHolder1$UsernameTextBox': 'joe',
                   'ctl00$ContentPlaceHolder1$PasswordTextBox': 'secret'})
 
     @mock.patch(GET, return_value=mock.Mock(text=adfs_login_form))
     def test_unmatch_role(self, patched_get):
         profile = {
-            'saml_endpoint': 'http://example.com/login.asp',
+            'saml_endpoint': 'https://example.com/login.asp',
             'saml_authentication_type': 'form',
             'saml_provider': 'adfs',
             'saml_username': 'joe',

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1006,7 +1006,7 @@ class TestSamlGenericFormsBasedAuthenticator(unittest.TestCase):
 
     @mock.patch(GET, return_value=mock.Mock(text='<html>wrong way</html>'))
     def test_login_form_not_exist(self, _get):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(botocore.exceptions.SamlError):
             if self.authenticator.is_suitable(self.profile):
                 self.authenticator.authenticate(
                     self.profile, lambda prompt: 'foo', lambda prompt: 'bar')
@@ -1075,7 +1075,7 @@ class TestAssumeRoleWithSamlProvider(unittest.TestCase):
             username_prompter=lambda prompt: 'joe',
             password_prompter=lambda prompt: 'secret')
         creds = provider.load()
-        with self.assertRaises(credentials.RefreshUnsupportedError):
+        with self.assertRaises(botocore.exceptions.RefreshUnsupportedError):
             # access_key is a property that will refresh credentials.
             # Forms-based SAML authentication will currently raise an exception
             creds.access_key
@@ -1119,7 +1119,7 @@ class TestAssumeRoleWithSamlProvider(unittest.TestCase):
             'saml_username': 'joe',
             'role_arn': 'arn:aws:iam::123456789012:role/does_not_match',
         }
-        with self.assertRaises(ValueError):
+        with self.assertRaises(botocore.exceptions.SamlError):
             self.load_cred(profile)
 
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1025,7 +1025,7 @@ class TestSamlFormsBasedAuthenticator(unittest.TestCase):
 class TestAssumeRoleWithSamlProvider(unittest.TestCase):
     GET = 'botocore.credentials.requests.get'
     POST = 'botocore.credentials.requests.post'
-    assertion = base64.b64encode("""<?xml version="1.0" encoding="UTF-8"?>
+    assertion = base64.b64encode(b"""<?xml version="1.0" encoding="UTF-8"?>
         <saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
         <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
             <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
@@ -1043,7 +1043,7 @@ class TestAssumeRoleWithSamlProvider(unittest.TestCase):
             'botocore.credentials.requests.post',
             return_value=mock.Mock(
                 text='<form><input name="SAMLResponse" value="%s"/></form>'
-                    % self.assertion))
+                    % self.assertion.decode('utf-8')))
         self._post = patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -991,7 +991,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
             provider.load()
 
 
-class TestSamlGenericFormsBasedAuthenticator(unittest.TestCase):
+class TestSAMLGenericFormsBasedAuthenticator(unittest.TestCase):
     login_form = '''<html><form action="login">
         <div>The &nbsp; in the form will not confuse our parser.</div>
         <input name="foo" value="bar"/>
@@ -1004,7 +1004,7 @@ class TestSamlGenericFormsBasedAuthenticator(unittest.TestCase):
         'saml_authentication_type': 'form',}
 
     def setUp(self):
-        self.authenticator = credentials.SamlGenericFormsBasedAuthenticator()
+        self.authenticator = credentials.SAMLGenericFormsBasedAuthenticator()
 
     @mock.patch(GET, return_value=mock.Mock(text='<html>wrong way</html>'))
     def test_login_form_not_exist(self, patched_get):
@@ -1031,7 +1031,7 @@ class TestSamlGenericFormsBasedAuthenticator(unittest.TestCase):
             self.profile, lambda prompt: 'joe', lambda prompt: 'secret'))
 
 
-class TestAssumeRoleWithSamlProvider(unittest.TestCase):
+class TestAssumeRoleWithSAMLProvider(unittest.TestCase):
     GET = 'botocore.credentials.requests.get'
     POST = 'botocore.credentials.requests.post'
     assertion = base64.b64encode(b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -1071,7 +1071,7 @@ class TestAssumeRoleWithSamlProvider(unittest.TestCase):
         return mock.Mock(return_value=client)
 
     def load_cred(self, profile):
-        provider = credentials.AssumeRoleWithSamlProvider(
+        provider = credentials.AssumeRoleWithSAMLProvider(
             lambda: {'profiles': {'saml': profile}},
             self.create_client_creator(), cache={}, profile_name='saml',
             username_prompter=lambda prompt: 'joe',

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -991,6 +991,28 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
             provider.load()
 
 
+class TestFormParser(unittest.TestCase):
+    def test_form2str(self):
+        html_input = '''
+            <input type="button" value="nameless button at outside of form"/>
+            <form action="/path/login/?foo=foo&amp;bar=bar">
+            <div>The &nbsp; in the form will not confuse our parser.</div>
+            <input name="foo" value="bar&amp;baz"/>
+            <input name="username"/><input name="password"/>
+            </form>
+            <input type="button" value="nameless button at outside of form"/>
+            </html>
+            '''
+        html_output = (
+            '<form action="/path/login/?foo=foo&amp;bar=bar">'
+            '<input name="foo" value="bar&amp;baz"/>'
+            '<input name="username"/><input name="password"/>'
+            '</form>')
+        p = credentials.FormParser()
+        p.feed(html_input)
+        self.assertEqual(p.form2str(), html_output)
+
+
 class TestSAMLGenericFormsBasedAuthenticator(unittest.TestCase):
     login_form = '''<html><form action="login">
         <div>The &nbsp; in the form will not confuse our parser.</div>

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -992,7 +992,6 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
 
 
 class TestSamlGenericFormsBasedAuthenticator(unittest.TestCase):
-    authenticator = credentials.SamlGenericFormsBasedAuthenticator()
     login_form = '''<html><form action="login">
         <div>The &nbsp; in the form will not confuse our parser.</div>
         <input name="foo" value="bar"/>
@@ -1003,6 +1002,9 @@ class TestSamlGenericFormsBasedAuthenticator(unittest.TestCase):
     profile = {
         'saml_endpoint': 'http://notexist.com',
         'saml_authentication_type': 'form',}
+
+    def setUp(self):
+        self.authenticator = credentials.SamlGenericFormsBasedAuthenticator()
 
     @mock.patch(GET, return_value=mock.Mock(text='<html>wrong way</html>'))
     def test_login_form_not_exist(self, _get):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1009,7 +1009,7 @@ class TestSAMLGenericFormsBasedAuthenticator(unittest.TestCase):
     @mock.patch(GET, return_value=mock.Mock(text='<html>wrong way</html>'))
     def test_login_form_not_exist(self, patched_get):
         self.assertTrue(self.authenticator.is_suitable(self.profile))
-        with self.assertRaisesRegexp(botocore.exceptions.SamlError, 'form'):
+        with self.assertRaisesRegexp(botocore.exceptions.SAMLError, 'form'):
             self.authenticator.authenticate(
                 self.profile, lambda prompt: 'foo', lambda prompt: 'bar')
 
@@ -1121,7 +1121,7 @@ class TestAssumeRoleWithSAMLProvider(unittest.TestCase):
             'saml_username': 'joe',
             'role_arn': 'arn:aws:iam::123456789012:role/does_not_match',
         }
-        with self.assertRaisesRegexp(botocore.exceptions.SamlError,
+        with self.assertRaisesRegexp(botocore.exceptions.SAMLError,
                                      'Unable to choose role'):
             self.load_cred(profile)
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -24,7 +24,7 @@ import mock
 import botocore.session
 import botocore.exceptions
 from botocore.model import ServiceModel
-from botocore import client
+from botocore import client, UNSIGNED
 from botocore.hooks import HierarchicalEmitter
 from botocore.waiter import WaiterModel
 from botocore.paginate import PaginatorModel
@@ -412,6 +412,16 @@ class TestCreateClient(BaseSessionTest):
                          "Credential provider was called even though "
                          "explicit credentials were provided to the "
                          "create_client call.")
+
+    def test_credential_provider_not_called_when_signature_unsigned(self):
+        cred_provider = mock.Mock()
+        self.session.register_component('credential_provider', cred_provider)
+        self.session.create_client(
+            'sts', config=client.Config(signature_version=UNSIGNED))
+        self.assertFalse(cred_provider.load_credentials.called,
+                         "Credential provider was called even though "
+                         "explicit UNSIGNED signature_version were provided "
+                         "to the create_client call.")
 
     @mock.patch('botocore.client.ClientCreator')
     def test_config_passed_to_client_creator(self, client_creator):


### PR DESCRIPTION
Now customers can configure a profile to authenticate against a SAML Identity Provider (IdP). Only forms-based authentication is supported so far. The profile will look like this.

Tested with Okta.

```
[default]
saml_endpoint = https://dev-123456.oktapreview.com/home/amazon_aws/hash/123
saml_authentication_type = form
saml_username = your_username@your_idp.com
role_arn = arn:aws:iam::123456789012:role/okta_websso
```

Tested with ADFS.

```
[profile jamesls]
saml_endpoint = https://your.adfs.example.com/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices
saml_authentication_type = form
saml_provider = adfs
role_arn = arn:aws:iam::123456789012:role/okta_websso
```

In both cases,
- `saml_username` can be provided by callback function, so it is optional in the configuration.
- ~~you don't have to specify the `role_arn`, CLI will prompt and ask for your input~~ You STILL NEED to specify the `role_arn` in config.
