### PR TITLE
Fix remove_dot_segments

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -71,6 +71,8 @@ def normalize_url_path(path):
 
 def remove_dot_segments(url):
     # RFC 3986, section 5.2.4 "Remove Dot Segments"
+    # Also, AWS services require consecutive slashes to be removed,
+    # so that's done here as well
     input_url = url.split('/')
     output_list = []
     for x in input_url:
@@ -81,8 +83,6 @@ def remove_dot_segments(url):
             else:
                 output_list.append(x)
     first = '/' if url[0] == '/' else ''
-    # This doesn't seem to be in the RFC but AWS auth services require
-    # consecutive slashes to be removed:
     last = '/' if url[-1] == '/' and len(output_list) > 0 else ''
     return first + '/'.join(output_list) + last
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -70,44 +70,21 @@ def normalize_url_path(path):
 
 
 def remove_dot_segments(url):
-    # RFC 2986, section 5.2.4 "Remove Dot Segments"
-    output = []
-    while url:
-        if url.startswith('../'):
-            url = url[3:]
-        elif url.startswith('./'):
-            url = url[2:]
-        elif url.startswith('/./'):
-            url = '/' + url[3:]
-        elif url.startswith('/../'):
-            url = '/' + url[4:]
-            if output:
-                output.pop()
-        elif url.startswith('/..'):
-            url = '/' + url[3:]
-            if output:
-                output.pop()
-        elif url.startswith('/.'):
-            url = '/' + url[2:]
-        elif url == '.' or url == '..':
-            url = ''
-        elif url.startswith('//'):
-            # As far as I can tell, this is not in the RFC,
-            # but AWS auth services require consecutive
-            # slashes are removed.
-            url = url[1:]
-        else:
-            if url[0] == '/':
-                next_slash = url.find('/', 1)
+    # RFC 3986, section 5.2.4 "Remove Dot Segments"
+    input_url = url.split('/')
+    output_list = []
+    for x in input_url:
+        if x and x != '.':
+            if x == '..':
+                if output_list:
+                    output_list.pop()
             else:
-                next_slash = url.find('/', 0)
-            if next_slash == -1:
-                output.append(url)
-                url = ''
-            else:
-                output.append(url[:next_slash])
-                url = url[next_slash:]
-    return ''.join(output)
+                output_list.append(x)
+    first = '/' if url[0] == '/' else ''
+    # This doesn't seem to be in the RFC but AWS auth services require
+    # consecutive slashes to be removed:
+    last = '/' if url[-1] == '/' and len(output_list) > 0 else ''
+    return first + '/'.join(output_list) + last
 
 
 def validate_jmespath_for_set(expression):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -62,6 +62,7 @@ class TestURINormalization(unittest.TestCase):
         self.assertEqual(remove_dot_segments('..'), '')
         self.assertEqual(remove_dot_segments('.'), '')
         self.assertEqual(remove_dot_segments('/.'), '/')
+        self.assertEqual(remove_dot_segments('/.foo'), '/.foo')
         # I don't think this is RFC compliant...
         self.assertEqual(remove_dot_segments('//foo//'), '/foo/')
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -63,6 +63,7 @@ class TestURINormalization(unittest.TestCase):
         self.assertEqual(remove_dot_segments('.'), '')
         self.assertEqual(remove_dot_segments('/.'), '/')
         self.assertEqual(remove_dot_segments('/.foo'), '/.foo')
+        self.assertEqual(remove_dot_segments('/..foo'), '/..foo')
         # I don't think this is RFC compliant...
         self.assertEqual(remove_dot_segments('//foo//'), '/foo/')
 


### PR DESCRIPTION
In the [RFC 3986, section 5.2.4](https://tools.ietf.org/html/rfc3986#section-5.2.4), 2A and 2B, it's indicated to remove `/.` or `/..` but only if `.` or `..` are complete path segments. The problem was that these were always removed, so an URL like `/.example/` would become `/example/`, then the signature would be rejected by the services.

Rewrote the function in a (I think) more pythonic way. Also, added two tests to cover those cases.