### PR TITLE
Improve thread safety of temp cred refresh

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -16,6 +16,8 @@ import datetime
 import logging
 import os
 import getpass
+import threading
+from collections import namedtuple
 
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
@@ -32,6 +34,8 @@ from botocore.utils import InstanceMetadataFetcher, parse_key_val_file
 
 
 logger = logging.getLogger(__name__)
+ReadOnlyCredentials = namedtuple('ReadOnlyCredentials',
+                                 ['access_key', 'secret_key', 'token'])
 
 
 def create_credential_resolver(session):
@@ -178,6 +182,11 @@ class Credentials(object):
         self.access_key = botocore.compat.ensure_unicode(self.access_key)
         self.secret_key = botocore.compat.ensure_unicode(self.secret_key)
 
+    def get_frozen_credentials(self):
+        return ReadOnlyCredentials(self.access_key,
+                                   self.secret_key,
+                                   self.token)
+
 
 class RefreshableCredentials(Credentials):
     """
@@ -205,6 +214,7 @@ class RefreshableCredentials(Credentials):
         self._token = token
         self._expiry_time = expiry_time
         self._time_fetcher = time_fetcher
+        self._refresh_lock = threading.RLock()
         self.method = method
         self._normalize()
 
@@ -271,11 +281,12 @@ class RefreshableCredentials(Credentials):
         return True
 
     def _refresh(self):
-        if not self.refresh_needed():
-            return
+        with self._refresh_lock:
+            if not self.refresh_needed():
+                return
 
-        metadata = self._refresh_using()
-        self._set_from_data(metadata)
+            metadata = self._refresh_using()
+            self._set_from_data(metadata)
 
     @staticmethod
     def _expiry_datetime(time_str):
@@ -289,9 +300,45 @@ class RefreshableCredentials(Credentials):
         logger.debug("Retrieved credentials will expire at: %s", self._expiry_time)
         self._normalize()
 
-    def get_credential_set(self):
-        self._refresh()
-        return Credentials(self._access_key, self._secret_key, token=self._token)
+    def get_frozen_credentials(self):
+        """Return immutable credentials.
+
+        The ``access_key``, ``secret_key``, and ``token`` properties
+        on this class will always check and refresh credentials if
+        needed before returning the particular credentials.
+
+        This has an edge case where you can get inconsistent
+        credentials.  Image this:
+
+            # Current creds are "t1"
+            tmp.access_key  ---> expired? no, so return t1.access_key
+            # ---- time is now expired, creds need refreshing to "t2" ----
+            tmp.secret_key  ---> expired? yes, refresh and return t2.secret_key
+
+        This means we're using the access key from t1 with the secret key
+        from t2.  To fix this issue, you can request a frozen credential object
+        which is guaranteed not to change.
+
+        The frozen credentials returned from this method should be used
+        immediately and then discarded.  The typical usage pattern would
+        be::
+
+            creds = RefreshableCredentials(...)
+            some_code = SomeSignerObject()
+            # I'm about to sign the request.
+            # The frozen credentials are only used for the
+            # duration of generate_presigned_url and will be
+            # immediately thrown away.
+            request = some_code.sign_some_request(
+                with_credentials=creds.get_frozen_credentials())
+            print("Signed request:", request)
+
+        """
+        with self._refresh_lock:
+            self._refresh()
+            return ReadOnlyCredentials(self._access_key,
+                                    self._secret_key,
+                                    self._token)
 
 
 class CredentialProvider(object):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -289,6 +289,10 @@ class RefreshableCredentials(Credentials):
         logger.debug("Retrieved credentials will expire at: %s", self._expiry_time)
         self._normalize()
 
+    def get_credential_set(self):
+        self._refresh()
+        return Credentials(self._access_key, self._secret_key, token=self._token)
+
 
 class CredentialProvider(object):
 

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -150,12 +150,7 @@ class RequestSigner(object):
         if cls is None:
             raise UnknownSignatureVersionError(
                 signature_version=signature_version)
-        # Get consistent set of credentials and don't cache RefreshableCredentials
-        if hasattr(self._credentials, 'get_credential_set'):
-            kwargs['credentials'] = self._credentials.get_credential_set()
-            cache_key = None
-        else:
-            kwargs['credentials'] = self._credentials
+        kwargs['credentials'] = self._credentials.get_frozen_credentials()
         if cls.REQUIRES_REGION:
             if self._region_name is None:
                 raise botocore.exceptions.NoRegionError()

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -150,7 +150,12 @@ class RequestSigner(object):
         if cls is None:
             raise UnknownSignatureVersionError(
                 signature_version=signature_version)
-        kwargs['credentials'] = self._credentials
+        # Get consistent set of credentials and don't cache RefreshableCredentials
+        if hasattr(self._credentials, 'get_credential_set'):
+            kwargs['credentials'] = self._credentials.get_credential_set()
+            cache_key = None
+        else:
+            kwargs['credentials'] = self._credentials
         if cls.REQUIRES_REGION:
             if self._region_name is None:
                 raise botocore.exceptions.NoRegionError()

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -118,12 +118,13 @@ class RequestSigner(object):
             signature_version=signature_version, request_signer=self)
 
         if signature_version != botocore.UNSIGNED:
-            signer = self.get_auth_instance(self._signing_name, self._region_name,
-                                    signature_version)
+            signer = self.get_auth_instance(self._signing_name,
+                                            self._region_name,
+                                            signature_version)
             signer.add_auth(request=request)
 
-    def get_auth_instance(self, signing_name, region_name, signature_version=None,
-                          **kwargs):
+    def get_auth_instance(self, signing_name, region_name,
+                          signature_version=None, **kwargs):
         """
         Get an auth instance which can be used to sign a request
         using the given signature version.

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -40,18 +40,24 @@ class RequestSigner(object):
 
     :type service_name: string
     :param service_name: Name of the service, e.g. ``S3``
+
     :type region_name: string
     :param region_name: Name of the service region, e.g. ``us-east-1``
+
     :type signing_name: string
     :param signing_name: Service signing name. This is usually the
                          same as the service name, but can differ. E.g.
                          ``emr`` vs. ``elasticmapreduce``.
+
     :type signature_version: string
     :param signature_version: Signature name like ``v4``.
+
     :type credentials: :py:class:`~botocore.credentials.Credentials`
     :param credentials: User credentials with which to sign requests.
+
     :type event_emitter: :py:class:`~botocore.hooks.BaseEventHooks`
     :param event_emitter: Extension mechanism to fire events.
+
     """
     def __init__(self, service_name, region_name, signing_name,
                  signature_version, credentials, event_emitter):
@@ -63,10 +69,6 @@ class RequestSigner(object):
 
         # We need weakref to prevent leaking memory in Python 2.6 on Linux 2.6
         self._event_emitter = weakref.proxy(event_emitter)
-
-        # Used to cache auth instances since one request signer
-        # can be used for many requests in a single client.
-        self._cache = {}
 
     @property
     def region_name(self):
@@ -81,11 +83,14 @@ class RequestSigner(object):
         return self._signing_name
 
     def handler(self, operation_name=None, request=None, **kwargs):
+        # This is typically hooked up to the "request-created" event
+        # from a client's event emitter.  When a new request is created
+        # this method is invoked to sign the request.
+        # Don't call this method directly.
         return self.sign(operation_name, request)
 
     def sign(self, operation_name, request):
-        """
-        Sign a request before it goes out over the wire.
+        """Sign a request before it goes out over the wire.
 
         :type operation_name: string
         :param operation_name: The name of the current operation, e.g.
@@ -112,14 +117,13 @@ class RequestSigner(object):
             region_name=self._region_name,
             signature_version=signature_version, request_signer=self)
 
-        # Sign the request if the signature version isn't None or blank
         if signature_version != botocore.UNSIGNED:
-            signer = self.get_auth(self._signing_name, self._region_name,
+            signer = self.get_auth_instance(self._signing_name, self._region_name,
                                     signature_version)
             signer.add_auth(request=request)
 
-    def get_auth(self, signing_name, region_name, signature_version=None,
-                 **kwargs):
+    def get_auth_instance(self, signing_name, region_name, signature_version=None,
+                          **kwargs):
         """
         Get an auth instance which can be used to sign a request
         using the given signature version.
@@ -128,21 +132,18 @@ class RequestSigner(object):
         :param signing_name: Service signing name. This is usually the
                              same as the service name, but can differ. E.g.
                              ``emr`` vs. ``elasticmapreduce``.
+
         :type region_name: string
         :param region_name: Name of the service region, e.g. ``us-east-1``
+
         :type signature_version: string
         :param signature_version: Signature name like ``v4``.
+
         :rtype: :py:class:`~botocore.auth.BaseSigner`
         :return: Auth instance to sign a request.
         """
         if signature_version is None:
             signature_version = self._signature_version
-
-        expires = kwargs.get('expires')
-        cache_key = self._get_signer_cache_key(signature_version, region_name,
-                                               signing_name, expires)
-        if cache_key and cache_key in self._cache:
-            return self._cache[cache_key]
 
         cls = botocore.auth.AUTH_TYPE_MAPS.get(signature_version)
         if cls is None:
@@ -155,19 +156,10 @@ class RequestSigner(object):
             kwargs['region_name'] = region_name
             kwargs['service_name'] = signing_name
         auth = cls(**kwargs)
-        # Only cache the client if a cache key was created.
-        if cache_key:
-            self._cache[cache_key] = auth
         return auth
 
-    def _get_signer_cache_key(self, signature_version, region_name,
-                              signing_name, expires):
-        # Do not cache signers with an expires value as the cache hit
-        # ratio will be virtually 0.
-        if expires is not None:
-            return None
-        return '{0}.{1}.{2}'.format(signature_version, region_name,
-                                    signing_name)
+    # Alias get_auth for backwards compatibility.
+    get_auth = get_auth_instance
 
     def generate_presigned_url(self, request_dict, expires_in=3600,
                                region_name=None):
@@ -200,7 +192,7 @@ class RequestSigner(object):
 
         signature_type = signature_version.split('-', 1)[0]
         try:
-            auth = self.get_auth(**kwargs)
+            auth = self.get_auth_instance(**kwargs)
         except UnknownSignatureVersionError:
             raise UnsupportedSignatureVersionError(
                 signature_version=signature_type)
@@ -423,7 +415,7 @@ class S3PostPresigner(object):
         signature_type = signature_version.split('-', 1)[0]
 
         try:
-            auth = self._request_signer.get_auth(**kwargs)
+            auth = self._request_signer.get_auth_instance(**kwargs)
         except UnknownSignatureVersionError:
             raise UnsupportedSignatureVersionError(
                 signature_version=signature_type)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -304,6 +304,10 @@ class IntegerRefresher(credentials.RefreshableCredentials):
         }
 
     def _seconds_later(self, num_seconds):
+        # We need to guarantee at *least* num_seconds.
+        # Because this doesn't handle subsecond precision
+        # we'll round up to the next second.
+        num_seconds += 1
         t = self._current_datetime() + datetime.timedelta(seconds=num_seconds)
         return self._to_timestamp(t)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -282,7 +282,7 @@ class IntegerRefresher(credentials.RefreshableCredentials):
         if refresh_function is None:
             refresh_function = self._do_refresh
         super(IntegerRefresher, self).__init__(
-            '1', '1', '1', expires_in,
+            '0', '0', '0', expires_in,
             refresh_function, 'INTREFRESH')
         self.creds_last_for = creds_last_for
         self.refresh_counter = 0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,9 +22,10 @@ import tempfile
 import binascii
 import platform
 import select
+import datetime
 from subprocess import Popen, PIPE
 
-
+from dateutil.tz import tzlocal
 # The unittest module got a significant overhaul
 # in 2.7, so if we're in 2.6 we can use the backported
 # version unittest2.
@@ -36,6 +37,10 @@ else:
 
 import botocore.loaders
 import botocore.session
+from botocore import utils
+from botocore import credentials
+
+
 _LOADER = botocore.loaders.Loader()
 
 
@@ -242,3 +247,72 @@ class ClientDriver(object):
         if result != b'OK':
             raise RuntimeError(
                 "Error from command '%s': %s" % (cmd, result))
+
+
+# This is added to this file because it's used in both
+# the functional and unit tests for cred refresh.
+class IntegerRefresher(credentials.RefreshableCredentials):
+    """Refreshable credentials to help with testing.
+
+    This class makes testing refreshable credentials easier.
+    It has the following functionality:
+
+        * A counter, self.refresh_counter, to indicate how many
+          times refresh was called.
+        * A way to specify how many seconds to make credentials
+          valid.
+        * Configurable advisory/mandatory refresh.
+        * An easy way to check consistency.  Each time creds are
+          refreshed, all the cred values are set to the next
+          incrementing integer.  Frozen credentials should always
+          have this value.
+    """
+
+    _advisory_refresh_timeout = 2
+    _mandatory_refresh_timeout = 1
+    _credentials_expire = 3
+
+    def __init__(self, creds_last_for=_credentials_expire,
+                 advisory_refresh=_advisory_refresh_timeout,
+                 mandatory_refresh=_mandatory_refresh_timeout,
+                 refresh_function=None):
+        expires_in = (
+            self._current_datetime() +
+            datetime.timedelta(seconds=creds_last_for))
+        if refresh_function is None:
+            refresh_function = self._do_refresh
+        super(IntegerRefresher, self).__init__(
+            '1', '1', '1', expires_in,
+            refresh_function, 'INTREFRESH')
+        self.creds_last_for = creds_last_for
+        self.refresh_counter = 0
+        if advisory_refresh is not None:
+            self._advisory_refresh_timeout = advisory_refresh
+        if mandatory_refresh is not None:
+            self._mandatory_refresh_timeout = mandatory_refresh
+
+    def _do_refresh(self):
+        self.refresh_counter += 1
+        current = int(self._access_key)
+        next_id = str(current + 1)
+
+        return {
+            'access_key': next_id,
+            'secret_key': next_id,
+            'token': next_id,
+            'expiry_time': self._seconds_later(self.creds_last_for),
+        }
+
+    def _seconds_later(self, num_seconds):
+        t = self._current_datetime() + datetime.timedelta(seconds=num_seconds)
+        return self._to_timestamp(t)
+
+    def _to_timestamp(self, datetime_obj):
+        obj = utils.parse_to_aware_datetime(datetime_obj)
+        return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    def _current_timestamp(self):
+        return self._to_timestamp(self._current_datetime())
+
+    def _current_datetime(self):
+        return datetime.datetime.now(tzlocal())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -286,10 +286,8 @@ class IntegerRefresher(credentials.RefreshableCredentials):
             refresh_function, 'INTREFRESH')
         self.creds_last_for = creds_last_for
         self.refresh_counter = 0
-        if advisory_refresh is not None:
-            self._advisory_refresh_timeout = advisory_refresh
-        if mandatory_refresh is not None:
-            self._mandatory_refresh_timeout = mandatory_refresh
+        self._advisory_refresh_timeout = advisory_refresh
+        self._mandatory_refresh_timeout = mandatory_refresh
 
     def _do_refresh(self):
         self.refresh_counter += 1

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -1,0 +1,76 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest, mock, IntegerRefresher
+import datetime
+import threading
+import math
+import time
+
+from dateutil.tz import tzlocal
+
+from botocore import credentials
+from botocore import utils
+
+
+class TestCredentialRefreshRaces(unittest.TestCase):
+    def assert_consistent_credentials_seen(self, creds, func):
+        collected = []
+        threads = []
+        for _ in range(20):
+            threads.append(threading.Thread(target=func, args=(collected,)))
+        start = time.time()
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        for triple in collected:
+            self.assertTrue(triple[0] == triple[1] == triple[2], triple)
+
+    def test_has_no_race_conditions(self):
+        creds = IntegerRefresher(
+            creds_last_for=2,
+            advisory_refresh=1,
+            mandatory_refresh=0
+        )
+        def _run_in_thread(collected):
+            for _ in range(4000):
+                frozen = creds.get_frozen_credentials()
+                collected.append((frozen.access_key,
+                                  frozen.secret_key,
+                                  frozen.token))
+        start = time.time()
+        self.assert_consistent_credentials_seen(creds, _run_in_thread)
+        end = time.time()
+        # creds_last_for = 2 seconds (from above)
+        # So, for example, if execution time took 6.1 seconds, then
+        # we should see a maximum number of refreshes being (6 / 2.0) + 1 = 4
+        max_calls_allowed = math.ceil((end - start) / 2.0) + 1
+        self.assertTrue(creds.refresh_counter <= max_calls_allowed,
+                        "Too many cred refreshes, max: %s, actual: %s, "
+                        "time_delta: %.4f" % (max_calls_allowed,
+                                              creds.refresh_counter,
+                                              (end - start)))
+
+    def test_no_race_for_immediate_expiration(self):
+        creds = IntegerRefresher(
+            creds_last_for=1,
+            advisory_refresh=1,
+            mandatory_refresh=0
+        )
+        def _run_in_thread(collected):
+            for _ in range(100):
+                frozen = creds.get_frozen_credentials()
+                collected.append((frozen.access_key,
+                                  frozen.secret_key,
+                                  frozen.token))
+        self.assert_consistent_credentials_seen(creds, _run_in_thread)

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -82,7 +82,7 @@ class TestCredentialRefreshRaces(unittest.TestCase):
                                               creds.refresh_counter,
                                               (end - start)))
 
-    def test_no_race_for_immediate_expiration(self):
+    def test_no_race_for_immediate_advisory_expiration(self):
         creds = IntegerRefresher(
             creds_last_for=1,
             advisory_refresh=1,

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1000,7 +1000,7 @@ class TestRefreshLogic(unittest.TestCase):
             advisory_refresh=3)
         temp = creds.get_frozen_credentials()
         self.assertEqual(
-            temp, credentials.ReadOnlyCredentials('2', '2', '2'))
+            temp, credentials.ReadOnlyCredentials('1', '1', '1'))
 
     def test_advisory_refresh_needed(self):
         creds = IntegerRefresher(
@@ -1011,7 +1011,7 @@ class TestRefreshLogic(unittest.TestCase):
             advisory_refresh=5)
         temp = creds.get_frozen_credentials()
         self.assertEqual(
-            temp, credentials.ReadOnlyCredentials('2', '2', '2'))
+            temp, credentials.ReadOnlyCredentials('1', '1', '1'))
 
     def test_refresh_fails_is_not_an_error_during_advisory_period(self):
         fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
@@ -1029,7 +1029,7 @@ class TestRefreshLogic(unittest.TestCase):
         # the exception and return the current set of credentials
         # (generation '1').
         self.assertEqual(
-            temp, credentials.ReadOnlyCredentials('1', '1', '1'))
+            temp, credentials.ReadOnlyCredentials('0', '0', '0'))
 
     def test_exception_propogated_on_error_during_mandatory_period(self):
         fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -113,11 +113,12 @@ class TestRefreshableCredentials(TestCredentials):
         self.assertEqual(self.creds.token, 'ORIGINAL-TOKEN')
 
     def test_get_credentials_set(self):
-        # We need to return a consistent set of credentials to use during the signing process
+        # We need to return a consistent set of credentials to use during the
+        # signing process.
         self.mock_time.return_value = (
             datetime.now(tzlocal()) - timedelta(minutes=60))
         self.assertTrue(not self.creds.refresh_needed())
-        credential_set = self.creds.get_credential_set()
+        credential_set = self.creds.get_frozen_credentials()
         self.assertEqual(credential_set.access_key, 'ORIGINAL-ACCESS')
         self.assertEqual(credential_set.secret_key, 'ORIGINAL-SECRET')
         self.assertEqual(credential_set.token, 'ORIGINAL-TOKEN')

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -112,6 +112,16 @@ class TestRefreshableCredentials(TestCredentials):
         self.assertEqual(self.creds.secret_key, 'ORIGINAL-SECRET')
         self.assertEqual(self.creds.token, 'ORIGINAL-TOKEN')
 
+    def test_get_credentials_set(self):
+        # We need to return a consistent set of credentials to use during the signing process
+        self.mock_time.return_value = (
+            datetime.now(tzlocal()) - timedelta(minutes=60))
+        self.assertTrue(not self.creds.refresh_needed())
+        credential_set = self.creds.get_credential_set()
+        self.assertEqual(credential_set.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(credential_set.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(credential_set.token, 'ORIGINAL-TOKEN')
+
 
 class TestEnvVar(BaseEnvVar):
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env
 # Copyright (c) 2012-2013 Mitch Garnaat http://garnaat.org/
-# Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -22,7 +21,7 @@ from botocore import credentials
 from botocore.credentials import EnvProvider
 import botocore.exceptions
 import botocore.session
-from tests import unittest, BaseEnvVar
+from tests import unittest, BaseEnvVar, IntegerRefresher
 
 
 # Passed to session to keep it from finding default config file
@@ -72,16 +71,17 @@ class TestRefreshableCredentials(TestCredentials):
     def setUp(self):
         super(TestRefreshableCredentials, self).setUp()
         self.refresher = mock.Mock()
+        self.future_time = datetime.now(tzlocal()) + timedelta(hours=24)
+        self.expiry_time = \
+            datetime.now(tzlocal()) - timedelta(minutes=30)
         self.metadata = {
             'access_key': 'NEW-ACCESS',
             'secret_key': 'NEW-SECRET',
             'token': 'NEW-TOKEN',
-            'expiry_time': '2015-03-07T15:24:46Z',
+            'expiry_time': self.future_time.isoformat(),
             'role_name': 'rolename',
         }
         self.refresher.return_value = self.metadata
-        self.expiry_time = \
-            datetime.now(tzlocal()) - timedelta(minutes=30)
         self.mock_time = mock.Mock()
         self.creds = credentials.RefreshableCredentials(
             'ORIGINAL-ACCESS', 'ORIGINAL-SECRET', 'ORIGINAL-TOKEN',
@@ -471,12 +471,14 @@ class TestOriginalEC2Provider(BaseEnvVar):
 
 class TestInstanceMetadataProvider(BaseEnvVar):
     def test_load_from_instance_metadata(self):
+        timeobj = datetime.now(tzlocal())
+        timestamp = (timeobj + timedelta(hours=24)).isoformat()
         fetcher = mock.Mock()
         fetcher.retrieve_iam_role_credentials.return_value = {
             'access_key': 'a',
             'secret_key': 'b',
             'token': 'c',
-            'expiry_time': '2014-04-23T15:24:46Z',
+            'expiry_time': timestamp,
             'role_name': 'myrole',
         }
         provider = credentials.InstanceMetadataProvider(
@@ -692,13 +694,17 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         client.assume_role.return_value = with_response
         return mock.Mock(return_value=client)
 
+    def some_future_time(self):
+        timeobj = datetime.now(tzlocal())
+        return timeobj + timedelta(hours=24)
+
     def test_assume_role_with_no_cache(self):
         response = {
             'Credentials': {
                 'AccessKeyId': 'foo',
                 'SecretAccessKey': 'bar',
                 'SessionToken': 'baz',
-                'Expiration': datetime.now(tzlocal()).isoformat()
+                'Expiration': self.some_future_time().isoformat()
             },
         }
         client_creator = self.create_client_creator(with_response=response)
@@ -723,7 +729,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
                 # we test both parsing as well as serializing
                 # from a given datetime because the credentials
                 # are immediately expired.
-                'Expiration': datetime.now(tzlocal())
+                'Expiration': datetime.now(tzlocal()) + timedelta(hours=20)
             },
         }
         client_creator = self.create_client_creator(with_response=response)
@@ -813,13 +819,14 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
 
     def test_assume_role_in_cache_but_expired(self):
         expired_creds = datetime.utcnow()
+        valid_creds = expired_creds + timedelta(seconds=60)
         utc_timestamp = expired_creds.isoformat() + 'Z'
         response = {
             'Credentials': {
                 'AccessKeyId': 'foo',
                 'SecretAccessKey': 'bar',
                 'SessionToken': 'baz',
-                'Expiration': utc_timestamp,
+                'Expiration': valid_creds.isoformat() + 'Z',
             },
         }
         client_creator = self.create_client_creator(with_response=response)
@@ -983,5 +990,91 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
             provider.load()
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestRefreshLogic(unittest.TestCase):
+    def test_mandatory_refresh_needed(self):
+        creds = IntegerRefresher(
+            # These values will immediately trigger
+            # a manadatory refresh.
+            creds_last_for=2,
+            mandatory_refresh=3,
+            advisory_refresh=3)
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(
+            temp, credentials.ReadOnlyCredentials('2', '2', '2'))
+
+    def test_advisory_refresh_needed(self):
+        creds = IntegerRefresher(
+            # These values will immediately trigger
+            # a manadatory refresh.
+            creds_last_for=4,
+            mandatory_refresh=2,
+            advisory_refresh=5)
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(
+            temp, credentials.ReadOnlyCredentials('2', '2', '2'))
+
+    def test_refresh_fails_is_not_an_error_during_advisory_period(self):
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            creds_last_for=5,
+            advisory_refresh=7,
+            mandatory_refresh=3,
+            refresh_function=fail_refresh
+        )
+        temp = creds.get_frozen_credentials()
+        # We should have called the refresh function.
+        self.assertTrue(fail_refresh.called)
+        # The fail_refresh function will raise an exception.
+        # Because we're in the advisory period we'll not propogate
+        # the exception and return the current set of credentials
+        # (generation '1').
+        self.assertEqual(
+            temp, credentials.ReadOnlyCredentials('1', '1', '1'))
+
+    def test_exception_propogated_on_error_during_mandatory_period(self):
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            creds_last_for=5,
+            advisory_refresh=10,
+            # Note we're in the mandatory period now (5 < 7< 10).
+            mandatory_refresh=7,
+            refresh_function=fail_refresh
+        )
+        with self.assertRaisesRegexp(Exception, 'refresh failed'):
+            creds.get_frozen_credentials()
+
+    def test_exception_propogated_on_expired_credentials(self):
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            # Setting this to 0 mean the credentials are immediately
+            # expired.
+            creds_last_for=0,
+            advisory_refresh=10,
+            mandatory_refresh=7,
+            refresh_function=fail_refresh
+        )
+        with self.assertRaisesRegexp(Exception, 'refresh failed'):
+            # Because credentials are actually expired, any
+            # failure to refresh should be propagated.
+            creds.get_frozen_credentials()
+
+    def test_refresh_giving_expired_credentials_raises_exception(self):
+        # This verifies an edge cases where refreshed credentials
+        # still give expired credentials:
+        # 1. We see credentials are expired.
+        # 2. We try to refresh the credentials.
+        # 3. The "refreshed" credentials are still expired.
+        #
+        # In this case, we hard fail and let the user know what
+        # happened.
+        creds = IntegerRefresher(
+            # Negative number indicates that the credentials
+            # have already been expired for 2 seconds, even
+            # on refresh.
+            creds_last_for=-2,
+        )
+        err_msg = 'refreshed credentials are still expired'
+        with self.assertRaisesRegexp(RuntimeError, err_msg):
+            # Because credentials are actually expired, any
+            # failure to refresh should be propagated.
+            creds.get_frozen_credentials()

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -68,30 +68,6 @@ class TestSigner(BaseSignerTest):
                 credentials=self.credentials, service_name='service_name',
                 region_name='region_name')
 
-    def test_get_auth_cached(self):
-        def side_effect(*args, **kwargs):
-            return mock.Mock()
-        auth_cls = mock.Mock(side_effect=side_effect)
-        with mock.patch.dict(botocore.auth.AUTH_TYPE_MAPS,
-                             {'v4': auth_cls}):
-            auth1 = self.signer.get_auth('service_name', 'region_name')
-            auth2 = self.signer.get_auth('service_name', 'region_name')
-
-        self.assertEqual(auth1, auth2)
-
-    def test_get_auth_cached_expires(self):
-        def side_effect(*args, **kwargs):
-            return mock.Mock()
-        auth_cls = mock.Mock(side_effect=side_effect)
-        with mock.patch.dict(botocore.auth.AUTH_TYPE_MAPS,
-                             {'v4': auth_cls}):
-            auth1 = self.signer.get_auth('service_name', 'region_name',
-                                         expires=60)
-            auth2 = self.signer.get_auth('service_name', 'region_name',
-                                         expires=90)
-
-        self.assertNotEqual(auth1, auth2)
-
     def test_get_auth_signature_override(self):
         auth_cls = mock.Mock()
         with mock.patch.dict(botocore.auth.AUTH_TYPE_MAPS,


### PR DESCRIPTION
This builds on the pull request from https://github.com/boto/botocore/pull/764 and introduces a few additional enhancements for multithreaded credential refresh.  Includes:

* The original fix from #764.  Credentials must be accessed as a fixed set to ensure you don't get access_key from time t_1 and secret_key from time t_2.
* Introduce locking to ensure only one thread starts the refresh process.  The previous behavior was that every thread, once determining a refresh was needed, would all call the refresh function.  Additionally, double checked locking is used to avoid lock acquisition in the common case where a refresh isn't needed.
* Don't hard fail if refreshing initially fails.

To expand on the last point, there's now two time periods for refresh, the advisory period and the mandatory period.

##### Advisory period

* Only the thread that acquires the lock will refresh.  If a thread can't acquire the refresh lock during this period it uses the existing temporary creds.
* If the refresh function fails, a warning is logged, and the existing set of temporary creds are used.

##### Mandatory period

* All threads block on the refresh lock.
* Any exceptions raised during the refresh function will propagate back to the user.


There's still a few improvements that can be added (backoff delay during advisory period), but I think this is a good set of improvements.

Note: this builds on https://github.com/boto/botocore/pull/787 so the diff will show up here until that PR gets merged.

cc @kyleknap @rayluo @JordonPhillips 