### PR TITLE
Change one StubResponseError to StubAssertionError

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -357,6 +357,10 @@ class StubResponseError(BotoCoreError):
     fmt = 'Error getting response stub for operation {operation_name}: {reason}'
 
 
+class StubAssertionError(StubResponseError, AssertionError):
+    fmt = 'Error getting response stub for operation {operation_name}: {reason}'
+
+
 class InvalidConfigError(BotoCoreError):
     fmt = '{error_msg}'
 

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -13,7 +13,8 @@
 import copy
 from collections import deque
 from botocore.validate import validate_parameters
-from botocore.exceptions import ParamValidationError, StubResponseError
+from botocore.exceptions import ParamValidationError, \
+    StubResponseError, StubAssertionError
 from botocore.vendored.requests.models import Response
 
 
@@ -216,10 +217,10 @@ class Stubber(object):
         self._assert_expected_call_order(model, params)
         expected_params = self._queue[0]['expected_params']
         if expected_params is not None and params != expected_params:
-            raise StubResponseError(
+            raise StubAssertionError(
                 operation_name=model.name,
                 reason='Expected parameters: %s, but received: %s' % (
-                    params, expected_params))
+                    expected_params, params))
 
     def _validate_response(self, operation_name, service_response):
         service_model = self.client.meta.service_model


### PR DESCRIPTION
The newly introduced StubAssertionError derives from AssertionError,
so that it will be (properly) classified as test failure rather than
test error when your test cases fail on that.