### PR TITLE
Provide better error when page size is not supported

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -45,7 +45,6 @@ class PageIterator(object):
                  result_keys, non_aggregate_keys, limit_key, max_items,
                  starting_token, page_size, op_kwargs):
         self._method = method
-        self._op_kwargs = op_kwargs
         self._input_token = input_token
         self._output_token = output_token
         self._more_results = more_results
@@ -472,6 +471,10 @@ class Paginator(object):
             max_items = int(max_items)
         page_size = pagination_config.get('PageSize', None)
         if page_size is not None:
+            if self._pagination_cfg.get('limit_key', None) is None:
+                raise PaginationError(
+                    message="PageSize parameter is not supported for the "
+                            "pagination interface for this operation.")
             page_size = int(page_size)
         return {
             'MaxItems': max_items,

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -286,6 +286,14 @@ class TestPaginatorPageSize(unittest.TestCase):
         pages._inject_starting_params(extracted_kwargs)
         self.assertEqual(extracted_kwargs, ref_kwargs)
 
+    def test_page_size_incorrectly_provided(self):
+        kwargs = {'arg1': 'foo', 'arg2': 'bar',
+                  'PaginationConfig': {'PageSize': 5}}
+        del self.paginate_config['limit_key']
+
+        with self.assertRaises(PaginationError):
+            self.paginator.paginate(**kwargs)
+
 
 class TestPaginatorWithPathExpressions(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Some paginate-able operations do not support page size. Before, we would
just blindly try to toss it in anyway, leading to a very confusing error.
This raises an error on a call to paginator.paginate if page size is
provided, but not supported.

Fixes #876

cc @jamesls @kyleknap