### PR TITLE
Retry 502 responses

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -35,6 +35,13 @@
         }
       }
     },
+    "bad_gateway": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 502
+        }
+      }
+    },
     "service_unavailable": {
       "applies_when": {
         "response": {


### PR DESCRIPTION
Last part of the fix required for aws/aws-cli#1679.

First part was ensuring we can parse out the appropriate errors from proxy responses (https://github.com/boto/botocore/pull/850)


cc @kyleknap @JordonPhillips 