### PR TITLE
Add testcase for #751 (assume role provided bug)

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -900,9 +900,6 @@ class AssumeRoleProvider(CredentialProvider):
         client = self._create_client_from_config(config)
 
         assume_role_kwargs = self._assume_role_base_kwargs(config)
-        if assume_role_kwargs.get('RoleSessionName') is None:
-            role_session_name = 'AWS-CLI-session-%s' % (int(time.time()))
-            assume_role_kwargs['RoleSessionName'] = role_session_name
 
         response = client.assume_role(**assume_role_kwargs)
         creds = self._create_creds_from_response(response)
@@ -918,6 +915,9 @@ class AssumeRoleProvider(CredentialProvider):
             assume_role_kwargs['TokenCode'] = token_code
         if config['role_session_name'] is not None:
             assume_role_kwargs['RoleSessionName'] = config['role_session_name']
+        else:
+            role_session_name = 'AWS-CLI-session-%s' % (int(time.time()))
+            assume_role_kwargs['RoleSessionName'] = role_session_name
         return assume_role_kwargs
 
 


### PR DESCRIPTION
This pulls in #751 and adds a testcase that demonstrates the issue.

Essentially, the `RoleSessionName` argument was only being provided in the first `assume_role` call, and not in subsequent `assume_role` refresh calls.

cc @kyleknap @JordonPhillips 

Closes #751.