### PR TITLE
Don't use hardcoded service-2 for type name

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -28,7 +28,16 @@ class BotoCoreError(Exception):
         self.kwargs = kwargs
 
 
-class UnknownServiceError(BotoCoreError):
+class DataNotFoundError(BotoCoreError):
+    """
+    The data associated with a particular path could not be loaded.
+
+    :ivar path: The data path that the user attempted to load.
+    """
+    fmt = 'Unable to load data for: {data_path}'
+
+
+class UnknownServiceError(DataNotFoundError):
     """Raised when trying to load data for an unknown service.
 
     :ivar service_name: The name of the unknown service.
@@ -37,15 +46,6 @@ class UnknownServiceError(BotoCoreError):
     fmt = (
         "Unknown service: '{service_name}'. Valid service names are: "
         "{known_service_names}")
-
-
-class DataNotFoundError(BotoCoreError):
-    """
-    The data associated with a particular path could not be loaded.
-
-    :ivar path: The data path that the user attempted to load.
-    """
-    fmt = 'Unable to load data for: {data_path}'
 
 
 class ApiVersionNotFoundError(BotoCoreError):

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -341,7 +341,7 @@ class Loader(object):
         """
         # Wrapper around the load_data.  This will calculate the path
         # to call load_data with.
-        known_services = self.list_available_services('service-2')
+        known_services = self.list_available_services(type_name)
         if service_name not in known_services:
             raise UnknownServiceError(
                 service_name=service_name,

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -158,6 +158,22 @@ class TestLoader(BaseEnvVar):
                                      'Unknown service.*BAZ.*baz'):
             loader.load_service_model('BAZ', type_name='service-2')
 
+    def test_load_service_model_uses_provided_type_name(self):
+        loader = Loader(extra_search_paths=['foo'],
+                        file_loader=mock.Mock(),
+                        include_default_search_paths=False)
+        loader.list_available_services = mock.Mock(return_value=['baz'])
+
+        # Should have a) the unknown service name and b) list of valid
+        # service names.
+        provided_type_name = 'not-service-2'
+        with self.assertRaisesRegexp(UnknownServiceError,
+                                     'Unknown service.*BAZ.*baz'):
+            loader.load_service_model(
+                'BAZ', type_name=provided_type_name)
+
+        loader.list_available_services.assert_called_with(provided_type_name)
+
     def test_create_loader_parses_data_path(self):
         search_path = os.pathsep.join(['foo', 'bar', 'baz'])
         loader = create_loader(search_path)


### PR DESCRIPTION
This makes it general enough to use for boto3 resources.

In order to make this backwards compatible, the UnknownServiceError
subclasses from DataNotFoundError.

cc @kyleknap @JordonPhillips 