### PR TITLE
Assume role via instance metadata credentials

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -52,7 +52,7 @@ def create_credential_resolver(session):
     metadata_timeout = session.get_config_variable('metadata_service_timeout')
     num_attempts = session.get_config_variable('metadata_service_num_attempts')
 
-    instance_metadata_provider=InstanceMetadataProvider(
+    instance_metadata_provider = InstanceMetadataProvider(
             iam_role_fetcher=InstanceMetadataFetcher(
                 timeout=metadata_timeout,
                 num_attempts=num_attempts)
@@ -614,7 +614,7 @@ class SharedCredentialProvider(CredentialProvider):
                             self._creds_filename)
                 access_key, secret_key = self._extract_creds_from_mapping(
                     config, self.ACCESS_KEY, self.SECRET_KEY)
-                token =  self._get_session_token(config)
+                token = self._get_session_token(config)
                 return Credentials(access_key, secret_key, token,
                                    method=self.METHOD)
 
@@ -668,7 +668,7 @@ class ConfigProvider(CredentialProvider):
                     profile_config, self.ACCESS_KEY, self.SECRET_KEY)
                 token = self._get_session_token(profile_config)
                 return Credentials(access_key, secret_key, token,
-                                method=self.METHOD)
+                                   method=self.METHOD)
         else:
             return None
 
@@ -831,9 +831,10 @@ class AssumeRoleProvider(CredentialProvider):
         # On windows, ':' is not allowed in filenames, so we'll
         # replace them with '_' instead.
         role_arn = role_config['role_arn'].replace(':', '_')
-        role_session_name=role_config.get('role_session_name')
+        role_session_name = role_config.get('role_session_name')
         if role_session_name:
-            cache_key = '%s--%s--%s' % (self._profile_name, role_arn, role_session_name)
+            cache_key = '%s--%s--%s' % (
+                self._profile_name, role_arn, role_session_name)
         else:
             cache_key = '%s--%s' % (self._profile_name, role_arn)
 
@@ -845,14 +846,14 @@ class AssumeRoleProvider(CredentialProvider):
     def _get_role_config_values(self):
         # This returns the role related configuration.
         profiles = self._loaded_config.get('profiles', {})
-        role_profile=profiles[self._profile_name];
-        
+        role_profile = profiles[self._profile_name]
+
         source_profile = role_profile.get('source_profile')
         role_arn = role_profile['role_arn']
         mfa_serial = role_profile.get('mfa_serial')
         external_id = role_profile.get('external_id')
         role_session_name = role_profile.get('role_session_name')
-        
+
         return {
             'role_arn': role_arn,
             'external_id': external_id,
@@ -861,15 +862,14 @@ class AssumeRoleProvider(CredentialProvider):
             'role_session_name': role_session_name
         }
 
-        
-    def _get_source_profile_credentials(self,source_profile):
+    def _get_source_profile_credentials(self, source_profile):
         profiles = self._loaded_config.get('profiles', {})
-        if source_profile == None :
-            if self._fallback_cred_provider == None:
-                raise PartialCredentialsError(provider=self.METHOD,
+        if source_profile is None:
+            if self._fallback_cred_provider is None:
+                raise PartialCredentialsError(
+                    provider=self.METHOD,
                     cred_var="source_profile")
             else:
-                logger.debug("Source profile missing. Loading from fallback provider")
                 return self._fallback_cred_provider.load()
 
         if source_profile not in profiles:
@@ -879,14 +879,13 @@ class AssumeRoleProvider(CredentialProvider):
                     'the profile "%s" does not exist.' % (
                         source_profile, self._profile_name)))
 
-        access_key_id=profiles[source_profile]['aws_access_key_id']
-        secret_key=profiles[source_profile]['aws_secret_access_key']
-        session_token=profiles[source_profile].get('aws_session_token')
+        access_key_id = profiles[source_profile]['aws_access_key_id']
+        secret_key = profiles[source_profile]['aws_secret_access_key']
+        session_token = profiles[source_profile].get('aws_session_token')
         return Credentials(
             access_key=access_key_id,
             secret_key=secret_key,
             token=session_token)
-
 
     def _create_creds_from_response(self, response):
         config = self._get_role_config_values()
@@ -909,8 +908,8 @@ class AssumeRoleProvider(CredentialProvider):
             refresh_using=refresh_func)
 
     def _create_client_from_config(self, config):
-        source_profile=config['source_profile'];
-        creds=self._get_source_profile_credentials(source_profile);
+        source_profile = config['source_profile']
+        creds = self._get_source_profile_credentials(source_profile)
         client = self._client_creator(
             'sts', aws_access_key_id=creds.access_key,
             aws_secret_access_key=creds.secret_key,

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -52,7 +52,7 @@ def create_credential_resolver(session):
     metadata_timeout = session.get_config_variable('metadata_service_timeout')
     num_attempts = session.get_config_variable('metadata_service_num_attempts')
 
-    instanceMetadataProvider=InstanceMetadataProvider(
+    instance_metadata_provider=InstanceMetadataProvider(
             iam_role_fetcher=InstanceMetadataFetcher(
                 timeout=metadata_timeout,
                 num_attempts=num_attempts)
@@ -66,7 +66,7 @@ def create_credential_resolver(session):
             client_creator=session.create_client,
             cache={},
             profile_name=profile_name,
-            fallback_cred_provider=instanceMetadataProvider
+            fallback_cred_provider=instance_metadata_provider
         ),
         SharedCredentialProvider(
             creds_filename=credential_file,
@@ -77,7 +77,7 @@ def create_credential_resolver(session):
         ConfigProvider(config_filename=config_file, profile_name=profile_name),
         OriginalEC2Provider(),
         BotoProvider(),
-        instanceMetadataProvider
+        instance_metadata_provider
     ]
 
     explicit_profile = session.get_config_variable('profile',

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1014,7 +1014,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         creds = provider.load()
         self.assertIsNone(creds)
 
-    def test_source_profile_not_provided(self):
+    def test_source_profile_not_provided_with_no_fallback_provider(self):
         del self.fake_config['profiles']['development']['source_profile']
         provider = credentials.AssumeRoleProvider(
             self.create_config_loader(),
@@ -1023,6 +1023,47 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         # source_profile is required, we shoudl get an error.
         with self.assertRaises(botocore.exceptions.PartialCredentialsError):
             provider.load()
+
+    def test_source_profile_not_provided_but_has_fallback_provider(self):
+        del self.fake_config['profiles']['development']['source_profile']
+
+        fallback_creds=credentials.Credentials(
+            access_key='access-fallback',
+            secret_key='secret-fallback',
+            token='token-fallback')
+
+        mock_fallback_provider=mock.Mock()
+        mock_fallback_provider.load.return_value=fallback_creds
+        
+        ten_min_from_now=datetime.now(tzlocal()) + timedelta(minutes=10)
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'AKI',
+                'SecretAccessKey': 'SAK',
+                'SessionToken': 'ST',
+                'Expiration':  ten_min_from_now.isoformat()
+            },
+        }
+        client = mock.Mock()
+        client.assume_role.return_value = response
+        def side_effect_of_create_client(*args,**kwargs):
+            self.assertEqual(args[0],'sts')
+            self.assertEqual(kwargs['aws_access_key_id'],'access-fallback')
+            self.assertEqual(kwargs['aws_secret_access_key'],'secret-fallback')
+            self.assertEqual(kwargs['aws_session_token'],'token-fallback')
+            return client;
+        
+        client_creator=mock.Mock(side_effect=side_effect_of_create_client)
+    
+        provider = credentials.AssumeRoleProvider(
+            self.create_config_loader(),
+            client_creator, cache={}, profile_name='development', 
+            fallback_cred_provider=mock_fallback_provider)
+
+        creds=provider.load()
+        self.assertEqual(creds.access_key, 'AKI')
+        self.assertEqual(creds.secret_key, 'SAK')
+        self.assertEqual(creds.token, 'ST')
 
     def test_source_profile_does_not_exist(self):
         dev_profile = self.fake_config['profiles']['development']


### PR DESCRIPTION
Allows a client to assume a role by using the credentials from the EC2 instance profile. If a profile in the configuration has a `role_arn` but not a `source_profile` the credentials used for assuming the role will come from the instance metadata.

This pull request is to address [AWS CLI issue 1390](https://github.com/aws/aws-cli/issues/1390). The issue was linked to the AWS CLI repo since that's where the AssumeRoleProvider code was at the time the issue was created. The AssumeRoleProvider was moved into botocore after that, so I've updated the relevant botocore code. 
