### PR TITLE
Validate S3 metadata only contains ascii chars

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -11,6 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from __future__ import unicode_literals
 from botocore.vendored.requests.exceptions import ConnectionError
 
 

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -40,6 +40,16 @@ class BaseS3OperationTest(BaseSessionTest):
         self.session_send_patch.stop()
 
 
+class TestOnlyAsciiCharsAllowed(BaseS3OperationTest):
+    def test_validates_non_ascii_chars_trigger_validation_error(self):
+        self.http_session_send_mock.return_value = mock.Mock(status_code=200,
+                                                             headers={},
+                                                             content=b'')
+        with self.assertRaises(ParamValidationError):
+            self.client.put_object(Bucket='foo', Key='bar',
+                                Metadata={'goodkey': 'good',
+                                          'non-ascii': u'\u2713'})
+
 class TestS3GetBucketLifecycle(BaseS3OperationTest):
     def test_multiple_transitions_returns_one(self):
         http_response = mock.Mock()

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -517,6 +517,27 @@ class TestHandlers(BaseSessionTest):
     def test_validation_is_noop_if_no_bucket_param_exists(self):
         self.assertIsNone(handlers.validate_bucket_name(params={}))
 
+    def test_validate_non_ascii_metadata_values(self):
+        with self.assertRaises(ParamValidationError):
+            handlers.validate_ascii_metadata({'Metadata': {'foo': u'\u2713'}})
+
+    def test_validate_non_ascii_metadata_keys(self):
+        with self.assertRaises(ParamValidationError):
+            handlers.validate_ascii_metadata(
+                {'Metadata': {u'\u2713': 'bar'}})
+
+    def test_validate_non_triggered_when_no_md_specified(self):
+        original = {'NotMetadata': ''}
+        copied = original.copy()
+        handlers.validate_ascii_metadata(copied)
+        self.assertEqual(original, copied)
+
+    def test_validation_passes_when_all_ascii_chars(self):
+        original = {'Metadata': {'foo': 'bar'}}
+        copied = original.copy()
+        handlers.validate_ascii_metadata(original)
+        self.assertEqual(original, copied)
+
     def test_set_encoding_type(self):
         params = {}
         context = {}


### PR DESCRIPTION
Fixes boto/boto3#478.

cc @kyleknap @JordonPhillips 