### PR TITLE
Add api_versions to session variable

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -80,6 +80,7 @@ class Session(object):
         'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
         'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
         'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
+        'api_versions': ('api_versions', None, {}, None),
 
         # This is the shared credentials file amongst sdks.
         'credentials_file': (None, 'AWS_SHARED_CREDENTIALS_FILE',
@@ -786,6 +787,10 @@ class Session(object):
         # configuration options.
         if verify is None:
             verify = self.get_config_variable('ca_bundle')
+
+        if api_version is None:
+            api_version = self.get_config_variable('api_versions').get(
+                service_name, None)
 
         loader = self.get_component('data_loader')
         event_emitter = self.get_component('event_emitter')

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -41,6 +41,7 @@ class BaseSessionTest(unittest.TestCase):
             'config_file': (None, 'FOO_CONFIG_FILE', None, None),
             'credentials_file': (None, None, '/tmp/nowhere', None),
             'ca_bundle': ('foo_ca_bundle', 'FOO_AWS_CA_BUNDLE', None, None),
+            'api_versions': ('foo_api_versions', None, {}, None)
         }
         self.environ = {}
         self.environ_patch = mock.patch('os.environ', self.environ)
@@ -553,6 +554,75 @@ class TestCreateClient(BaseSessionTest):
             # The verify parameter should override all the other
             # configurations
             self.assertEqual(call_kwargs['verify'], 'verify-certs.pem')
+
+    @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_use_no_api_version_by_default(self, client_creator):
+        self.session.create_client('myservice', 'us-west-2')
+        call_kwargs = client_creator.return_value.create_client.call_args[1]
+        self.assertEqual(call_kwargs['api_version'], None)
+
+    @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_uses_api_version_from_config(self, client_creator):
+        config_api_version = '2012-01-01'
+        with temporary_file('w') as f:
+            del self.environ['FOO_PROFILE']
+            self.environ['FOO_CONFIG_FILE'] = f.name
+            self.session = create_session(session_vars=self.env_vars)
+            f.write('[default]\n')
+            f.write('foo_api_versions =\n'
+                    '    myservice = %s\n' % config_api_version)
+            f.flush()
+
+            self.session.create_client('myservice', 'us-west-2')
+            call_kwargs = client_creator.return_value.\
+                create_client.call_args[1]
+            self.assertEqual(call_kwargs['api_version'], config_api_version)
+
+    @mock.patch('botocore.client.ClientCreator')
+    def test_can_specify_multiple_versions_from_config(self, client_creator):
+        config_api_version = '2012-01-01'
+        second_config_api_version = '2013-01-01'
+        with temporary_file('w') as f:
+            del self.environ['FOO_PROFILE']
+            self.environ['FOO_CONFIG_FILE'] = f.name
+            self.session = create_session(session_vars=self.env_vars)
+            f.write('[default]\n')
+            f.write('foo_api_versions =\n'
+                    '    myservice = %s\n'
+                    '    myservice2 = %s\n' % (
+                        config_api_version, second_config_api_version)
+            )
+            f.flush()
+
+            self.session.create_client('myservice', 'us-west-2')
+            call_kwargs = client_creator.return_value.\
+                create_client.call_args[1]
+            self.assertEqual(call_kwargs['api_version'], config_api_version)
+
+            self.session.create_client('myservice2', 'us-west-2')
+            call_kwargs = client_creator.return_value.\
+                create_client.call_args[1]
+            self.assertEqual(
+                call_kwargs['api_version'], second_config_api_version)
+
+    @mock.patch('botocore.client.ClientCreator')
+    def test_param_api_version_overrides_config_value(self, client_creator):
+        config_api_version = '2012-01-01'
+        override_api_version = '2014-01-01'
+        with temporary_file('w') as f:
+            del self.environ['FOO_PROFILE']
+            self.environ['FOO_CONFIG_FILE'] = f.name
+            self.session = create_session(session_vars=self.env_vars)
+            f.write('[default]\n')
+            f.write('foo_api_versions =\n'
+                    '    myservice = %s\n' % config_api_version)
+            f.flush()
+
+            self.session.create_client(
+                'myservice', 'us-west-2', api_version=override_api_version)
+            call_kwargs = client_creator.return_value.\
+                create_client.call_args[1]
+            self.assertEqual(call_kwargs['api_version'], override_api_version)
 
 
 class TestComponentLocator(unittest.TestCase):


### PR DESCRIPTION
Also allows use to specify ``api_versions`` in the config file so the CLI can start picking these up as well. It would looks like this in the config file:
```
api_versions =
    cloudsearch = 2011-02-01
    ec2 = 2014-10-01
```
If you want to set the api versions on the session, you would have to use the session's ``get_config_variable()`` and ``set_config_variable()`` methods.

cc @jamesls @JordonPhillips 