### PR TITLE
Don't preemptively convert unicode in rest-xml parser

### DIFF
--- a/.changes/next-release/bugfix-Serializer.json
+++ b/.changes/next-release/bugfix-Serializer.json
@@ -1,0 +1,5 @@
+{
+  "category": "Serializer", 
+  "type": "bugfix", 
+  "description": "In the rest xml parser, we were converting the input we recieve into a `str`, which was causing failures on python 2 when multibyte unicode strings were passed in. The fix is to simply use `six.text_type`, which is `unicode` on 2 and `str` on 3. The string will be encoded into the default encoding later on in the serializer. Fixes `#868 <https://github.com/boto/botocore/issues/868>`__"
+}

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -615,7 +615,7 @@ class RestXMLSerializer(BaseRestSerializer):
 
     def _default_serialize(self, xmlnode, params, shape, name):
         node = ElementTree.SubElement(xmlnode, name)
-        node.text = str(params)
+        node.text = six.text_type(params)
 
 
 SERIALIZERS = {


### PR DESCRIPTION
In the rest xml parser, we were converting the input we recieve into a
`str`, which was causing failures on python 2 when multibyte unicode
strings were passed in. The fix is to simply use `six.text_type`, which
is `unicode` on 2 and `str` on 3. The string will be encoded into the
default encoding later on in the serializer.

Fixes #868

cc @kyleknap @jamesls 