### PR TITLE
Add additional keys to error response

### DIFF
--- a/.changes/next-release/feature-Stubber.json
+++ b/.changes/next-release/feature-Stubber.json
@@ -1,0 +1,5 @@
+{
+  "category": "Stubber",
+  "description": "Allow adding additional keys to the service error response.",
+  "type": "feature"
+}

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -185,7 +185,8 @@ class Stubber(object):
         self._queue.append(response)
 
     def add_client_error(self, method, service_error_code='',
-                         service_message='', http_status_code=400):
+                         service_message='', http_status_code=400,
+                         service_error_meta=None):
         """
         Adds a ``ClientError`` to the response queue.
 
@@ -202,6 +203,10 @@ class Stubber(object):
 
         :param http_status_code: The HTTP status code to return, e.g. 404, etc
         :type http_status_code: int
+
+        :param service_error_meta: Additional keys to be added to the
+            service Error
+        :type service_error_meta: dict
         """
         http_response = Response()
         http_response.status_code = http_status_code
@@ -216,6 +221,9 @@ class Stubber(object):
                 'Code': service_error_code
             }
         }
+
+        if service_error_meta is not None:
+            parsed_response['Error'].update(service_error_meta)
 
         operation_name = self.client.meta.method_to_api_mapping.get(method)
         # Note that we do not allow for expected_params while

--- a/tests/unit/test_stub.py
+++ b/tests/unit/test_stub.py
@@ -159,6 +159,22 @@ class TestStubber(unittest.TestCase):
         self.assertEqual(response[1]['Error']['Message'], service_message)
         self.assertEqual(response[1]['Error']['Code'], error_code)
 
+    def test_get_client_error_with_extra_keys(self):
+        error_code = "foo"
+        error_message = "bar"
+        error_meta = {
+            "Endpoint": "https://foo.bar.baz",
+        }
+        self.stubber.add_client_error(
+            'foo', error_code, error_message,
+            http_status_code=301,
+            service_error_meta=error_meta)
+        with self.stubber:
+            response = self.emit_get_response_event()
+        error = response[1]['Error']
+        self.assertIn('Endpoint', error)
+        self.assertEqual(error['Endpoint'], "https://foo.bar.baz")
+
     def test_get_response_errors_with_no_stubs(self):
         self.stubber.activate()
         with self.assertRaises(StubResponseError):


### PR DESCRIPTION
Some services return additional error keys that may be relevant
in debugging, this adds the ability to add arbitrary keys to the
stubbed error response.

cc @kyleknap @jamesls