### PR TITLE
Allow paramters to be ignored in Stubber validation

### DIFF
--- a/.changes/next-release/feature-Stubber.json
+++ b/.changes/next-release/feature-Stubber.json
@@ -1,0 +1,5 @@
+{
+  "category": "Stubber",
+  "type": "feature",
+  "description": "Allow certain paramters to be ignored by specifying stub.ANY. Resolves `#931 <https://github.com/boto/botocore/issues/931>`__"
+}


### PR DESCRIPTION
This allows users to specify stub.ANY for expected parameters if
they don't care about a specific parameter's value.

Resolves #931

cc @kyleknap  @jamesls