### PR TITLE
Verify MD5 is available

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -237,3 +237,17 @@ def total_seconds(delta):
     day_in_seconds = delta.days * 24 * 3600.0
     micro_in_seconds = delta.microseconds / 10.0**6
     return day_in_seconds + delta.seconds + micro_in_seconds
+
+
+def md5_available():
+    """
+    Checks to see if md5 is available on this system. A given system might not
+    have access to it for various reasons, such as FIPS mode being enabled.
+    :return: True if md5 is available. False if not.
+    """
+    try:
+        import hashlib
+        hashlib.md5()
+        return True
+    except:
+        return False

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -253,7 +253,7 @@ except ValueError:
     MD5_AVAILABLE = False
 
 
-def get_md5(raise_error_if_unavailable=True, *args, **kwargs):
+def get_md5(*args, **kwargs):
     """
     Attempts to get an md5 hashing object.
 
@@ -267,8 +267,5 @@ def get_md5(raise_error_if_unavailable=True, *args, **kwargs):
     """
     if MD5_AVAILABLE:
         return hashlib.md5(*args, **kwargs)
-    elif raise_error_if_unavailable:
-        raise MD5UnavailableError()
     else:
-        logging.debug("This system does not support MD5 generation.")
-        return None
+        raise MD5UnavailableError()

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -367,3 +367,7 @@ class InvalidConfigError(BotoCoreError):
 
 class RefreshWithMFAUnsupportedError(BotoCoreError):
     fmt = 'Cannot refresh credentials: MFA token required.'
+
+
+class MD5UnavailableError(BotoCoreError):
+    fmt = "This system does not support MD5 generation."

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -17,7 +17,6 @@ This module contains builtin handlers for events emitted by botocore.
 """
 
 import base64
-import hashlib
 import logging
 import xml.etree.cElementTree
 import copy
@@ -25,13 +24,13 @@ import re
 import warnings
 
 from botocore.compat import urlsplit, urlunsplit, unquote, \
-    json, quote, six, unquote_str, ensure_bytes, md5_available
+    json, quote, six, unquote_str, ensure_bytes, get_md5, MD5_AVAILABLE
 from botocore.docs.utils import AutoPopulatedParam
 from botocore.docs.utils import HideParamFromOperations
 from botocore.docs.utils import AppendParamDocumentation
 from botocore.signers import add_generate_presigned_url
 from botocore.signers import add_generate_presigned_post
-from botocore.exceptions import ParamValidationError, MD5UnavailableError
+from botocore.exceptions import ParamValidationError
 from botocore.exceptions import UnsupportedTLSVersionWarning
 from botocore.utils import percent_encode, SAFE_CHARS
 
@@ -122,9 +121,6 @@ def json_decode_template_body(parsed, **kwargs):
 
 
 def calculate_md5(params, **kwargs):
-    if not md5_available():
-        raise MD5UnavailableError()
-
     request_dict = params
     if request_dict['body'] and 'Content-MD5' not in params['headers']:
         body = request_dict['body']
@@ -137,13 +133,13 @@ def calculate_md5(params, **kwargs):
 
 
 def _calculate_md5_from_bytes(body_bytes):
-    md5 = hashlib.md5(body_bytes)
+    md5 = get_md5(body_bytes)
     return md5.digest()
 
 
 def _calculate_md5_from_file(fileobj):
     start_position = fileobj.tell()
-    md5 = hashlib.md5()
+    md5 = get_md5()
     for chunk in iter(lambda: fileobj.read(1024 * 1024), b''):
         md5.update(chunk)
     fileobj.seek(start_position)
@@ -153,7 +149,7 @@ def _calculate_md5_from_file(fileobj):
 def conditionally_calculate_md5(params, **kwargs):
     """Only add a Content-MD5 when not using sigv4"""
     signer = kwargs['request_signer']
-    if signer.signature_version not in ['v4', 's3v4'] and md5_available():
+    if signer.signature_version not in ['v4', 's3v4'] and MD5_AVAILABLE:
         calculate_md5(params, **kwargs)
 
 
@@ -191,8 +187,6 @@ def copy_source_sse_md5(params, **kwargs):
 def _sse_md5(params, sse_member_prefix='SSECustomer'):
     if not _needs_s3_sse_customization(params, sse_member_prefix):
         return
-    if not md5_available():
-        raise MD5UnavailableError()
 
     sse_key_member = sse_member_prefix + 'Key'
     sse_md5_member = sse_member_prefix + 'KeyMD5'
@@ -200,7 +194,7 @@ def _sse_md5(params, sse_member_prefix='SSECustomer'):
     if isinstance(key_as_bytes, six.text_type):
         key_as_bytes = key_as_bytes.encode('utf-8')
     key_md5_str = base64.b64encode(
-        hashlib.md5(key_as_bytes).digest()).decode('utf-8')
+        get_md5(key_as_bytes).digest()).decode('utf-8')
     key_b64_encoded = base64.b64encode(key_as_bytes).decode('utf-8')
     params[sse_key_member] = key_b64_encoded
     params[sse_md5_member] = key_md5_str

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -12,8 +12,11 @@
 # language governing permissions and limitations under the License.
 
 import datetime
+import mock
 
-from botocore.compat import total_seconds, unquote_str, six, ensure_bytes
+from botocore.compat import (
+    total_seconds, unquote_str, six, ensure_bytes, md5_available
+)
 
 from tests import BaseEnvVar, unittest
 
@@ -78,3 +81,14 @@ class TestEnsureBytes(unittest.TestCase):
         value = 500
         with self.assertRaises(ValueError):
             ensure_bytes(value)
+
+
+class TestMD5Available(unittest.TestCase):
+    def test_available(self):
+        with mock.patch('hashlib.md5'):
+            self.assertTrue(md5_available())
+
+    def test_unavailable(self):
+        with mock.patch('hashlib.md5') as md5:
+            md5.side_effect = ValueError()
+            self.assertFalse(md5_available())

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -87,14 +87,14 @@ class TestEnsureBytes(unittest.TestCase):
 class TestGetMD5(unittest.TestCase):
     def test_available(self):
         md5 = mock.Mock()
-        with mock.patch('botocore.compat.MD5_AVAILABLE', True), \
-             mock.patch('hashlib.md5', mock.Mock(return_value=md5)):
-            self.assertEqual(get_md5(), md5)
+        with mock.patch('botocore.compat.MD5_AVAILABLE', True):
+            with mock.patch('hashlib.md5', mock.Mock(return_value=md5)):
+                self.assertEqual(get_md5(), md5)
 
     def test_unavailable_raises_error(self):
-        with mock.patch('botocore.compat.MD5_AVAILABLE', False), \
-             self.assertRaises(MD5UnavailableError):
-            get_md5(raise_error_if_unavailable=True)
+        with mock.patch('botocore.compat.MD5_AVAILABLE', False):
+            with self.assertRaises(MD5UnavailableError):
+                get_md5(raise_error_if_unavailable=True)
 
     def test_unavailable_returns_null(self):
         with mock.patch('botocore.compat.MD5_AVAILABLE', False):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -94,8 +94,4 @@ class TestGetMD5(unittest.TestCase):
     def test_unavailable_raises_error(self):
         with mock.patch('botocore.compat.MD5_AVAILABLE', False):
             with self.assertRaises(MD5UnavailableError):
-                get_md5(raise_error_if_unavailable=True)
-
-    def test_unavailable_returns_null(self):
-        with mock.patch('botocore.compat.MD5_AVAILABLE', False):
-            self.assertFalse(get_md5(raise_error_if_unavailable=False))
+                get_md5()

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -20,7 +20,7 @@ import os
 
 import botocore
 import botocore.session
-from botocore.exceptions import ParamValidationError
+from botocore.exceptions import ParamValidationError, MD5UnavailableError
 from botocore.awsrequest import AWSRequest
 from botocore.compat import quote, six
 from botocore.model import OperationModel, ServiceModel
@@ -509,60 +509,7 @@ class TestHandlers(BaseSessionTest):
         handlers.switch_host_with_param(request, 'PredictEndpoint')
         self.assertEqual(request.url, new_endpoint)
 
-    def test_does_not_add_md5_when_v4(self):
-        credentials = Credentials('key', 'secret')
-        request_signer = RequestSigner(
-            's3', 'us-east-1', 's3', 'v4', credentials, mock.Mock())
-        request_dict = {'body': b'bar',
-                        'url': 'https://s3.us-east-1.amazonaws.com',
-                        'method': 'PUT',
-                        'headers': {}}
-        handlers.conditionally_calculate_md5(request_dict,
-                                             request_signer=request_signer)
-        self.assertTrue('Content-MD5' not in request_dict['headers'])
 
-    def test_does_not_add_md5_when_s3v4(self):
-        credentials = Credentials('key', 'secret')
-        request_signer = RequestSigner(
-            's3', 'us-east-1', 's3', 's3v4', credentials, mock.Mock())
-        request_dict = {'body': b'bar',
-                        'url': 'https://s3.us-east-1.amazonaws.com',
-                        'method': 'PUT',
-                        'headers': {}}
-        handlers.conditionally_calculate_md5(request_dict,
-                                             request_signer=request_signer)
-        self.assertTrue('Content-MD5' not in request_dict['headers'])
-
-    def test_adds_md5_when_not_v4(self):
-        credentials = Credentials('key', 'secret')
-        request_signer = RequestSigner(
-            's3', 'us-east-1', 's3', 's3', credentials, mock.Mock())
-        request_dict = {'body': b'bar',
-                        'url': 'https://s3.us-east-1.amazonaws.com',
-                        'method': 'PUT',
-                        'headers': {}}
-        handlers.conditionally_calculate_md5(request_dict,
-                                             request_signer=request_signer)
-        self.assertTrue('Content-MD5' in request_dict['headers'])
-
-    def test_adds_md5_with_file_like_body(self):
-        request_dict = {
-            'body': six.BytesIO(b'foobar'),
-            'headers': {}
-        }
-        handlers.calculate_md5(request_dict)
-        self.assertEqual(request_dict['headers']['Content-MD5'],
-                         'OFj2IjCsPJFfMAxmQxLGPw==')
-
-    def test_adds_md5_with_bytes_object(self):
-        request_dict = {
-            'body': b'foobar',
-            'headers': {}
-        }
-        handlers.calculate_md5(request_dict)
-        self.assertEqual(
-            request_dict['headers']['Content-MD5'],
-            'OFj2IjCsPJFfMAxmQxLGPw==')
 
     def test_invalid_char_in_bucket_raises_exception(self):
         params = {
@@ -735,3 +682,127 @@ class TestRetryHandlerOrder(BaseSessionTest):
         self.assertTrue(s3_200_handler < general_retry_handler,
                         "S3 200 error handler was supposed to be before "
                         "the general retry handler, but it was not.")
+
+
+class BaseMD5Test(BaseSessionTest):
+    def setUp(self, **environ):
+        super(BaseMD5Test, self).setUp(**environ)
+        self.md5_object = mock.Mock()
+        self.md5_digest = mock.Mock(return_value=b'foo')
+        self.md5_object.digest = self.md5_digest
+        self.md5_builder = mock.Mock(return_value=self.md5_object)
+        self.md5_patch = mock.patch('hashlib.md5', self.md5_builder)
+        self.md5_patch.start()
+
+    def tearDown(self):
+        super(BaseMD5Test, self).tearDown()
+        self.md5_patch.stop()
+
+
+class TestSSEMD5(BaseMD5Test):
+    def test_sse_md5(self):
+        key = 'SSECustomerKey'
+        params = {key: b'foo'}
+        handlers.sse_md5(params)
+        self.assertEqual(params[key + 'MD5'], 'Zm9v')
+
+        key = 'CopySourceSSECustomerKey'
+        params = {key: b'foo'}
+        handlers.copy_source_sse_md5(params)
+        self.assertEqual(params[key + 'MD5'], 'Zm9v')
+
+    def test_raises_error_when_md5_unavailable(self):
+        self.md5_builder.side_effect = ValueError()
+
+        with self.assertRaises(MD5UnavailableError):
+            handlers.sse_md5({'SSECustomerKey': b'foo'})
+
+        with self.assertRaises(MD5UnavailableError):
+            handlers.copy_source_sse_md5({'CopySourceSSECustomerKey': b'foo'})
+
+
+class TestAddMD5(BaseMD5Test):
+    def test_does_not_add_md5_when_v4(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 'v4', credentials, mock.Mock())
+        request_dict = {'body': b'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+        handlers.conditionally_calculate_md5(request_dict,
+                                             request_signer=request_signer)
+        self.assertTrue('Content-MD5' not in request_dict['headers'])
+
+    def test_does_not_add_md5_when_s3v4(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 's3v4', credentials, mock.Mock())
+        request_dict = {'body': b'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+        handlers.conditionally_calculate_md5(request_dict,
+                                             request_signer=request_signer)
+        self.assertTrue('Content-MD5' not in request_dict['headers'])
+
+    def test_conditional_does_not_add_when_md5_unavailable(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 's3', credentials, mock.Mock())
+        request_dict = {'body': b'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+
+        self.md5_builder.side_effect = ValueError()
+        handlers.conditionally_calculate_md5(
+            request_dict, request_signer=request_signer)
+        self.assertFalse('Content-MD5' in request_dict['headers'])
+
+    def test_add_md5_raises_error_when_md5_unavailable(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 's3', credentials, mock.Mock())
+        request_dict = {'body': b'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+
+        self.md5_builder.side_effect = ValueError()
+        with self.assertRaises(MD5UnavailableError):
+            handlers.calculate_md5(
+                request_dict, request_signer=request_signer)
+
+    def test_adds_md5_when_not_v4(self):
+        credentials = Credentials('key', 'secret')
+        request_signer = RequestSigner(
+            's3', 'us-east-1', 's3', 's3', credentials, mock.Mock())
+        request_dict = {'body': b'bar',
+                        'url': 'https://s3.us-east-1.amazonaws.com',
+                        'method': 'PUT',
+                        'headers': {}}
+        handlers.conditionally_calculate_md5(request_dict,
+                                             request_signer=request_signer)
+        self.assertTrue('Content-MD5' in request_dict['headers'])
+
+    def test_add_md5_with_file_like_body(self):
+        request_dict = {
+            'body': six.BytesIO(b'foobar'),
+            'headers': {}
+        }
+        self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
+        handlers.calculate_md5(request_dict)
+        self.assertEqual(request_dict['headers']['Content-MD5'],
+                         'OFj2IjCsPJFfMAxmQxLGPw==')
+
+    def test_add_md5_with_bytes_object(self):
+        request_dict = {
+            'body': b'foobar',
+            'headers': {}
+        }
+        self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
+        handlers.calculate_md5(request_dict)
+        self.assertEqual(
+            request_dict['headers']['Content-MD5'],
+            'OFj2IjCsPJFfMAxmQxLGPw==')

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -199,45 +199,6 @@ class TestHandlers(BaseSessionTest):
         # object is None.  We need to handle this case.
         handlers.check_for_200_error(None)
 
-    def test_sse_params(self):
-        for op in ('HeadObject', 'GetObject', 'PutObject', 'CopyObject',
-                   'CreateMultipartUpload', 'UploadPart', 'UploadPartCopy'):
-            event = 'before-parameter-build.s3.%s' % op
-            params = {'SSECustomerKey': b'bar',
-                      'SSECustomerAlgorithm': 'AES256'}
-            self.session.emit(event, params=params, model=mock.Mock())
-            self.assertEqual(params['SSECustomerKey'], 'YmFy')
-            self.assertEqual(params['SSECustomerKeyMD5'],
-                             'N7UdGUp1E+RbVvZSTy1R8g==')
-
-    def test_sse_params_as_str(self):
-        event = 'before-parameter-build.s3.PutObject'
-        params = {'SSECustomerKey': 'bar',
-                  'SSECustomerAlgorithm': 'AES256'}
-        self.session.emit(event, params=params, model=mock.Mock())
-        self.assertEqual(params['SSECustomerKey'], 'YmFy')
-        self.assertEqual(params['SSECustomerKeyMD5'],
-                         'N7UdGUp1E+RbVvZSTy1R8g==')
-
-    def test_copy_source_sse_params(self):
-        for op in ['CopyObject', 'UploadPartCopy']:
-            event = 'before-parameter-build.s3.%s' % op
-            params = {'CopySourceSSECustomerKey': b'bar',
-                      'CopySourceSSECustomerAlgorithm': 'AES256'}
-            self.session.emit(event, params=params, model=mock.Mock())
-            self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
-            self.assertEqual(params['CopySourceSSECustomerKeyMD5'],
-                             'N7UdGUp1E+RbVvZSTy1R8g==')
-
-    def test_copy_source_sse_params_as_str(self):
-        event = 'before-parameter-build.s3.CopyObject'
-        params = {'CopySourceSSECustomerKey': 'bar',
-                  'CopySourceSSECustomerAlgorithm': 'AES256'}
-        self.session.emit(event, params=params, model=mock.Mock())
-        self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
-        self.assertEqual(params['CopySourceSSECustomerKeyMD5'],
-                         'N7UdGUp1E+RbVvZSTy1R8g==')
-
     def test_route53_resource_id(self):
         event = 'before-parameter-build.route53.GetHostedZone'
         params = {'Id': '/hostedzone/ABC123',
@@ -712,17 +673,6 @@ class BaseMD5Test(BaseSessionTest):
 
 
 class TestSSEMD5(BaseMD5Test):
-    def test_sse_md5(self):
-        key = 'SSECustomerKey'
-        params = {key: b'foo'}
-        handlers.sse_md5(params)
-        self.assertEqual(params[key + 'MD5'], 'Zm9v')
-
-        key = 'CopySourceSSECustomerKey'
-        params = {key: b'foo'}
-        handlers.copy_source_sse_md5(params)
-        self.assertEqual(params[key + 'MD5'], 'Zm9v')
-
     def test_raises_error_when_md5_unavailable(self):
         self.set_md5_available(False)
 
@@ -731,6 +681,41 @@ class TestSSEMD5(BaseMD5Test):
 
         with self.assertRaises(MD5UnavailableError):
             handlers.copy_source_sse_md5({'CopySourceSSECustomerKey': b'foo'})
+
+    def test_sse_params(self):
+        for op in ('HeadObject', 'GetObject', 'PutObject', 'CopyObject',
+                   'CreateMultipartUpload', 'UploadPart', 'UploadPartCopy'):
+            event = 'before-parameter-build.s3.%s' % op
+            params = {'SSECustomerKey': b'bar',
+                      'SSECustomerAlgorithm': 'AES256'}
+            self.session.emit(event, params=params, model=mock.Mock())
+            self.assertEqual(params['SSECustomerKey'], 'YmFy')
+            self.assertEqual(params['SSECustomerKeyMD5'], 'Zm9v')
+
+    def test_sse_params_as_str(self):
+        event = 'before-parameter-build.s3.PutObject'
+        params = {'SSECustomerKey': 'bar',
+                  'SSECustomerAlgorithm': 'AES256'}
+        self.session.emit(event, params=params, model=mock.Mock())
+        self.assertEqual(params['SSECustomerKey'], 'YmFy')
+        self.assertEqual(params['SSECustomerKeyMD5'], 'Zm9v')
+
+    def test_copy_source_sse_params(self):
+        for op in ['CopyObject', 'UploadPartCopy']:
+            event = 'before-parameter-build.s3.%s' % op
+            params = {'CopySourceSSECustomerKey': b'bar',
+                      'CopySourceSSECustomerAlgorithm': 'AES256'}
+            self.session.emit(event, params=params, model=mock.Mock())
+            self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
+            self.assertEqual(params['CopySourceSSECustomerKeyMD5'], 'Zm9v')
+
+    def test_copy_source_sse_params_as_str(self):
+        event = 'before-parameter-build.s3.CopyObject'
+        params = {'CopySourceSSECustomerKey': 'bar',
+                  'CopySourceSSECustomerAlgorithm': 'AES256'}
+        self.session.emit(event, params=params, model=mock.Mock())
+        self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
+        self.assertEqual(params['CopySourceSSECustomerKeyMD5'], 'Zm9v')
 
 
 class TestAddMD5(BaseMD5Test):


### PR DESCRIPTION
On some systems, such as a FIPS enabled system, MD5 hashing is unavailable. This commit will detect when that is the case, avoiding it where possible and raising a better error otherwise.

cc @jamesls @rayluo @kyleknap 