### PR TITLE
Use compat unittest

### DIFF
--- a/tests/integration/test_rds.py
+++ b/tests/integration/test_rds.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import unittest
+from tests import unittest
 import itertools
 
 import botocore.session

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import unittest
-import itertools
+from tests import unittest
 
 import botocore.session
 from botocore.exceptions import ClientError


### PR DESCRIPTION
A few tests were using base unittest rather than our compat version.

cc @jamesls @kyleknap 