### PR TITLE
Do not sign user-agent

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -44,7 +44,8 @@ PAYLOAD_BUFFER = 1024 * 1024
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 SIGV4_TIMESTAMP = '%Y%m%dT%H%M%SZ'
 SIGNED_HEADERS_BLACKLIST = [
-    'expect'
+    'expect',
+    'user-agent'
 ]
 
 

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -319,16 +319,22 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
         cqs = self.auth.canonical_query_string(request)
         self.assertEqual('marker=%C3%A4%C3%B6%C3%BC-01.txt&prefix=', cqs)
 
-    def test_blacklist_expect_headers(self):
+    def _test_blacklist_header(self, header, value):
         request = AWSRequest()
         request.url = 'https://s3.amazonaws.com/bucket/foo'
         request.method = 'PUT'
-        request.headers['expect'] = '100-Continue'
+        request.headers[header] = value
         credentials = botocore.credentials.Credentials('access_key',
                                                        'secret_key')
         auth = botocore.auth.S3SigV4Auth(credentials, 's3', 'us-east-1')
         auth.add_auth(request)
-        self.assertNotIn('expect', request.headers['Authorization'])
+        self.assertNotIn(header, request.headers['Authorization'])
+
+    def test_blacklist_expect_headers(self):
+        self._test_blacklist_header('expect', '100-continue')
+
+    def test_blacklist_headers(self):
+        self._test_blacklist_header('user-agent', 'botocore/1.4.11')
 
 
 class TestSigV4(unittest.TestCase):


### PR DESCRIPTION
The user agent may be changed somewhere along the line, so we should not
be signing it.

 #846

cc @kyleknap @jamesls 