### PR TITLE
Convert boolean config values to boolean types

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -93,12 +93,32 @@ class Config(object):
         config_vars = copy.copy(self.OPTION_DEFAULTS)
         config_vars.update(self._user_provided_options)
 
+        # All args come in as strings, so it is useful to convert them to other
+        # data types if necessary. i.e. to 'True' to True
+        config_vars = self._preprocess_config(config_vars)
+
         # Set the attributes based on the config_vars
         for key, value in config_vars.items():
             setattr(self, key, value)
 
         # Validate the s3 options
         self._validate_s3_configuration(self.s3)
+
+    def _preprocess_config(self, config_vars):
+        for key, value in config_vars.items():
+            if isinstance(value, str):
+                config_vars[key] = self._string_to_boolean(value)
+            elif isinstance(value, dict):
+                config_vars[key] = self._preprocess_config(value)
+        return config_vars
+
+    def _string_to_boolean(self, value):
+        lower_value = value.lower()
+        if lower_value == 'true':
+            return True
+        elif lower_value == 'false':
+            return False
+        return value
 
     def _record_user_provided_options(self, args, kwargs):
         option_order = list(self.OPTION_DEFAULTS)

--- a/tests/unit/cfg/aws_config_boolean
+++ b/tests/unit/cfg/aws_config_boolean
@@ -1,0 +1,5 @@
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = bar
+some_boolean_true = True
+some_boolean_false = False

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1327,6 +1327,13 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(new_config.region_name, 'us-west-2')
         self.assertEqual(new_config.signature_version, 's3v4')
 
+    def test_boolean_conversion(self):
+        config = botocore.config.Config(parameter_validation='True')
+        self.assertEqual(config.parameter_validation, True)
+
+        config = botocore.config.Config(parameter_validation='False')
+        self.assertEqual(config.parameter_validation, False)
+
 
 class TestClientEndpointBridge(unittest.TestCase):
     def test_guesses_endpoint_as_last_resort(self):


### PR DESCRIPTION
All values read from the config file are imported as strings,
even if they look like other python data types. This will convert
strings that look like booleans to boolean types to avoid subtle
bugs since strings are truthy.

cc @kyleknap @jamesls