### PR TITLE
Nested docstring lists

### DIFF
--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -11,10 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore.compat import six
-from six.moves import html_parser
 
 
-class DocStringParser(html_parser.HTMLParser):
+class DocStringParser(six.moves.html_parser.HTMLParser):
     """
     A simple HTML parser.  Focused on converting the subset of HTML
     that appears in the documentation strings of the JSON models into
@@ -22,30 +21,180 @@ class DocStringParser(html_parser.HTMLParser):
     """
 
     def __init__(self, doc):
-        html_parser.HTMLParser.__init__(self)
+        self.tree = None
         self.doc = doc
-        self.unhandled_tags = []
+        six.moves.html_parser.HTMLParser.__init__(self)
+
+    def reset(self):
+        six.moves.html_parser.HTMLParser.reset(self)
+        self.tree = HTMLTree(self.doc)
+
+    def feed(self, data):
+        # HTMLParser is an old style class, so the super() method will not work.
+        six.moves.html_parser.HTMLParser.feed(self, data)
+        self.tree.write()
+        self.tree = HTMLTree(self.doc)
+
+    def close(self):
+        six.moves.html_parser.HTMLParser.close(self)
+        # Write if there is anything remaining.
+        self.tree.write()
+        self.tree = HTMLTree(self.doc)
 
     def handle_starttag(self, tag, attrs):
-        handler_name = 'start_%s' % tag
-        if hasattr(self.doc.style, handler_name):
-            getattr(self.doc.style, handler_name)(attrs)
-        else:
-            self.unhandled_tags.append(tag)
+        self.tree.add_tag(tag, attrs=attrs)
 
     def handle_endtag(self, tag):
-        handler_name = 'end_%s' % tag
-        if hasattr(self.doc.style, handler_name):
-            getattr(self.doc.style, handler_name)()
+        self.tree.add_tag(tag, is_start=False)
 
     def handle_data(self, data):
-        if data.isspace():
-            data = ' '
+        self.tree.add_data(data)
+
+
+class HTMLTree(object):
+    """
+    A tree which handles HTML nodes. Designed to work with a python HTML parser,
+    meaning that the current_node will be the most recently opened tag. When
+    a tag is closed, the current_node moves up to the parent node.
+    """
+    def __init__(self, doc):
+        self.doc = doc
+        self.head = StemNode()
+        self.current_node = self.head
+        self.unhandled_tags = []
+
+    def add_tag(self, tag, attrs=None, is_start=True):
+        if not self._doc_has_handler(tag, is_start):
+            self.unhandled_tags.append(tag)
+            return
+
+        if is_start:
+            if tag == 'li':
+                node = LineItemNode(attrs)
+            else:
+                node = TagNode(tag, attrs)
+            self.current_node.add_child(node)
+            self.current_node = node
         else:
-            end_space = data[-1].isspace()
-            words = data.split()
-            words = self.doc.translate_words(words)
-            data = ' '.join(words)
+            self.current_node = self.current_node.parent
+
+    def _doc_has_handler(self, tag, is_start):
+        if is_start:
+            handler_name = 'start_%s' % tag
+        else:
+            handler_name = 'end_%s' % tag
+
+        return hasattr(self.doc.style, handler_name)
+
+    def add_data(self, data):
+        self.current_node.add_child(DataNode(data))
+
+    def write(self):
+        self.head.write(self.doc)
+
+
+class Node(object):
+    def __init__(self, parent=None):
+        self.parent = parent
+
+    def write(self, doc):
+        raise NotImplementedError
+
+
+class StemNode(Node):
+    def __init__(self, parent=None):
+        super(StemNode, self).__init__(parent)
+        self.children = []
+
+    def add_child(self, child):
+        child.parent = self
+        self.children.append(child)
+
+    def write(self, doc):
+        self._write_children(doc)
+
+    def _write_children(self, doc):
+        for child in self.children:
+            child.write(doc)
+
+
+class TagNode(StemNode):
+    """
+    A generic Tag node. It will verify that handlers exist before writing.
+    """
+    def __init__(self, tag, attrs=None, parent=None):
+        super(TagNode, self).__init__(parent)
+        self.attrs = attrs
+        self.tag = tag
+
+    def write(self, doc):
+        self._write_start(doc)
+        self._write_children(doc)
+        self._write_end(doc)
+
+    def _write_start(self, doc):
+        handler_name = 'start_%s' % self.tag
+        if hasattr(doc.style, handler_name):
+            getattr(doc.style, handler_name)(self.attrs)
+
+    def _write_end(self, doc):
+        handler_name = 'end_%s' % self.tag
+        if hasattr(doc.style, handler_name):
+            getattr(doc.style, handler_name)()
+
+
+class LineItemNode(TagNode):
+    def __init__(self, attrs=None, parent=None):
+        super(LineItemNode, self).__init__('li', attrs, parent)
+
+    def write(self, doc):
+        self._lstrip(self)
+        super(LineItemNode, self).write(doc)
+
+    def _lstrip(self, node):
+        """
+        Traverses the tree, stripping out whitespace until text data is found
+        :param node: The node to strip
+        :return: True if non-whitespace data was found, False otherwise
+        """
+        for child in node.children:
+            if isinstance(child, DataNode):
+                child.lstrip()
+                if child.data:
+                    return True
+            else:
+                found = self._lstrip(child)
+                if found:
+                    return True
+
+        return False
+
+
+class DataNode(Node):
+    """
+    A Node that contains only string data.
+    """
+    def __init__(self, data, parent=None):
+        super(DataNode, self).__init__(parent)
+        if not isinstance(data, six.string_types):
+            raise ValueError("Expecting string type, %s given." % type(data))
+        self.data = data
+
+    def lstrip(self):
+        self.data = self.data.lstrip()
+
+    def write(self, doc):
+        if not self.data:
+            return
+
+        if self.data.isspace():
+            str_data = ' '
+        else:
+            end_space = self.data[-1].isspace()
+            words = self.data.split()
+            words = doc.translate_words(words)
+            str_data = ' '.join(words)
             if end_space:
-                data += ' '
-        self.doc.handle_data(data)
+                str_data += ' '
+
+        doc.handle_data(str_data)

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -72,12 +72,10 @@ class ReSTStyle(BaseStyle):
         self.a_href = None
 
     def new_paragraph(self):
-        if self.do_p:
-            self.doc.write('\n\n%s' % self.spaces())
+        self.doc.write('\n\n%s' % self.spaces())
 
     def new_line(self):
-        if self.do_p:
-            self.doc.write('\n%s' % self.spaces())
+        self.doc.write('\n%s' % self.spaces())
 
     def _start_inline(self, markup):
         self.doc.write(markup)

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -70,6 +70,7 @@ class ReSTStyle(BaseStyle):
         BaseStyle.__init__(self, doc, indent_width)
         self.do_p = True
         self.a_href = None
+        self.list_depth = 0
 
     def new_paragraph(self):
         self.doc.write('\n\n%s' % self.spaces())
@@ -259,16 +260,28 @@ class ReSTStyle(BaseStyle):
             self.end_li()
 
     def start_ul(self, attrs=None):
+        if self.list_depth != 0:
+            self.indent()
+        self.list_depth += 1
         self.new_paragraph()
 
     def end_ul(self):
+        self.list_depth -= 1
+        if self.list_depth != 0:
+            self.dedent()
         self.new_paragraph()
 
     def start_ol(self, attrs=None):
         # TODO: Need to control the bullets used for LI items
+        if self.list_depth != 0:
+            self.indent()
+        self.list_depth += 1
         self.new_paragraph()
 
     def end_ol(self):
+        self.list_depth -= 1
+        if self.list_depth != 0:
+            self.dedent()
         self.new_paragraph()
 
     def start_examples(self, attrs=None):

--- a/tests/unit/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/docs/bcdoc/test_docstringparser.py
@@ -1,0 +1,212 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+import mock
+from tests import unittest
+
+import botocore.docs.bcdoc.docstringparser as parser
+from botocore.docs.bcdoc.restdoc import ReSTDocument
+
+
+class TestDocStringParser(unittest.TestCase):
+    def parse(self, html):
+        docstring_parser = parser.DocStringParser(ReSTDocument())
+        docstring_parser.feed(html)
+        docstring_parser.close()
+        return docstring_parser.doc.getvalue()
+
+    def assert_contains_exact_lines_in_order(self, actual, expected):
+        # Get each line and filter out empty lines
+        contents = actual.split(b'\n')
+        contents = [line for line in contents if line and not line.isspace()]
+
+        for line in expected:
+            self.assertIn(line, contents)
+            beginning = contents.index(line)
+            contents = contents[beginning:]
+
+    def test_nested_lists(self):
+        html = "<ul><li>Wello</li><ul><li>Horld</li></ul></ul>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [
+            b'* Wello',
+            b'  * Horld'
+        ])
+
+    def test_nested_lists_with_extra_white_space(self):
+        html = "<ul> <li> Wello</li><ul> <li> Horld</li></ul></ul>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [
+            b'* Wello',
+            b'  * Horld'
+        ])
+
+
+class TestHTMLTree(unittest.TestCase):
+    def setUp(self):
+        self.style = mock.Mock()
+        self.doc = mock.Mock()
+        self.doc.style = self.style
+        self.tree = parser.HTMLTree(self.doc)
+
+    def test_add_tag(self):
+        self.tree.add_tag('foo')
+        self.assertIsInstance(self.tree.current_node, parser.TagNode)
+        self.assertEqual(self.tree.current_node.tag, 'foo')
+
+    def test_add_unsupported_tag(self):
+        del self.style.start_foo
+        del self.style.end_foo
+        self.tree.add_tag('foo')
+        self.assertIn('foo', self.tree.unhandled_tags)
+
+    def test_add_data(self):
+        self.tree.add_data('foo')
+        self.assertNotIsInstance(self.tree.current_node, parser.DataNode)
+        node = self.tree.head.children[0]
+        self.assertIsInstance(node, parser.DataNode)
+        self.assertEqual(node.data, 'foo')
+
+
+class TestStemNode(unittest.TestCase):
+    def setUp(self):
+        self.style = mock.Mock()
+        self.doc = mock.Mock()
+        self.doc.style = self.style
+        self.node = parser.StemNode()
+
+    def test_add_child(self):
+        child = parser.StemNode()
+        self.node.add_child(child)
+        self.assertIn(child, self.node.children)
+        self.assertEqual(child.parent, self.node)
+
+    def test_write(self):
+        self.node.add_child(mock.Mock())
+        self.node.add_child(mock.Mock())
+
+        self.node.write(mock.Mock())
+        for child in self.node.children:
+            self.assertTrue(child.write.called)
+
+
+class TestTagNode(unittest.TestCase):
+    def setUp(self):
+        self.style = mock.Mock()
+        self.doc = mock.Mock()
+        self.doc.style = self.style
+        self.tag = 'foo'
+        self.node = parser.TagNode(self.tag)
+
+    def test_write_calls_style(self):
+        self.node.write(self.doc)
+        self.assertTrue(self.style.start_foo.called)
+        self.assertTrue(self.style.end_foo.called)
+
+    def test_write_unsupported_tag(self):
+        del self.style.start_foo
+        del self.style.end_foo
+
+        try:
+            self.node.write(self.doc)
+        except AttributeError as e:
+            self.fail(str(e))
+
+
+class TestDataNode(unittest.TestCase):
+    def setUp(self):
+        self.style = mock.Mock()
+        self.doc = mock.Mock()
+        self.doc.style = self.style
+
+    def test_string_data(self):
+        node = parser.DataNode('foo')
+        self.assertEqual(node.data, 'foo')
+
+    def test_non_string_data_raises_error(self):
+        with self.assertRaises(ValueError):
+            parser.DataNode(5)
+
+    def test_lstrip(self):
+        node = parser.DataNode(' foo')
+        node.lstrip()
+        self.assertEqual(node.data, 'foo')
+
+    def test_write(self):
+        node = parser.DataNode('foo   bar baz')
+        self.doc.translate_words.return_value = ['foo', 'bar', 'baz']
+        node.write(self.doc)
+        self.doc.handle_data.assert_called_once_with('foo bar baz')
+
+    def test_write_space(self):
+        node = parser.DataNode(' ')
+        node.write(self.doc)
+        self.doc.handle_data.assert_called_once_with(' ')
+        self.doc.handle_data.reset_mock()
+
+        node = parser.DataNode('              ')
+        node.write(self.doc)
+        self.doc.handle_data.assert_called_once_with(' ')
+
+    def test_write_empty_string(self):
+        node = parser.DataNode('')
+        node.write(self.doc)
+        self.assertFalse(self.doc.handle_data.called)
+
+
+class TestLineItemNode(unittest.TestCase):
+    def setUp(self):
+        self.style = mock.Mock()
+        self.doc = mock.Mock()
+        self.doc.style = self.style
+        self.doc.translate_words.return_value = ['foo']
+        self.node = parser.LineItemNode()
+
+    def test_write_strips_white_space(self):
+        self.node.add_child(parser.DataNode('  foo'))
+        self.node.write(self.doc)
+        self.doc.handle_data.assert_called_once_with('foo')
+
+    def test_write_strips_nested_white_space(self):
+        self.node.add_child(parser.DataNode('  '))
+        tag_child = parser.TagNode('foo')
+        tag_child.add_child(parser.DataNode('  '))
+        tag_child_2 = parser.TagNode('foo')
+        tag_child_2.add_child(parser.DataNode(' foo'))
+        tag_child.add_child(tag_child_2)
+        self.node.add_child(tag_child)
+
+        self.node.write(self.doc)
+        self.doc.handle_data.assert_called_once_with('foo')
+
+    def test_write_only_strips_until_text_is_found(self):
+        self.node.add_child(parser.DataNode('  '))
+        tag_child = parser.TagNode('foo')
+        tag_child.add_child(parser.DataNode('  '))
+        tag_child_2 = parser.TagNode('foo')
+        tag_child_2.add_child(parser.DataNode(' foo'))
+        tag_child_2.add_child(parser.DataNode(' '))
+        tag_child.add_child(tag_child_2)
+        self.node.add_child(tag_child)
+
+        self.node.write(self.doc)
+
+        calls = [mock.call('foo'), mock.call(' ')]
+        self.doc.handle_data.assert_has_calls(calls)

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -241,3 +241,12 @@ class TestStyle(unittest.TestCase):
         )
         style.write_py_doc_string(docstring)
         self.assertEqual(style.doc.getvalue(), six.b(docstring + '\n'))
+
+    def test_new_line(self):
+        style = ReSTStyle(ReSTDocument())
+        style.new_line()
+        self.assertEqual(style.doc.getvalue(), six.b('\n'))
+
+        style.do_p = False
+        style.new_line()
+        self.assertEqual(style.doc.getvalue(), six.b('\n\n'))

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -250,3 +250,32 @@ class TestStyle(unittest.TestCase):
         style.do_p = False
         style.new_line()
         self.assertEqual(style.doc.getvalue(), six.b('\n\n'))
+
+    def test_list(self):
+        style = ReSTStyle(ReSTDocument())
+        style.li('foo')
+        self.assertEqual(style.doc.getvalue(), six.b('\n* foo\n\n'))
+
+    def test_non_top_level_lists_are_indented(self):
+        style = ReSTStyle(ReSTDocument())
+
+        # Start the top level list
+        style.start_ul()
+
+        # Write one list element
+        style.start_li()
+        style.doc.handle_data('foo')
+        style.end_li()
+
+        self.assertEqual(style.doc.getvalue(), six.b("\n\n\n* foo\n"))
+
+        # Start the nested list
+        style.start_ul()
+
+        # Write an element to the nested list
+        style.start_li()
+        style.doc.handle_data('bar')
+        style.end_li()
+
+        self.assertEqual(style.doc.getvalue(),
+                         six.b("\n\n\n* foo\n\n\n  \n  * bar\n  "))


### PR DESCRIPTION
Fixes boto/boto3#310

There were three issues at play:

1. We were completely disabling newlines when going through lists
2. Nested lists need to be indented, but the top level list should not be.
3. The doc strings contain, in some cases, several spaces between the start of an `li` and the first instance of text. This causes all sorts of problems in rst.

To make things easier, I separated this PR into three commits, one for each of the items above. Item 3 is the trickiest customer, and required a significant change.

Basically, we need to have full context of the lists before we write them so that we can remove vestigial spaces. What I have done here is change the DocStringParser so that it writes to a tree, and then flushes it all out at close. This allows us to do inspections before anything is written.

We could, alternatively, pull in beautifulsoup to generate this tree for us. The advantage would be that it is far more robust, but at the cost of a large dependency that may take more time than our specialized need requires.

Another potential option is to modify `ReSTStyle` such that it generates a string that is then output to rst, allowing us to apply transformations after generation but before writing. Since this affects more than just doc strings, however, it could result in massive strings being buffered into memory. While we can't be sure of the size of doc strings, they aren't usually more than a few paragraphs.

cc @jamesls @rayluo @kyleknap 