### PR TITLE
Automatically wrap S3 string upload bodies with BytesIO.

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -65,6 +65,13 @@ if six.PY3:
         # NOOP in Python 3, because every string is already unicode
         return s
 
+    def ensure_bytes(s, encoding='utf-8', errors='strict'):
+        if isinstance(s, str):
+            return s.encode(encoding, errors)
+        if isinstance(s, bytes):
+            return s
+        raise ValueError("Expected str or bytes, received %s." % type(s))
+
 else:
     from urllib import quote
     from urllib import urlencode
@@ -117,6 +124,13 @@ else:
         if isinstance(s, six.text_type):
             return s
         return unicode(s, encoding, errors)
+
+    def ensure_bytes(s, encoding='utf-8', errors='strict'):
+        if isinstance(s, unicode):
+            return s.encode(encoding, errors)
+        if isinstance(s, str):
+            return s
+        raise ValueError("Expected str or unicode, received %s." % type(s))
 
 try:
     from collections import OrderedDict

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -25,7 +25,7 @@ import re
 import warnings
 
 from botocore.compat import urlsplit, urlunsplit, unquote, \
-    json, quote, six, unquote_str
+    json, quote, six, unquote_str, ensure_unicode
 from botocore.docs.utils import AutoPopulatedParam
 from botocore.docs.utils import HideParamFromOperations
 from botocore.docs.utils import AppendParamDocumentation
@@ -619,11 +619,22 @@ def decode_list_object(parsed, context, **kwargs):
                 for member in parsed[top_key]:
                     member[child_key] = unquote_str(member[child_key])
 
+
+def convert_string_body_to_file_like_object(params, **kwargs):
+    if 'Body' in params and isinstance(params['Body'], six.string_types):
+
+        body = ensure_unicode(params['Body']).encode('utf-8')
+        params['Body'] = six.BytesIO(body)
+
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be
 # automatically registered with that Session.
 
 BUILTIN_HANDLERS = [
+    ('before-parameter-build.s3.UploadPart',
+     convert_string_body_to_file_like_object, REGISTER_LAST),
+    ('before-parameter-build.s3.PutObject',
+     convert_string_body_to_file_like_object, REGISTER_LAST),
     ('creating-client-class', add_generate_presigned_url),
     ('creating-client-class.s3', add_generate_presigned_post),
     ('creating-client-class.iot-data', check_openssl_supports_tls_version_1_2),

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -942,6 +942,10 @@ class TestSupportedPutObjectBodyTypes(TestS3BaseWithBucket):
     def test_can_put_non_ascii_bytes(self):
         self.assert_can_put_object(body=u'\u2713'.encode('utf-8'))
 
+    def test_can_put_arbitrary_binary_data(self):
+        body = os.urandom(5 * (1024 ** 2))
+        self.assert_can_put_object(body)
+
     def test_can_put_binary_file(self):
         tempdir = self.make_tempdir()
         filename = os.path.join(tempdir, 'foo')

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -252,6 +252,12 @@ class TestS3Objects(TestS3BaseWithBucket):
             Bucket=self.bucket_name, Key='foobarbaz')
         self.assertEqual(data['Body'].read().decode('utf-8'), 'body contents')
 
+    def test_can_put_large_string_body_on_new_bucket(self):
+        body = '*' * (5 * (1024 ** 2))
+        response = self.client.put_object(
+            Bucket=self.bucket_name, Key='foo', Body=body)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
     def test_get_object_stream_wrapper(self):
         self.create_object('foobarbaz', body='body contents')
         response = self.client.get_object(

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -13,7 +13,7 @@
 
 import datetime
 
-from botocore.compat import total_seconds, unquote_str
+from botocore.compat import total_seconds, unquote_str, six, ensure_bytes
 
 from tests import BaseEnvVar, unittest
 
@@ -47,3 +47,34 @@ class TestUnquoteStr(unittest.TestCase):
         # Note: decoded to unicode and utf-8 decoded as well.
         # This would work in python2 and python3.
         self.assertEqual(unquote_str(value), 'foo bar')
+
+
+class TestEnsureBytes(unittest.TestCase):
+    def test_string(self):
+        value = 'foo'
+        response = ensure_bytes(value)
+        self.assertIsInstance(response, six.binary_type)
+        self.assertEqual(response, b'foo')
+
+    def test_binary(self):
+        value = b'bar'
+        response = ensure_bytes(value)
+        self.assertIsInstance(response, six.binary_type)
+        self.assertEqual(response, b'bar')
+
+    def test_unicode(self):
+        value = u'baz'
+        response = ensure_bytes(value)
+        self.assertIsInstance(response, six.binary_type)
+        self.assertEqual(response, b'baz')
+
+    def test_non_ascii(self):
+        value = u'\u2713'
+        response = ensure_bytes(value)
+        self.assertIsInstance(response, six.binary_type)
+        self.assertEqual(response, b'\xe2\x9c\x93')
+
+    def test_non_string_or_bytes_raises_error(self):
+        value = 500
+        with self.assertRaises(ValueError):
+            ensure_bytes(value)


### PR DESCRIPTION
This is to avoid sending large initial requests to S3, which can result in S3 terminating the connection and a broken pipe on our end.