### PR TITLE
Remove Transfer-Encoding if Content-Length is set.

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -423,6 +423,8 @@ class AWSPreparedRequest(models.PreparedRequest):
             raise UnseekableStreamError(stream_object=self.body)
 
     def prepare_body(self, data, files, json=None):
+        caller_set_tencoding = 'Transfer-Encoding' in self.headers
+
         """Prepares the given HTTP body data."""
         super(AWSPreparedRequest, self).prepare_body(data, files, json)
 
@@ -443,6 +445,12 @@ class AWSPreparedRequest(models.PreparedRequest):
                 # AWS Services so remove it if it is added.
                 if 'Transfer-Encoding' in self.headers:
                     self.headers.pop('Transfer-Encoding')
+
+        elif not caller_set_tencoding and 'Transfer-Encoding' in self.headers:
+            # Both Content-Length and Transfer-Encoding were set; we remove
+            # the Transfer-Encoding in this case, as the caller set
+            # Content-Length
+            self.headers.pop('Transfer-Encoding')
 
 HTTPSConnectionPool.ConnectionCls = AWSHTTPSConnection
 HTTPConnectionPool.ConnectionCls = AWSHTTPConnection

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -225,6 +225,16 @@ class TestAWSPreparedRequest(unittest.TestCase):
             self.prepared_request.headers['Transfer-Encoding'],
             'chunked')
 
+    def test_stream_content_length_set(self):
+        class Stream(object):
+            def __iter__(self):
+                return self
+
+        self.prepared_request.headers['Content-Length'] = 10
+        self.prepared_request.prepare_body(data=Stream(), files=None)
+        self.assertNotIn('Transfer-Encoding', self.prepared_request.headers)
+        self.assertEqual(self.prepared_request.headers['Content-Length'], 10)
+
 
 class TestAWSHTTPConnection(unittest.TestCase):
     def create_tunneled_connection(self, url, port, response):


### PR DESCRIPTION
The requests library will set the Transfer-Encoding header if the
following is true:
1. the data object is a stream (has **iter**() defined)
2. is not a list, tuple, dict, or a string
3. the length cannot be determined

Notably, a user-supplied Content-Length header is ignored and there
is no knob to set Transfer-Encoding.

As AWS S3 version 2 signer does not support chunked Transfer-Encoding,
boto3 needs to be careful about propagating the Transfer-Encoding
flag. This patch removes the Transfer-Encoding header if
Content-Length is set by the user (even if length of the data cannot
be determined).

Fixes #911
