### PR TITLE
Don't overwrite the Accept header if it is already set

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -519,8 +519,9 @@ def add_glacier_version(model, params, **kwargs):
 
 
 def add_accept_header(model, params, **kwargs):
-    request_dict = params
-    request_dict['headers']['Accept'] = 'application/json'
+    if params['headers'].get('Accept', None) is None:
+        request_dict = params
+        request_dict['headers']['Accept'] = 'application/json'
 
 
 def add_glacier_checksums(params, **kwargs):

--- a/tests/functional/test_apigateway.py
+++ b/tests/functional/test_apigateway.py
@@ -1,0 +1,42 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+
+from botocore.stub import Stubber
+from tests import BaseSessionTest
+
+
+class TestApiGateway(BaseSessionTest):
+    def setUp(self):
+        super(TestApiGateway, self).setUp()
+        self.region = 'us-west-2'
+        self.client = self.session.create_client(
+            'apigateway', self.region)
+        self.stubber = Stubber(self.client)
+
+    def test_get_export(self):
+        params = {
+            'restApiId': 'foo',
+            'stageName': 'bar',
+            'exportType': 'swagger',
+            'accepts': 'application/yaml'
+        }
+
+        with mock.patch('botocore.endpoint.Session.send') as _send:
+            _send.return_value = mock.Mock(
+                status_code=200, headers={}, content=b'{}')
+            self.client.get_export(**params)
+            sent_request = _send.call_args[0][0]
+            self.assertEqual(sent_request.method, 'GET')
+            self.assertEqual(
+                sent_request.headers.get('Accept'), b'application/yaml')

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -412,6 +412,13 @@ class TestHandlers(BaseSessionTest):
         handlers.add_accept_header(None, request_dict)
         self.assertEqual(request_dict['headers']['Accept'], 'application/json')
 
+    def test_accept_header_not_added_if_present(self):
+        request_dict = {
+            'headers': {'Accept': 'application/yaml'}
+        }
+        handlers.add_accept_header(None, request_dict)
+        self.assertEqual(request_dict['headers']['Accept'], 'application/yaml')
+
     def test_glacier_checksums_added(self):
         request_dict = {
             'headers': {},


### PR DESCRIPTION
APIGateway has at least one function, `get_export`, which relies on the use of the `Accept` header. We were over-writing that with `application/json`, so this checks to see if the header is already set before we put that in.

cc @kyleknap @jamesls 