### PR TITLE
Retry 502 and 504 status codes

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -49,6 +49,13 @@
         }
       }
     },
+    "gateway_timeout": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 504
+        }
+      }
+    },
     "limit_exceeded": {
       "applies_when": {
         "response": {
@@ -68,7 +75,9 @@
       "policies": {
           "general_socket_errors": {"$ref": "general_socket_errors"},
           "general_server_error": {"$ref": "general_server_error"},
+          "bad_gateway": {"$ref": "bad_gateway"},
           "service_unavailable": {"$ref": "service_unavailable"},
+          "gateway_timeout": {"$ref": "gateway_timeout"},
           "limit_exceeded": {"$ref": "limit_exceeded"},
           "throttling_exception": {"$ref": "throttling_exception"},
           "throttling": {"$ref": "throttling"},


### PR DESCRIPTION
There was a bug with the 502 retries where it was added to
the definitions, but not to the default list of retry policies.

I've verified that 502 and 504 are in fact retried now.

cc @kyleknap @JordonPhillips 