### PR TITLE
Include more info in debug logs

### DIFF
--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -94,11 +94,15 @@ version to use.
 
 """
 import os
+import logging
 
 from botocore import BOTOCORE_ROOT
 from botocore.compat import json
 from botocore.compat import OrderedDict
 from botocore.exceptions import DataNotFoundError, UnknownServiceError
+
+
+logger = logging.getLogger(__name__)
 
 
 def instance_cache(func):
@@ -158,6 +162,7 @@ class JSONFileLoader(object):
         # We specify "utf8" here to ensure the correct behavior.
         with open(full_path, 'rb') as fp:
             payload = fp.read().decode('utf-8')
+            logger.debug("Loading JSON file: %s", full_path)
             return json.loads(payload, object_pairs_hook=OrderedDict)
 
 

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -432,6 +432,9 @@ class OperationModel(object):
                 return payload_shape
         return None
 
+    def __repr__(self):
+        return '%s(name=%s)' % (self.__class__.__name__, self.name)
+
 
 class ShapeResolver(object):
     """Resolves shape references."""

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -123,6 +123,11 @@ class TestOperationModelFromService(unittest.TestCase):
         self.assertEqual(operation.name, 'Foo')
         self.assertEqual(operation.wire_name, 'OperationName')
 
+    def test_operation_name_in_repr(self):
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('OperationName')
+        self.assertIn('OperationName', repr(operation))
+
     def test_name_and_wire_name_defaults_to_same_value(self):
         service_model = model.ServiceModel(self.model)
         operation = model.OperationModel(


### PR DESCRIPTION
This includes two things:

1. Add location of JSON file from loaders:

```
$ aws s3api list-buckets --debug
2016-05-12 15:00:56,727 - MainThread - botocore.loaders - DEBUG - Loading JSON file: /Users/foo/Source/botocore/botocore/data/s3/2006-03-01/waiters-2.json
```

2. Add operation name to the repr:

```
$ aws s3 cp foo s3://bucket/ --debug 2>&1 | grep OperationModel | awk '{print $13}'
OperationModel(name=CreateMultipartUpload)
OperationModel(name=UploadPart)
OperationModel(name=UploadPart)
OperationModel(name=UploadPart)
OperationModel(name=UploadPart)
OperationModel(name=UploadPart)
OperationModel(name=UploadPart)
OperationModel(name=UploadPart)
OperationModel(name=CompleteMultipartUpload)
```

cc @kyleknap @JordonPhillips 