### PR TITLE
Bump delay time for VpnConnection waiter

### DIFF
--- a/botocore/data/ec2/2015-10-01/waiters-2.json
+++ b/botocore/data/ec2/2015-10-01/waiters-2.json
@@ -525,7 +525,7 @@
       ]
     },
     "VpnConnectionAvailable": {
-      "delay": 15,
+      "delay": 60,
       "operation": "DescribeVpnConnections",
       "maxAttempts": 40,
       "acceptors": [


### PR DESCRIPTION
Users were seeing waiter timeouts with this.  So bumped up the delay time as it can take roughly 30 minutes for it to be available.

cc @jamesls @JordonPhillips 