### PR TITLE
fix when use custom endpoint_url

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -646,7 +646,7 @@ def fix_s3_host(request, signature_version, region_name, **kwargs):
         return
     try:
         switch_to_virtual_host_style(
-            request, signature_version, 's3.amazonaws.com')
+            request, signature_version, None)
     except InvalidDNSNameError as e:
         bucket_name = e.kwargs['bucket_name']
         logger.debug('Not changing URI, bucket is not DNS compatible: %s',


### PR DESCRIPTION
If I use a custom endpoint_url which is not s3.amazonaws.com, boto3 will fail to work.