### PR TITLE
Don't use MD5 with s3v4

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -150,7 +150,7 @@ def _calculate_md5_from_file(fileobj):
 def conditionally_calculate_md5(params, **kwargs):
     """Only add a Content-MD5 when not using sigv4"""
     signer = kwargs['request_signer']
-    if signer.signature_version != 'v4':
+    if signer.signature_version not in ['v4', 's3v4']:
         calculate_md5(params, **kwargs)
 
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -521,6 +521,18 @@ class TestHandlers(BaseSessionTest):
                                              request_signer=request_signer)
         self.assertTrue('Content-MD5' not in request_dict['headers'])
 
+    def test_does_not_add_md5_when_s3v4(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 's3v4', credentials, mock.Mock())
+        request_dict = {'body': b'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+        handlers.conditionally_calculate_md5(request_dict,
+                                             request_signer=request_signer)
+        self.assertTrue('Content-MD5' not in request_dict['headers'])
+
     def test_adds_md5_when_not_v4(self):
         credentials = Credentials('key', 'secret')
         request_signer = RequestSigner(


### PR DESCRIPTION
We have a function which avoids md5 when in sigv4, but forgot to include s3v4 even though we attach the function to several s3 commands.

cc @jamesls @kyleknap @rayluo 