### PR TITLE
Fix patch matchers to only search non error responses

### DIFF
--- a/.changes/next-release/bugfix-Waiters.json
+++ b/.changes/next-release/bugfix-Waiters.json
@@ -1,0 +1,5 @@
+{
+  "category": "Waiters", 
+  "type": "bugfix", 
+  "description": "Fix ``JMESPathTypeError`` exception being raised (`#906 <https://github.com/boto/botocore/issues/906>`__, `#907 <https://github.com/boto/botocore/issues/907>`__)"
+}

--- a/botocore/data/ec2/2015-10-01/waiters-2.json
+++ b/botocore/data/ec2/2015-10-01/waiters-2.json
@@ -7,8 +7,9 @@
       "operation": "DescribeInstances",
       "acceptors": [
         {
-          "matcher": "status",
-          "expected": 200,
+          "matcher": "path",
+          "expected": true,
+          "argument": "length(Reservations[]) > `0`",
           "state": "success"
         },
         {

--- a/botocore/data/ec2/2015-10-01/waiters-2.json
+++ b/botocore/data/ec2/2015-10-01/waiters-2.json
@@ -7,9 +7,8 @@
       "operation": "DescribeInstances",
       "acceptors": [
         {
-          "matcher": "path",
-          "expected": true,
-          "argument": "length(Reservations[]) > `0`",
+          "matcher": "status",
+          "expected": 200,
           "state": "success"
         },
         {

--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -191,6 +191,8 @@ class AcceptorConfig(object):
         expected = self.expected
 
         def acceptor_matches(response):
+            if 'Error' in response:
+                return
             return expression.search(response) == expected
         return acceptor_matches
 
@@ -199,6 +201,8 @@ class AcceptorConfig(object):
         expected = self.expected
 
         def acceptor_matches(response):
+            if 'Error' in response:
+                return
             result = expression.search(response)
             if not isinstance(result, list) or not result:
                 # pathAll matcher must result in a list.
@@ -217,6 +221,8 @@ class AcceptorConfig(object):
         expected = self.expected
 
         def acceptor_matches(response):
+            if 'Error' in response:
+                return
             result = expression.search(response)
             if not isinstance(result, list) or not result:
                 # pathAny matcher must result in a list.

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -16,7 +16,7 @@ import itertools
 from nose.plugins.attrib import attr
 
 import botocore.session
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, WaiterError
 
 
 class TestEC2(unittest.TestCase):
@@ -36,6 +36,20 @@ class TestEC2(unittest.TestCase):
         # on error.
         with self.assertRaises(ClientError):
             self.client.get_console_output(InstanceId='i-12345')
+
+
+class TestEC2Waiter(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client(
+            'ec2', region_name='us-west-2')
+
+    def test_instance_wait_error(self):
+        """Test that InstanceExists can handle a nonexistent instance."""
+        waiter = self.client.get_waiter('instance_exists')
+        waiter.config.max_attempts = 1
+        with self.assertRaises(WaiterError):
+            waiter.wait(InstanceIds=['i-12345'])
 
 
 class TestEC2Pagination(unittest.TestCase):

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -28,7 +28,8 @@ class TestEC2(unittest.TestCase):
     def test_can_make_request(self):
         # Basic smoke test to ensure we can talk to ec2.
         result = self.client.describe_availability_zones()
-        zones = list(sorted(a['ZoneName'] for a in result['AvailabilityZones']))
+        zones = list(
+            sorted(a['ZoneName'] for a in result['AvailabilityZones']))
         self.assertEqual(zones, ['us-west-2a', 'us-west-2b', 'us-west-2c'])
 
     def test_get_console_output_handles_error(self):

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -16,7 +16,7 @@ import itertools
 from nose.plugins.attrib import attr
 
 import botocore.session
-from botocore.exceptions import ClientError, WaiterError
+from botocore.exceptions import ClientError
 
 
 class TestEC2(unittest.TestCase):
@@ -36,20 +36,6 @@ class TestEC2(unittest.TestCase):
         # on error.
         with self.assertRaises(ClientError):
             self.client.get_console_output(InstanceId='i-12345')
-
-
-class TestEC2Waiter(unittest.TestCase):
-    def setUp(self):
-        self.session = botocore.session.get_session()
-        self.client = self.session.create_client(
-            'ec2', region_name='us-west-2')
-
-    def test_instance_wait_error(self):
-        """Test that InstanceExists can handle a nonexistent instance."""
-        waiter = self.client.get_waiter('instance_exists')
-        waiter.config.max_attempts = 1
-        with self.assertRaises(WaiterError):
-            waiter.wait(InstanceIds=['i-12345'])
 
 
 class TestEC2Pagination(unittest.TestCase):

--- a/tests/integration/test_waiters.py
+++ b/tests/integration/test_waiters.py
@@ -10,13 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import time
 from tests import unittest, random_chars
 
 from nose.plugins.attrib import attr
 
 import botocore.session
-from botocore.exceptions import ClientError, WaiterError
+from botocore.exceptions import WaiterError
 
 
 # This is the same test as above, except using the client interface.

--- a/tests/integration/test_waiters.py
+++ b/tests/integration/test_waiters.py
@@ -16,7 +16,7 @@ from tests import unittest, random_chars
 from nose.plugins.attrib import attr
 
 import botocore.session
-from botocore.client import ClientError
+from botocore.exceptions import ClientError, WaiterError
 
 
 # This is the same test as above, except using the client interface.
@@ -52,3 +52,17 @@ class TestCanGetWaitersThroughClientInterface(unittest.TestCase):
         # If we have at least one waiter in the list, we know that we have
         # actually loaded the waiters and this test has passed.
         self.assertTrue(len(client.waiter_names) > 0)
+
+
+class TestMatchersWithErrors(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client(
+            'ec2', region_name='us-west-2')
+
+    def test_dont_search_on_error_responses(self):
+        """Test that InstanceExists can handle a nonexistent instance."""
+        waiter = self.client.get_waiter('instance_exists')
+        waiter.config.max_attempts = 1
+        with self.assertRaises(WaiterError):
+            waiter.wait(InstanceIds=['i-12345'])

--- a/tests/unit/test_waiters.py
+++ b/tests/unit/test_waiters.py
@@ -214,6 +214,23 @@ class TestWaiterModel(unittest.TestCase):
         self.assertTrue(
             matches({'Tables': [{"State": "GOOD"}, {"State": "FAIL"}]}))
 
+    def test_waiter_handles_error_responses_with_path_matchers(self):
+        path_any = self.create_acceptor_function(
+            for_config={'state': 'success', 'matcher': 'pathAny',
+                        'argument': 'length(Tables) > `0`',
+                        'expected': True})
+        path_all = self.create_acceptor_function(
+            for_config={'state': 'success', 'matcher': 'pathAll',
+                        'argument': 'length(Tables) > `0`',
+                        'expected': True})
+        path = self.create_acceptor_function(
+            for_config={'state': 'success', 'matcher': 'path',
+                        'argument': 'length(Tables) > `0`',
+                        'expected': True})
+        self.assertFalse(path_any({'Error': {'Code': 'DoesNotExist'}}))
+        self.assertFalse(path_all({'Error': {'Code': 'DoesNotExist'}}))
+        self.assertFalse(path({'Error': {'Code': 'DoesNotExist'}}))
+
     def test_single_waiter_does_not_match_path_all(self):
         matches = self.create_acceptor_function(
             for_config={'state': 'success', 'matcher': 'pathAll',


### PR DESCRIPTION
Builds on #907 to fix #906.

Because of the normalized responses the waiter gets, we should only try jmespath searching if we receive a non error response.


cc @kyleknap @JordonPhillips 