### PR TITLE
NextToken should be a string, not bytes.

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -77,7 +77,7 @@ class PageIterator(object):
 
         if token_keys == dict_keys:
             self._resume_token = base64.b64encode(
-                json.dumps(value).encode('utf-8'))
+                json.dumps(value).encode('utf-8')).decode('utf-8')
         else:
             raise ValueError("Bad starting token: %s" % value)
 


### PR DESCRIPTION
On python 3, the output of base64 encoding is a `bytes` object, which does not play well with the JSON encoder / decoder.

cc @jamesls @kyleknap @rayluo 