### PR TITLE
Lock tox to 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tox==1.4
+tox>=2.3.1,<3.0.0
 python-dateutil>=2.1,<3.0.0
 nose==1.3.0
 mock==1.3.0


### PR DESCRIPTION
Same change was made in the AWS CLI, this PR keeps
botocore in sync with the AWS CLI.

Verified `tox` runs successfully for me.

cc @kyleknap @rayluo @JordonPhillips 