### PR TITLE
Pretty print expected params

### DIFF
--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 import copy
 from collections import deque
+from pprint import pformat
+
 from botocore.validate import validate_parameters
 from botocore.exceptions import ParamValidationError, \
     StubResponseError, StubAssertionError
@@ -238,8 +240,8 @@ class Stubber(object):
         if not self._queue:
             raise StubResponseError(
                 operation_name=model.name,
-                reason='Unexpected API Call: called with parameters %s' %
-                       params)
+                reason=('Unexpected API Call: called with parameters:\n%s' %
+                        pformat(params)))
 
         name = self._queue[0]['operation_name']
         if name != model.name:
@@ -258,8 +260,8 @@ class Stubber(object):
         if expected_params is not None and params != expected_params:
             raise StubAssertionError(
                 operation_name=model.name,
-                reason='Expected parameters: %s, but received: %s' % (
-                    expected_params, params))
+                reason='Expected parameters:\n%s,\nbut received:\n%s' % (
+                    pformat(expected_params), pformat(params)))
 
     def _validate_response(self, operation_name, service_response):
         service_model = self.client.meta.service_model

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -48,8 +48,14 @@ class TestStubber(unittest.TestCase):
 
     def test_activated_stubber_errors_with_no_registered_stubs(self):
         self.stubber.activate()
-        with self.assertRaises(StubResponseError):
-            self.client.list_objects(Bucket='foo')
+        # Params one per line for readability.
+        with self.assertRaisesRegexp(StubResponseError,
+                                     "'Bucket': 'asdfasdfasdfasdf',\n"):
+            self.client.list_objects(
+                Bucket='asdfasdfasdfasdf',
+                Delimiter='asdfasdfasdfasdf',
+                Prefix='asdfasdfasdfasdf',
+                EncodingType='url')
 
     def test_stubber_errors_when_stubs_are_used_up(self):
         self.stubber.add_response('list_objects', {})
@@ -87,7 +93,8 @@ class TestStubber(unittest.TestCase):
             'list_objects', service_response, expected_params)
         self.stubber.activate()
         # This should call should raise an for mismatching expected params.
-        with self.assertRaises(StubResponseError):
+        with self.assertRaisesRegexp(StubResponseError,
+                                     "{'Bucket': 'bar'},\n"):
             self.client.list_objects(Bucket='foo')
 
     def test_expected_params_mixed_with_errors_responses(self):


### PR DESCRIPTION
Makes the error messages a little easier to read::

```
StubAssertionError: Error getting response stub for operation PutIntegration: Expected parameters:
{'authorizationType': 'NONE',
 'httpMethod': 'GET',
 'resourceId': 'parent-id',
 'restApiId': 'rest-api-id'},
but received:
{'httpMethod': 'GET',
 'integrationHttpMethod': 'POST',
 'requestTemplates': {'application/json': '{...}'},
 'resourceId': 'parent-id',
 'restApiId': 'rest-api-id',
 'type': 'AWS',
 'uri': 'arn:aws:apigateway:us-west-2:...'}
```

cc @kyleknap @JordonPhillips 