### PR TITLE
Cache bucket regions on redirect

### DIFF
--- a/.changes/next-release/feature-s3-17030.json
+++ b/.changes/next-release/feature-s3-17030.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3",
+  "description": "Cache bucket region to prevent additional requests.",
+  "type": "feature"
+}

--- a/.changes/next-release/feature-s3.json
+++ b/.changes/next-release/feature-s3.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3",
+  "type": "feature",
+  "description": "Automatically redirect S3 requests sent to the wrong region."
+}

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -534,7 +534,7 @@ class BaseClient(object):
             http, parsed_response = event_response
         else:
             http, parsed_response = self._endpoint.make_request(
-                operation_model, request_dict)
+                operation_model, request_dict, request_context)
 
         self.meta.events.emit(
             'after-call.{endpoint_prefix}.{operation_name}'.format(

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -527,7 +527,7 @@ class BaseClient(object):
             'before-call.{endpoint_prefix}.{operation_name}'.format(
                 endpoint_prefix=self._service_model.endpoint_prefix,
                 operation_name=operation_name),
-            model=operation_model, params=request_dict,
+            model=operation_model, params=request_dict, cache=self._cache,
             request_signer=self._request_signer, context=request_context)
 
         if event_response is not None:
@@ -540,7 +540,7 @@ class BaseClient(object):
             'after-call.{endpoint_prefix}.{operation_name}'.format(
                 endpoint_prefix=self._service_model.endpoint_prefix,
                 operation_name=operation_name),
-            http_response=http, parsed=parsed_response,
+            http_response=http, parsed=parsed_response, cache=self._cache,
             model=operation_model, context=request_context
         )
 
@@ -571,7 +571,8 @@ class BaseClient(object):
             event_name.format(
                 endpoint_prefix=self._service_model.endpoint_prefix,
                 operation_name=operation_name),
-            params=api_params, model=operation_model, context=context)
+            params=api_params, model=operation_model, context=context,
+            cache=self._cache)
 
         request_dict = self._serializer.serialize_to_request(
             api_params, operation_model)

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -97,7 +97,13 @@ def s3_redirect_request(params, context, **kwargs):
     if len(url_params) > 1:
         new_url += '?' + url_params[1]
     params['url'] = new_url
-    params['url_path'] = '/'
+
+    bucket_name = context['signing']['bucket']
+    path_parts = params['url_path'].split('/')
+    if path_parts[0] == bucket_name:
+        del path_parts[0]
+
+    params['url_path'] = '/' + '/'.join(path_parts)
 
 
 def s3_cache_bucket_signing_context(context, cache, **kwargs):

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -14,7 +14,8 @@ from tests import unittest, mock, BaseSessionTest
 
 import botocore.session
 from botocore.config import Config
-from botocore.exceptions import ParamValidationError
+from botocore.exceptions import ParamValidationError, ClientError
+from botocore.stub import Stubber
 
 
 class TestS3BucketValidation(unittest.TestCase):
@@ -49,6 +50,7 @@ class TestOnlyAsciiCharsAllowed(BaseS3OperationTest):
             self.client.put_object(Bucket='foo', Key='bar',
                                 Metadata={'goodkey': 'good',
                                           'non-ascii': u'\u2713'})
+
 
 class TestS3GetBucketLifecycle(BaseS3OperationTest):
     def test_multiple_transitions_returns_one(self):
@@ -293,3 +295,51 @@ class TestS3Accelerate(BaseS3AddressingStyle):
         # Even if path is specified as the addressing style, use virtual
         # because path style will **not** work with S3 Accelerate
         self.assert_uses_accelerate_endpoint_correctly(s3)
+
+
+class TestRegionRedirect(BaseS3OperationTest):
+    def setUp(self):
+        super(TestRegionRedirect, self).setUp()
+        self.redirect_response = mock.Mock()
+        self.redirect_response.headers = {}
+        self.redirect_response.status_code = 301
+        self.redirect_response.content = (
+            b'<?xml version="1.0" encoding="UTF-8"?>\n'
+            b'<Error>'
+            b'    <Code>PermanentRedirect</Code>'
+            b'    <Message>The bucket you are attempting to access must be '
+            b'        addressed using the specified endpoint. Please send all '
+            b'        future requests to this endpoint.'
+            b'    </Message>'
+            b'    <Bucket>foo</Bucket>'
+            b'    <Endpoint>foo.s3.eu-central-1.amazonaws.com</Endpoint>'
+            b'</Error>')
+
+        self.success_response = mock.Mock()
+        self.success_response.headers = {}
+        self.success_response.status_code = 200
+        self.success_response.content = (
+            b'<?xml version="1.0" encoding="UTF-8"?>\n'
+            b'<ListBucketResult>'
+            b'    <Name>foo</Name>'
+            b'    <Prefix></Prefix>'
+            b'    <Marker></Marker>'
+            b'    <MaxKeys>1000</MaxKeys>'
+            b'    <EncodingType>url</EncodingType>'
+            b'    <IsTruncated>false</IsTruncated>'
+            b'</ListBucketResult>')
+
+    def test_region_redirect(self):
+        self.http_session_send_mock.side_effect = [
+            self.redirect_response, self.success_response]
+        response = self.client.list_objects(Bucket='foo')
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        self.assertEqual(self.http_session_send_mock.call_count, 2)
+
+        calls = [c[0][0] for c in self.http_session_send_mock.call_args_list]
+        initial_url = 'https://foo.s3.amazonaws.com/?encoding-type=url'
+        self.assertEqual(calls[0].url, initial_url)
+
+        fixed_url = ('https://foo.s3.eu-central-1.amazonaws.com'
+                     '/?encoding-type=url')
+        self.assertEqual(calls[1].url, fixed_url)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -32,6 +32,7 @@ import botocore.auth
 import botocore.credentials
 import botocore.vendored.requests as requests
 from botocore.config import Config
+from botocore.exceptions import ClientError
 
 
 def random_bucketname():
@@ -1033,5 +1034,26 @@ class TestS3PathAddressing(TestAutoS3Addressing):
         self.client = self.create_client()
 
 
-if __name__ == '__main__':
-    unittest.main()
+class TestS3RegionRedirect(BaseS3ClientTest):
+    def setUp(self):
+        super(TestS3RegionRedirect, self).setUp()
+        self.bucket_region = 'eu-central-1'
+        self.client_region = 'us-west-2'
+
+        # Need to set the client for bucket creation
+        self.client = self.session.create_client(
+            's3', region_name=self.bucket_region,
+            config=Config(signature_version='s3v4'))
+        self.bucket = self.create_bucket(self.bucket_region)
+
+        self.client = self.session.create_client(
+            's3', region_name=self.client_region,
+            config=Config(signature_version='s3v4'))
+
+    def test_region_redirects(self):
+        try:
+            response = self.client.list_objects(Bucket=self.bucket)
+            self.assertEqual(
+                response['ResponseMetadata']['HTTPStatusCode'], 200)
+        except ClientError:
+            self.fail("S3 client failed to redirect to the proper region.")

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1057,3 +1057,14 @@ class TestS3RegionRedirect(BaseS3ClientTest):
                 response['ResponseMetadata']['HTTPStatusCode'], 200)
         except ClientError:
             self.fail("S3 client failed to redirect to the proper region.")
+
+    def test_region_redirects_multiple_requests(self):
+        try:
+            response = self.client.list_objects(Bucket=self.bucket)
+            self.assertEqual(
+                response['ResponseMetadata']['HTTPStatusCode'], 200)
+            second_response = self.client.list_objects(Bucket=self.bucket)
+            self.assertEqual(
+                second_response['ResponseMetadata']['HTTPStatusCode'], 200)
+        except ClientError:
+            self.fail("S3 client failed to redirect to the proper region.")

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -336,6 +336,20 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
     def test_blacklist_headers(self):
         self._test_blacklist_header('user-agent', 'botocore/1.4.11')
 
+    def test_context_sets_signing_region(self):
+        original_signing_region = 'eu-central-1'
+        new_signing_region = 'us-west-2'
+        self.auth.add_auth(self.request)
+        auth = self.request.headers['Authorization']
+        self.assertIn(original_signing_region, auth)
+        self.assertNotIn(new_signing_region, auth)
+
+        self.request.context = {'signing': {'region': new_signing_region}}
+        self.auth.add_auth(self.request)
+        auth = self.request.headers['Authorization']
+        self.assertIn(new_signing_region, auth)
+        self.assertNotIn(original_signing_region, auth)
+
 
 class TestSigV4(unittest.TestCase):
     def setUp(self):
@@ -685,6 +699,7 @@ class BaseS3PresignPostTest(unittest.TestCase):
         self.request.context['s3-presign-post-fields'] = self.fields
         self.request.context['s3-presign-post-policy'] = self.policy
 
+
 class TestS3SigV2Post(BaseS3PresignPostTest):
     def setUp(self):
         super(TestS3SigV2Post, self).setUp()
@@ -735,6 +750,7 @@ class TestS3SigV2Post(BaseS3PresignPostTest):
             result_fields['policy']).decode('utf-8'))
         self.assertEqual(result_policy['conditions'], [])
         self.assertIn('signature', result_fields)
+
 
 class TestS3SigV4Post(BaseS3PresignPostTest):
     def setUp(self):

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -125,6 +125,13 @@ class TestEndpointFeatures(TestEndpointBase):
                                      'Connection was closed'):
             self.endpoint.make_request(self.op, request_dict())
 
+    def test_make_request_with_context(self):
+        context = {'signing': {'region': 'us-west-2'}}
+        with patch('botocore.endpoint.Endpoint.prepare_request') as prepare:
+            self.endpoint.make_request(self.op, request_dict(), context)
+        request = prepare.call_args[0][0]
+        self.assertEqual(request.context['signing']['region'], 'us-west-2')
+
 
 class TestRetryInterface(TestEndpointBase):
     def setUp(self):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -721,7 +721,8 @@ class TestSSEMD5(BaseMD5Test):
             event = 'before-parameter-build.s3.%s' % op
             params = {'SSECustomerKey': b'bar',
                       'SSECustomerAlgorithm': 'AES256'}
-            self.session.emit(event, params=params, model=mock.Mock())
+            self.session.emit(
+                event, params=params, model=mock.Mock(), context={}, cache={})
             self.assertEqual(params['SSECustomerKey'], 'YmFy')
             self.assertEqual(params['SSECustomerKeyMD5'], 'Zm9v')
 
@@ -729,7 +730,8 @@ class TestSSEMD5(BaseMD5Test):
         event = 'before-parameter-build.s3.PutObject'
         params = {'SSECustomerKey': 'bar',
                   'SSECustomerAlgorithm': 'AES256'}
-        self.session.emit(event, params=params, model=mock.Mock())
+        self.session.emit(
+            event, params=params, model=mock.Mock(), context={}, cache={})
         self.assertEqual(params['SSECustomerKey'], 'YmFy')
         self.assertEqual(params['SSECustomerKeyMD5'], 'Zm9v')
 
@@ -738,7 +740,8 @@ class TestSSEMD5(BaseMD5Test):
             event = 'before-parameter-build.s3.%s' % op
             params = {'CopySourceSSECustomerKey': b'bar',
                       'CopySourceSSECustomerAlgorithm': 'AES256'}
-            self.session.emit(event, params=params, model=mock.Mock())
+            self.session.emit(
+                event, params=params, model=mock.Mock(), context={}, cache={})
             self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
             self.assertEqual(params['CopySourceSSECustomerKeyMD5'], 'Zm9v')
 
@@ -746,7 +749,8 @@ class TestSSEMD5(BaseMD5Test):
         event = 'before-parameter-build.s3.CopyObject'
         params = {'CopySourceSSECustomerKey': 'bar',
                   'CopySourceSSECustomerAlgorithm': 'AES256'}
-        self.session.emit(event, params=params, model=mock.Mock())
+        self.session.emit(
+            event, params=params, model=mock.Mock(), context={}, cache={})
         self.assertEqual(params['CopySourceSSECustomerKey'], 'YmFy')
         self.assertEqual(params['CopySourceSSECustomerKeyMD5'], 'Zm9v')
 
@@ -922,8 +926,8 @@ class TestParameterAlias(unittest.TestCase):
         self.assertNotIn(self.original_name + '=', contents)
 
 
-class TestS3RedirectRegion(unittest.TestCase):
-    def test_does_not_redirect_if_error_not_permanentredirect(self):
+class TestS3Redirect(unittest.TestCase):
+    def test_redirect_region_on_incorrect_error(self):
         context = {}
         request_dict = {}
         service_response = ((), {'Error': {'Code': 'BucketNotFound'}})
@@ -935,7 +939,7 @@ class TestS3RedirectRegion(unittest.TestCase):
 
     def test_redirect_region(self):
         signing_region = 'eu-central-1'
-        context = {'signing': {'region': signing_region}}
+        context = {}
         request_dict = {
             'url': 'https://s3-us-west-2.amazonaws.com/foo',
             'url_path': '/foo'
@@ -965,25 +969,92 @@ class TestS3RedirectRegion(unittest.TestCase):
                          'https://foo.s3.eu-central-1.amazonaws.com/')
         self.assertEqual(request_dict['url_path'], '/')
 
-    def test_redirect_sets_url_params(self):
-        signing_region = 'eu-central-1'
-        context = {'signing': {'region': signing_region}}
+    def test_redirect_request(self):
+        context = {
+            'signing': {
+                'region': 'eu-central-1',
+                'bucket': 'foo',
+                'endpoint': 'foo.s3.eu-central-1.amazonaws.com'
+            }
+        }
+        request_dict = {
+            'url': 'https://s3-us-west-2.amazonaws.com/foo',
+            'url_path': '/foo'
+        }
+
+        handlers.s3_redirect_request(request_dict, context)
+        self.assertEqual(request_dict['url'],
+                         'https://foo.s3.eu-central-1.amazonaws.com/')
+        self.assertEqual(request_dict['url_path'], '/')
+
+    def test_redirect_request_sets_url_params(self):
+        context = {
+            'signing': {
+                'region': 'eu-central-1',
+                'bucket': 'foo',
+                'endpoint': 'foo.s3.eu-central-1.amazonaws.com'
+            }
+        }
         request_dict = {
             'url': 'https://s3-us-west-2.amazonaws.com/foo?encoding-type=url',
             'url_path': '/foo'
         }
-        service_response = ((), {
-            'Error': {
-                'Code': 'PermanentRedirect',
-                'Message': 'The bucket you are attempting to access must be '
-                           'addressed using the specified endpoint. Please '
-                           'send all future requests to this endpoint.',
-                'Bucket': 'foo',
-                'Endpoint': 'foo.s3.eu-central-1.amazonaws.com'
-            }
-        })
-        handlers.s3_redirect_region(request_dict, service_response, context)
+        handlers.s3_redirect_request(request_dict, context)
 
         self.assertEqual(
             request_dict['url'],
             'https://foo.s3.eu-central-1.amazonaws.com/?encoding-type=url')
+
+    def test_redirect_region_does_not_redirect_without_signing_context(self):
+        context = {}
+        request_dict = {
+            'url': 'https://s3-us-west-2.amazonaws.com/foo',
+            'url_path': '/foo'
+        }
+
+        handlers.s3_redirect_request(request_dict, context)
+        self.assertEqual(request_dict['url'],
+                         'https://s3-us-west-2.amazonaws.com/foo')
+        self.assertEqual(request_dict['url_path'], '/foo')
+
+    def test_cache_bucket_signing_context(self):
+        context = {
+            'signing': {
+                'region': 'eu-central-1',
+                'bucket': 'foo',
+                'endpiont': 'foo.s3.eu-central-1.amazonaws.com'
+            }
+        }
+        cache = {}
+        handlers.s3_cache_bucket_signing_context(context, cache)
+
+        cached_context = cache.get('bucket_locations', {}).get('foo')
+        self.assertEqual(cached_context, context['signing'])
+
+    def test_does_not_cache_without_signing_context(self):
+        context = {}
+        cache = {}
+        handlers.s3_cache_bucket_signing_context(context, cache)
+        self.assertFalse(cache.get('bucket_locations', None))
+
+    def test_retrieve_signing_context_from_cache(self):
+        context = {}
+        signing_context = {
+            'region': 'eu-central-1',
+            'bucket': 'foo',
+            'endpiont': 'foo.s3.eu-central-1.amazonaws.com'
+        }
+        cache = {'bucket_locations': {'foo': signing_context}}
+        params = {'Bucket': 'foo'}
+        handlers.s3_get_bucket_signing_context_from_cache(
+            params, context, cache)
+
+        self.assertEqual(context.get('signing'), signing_context)
+
+    def test_does_not_set_signing_context_if_not_in_cache(self):
+        context = {}
+        cache = {}
+        params = {'Bucket': 'foo'}
+        handlers.s3_get_bucket_signing_context_from_cache(
+            params, context, cache)
+        self.assertNotIn('signing', context)


### PR DESCRIPTION
This caches the redirect information so that we only have to worry
about one additional request if the client is configured to the
wrong region.

Depends on #929. They should both be merged at the same time, but I felt that it would be good for them to be reviewed independently.

cc @kyleknap @jamesls