### PR TITLE
Allow stubber to be used with GetBucketLocation

### DIFF
--- a/.changes/next-release/bugfix-s3.json
+++ b/.changes/next-release/bugfix-s3.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3",
+  "description": "Make the stubber work with get_bucket_location",
+  "type": "bugfix"
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -424,6 +424,9 @@ def parse_get_bucket_location(parsed, http_response, **kwargs):
     # The "parsed" passed in only has the ResponseMetadata
     # filled out.  This handler will fill in the LocationConstraint
     # value.
+    if 'LocationConstraint' in parsed:
+        # Response already set - a stub?
+        return
     response_body = http_response.content
     parser = xml.etree.cElementTree.XMLParser(
         target=xml.etree.cElementTree.TreeBuilder(),

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -610,6 +610,13 @@ class TestHandlers(BaseSessionTest):
         handlers.decode_list_object(parsed, context=context)
         self.assertEqual(parsed['Delimiter'], u'\xe7\xf6s% asd\x08 c')
 
+    def test_get_bucket_location_optional(self):
+        # This handler should no-op if another hook (i.e. stubber) has already
+        # filled in response
+        response = {"LocationConstraint": "eu-west-1"}
+        handlers.parse_get_bucket_location(response, None),
+        self.assertEqual(response["LocationConstraint"], "eu-west-1")
+
 
 class TestConvertStringBodyToFileLikeObject(BaseSessionTest):
     def assert_converts_to_file_like_object_with_bytes(self, body, body_bytes):


### PR DESCRIPTION
Right now you can't use the `Stubber` object with s3's `get_bucket_location` because it has an override that assumes a body of xml is available. This patch allows the override to be skipped where something (in this case the stubber) has already 'parsed' the response.