### PR TITLE
Fix bug when params including multibyte characters

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -615,7 +615,7 @@ class RestXMLSerializer(BaseRestSerializer):
 
     def _default_serialize(self, xmlnode, params, shape, name):
         node = ElementTree.SubElement(xmlnode, name)
-        node.text = str(params)
+        node.text = params
 
 
 SERIALIZERS = {


### PR DESCRIPTION
With Python 2.7.x

```
import boto3
client = boto3.client('s3')
client.put_object(Bucket='<your_bucket_name>', Key=u'日本語でおｋ')
client.delete_objects(Bucket='<your_bucket_name>', Delete={'Objects': [{'Key': u'日本語でおｋ'}]})
```

It raises
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/client.py", line 236, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/client.py", line 476, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/client.py", line 529, in _convert_to_request_dict
    api_params, operation_model)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/validate.py", line 271, in serialize_to_request
    operation_model)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 415, in serialize_to_request
    serialized, shape, shape_members)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 457, in _serialize_payload
    shape_members[payload_member])
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 532, in _serialize_body_params
    self._serialize(shape, params, pseudo_root, root_name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 539, in _serialize
    method(xmlnode, params, shape, name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 565, in _serialize_type_structure
    self._serialize(member_shape, value, structure_node, member_name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 539, in _serialize
    method(xmlnode, params, shape, name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 576, in _serialize_type_list
    self._serialize(member_shape, item, list_node, element_name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 539, in _serialize
    method(xmlnode, params, shape, name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 565, in _serialize_type_structure
    self._serialize(member_shape, value, structure_node, member_name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 539, in _serialize
    method(xmlnode, params, shape, name)
  File "/home/ec2-user/Workspace/test/local/lib/python2.7/site-packages/botocore/serialize.py", line 618, in _default_serialize
    node.text = str(params)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)
```