### PR TITLE
Fall back to deprecated starting token parser

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -353,7 +353,8 @@ class PageIterator(object):
         This handles parsing of old style starting tokens, and attempts to
         coerce them into the new style.
         """
-        log.debug("Attempting to fall back to old starting token parser.")
+        log.debug("Attempting to fall back to old starting token parser. For "
+                  "token: %s" % self._starting_token)
         if self._starting_token is None:
             return None
 

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -18,9 +18,13 @@ from six import string_types
 import jmespath
 import json
 import base64
+import logging
 from botocore.exceptions import PaginationError
 from botocore.compat import zip
 from botocore.utils import set_value_from_jmespath, merge_dicts
+
+
+log = logging.getLogger(__name__)
 
 
 class PaginatorModel(object):
@@ -341,8 +345,42 @@ class PageIterator(object):
                 index = next_token.get('boto_truncate_amount')
                 del next_token['boto_truncate_amount']
         except (ValueError, TypeError):
-            raise ValueError("Bad starting token: %s" % self._starting_token)
+            next_token, index = self._parse_starting_token_deprecated()
         return next_token, index
+
+    def _parse_starting_token_deprecated(self):
+        """
+        This handles parsing of old style starting tokens, and attempts to
+        coerce them into the new style.
+        """
+        log.debug("Attempting to fall back to old starting token parser.")
+        if self._starting_token is None:
+            return None
+
+        parts = self._starting_token.split('___')
+        next_token = []
+        index = 0
+        if len(parts) == len(self._input_token) + 1:
+            try:
+                index = int(parts.pop())
+            except ValueError:
+                raise ValueError("Bad starting token: %s" %
+                                 self._starting_token)
+        for part in parts:
+            if part == 'None':
+                next_token.append(None)
+            else:
+                next_token.append(part)
+        return self._convert_deprecated_starting_token(next_token), index
+
+    def _convert_deprecated_starting_token(self, deprecated_token):
+        """
+        This attempts to convert a deprecated starting token into the new
+        style.
+        """
+        if len(deprecated_token) != len(self._input_token):
+            raise ValueError("Bad starting token: %s" % self._starting_token)
+        return dict(zip(self._input_token, deprecated_token))
 
 
 class Paginator(object):

--- a/tests/functional/test_paginate.py
+++ b/tests/functional/test_paginate.py
@@ -1,0 +1,60 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+from botocore.stub import Stubber, StubAssertionError
+import botocore.session
+
+
+class TestRDSPagination(unittest.TestCase):
+    def setUp(self):
+        self.region = 'us-west-2'
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client(
+            'rds', self.region)
+        self.stubber = Stubber(self.client)
+
+    def test_can_specify_zero_marker(self):
+        service_response = {
+            'LogFileData': 'foo',
+            'Marker': '2',
+            'AdditionalDataPending': True
+        }
+        expected_params = {
+            'DBInstanceIdentifier': 'foo',
+            'LogFileName': 'bar',
+            'NumberOfLines': 2,
+            'Marker': '0'
+        }
+        function_name = 'download_db_log_file_portion'
+
+        # The stubber will assert that the function is called with the expected
+        # parameters.
+        self.stubber.add_response(
+            function_name, service_response, expected_params)
+        self.stubber.activate()
+
+        try:
+            paginator = self.client.get_paginator(function_name)
+            result = paginator.paginate(
+                DBInstanceIdentifier='foo',
+                LogFileName='bar',
+                NumberOfLines=2,
+                PaginationConfig={
+                    'StartingToken': '0',
+                    'MaxItems': 3
+                }).build_full_result()
+            self.assertEqual(result['LogFileData'], 'foo')
+            self.assertIn('NextToken', result)
+        except StubAssertionError as e:
+            self.fail(str(e))
+

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -66,6 +66,19 @@ class TestEC2Pagination(unittest.TestCase):
             # page.
             self.assertEqual(len(reserved_inst_offer), 1)
 
+    def test_can_fall_back_to_old_starting_token(self):
+        # Using an operation that we know will paginate.
+        paginator = self.client.get_paginator(
+            'describe_reserved_instances_offerings')
+        pages = paginator.paginate(PaginationConfig={'NextToken': 'None___1'})
+
+        try:
+            results = list(itertools.islice(pages, 0, 3))
+            self.assertEqual(len(results), 3)
+            self.assertTrue(results[0]['NextToken'] != results[1]['NextToken'])
+        except ValueError:
+            self.fail("Old style paginator failed.")
+
 
 @attr('slow')
 class TestCopySnapshotCustomization(unittest.TestCase):


### PR DESCRIPTION
A recent change to paginators broke customers who were manually crafting pagination tokens in services where they did not make them opaque. This adds support for the old starting token format while still returning next tokens in the new format. If we are unable to parse the starting token in the new format, we'll attempt to parse it with the old format.

This addresses the root cause of aws/aws-cli#1835, but the docs should be updated to reflect the new tokens.

cc @kyleknap @jamesls 