### PR TITLE
Remove docutil dependency from setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,5 @@ universal = 1
 requires-dist =
 	python-dateutil>=2.1,<3.0.0
 	jmespath>=0.7.1,<1.0.0
-	docutils>=0.10
 	ordereddict==1.1; python_version=="2.6"
 	simplejson==3.3.0; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ from setuptools import setup, find_packages
 
 
 requires = ['jmespath>=0.7.1,<1.0.0',
-            'python-dateutil>=2.1,<3.0.0',
-            'docutils>=0.10']
+            'python-dateutil>=2.1,<3.0.0']
 
 
 if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
Docutil is used only in the following places:
- botocore/docs/bcdoc/textwriter.py

And is also referenced in:
- setup.py
- setup.cfg
- requirements.txt

Since during the setup.py execution the documentation is not generated,
I think we should not require docutil to be installed. We could create a
secondary target to create the documentation, but this is a different
problem/opportunity/situation.
