### PR TITLE
Use kwargs for optional params specified as kwargs when creating RequestSigner

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -144,8 +144,8 @@ class ClientCreator(object):
         event_emitter = copy.copy(self._event_emitter)
         response_parser = botocore.parsers.create_parser(protocol)
         endpoint_bridge = ClientEndpointBridge(
-            self._endpoint_resolver, scoped_config, client_config,
-            service_model.metadata.get('signingName'))
+            self._endpoint_resolver, scoped_config=scoped_config, client_config=client_config,
+            service_signing_name=service_model.metadata.get('signingName'))
         endpoint_config = endpoint_bridge.resolve(
             service_name, region_name, endpoint_url, is_secure)
 


### PR DESCRIPTION
This ensures that we are passing things in the correct spots.

Prior to this, the service_signing_name was being passed in in the position of default_endpoint, making it non functional.

Fixes issue: https://github.com/boto/botocore/issues/836

@kyleknap 