### PR TITLE
Add retry for kinesis DescribeStream

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -123,6 +123,20 @@
         }
       }
     },
+    "kinesis": {
+      "DescribeStream": {
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "LimitExceededException",
+                "http_status_code": 400
+              }
+            }
+          }
+        }
+      }
+    },
     "sqs": {
       "__default__": {
         "policies": {


### PR DESCRIPTION
It is here in the docs: http://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStream.html

Also here is an error that may be returned:
```
DEBUG:botocore.parsers:Response body:
{"__type":"LimitExceededException","message":"Rate exceeded for stream request_counters_temp under account XXXXXXXX."}
DEBUG:botocore.hooks:Event needs-retry.kinesis.DescribeStream: calling handler <botocore.retryhandler.RetryHandler object at 0x7f824d7bc4d0> 
```

cc @jamesls @JordonPhillips 