### PR TITLE
Assert ``expected_params`` stubber

### DIFF
--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -223,6 +223,11 @@ class Stubber(object):
         expected_params = self._pop_and_assert_expected_call_order(
             model, params, self._expected_params_queue)
         if expected_params is not None and params != expected_params:
+            # We are in failure mode at this point. Since this call is
+            # invoked first, we want to pop off the response queue as well
+            # so the two queues stay in sync since the result queue will
+            # never get its result popped off for this client call.
+            self._queue.popleft()
             raise StubResponseError(
                 operation_name=model.name,
                 reason='Expected parameters: %s, but received: %s' % (

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -176,7 +176,7 @@ class Stubber(object):
         }
 
         operation_name = self.client.meta.method_to_api_mapping.get(method)
-        # Note that we do not allow for expected_params in the
+        # Note that we do not allow for expected_params while
         # adding errors into the queue yet.
         response = {
             'operation_name': operation_name,

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -103,3 +103,18 @@ class TestStubber(unittest.TestCase):
         # The second call should throw an error for unexpected parameters
         with self.assertRaisesRegexp(StubResponseError, 'Expected parameters'):
             self.client.list_objects(Bucket='foo')
+
+    def test_can_assert_no_pending_responses_when_expect_params_fail(self):
+        service_response = {}
+        expected_params = {'Bucket': 'bar'}
+
+        self.stubber.add_response(
+            'list_objects', service_response, expected_params)
+
+        # Throw an error for unexpected parameters
+        with self.assertRaises(StubResponseError):
+            self.client.list_objects(Bucket='foo')
+
+        # The stubber should not have any responses queued up because the
+        # queue up response failed on parameter validation.
+        self.stubber.assert_no_pending_responses()


### PR DESCRIPTION
Allows you to specify what parameters that you are to expect for a response and if they do not match, throw an error.

I have been writing a fair amount of tests using this stubber. I have found this sort of response/expected_params matching as being pretty useful and was using it an awful lot.

The only behavior I am not sure about and would be up for opinions is what happens to the stubber's corresponding response when an ``expected_params`` does not match. Should it use up the response in the queue? Or should it keep the original response in the queue so that it can be called later? I decided to go with the later because in the current stubber logic if there is a parameter validation error with the client, we will not pop the response off of the queue. So I thought ``expected_params`` would have a similar expectation. 

cc @jamesls @mtdowling @rayluo @JordonPhillips 