### PR TITLE
SDB should use signature version 2

### DIFF
--- a/botocore/data/endpoints.json
+++ b/botocore/data/endpoints.json
@@ -663,6 +663,9 @@
             "protocols": [
               "http",
               "https"
+            ],
+            "signatureVersions": [
+              "v2"
             ]
           },
           "endpoints": {


### PR DESCRIPTION
Fixes failing smoke tests.

cc @kyleknap @JordonPhillips 