### PR TITLE
Fix for EC2.Waiter.InstanceExists raising JMESPathTypeError

### DIFF
--- a/botocore/data/ec2/2015-10-01/waiters-2.json
+++ b/botocore/data/ec2/2015-10-01/waiters-2.json
@@ -7,9 +7,8 @@
       "operation": "DescribeInstances",
       "acceptors": [
         {
-          "matcher": "path",
-          "expected": true,
-          "argument": "length(Reservations[]) > `0`",
+          "matcher": "status",
+          "expected": 200,
           "state": "success"
         },
         {

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -16,7 +16,7 @@ import itertools
 from nose.plugins.attrib import attr
 
 import botocore.session
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, WaiterError
 
 
 class TestEC2(unittest.TestCase):
@@ -36,6 +36,20 @@ class TestEC2(unittest.TestCase):
         # on error.
         with self.assertRaises(ClientError):
             self.client.get_console_output(InstanceId='i-12345')
+
+
+class TestEC2Waiter(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client(
+            'ec2', region_name='us-west-2')
+
+    def test_instance_wait_error(self):
+        """Test that InstanceExists can handle a nonexistent instance."""
+        waiter = self.client.get_waiter('instance_exists')
+        waiter.config.max_attempts = 1
+        with self.assertRaises(WaiterError):
+            waiter.wait(InstanceIds=['i-12345'])
 
 
 class TestEC2Pagination(unittest.TestCase):


### PR DESCRIPTION
Reverted the "success" acceptor for that waiter to an earlier version
that checks only the response code, not the response body.

Added a unit test that reproduces the issue and passes with the
change to the JSON file.

Bug: https://github.com/boto/botocore/issues/906