### PR TITLE
Add ability to alias parameters

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -241,6 +241,20 @@ class UnknownParameterError(ValidationError):
     )
 
 
+class AliasConflictParameterError(ValidationError):
+    """
+    Error when an alias is provided for a parameter as well as the original.
+
+    :ivar original: The name of the original parameter.
+    :ivar alias: The name of the alias
+    :ivar operation: The name of the operation.
+    """
+    fmt = (
+        "Parameter '{original}' and its alias '{alias}' were provided "
+        "for operation {operation}.  Only one of them may be used."
+    )
+
+
 class UnknownServiceStyle(BotoCoreError):
     """
     Unknown style of service invocation.

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -31,6 +31,7 @@ from botocore.docs.utils import AppendParamDocumentation
 from botocore.signers import add_generate_presigned_url
 from botocore.signers import add_generate_presigned_post
 from botocore.exceptions import ParamValidationError
+from botocore.exceptions import AliasConflictParameterError
 from botocore.exceptions import UnsupportedTLSVersionWarning
 from botocore.utils import percent_encode, SAFE_CHARS
 
@@ -671,6 +672,12 @@ class ParameterAlias(object):
             # input shape.
             if self._original_name in model.input_shape.members:
                 if self._alias_name in params:
+                    if self._original_name in params:
+                        raise AliasConflictParameterError(
+                            original=self._original_name,
+                            alias=self._alias_name,
+                            operation=model.name
+                        )
                     # Remove the alias parameter value and use the old name
                     # instead.
                     params[self._original_name] = params.pop(self._alias_name)

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -648,14 +648,16 @@ def _add_parameter_aliases(handler_list):
         # One handler is to handle when users provide the alias.
         # The other handler is to update the documentation to show only
         # the alias.
-        handler_for_parameter_build = (
+        parameter_build_event_handler_tuple = (
             'before-parameter-build.' + event_portion,
-            parameter_alias.alias_parameter_in_call)
-        handler_for_docs = (
+            parameter_alias.alias_parameter_in_call,
+            REGISTER_FIRST
+        )
+        docs_event_handler_tuple = (
             'docs.*.' + event_portion + '.complete-section',
             parameter_alias.alias_parameter_in_documentation)
-        handler_list.append(handler_for_parameter_build)
-        handler_list.append(handler_for_docs)
+        handler_list.append(parameter_build_event_handler_tuple)
+        handler_list.append(docs_event_handler_tuple)
 
 
 class ParameterAlias(object):

--- a/tests/functional/docs/test_alias.py
+++ b/tests/functional/docs/test_alias.py
@@ -1,0 +1,36 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.functional.docs import BaseDocsFunctionalTest
+from tests.functional.test_alias import ALIAS_CASES
+
+
+class TestAliasesDocumented(BaseDocsFunctionalTest):
+    def test_all_aliases_are_documented_correctly(self):
+        for case in ALIAS_CASES:
+            content = self.get_docstring_for_method(
+                case['service'], case['operation']).decode('utf-8')
+            new_name = case['new_name']
+            original_name = case['original_name']
+            param_name_template = ':param %s:'
+            param_type_template = ':type %s:'
+            param_example_template = '%s='
+
+            # Make sure the new parameters are in the documentation
+            # but the old names are not.
+            self.assertIn(param_name_template % new_name, content)
+            self.assertIn(param_type_template % new_name, content)
+            self.assertIn(param_example_template % new_name, content)
+
+            self.assertNotIn(param_name_template % original_name, content)
+            self.assertNotIn(param_type_template % original_name, content)
+            self.assertNotIn(param_example_template % original_name, content)

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -1,0 +1,84 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import botocore.session
+from botocore.stub import Stubber
+from botocore.exceptions import ParamValidationError
+
+
+ALIAS_CASES = [
+    {
+        'service': 'ec2',
+        'operation': 'describe_flow_logs',
+        'original_name': 'Filter',
+        'new_name': 'Filters',
+        'parameter_value': [{'Name': 'traffic-type', 'Values': ['ACCEPT']}]
+    },
+    {
+        'service': 'cloudsearchdomain',
+        'operation': 'search',
+        'original_name': 'return',
+        'new_name': 'returnFields',
+        'parameter_value': '_all_fields',
+        'extra_args': {'query': 'foo'}
+    },
+    {
+        'service': 'logs',
+        'operation': 'create_export_task',
+        'original_name': 'from',
+        'new_name': 'fromTime',
+        'parameter_value': 0,
+        'extra_args': {
+            'logGroupName': 'name',
+            'to': 10,
+            'destination': 'mybucket'
+        }
+    }
+]
+
+
+def test_can_use_alias():
+    session = botocore.session.get_session()
+    for case in ALIAS_CASES:
+        yield _can_use_parameter_in_client_call, session, case
+
+
+def test_can_use_original_name():
+    session = botocore.session.get_session()
+    for case in ALIAS_CASES:
+        yield _can_use_parameter_in_client_call, session, case, False
+
+
+def _can_use_parameter_in_client_call(session, case, use_alias=True):
+    client = session.create_client(
+        case['service'], region_name='us-east-1',
+        aws_access_key_id='foo', aws_secret_access_key='bar')
+
+    stubber = Stubber(client)
+    stubber.activate()
+    operation = case['operation']
+    params = case.get('extra_args', {})
+    params = params.copy()
+    param_name = case['original_name']
+    if use_alias:
+        param_name = case['new_name']
+    params[param_name] = case['parameter_value']
+    stubbed_response = case.get('stubbed_response', {})
+    stubber.add_response(operation, stubbed_response)
+    try:
+        getattr(client, operation)(**params)
+    except ParamValidationError as e:
+        raise AssertionError(
+            'Expecting %s to be valid parameter for %s.%s but received '
+            '%s.' % (
+                case['new_name'], case['service'], case['operation'], e)
+        )

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -21,6 +21,7 @@ import os
 import botocore
 import botocore.session
 from botocore.exceptions import ParamValidationError, MD5UnavailableError
+from botocore.exceptions import AliasConflictParameterError
 from botocore.awsrequest import AWSRequest
 from botocore.compat import quote, six
 from botocore.docs.bcdoc.restdoc import DocumentStructure
@@ -829,6 +830,15 @@ class TestParameterAlias(unittest.TestCase):
         self.parameter_alias.alias_parameter_in_call(
             params, self.operation_model)
         self.assertEqual(params, {self.original_name: value})
+
+    def test_alias_parameter_and_original_in_call(self):
+        params = {
+            self.original_name: 'orginal_value',
+            self.alias_name: 'alias_value'
+        }
+        with self.assertRaises(AliasConflictParameterError):
+            self.parameter_alias.alias_parameter_in_call(
+                params, self.operation_model)
 
     def test_alias_parameter_in_call_does_not_touch_original(self):
         value = 'value'


### PR DESCRIPTION
Fixes parameters that shadow reserved keywords in python and inconsistent
parameter names in ec2.

Fixes https://github.com/boto/botocore/issues/772

As to implementation, I followed a similar format (just a tad different) as the CLI so if the alias needed to be in both the CLI and boto3, we could import the dictionary in botocore and modify the ``HIDDEN_ALIAS`` dictionary in the CLI or just copy and paste entities in that dictionary from botocore to the CLI. I went with this path because it required less work and less of a wider impact in the code base then the ``all_member`` route we discussed . Also it would not be difficult for the CLI to pick up these aliases as it already has this functionality.

cc @jamesls @JordonPhillips 