### PR TITLE
Automatically redirect S3 requests

### DIFF
--- a/.changes/next-release/feature-s3.json
+++ b/.changes/next-release/feature-s3.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3",
+  "type": "feature",
+  "description": "Automatically redirect S3 requests sent to the wrong region."
+}

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -534,7 +534,7 @@ class BaseClient(object):
             http, parsed_response = event_response
         else:
             http, parsed_response = self._endpoint.make_request(
-                operation_model, request_dict)
+                operation_model, request_dict, request_context)
 
         self.meta.events.emit(
             'after-call.{endpoint_prefix}.{operation_name}'.format(

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -14,7 +14,8 @@ from tests import unittest, mock, BaseSessionTest
 
 import botocore.session
 from botocore.config import Config
-from botocore.exceptions import ParamValidationError
+from botocore.exceptions import ParamValidationError, ClientError
+from botocore.stub import Stubber
 
 
 class TestS3BucketValidation(unittest.TestCase):
@@ -49,6 +50,7 @@ class TestOnlyAsciiCharsAllowed(BaseS3OperationTest):
             self.client.put_object(Bucket='foo', Key='bar',
                                 Metadata={'goodkey': 'good',
                                           'non-ascii': u'\u2713'})
+
 
 class TestS3GetBucketLifecycle(BaseS3OperationTest):
     def test_multiple_transitions_returns_one(self):
@@ -293,3 +295,51 @@ class TestS3Accelerate(BaseS3AddressingStyle):
         # Even if path is specified as the addressing style, use virtual
         # because path style will **not** work with S3 Accelerate
         self.assert_uses_accelerate_endpoint_correctly(s3)
+
+
+class TestRegionRedirect(BaseS3OperationTest):
+    def setUp(self):
+        super(TestRegionRedirect, self).setUp()
+        self.redirect_response = mock.Mock()
+        self.redirect_response.headers = {}
+        self.redirect_response.status_code = 301
+        self.redirect_response.content = (
+            b'<?xml version="1.0" encoding="UTF-8"?>\n'
+            b'<Error>'
+            b'    <Code>PermanentRedirect</Code>'
+            b'    <Message>The bucket you are attempting to access must be '
+            b'        addressed using the specified endpoint. Please send all '
+            b'        future requests to this endpoint.'
+            b'    </Message>'
+            b'    <Bucket>foo</Bucket>'
+            b'    <Endpoint>foo.s3.eu-central-1.amazonaws.com</Endpoint>'
+            b'</Error>')
+
+        self.success_response = mock.Mock()
+        self.success_response.headers = {}
+        self.success_response.status_code = 200
+        self.success_response.content = (
+            b'<?xml version="1.0" encoding="UTF-8"?>\n'
+            b'<ListBucketResult>'
+            b'    <Name>foo</Name>'
+            b'    <Prefix></Prefix>'
+            b'    <Marker></Marker>'
+            b'    <MaxKeys>1000</MaxKeys>'
+            b'    <EncodingType>url</EncodingType>'
+            b'    <IsTruncated>false</IsTruncated>'
+            b'</ListBucketResult>')
+
+    def test_region_redirect(self):
+        self.http_session_send_mock.side_effect = [
+            self.redirect_response, self.success_response]
+        response = self.client.list_objects(Bucket='foo')
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        self.assertEqual(self.http_session_send_mock.call_count, 2)
+
+        calls = [c[0][0] for c in self.http_session_send_mock.call_args_list]
+        initial_url = 'https://foo.s3.amazonaws.com/?encoding-type=url'
+        self.assertEqual(calls[0].url, initial_url)
+
+        fixed_url = ('https://foo.s3.eu-central-1.amazonaws.com'
+                     '/?encoding-type=url')
+        self.assertEqual(calls[1].url, fixed_url)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -32,6 +32,7 @@ import botocore.auth
 import botocore.credentials
 import botocore.vendored.requests as requests
 from botocore.config import Config
+from botocore.exceptions import ClientError
 
 
 def random_bucketname():
@@ -1033,5 +1034,26 @@ class TestS3PathAddressing(TestAutoS3Addressing):
         self.client = self.create_client()
 
 
-if __name__ == '__main__':
-    unittest.main()
+class TestS3RegionRedirect(BaseS3ClientTest):
+    def setUp(self):
+        super(TestS3RegionRedirect, self).setUp()
+        self.bucket_region = 'eu-central-1'
+        self.client_region = 'us-west-2'
+
+        # Need to set the client for bucket creation
+        self.client = self.session.create_client(
+            's3', region_name=self.bucket_region,
+            config=Config(signature_version='s3v4'))
+        self.bucket = self.create_bucket(self.bucket_region)
+
+        self.client = self.session.create_client(
+            's3', region_name=self.client_region,
+            config=Config(signature_version='s3v4'))
+
+    def test_region_redirects(self):
+        try:
+            response = self.client.list_objects(Bucket=self.bucket)
+            self.assertEqual(
+                response['ResponseMetadata']['HTTPStatusCode'], 200)
+        except ClientError:
+            self.fail("S3 client failed to redirect to the proper region.")

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -336,6 +336,20 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
     def test_blacklist_headers(self):
         self._test_blacklist_header('user-agent', 'botocore/1.4.11')
 
+    def test_context_sets_signing_region(self):
+        original_signing_region = 'eu-central-1'
+        new_signing_region = 'us-west-2'
+        self.auth.add_auth(self.request)
+        auth = self.request.headers['Authorization']
+        self.assertIn(original_signing_region, auth)
+        self.assertNotIn(new_signing_region, auth)
+
+        self.request.context = {'signing': {'region': new_signing_region}}
+        self.auth.add_auth(self.request)
+        auth = self.request.headers['Authorization']
+        self.assertIn(new_signing_region, auth)
+        self.assertNotIn(original_signing_region, auth)
+
 
 class TestSigV4(unittest.TestCase):
     def setUp(self):
@@ -685,6 +699,7 @@ class BaseS3PresignPostTest(unittest.TestCase):
         self.request.context['s3-presign-post-fields'] = self.fields
         self.request.context['s3-presign-post-policy'] = self.policy
 
+
 class TestS3SigV2Post(BaseS3PresignPostTest):
     def setUp(self):
         super(TestS3SigV2Post, self).setUp()
@@ -735,6 +750,7 @@ class TestS3SigV2Post(BaseS3PresignPostTest):
             result_fields['policy']).decode('utf-8'))
         self.assertEqual(result_policy['conditions'], [])
         self.assertIn('signature', result_fields)
+
 
 class TestS3SigV4Post(BaseS3PresignPostTest):
     def setUp(self):

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -125,6 +125,13 @@ class TestEndpointFeatures(TestEndpointBase):
                                      'Connection was closed'):
             self.endpoint.make_request(self.op, request_dict())
 
+    def test_make_request_with_context(self):
+        context = {'signing': {'region': 'us-west-2'}}
+        with patch('botocore.endpoint.Endpoint.prepare_request') as prepare:
+            self.endpoint.make_request(self.op, request_dict(), context)
+        request = prepare.call_args[0][0]
+        self.assertEqual(request.context['signing']['region'], 'us-west-2')
+
 
 class TestRetryInterface(TestEndpointBase):
     def setUp(self):


### PR DESCRIPTION
Under sigV4, requests sent to the wrong region will fail. S3
will send back a 301 error with the correct endpoint to make
the request on. This will look for that endpoint, and retry
the request using it.

cc @kyleknap @jamesls