### PR TITLE
Hide PasswordLastUsed from CreateUser response

### DIFF
--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -191,8 +191,9 @@ class HideUnusedShapeMember(object):
             .get_section('member-value').get_section('structure-value')
         if self.member_name not in section.available_sections:
             return
-        if section.available_sections[-2] == self.member_name and \
-                'ending' in section.available_sections[-1]:
+        sections = section.available_sections
+        if len(sections) >= 3 and sections[-2] == self.member_name and \
+                'ending' in sections[-1]:
             # The member is the last documented member, so we need to go back
             # to delete the previous trailing comma and newline
             previous_member_name = section.available_sections[-3]

--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -165,6 +165,42 @@ class HideParamFromOperations(object):
             section.delete_section(self._parameter_name)
 
 
+class HideUnusedShapeMember(object):
+    def __init__(self, shape_name, member_name):
+        self.shape_name = shape_name
+        self.member_name = member_name
+
+    def hide_member(self, event_name, section, **kwargs):
+        if 'example' in event_name:
+            self._hide_example(section)
+        else:
+            self._hide_param(section)
+
+    def _hide_param(self, section):
+        if self.shape_name not in section.available_sections:
+            return
+        section = section.get_section(self.shape_name)
+        if self.member_name in section.available_sections:
+            section.delete_section(self.member_name)
+
+    def _hide_example(self, section):
+        section = section.get_section('structure-value')
+        if self.shape_name not in section.available_sections:
+            return
+        section = section.get_section(self.shape_name)\
+            .get_section('member-value').get_section('structure-value')
+        if self.member_name not in section.available_sections:
+            return
+        if section.available_sections[-2] == self.member_name and \
+                'ending' in section.available_sections[-1]:
+            # The member is the last documented member, so we need to go back
+            # to delete the previous trailing comma and newline
+            previous_member_name = section.available_sections[-3]
+            previous_section = section.get_section(previous_member_name)
+            previous_section.delete_section('ending-comma')
+        section.delete_section(self.member_name)
+
+
 class AppendParamDocumentation(object):
     """Appends documentation to a specific parameter"""
     def __init__(self, parameter_name, doc_string):

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -25,9 +25,9 @@ import warnings
 
 from botocore.compat import urlsplit, urlunsplit, unquote, \
     json, quote, six, unquote_str, ensure_bytes, get_md5, MD5_AVAILABLE
-from botocore.docs.utils import AutoPopulatedParam
-from botocore.docs.utils import HideParamFromOperations
-from botocore.docs.utils import AppendParamDocumentation
+from botocore.docs.utils import (
+    AutoPopulatedParam, HideParamFromOperations,
+    HideUnusedShapeMember, AppendParamDocumentation)
 from botocore.signers import add_generate_presigned_url
 from botocore.signers import add_generate_presigned_post
 from botocore.exceptions import ParamValidationError
@@ -749,5 +749,7 @@ BUILTIN_HANDLERS = [
           'PutBucketLifecycle', 'PutBucketLogging', 'PutBucketNotification',
           'PutBucketPolicy', 'PutBucketReplication', 'PutBucketRequestPayment',
           'PutBucketTagging', 'PutBucketVersioning', 'PutBucketWebsite',
-          'PutObjectAcl']).hide_param)
+          'PutObjectAcl']).hide_param),
+    ('docs.*.iam.CreateUser.complete-section',
+     HideUnusedShapeMember('User', 'PasswordLastUsed').hide_member)
 ]


### PR DESCRIPTION
CreateUser returns a User shape, which contains PasswordLastUsed. This attribute will never show up in a CreateUser response, however, so we hide it in the documentation.

Fixes boto/boto3#487

cc @kyleknap @jamesls 