### PR TITLE
create a reusable AssumeRoleProvider

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -998,7 +998,7 @@ class LazyAssumeRoleProvider(CredentialProvider):
                 'The provider factory cannot be updated '
                 'after the provider has been created'
             )
-        self._provider = partial(self._provider, **kwargs)
+        self._provider_factory = partial(self._provider_factory, **kwargs)
 
 
 class AssumeRoleProvider(CredentialProvider):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -803,6 +803,7 @@ class BaseAssumeRoleProvider(CredentialProvider):
         return self._create_creds_from_response(response)
 
     def _load_from_cache(self, cache_key):
+        # TODO: cache tranformations should be handled by the cache
         response = deepcopy(self.cache.get(cache_key))
         if response is not None:
             credentials = response['Credentials']
@@ -810,6 +811,7 @@ class BaseAssumeRoleProvider(CredentialProvider):
         return response
 
     def _write_to_cache(self, cache_key, response):
+        # TODO: cache tranformations should be handled by the cache
         response = deepcopy(response)
         credentials = response['Credentials']
         credentials['Expiration'] = credentials['Expiration'].isoformat()

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -67,7 +67,7 @@ def create_credential_resolver(session):
         #         profile_name=profile_name,
         # ),
         BaseAssumeRoleProvider.from_config(
-            session.create_client('sts'),
+            session.create_client,
             {},
             session.full_config,
             profile_name,
@@ -917,7 +917,7 @@ class BaseAssumeRoleProvider(CredentialProvider):
         :return:
         """
         profiles = config.get('profiles', {})
-        profile = profiles[profile_name]
+        profile = profiles.get(profile_name, {})
         if 'role_arn' in profile:
             try:
                 source_profile = profile['source_profile']

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -846,7 +846,7 @@ class BaseAssumeRoleProvider(CredentialProvider):
         # replace them with '_' instead.
         role_arn = self._role_arn.replace(':', '_')
         role_session_name=self._role_session_name
-        policy_hash = sha256(self._policy or '').hexdigest()
+        policy_hash = sha256((self._policy or '').encode()).hexdigest()
         cache_key = '%s--%s--%s' % (role_arn, role_session_name, policy_hash)
         return cache_key
 

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -884,6 +884,42 @@ class Session(object):
             pass
         return results
 
+    def assume_role(
+        self, role_arn, role_session_name,
+        policy=None, duration=900, cache={}, external_id=None,
+        mfa_serial=None, mfa_token_prompter=None
+    ):
+        """
+        Create a new session that uses assumed role credentials
+        :param role_arn:
+        :param role_session_name:
+        :param policy:
+        :param duration:
+        :param cache:
+        :param external_id:
+        :param mfa_serial:
+        :param mfa_token_prompter:
+        :return:
+        """
+        provider = botocore.credentials.BaseAssumeRoleProvider(
+            self.create_client,
+            cache,
+            role_arn,
+            role_session_name,
+            policy,
+            duration,
+            external_id,
+            mfa_serial,
+            mfa_token_prompter
+        )
+
+        role_session = botocore.session.Session()
+        role_session.register_component(
+            'credential_provider',
+            botocore.credentials.CredentialResolver([provider])
+        )
+        return role_session
+
 
 class ComponentLocator(object):
     """Service locator for session components."""

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -913,7 +913,7 @@ class Session(object):
             mfa_token_prompter
         )
 
-        role_session = botocore.session.Session()
+        role_session = Session()
         role_session.register_component(
             'credential_provider',
             botocore.credentials.CredentialResolver([provider])

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1160,7 +1160,7 @@ class TestBaseAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertNotIn(':', cache_key)
         self.assertIn('foo-role', cache_key)
         self.assertIn('mysession', cache_key)
-        self.assertTrue(cache_key.endswith(sha256('').hexdigest()))
+        self.assertTrue(cache_key.endswith(sha256(''.encode()).hexdigest()))
 
     def test_cache_key_with_policy(self):
         response = {
@@ -1194,7 +1194,9 @@ class TestBaseAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertNotIn(':', cache_key)
         self.assertIn('foo-role', cache_key)
         self.assertIn('mysession', cache_key)
-        self.assertTrue(cache_key.endswith(sha256(policy_json).hexdigest()))
+        self.assertTrue(
+            cache_key.endswith(sha256(policy_json.encode()).hexdigest())
+        )
 
     def test_assume_role_in_cache_but_expired(self):
         expired_creds = datetime.utcnow().replace(tzinfo=tzutc())


### PR DESCRIPTION
This PR is still a WIP. I am interested in getting feedback from the botocore maintainers on the direction, and am willing to invest more time in iterating on the solution.

The existing AssumeRoleProvider was a direct port of the implementation from the awscli, and was not created with the intent to be reused in cases where another application might need to use an assumed role. Thus far, implementers have created their own versions of AssumeRoleProvider, injecting it into a Session object, which can then be used in an application.

This PR defines a new BaseAssumeRoleProvider (a better name probably exists), which can be used by the awscli (or other applications that want to reuse its config files) and by applications that use botocore directly. Also, a convenience method is added to Session to easily allow the creation of a new session, which may only use the credentials provided by an assumed role provider. (Fixes #761)

The config loading strategy I used allows recursive role assumption from the awscli, which can be convenient for users who have access to one role through another role. For example:

```
$ cat ~/.aws/credentials
[default]
aws_access_key_id = foo
aws_secret_access_key = bar

[role1]
role_arn = role1arn
source_profile = default

[role2]
role_arn = role2arn
source_profile = role1

$ aws --profile role2 ...
```
