### PR TITLE
Consistently parse error responses with no body

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -229,7 +229,8 @@ class ResponseParser(object):
         # To prevent this case from happening we first need to check
         # whether or not this response looks like the generic response.
         if response['status_code'] >= 500:
-            return response['body'].strip().startswith(b'<html>')
+            body = response['body'].strip()
+            return body.startswith(b'<html>') or not body
 
     def _do_generic_error_parse(self, response):
         # There's not really much we can do when we get a generic

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -511,8 +511,8 @@ class TestParseErrorResponses(unittest.TestCase):
 
         self.assertIn('Error', parsed)
         self.assertEqual(parsed['Error'], {
-            'Code': '',
-            'Message': ''
+            'Code': '504',
+            'Message': 'Gateway Timeout'
         })
         self.assertEqual(parsed['ResponseMetadata'], {
             'HTTPStatusCode': 504,
@@ -642,19 +642,20 @@ def test_can_handle_generic_error_message():
     # There are times when you can get a service to respond with a generic
     # html error page.  We should be able to handle this case.
     for parser_cls in parsers.PROTOCOL_PARSERS.values():
-        yield _assert_parses_generic_error, parser_cls()
+        generic_html_body =  (
+            '<html><body><b>Http/1.1 Service Unavailable</b></body></html>'
+        ).encode('utf-8')
+        empty_body = b''
+        yield _assert_parses_generic_error, parser_cls(), generic_html_body
+        yield _assert_parses_generic_error, parser_cls(), empty_body
 
 
-def _assert_parses_generic_error(parser):
+def _assert_parses_generic_error(parser, body):
     # There are times when you can get a service to respond with a generic
     # html error page.  We should be able to handle this case.
-    body =  (
-        '<html><body><b>Http/1.1 Service Unavailable</b></body></html>'
-    ).encode('utf-8')
     parsed = parser.parse({
         'body': body, 'headers': {}, 'status_code': 503}, None)
     assert_equal(
-        parsed,
-        {'Error': {'Code': '503', 'Message': 'Service Unavailable'},
-         'ResponseMetadata': {'HTTPStatusCode': 503}}
-    )
+        parsed['Error'],
+        {'Code': '503', 'Message': 'Service Unavailable'})
+    assert_equal(parsed['ResponseMetadata']['HTTPStatusCode'], 503)


### PR DESCRIPTION
The generic error parsing code can now additionally be triggered by a 5xx response with an empty body in addition to an html response body.

This also required updating one test which was previously leaving the code/message blank in this scenario.

Fixes boto/boto3#574.

cc @kyleknap @JordonPhillips 