### PR TITLE
Update missing non aggregate key to pagination config 

### DIFF
--- a/.changes/next-release/bugfix-awskinesis.json
+++ b/.changes/next-release/bugfix-awskinesis.json
@@ -1,0 +1,5 @@
+{
+  "category": "``aws kinesis``", 
+  "type": "bugfix", 
+  "description": "Fix issue where \"EnhancedMonitoring\" was not displayed when running ``aws kinesis describe-stream`` (`#1929 <https://github.com/aws/aws-cli/issues/1929>`__)"
+}

--- a/botocore/data/kinesis/2013-12-02/paginators-1.json
+++ b/botocore/data/kinesis/2013-12-02/paginators-1.json
@@ -10,7 +10,8 @@
         "StreamDescription.StreamARN",
         "StreamDescription.StreamName",
         "StreamDescription.StreamStatus",
-        "StreamDescription.RetentionPeriodHours"
+        "StreamDescription.RetentionPeriodHours",
+        "StreamDescription.EnhancedMonitoring"
       ]
     },
     "ListStreams": {


### PR DESCRIPTION
Fixes aws/aws-cli#1929