### PR TITLE
Re-added and updated  documentation on supported Lambda runtimes

### DIFF
--- a/botocore/data/lambda/2015-03-31/service-2.json
+++ b/botocore/data/lambda/2015-03-31/service-2.json
@@ -617,7 +617,7 @@
         },
         "Runtime":{
           "shape":"Runtime",
-          "documentation":"<p>The runtime environment for the Lambda function you are uploading. </p>"
+          "documentation":"<p>The runtime environment for the Lambda function you are uploading. Supported runtimes are \"java\", \"nodejs\" and \"python2.7\".</p>"
         },
         "Role":{
           "shape":"RoleArn",


### PR DESCRIPTION
Documentation on supported runtimes got removed in 9b14a65, however I think having this information is pretty useful.

Python2.7 has been added as a supported runtime.