### PR TITLE
Add recursive role assumption.

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -727,8 +727,8 @@ class AssumeRoleProvider(CredentialProvider):
     # EXPIRY_WINDOW.
     EXPIRY_WINDOW_SECONDS = 60 * 15
 
-    def __init__(self, load_config, client_creator, cache, profile_name,
-                 prompter=getpass.getpass):
+    def __init__(self, load_config, client_creator, cache,
+                 profile_name, prompter=getpass.getpass):
         """
 
         :type load_config: callable
@@ -778,11 +778,31 @@ class AssumeRoleProvider(CredentialProvider):
     def load(self):
         self._loaded_config = self._load_config()
         if self._has_assume_role_config_vars():
-            return self._load_creds_via_assume_role()
+            if self._source_profile_has_keys():
+                return self._load_creds_via_assume_role()
+            else:
+                return self._load_creds_via_assume_role_from_indirect()
 
     def _has_assume_role_config_vars(self):
         profiles = self._loaded_config.get('profiles', {})
-        return self.ROLE_CONFIG_VAR in profiles.get(self._profile_name, {})
+        profile_config = profiles.get(self._profile_name, {})
+        if self.ROLE_CONFIG_VAR not in profile_config:
+            return False
+
+        if 'source_profile' not in profile_config:
+            msg = ('Profile (%s) has no source_profile defined.' %
+                   (self._profile_name,))
+            raise PartialCredentialsError(provider=self.METHOD,
+                                          cred_var=msg)
+
+        return True
+
+    def _source_profile_has_keys(self):
+        source_profile = (self._loaded_config['profiles']
+                          .get(self._profile_name, {})['source_profile'])
+        source_profile_config = (
+            self._loaded_config['profiles'].get(source_profile, {}))
+        return 'aws_access_key_id' in source_profile_config
 
     def _load_creds_via_assume_role(self):
         # We can get creds in one of two ways:
@@ -790,19 +810,22 @@ class AssumeRoleProvider(CredentialProvider):
         # * Cache doesn't have the creds (or is expired) so we need to make
         #   an assume role call to get temporary creds, which we then cache
         #   for subsequent requests.
-        creds = self._load_creds_from_cache()
+        role_config = self._get_role_config_values()
+        client = self._create_client_from_config(role_config)
+        creds = self._load_creds_from_cache(client)
         if creds is not None:
             logger.debug("Credentials for role retrieved from cache.")
             return creds
         else:
             # We get the Credential used by botocore as well
             # as the original parsed response from the server.
-            creds, response = self._retrieve_temp_credentials()
+            creds, response = self._retrieve_temp_credentials(role_config,
+                                                              client)
             cache_key = self._create_cache_key()
             self._write_cached_credentials(response, cache_key)
             return creds
 
-    def _load_creds_from_cache(self):
+    def _load_creds_from_cache(self, client):
         cache_key = self._create_cache_key()
         try:
             from_cache = self.cache[cache_key]
@@ -814,7 +837,7 @@ class AssumeRoleProvider(CredentialProvider):
                     "Credentials were found in cache, but they are expired.")
                 return None
             else:
-                return self._create_creds_from_response(from_cache)
+                return self._create_creds_from_response(from_cache, client)
         except KeyError:
             return None
 
@@ -824,17 +847,17 @@ class AssumeRoleProvider(CredentialProvider):
         seconds = total_seconds(end_time - now)
         return seconds < self.EXPIRY_WINDOW_SECONDS
 
-    def _create_cache_key(self):
+    def _create_cache_key(self, prefix=''):
         role_config = self._get_role_config_values()
         # On windows, ':' is not allowed in filenames, so we'll
         # replace them with '_' instead.
         role_arn = role_config['role_arn'].replace(':', '_')
         role_session_name = role_config.get('role_session_name')
         if role_session_name:
-            cache_key = '%s--%s--%s' % (self._profile_name, role_arn,
-                                        role_session_name)
+            cache_key = '%s%s--%s--%s' % (prefix, self._profile_name, role_arn,
+                                          role_session_name)
         else:
-            cache_key = '%s--%s' % (self._profile_name, role_arn)
+            cache_key = '%s%s--%s' % (prefix, self._profile_name, role_arn)
 
         return cache_key.replace('/', '-')
 
@@ -844,13 +867,9 @@ class AssumeRoleProvider(CredentialProvider):
     def _get_role_config_values(self):
         # This returns the role related configuration.
         profiles = self._loaded_config.get('profiles', {})
-        try:
-            source_profile = profiles[self._profile_name]['source_profile']
-            role_arn = profiles[self._profile_name]['role_arn']
-            mfa_serial = profiles[self._profile_name].get('mfa_serial')
-        except KeyError as e:
-            raise PartialCredentialsError(provider=self.METHOD,
-                                          cred_var=str(e))
+        role_arn = profiles[self._profile_name]['role_arn']
+        source_profile = profiles[self._profile_name]['source_profile']
+        mfa_serial = profiles[self._profile_name].get('mfa_serial')
         external_id = profiles[self._profile_name].get('external_id')
         role_session_name = \
             profiles[self._profile_name].get('role_session_name')
@@ -870,7 +889,7 @@ class AssumeRoleProvider(CredentialProvider):
             'role_session_name': role_session_name
         }
 
-    def _create_creds_from_response(self, response):
+    def _create_creds_from_response(self, response, client):
         config = self._get_role_config_values()
         if config.get('mfa_serial') is not None:
             # MFA would require getting a new TokenCode which would require
@@ -879,8 +898,7 @@ class AssumeRoleProvider(CredentialProvider):
             refresh_func = create_mfa_serial_refresher()
         else:
             refresh_func = create_assume_role_refresher(
-                self._create_client_from_config(config),
-                self._assume_role_base_kwargs(config))
+                client, self._assume_role_base_kwargs(config))
         return RefreshableCredentials(
             access_key=response['Credentials']['AccessKeyId'],
             secret_key=response['Credentials']['SecretAccessKey'],
@@ -899,15 +917,13 @@ class AssumeRoleProvider(CredentialProvider):
         )
         return client
 
-    def _retrieve_temp_credentials(self):
+    def _retrieve_temp_credentials(self, config, client):
         logger.debug("Retrieving credentials via AssumeRole.")
-        config = self._get_role_config_values()
-        client = self._create_client_from_config(config)
 
         assume_role_kwargs = self._assume_role_base_kwargs(config)
 
         response = client.assume_role(**assume_role_kwargs)
-        creds = self._create_creds_from_response(response)
+        creds = self._create_creds_from_response(response, client)
         return creds, response
 
     def _assume_role_base_kwargs(self, config):
@@ -924,6 +940,57 @@ class AssumeRoleProvider(CredentialProvider):
             role_session_name = 'AWS-CLI-session-%s' % (int(time.time()))
             assume_role_kwargs['RoleSessionName'] = role_session_name
         return assume_role_kwargs
+
+    def _load_creds_via_assume_role_from_indirect(self):
+        role_config = self._get_role_config_values()
+        client = self._create_client_from_indirect_config(role_config)
+        creds = self._load_indirect_creds_from_cache(client)
+        if creds is not None:
+            logger.debug("Credentials for role retrieved from cache.")
+            return creds
+        else:
+            # We get the Credential used by botocore as well
+            # as the original parsed response from the server.
+            creds, response = self._retrieve_temp_credentials(role_config,
+                                                              client)
+            cache_key = self._create_indirect_cache_key()
+            self._write_cached_credentials(response, cache_key)
+            return creds
+
+    def _load_indirect_creds_from_cache(self, client):
+        cache_key = self._create_indirect_cache_key()
+        try:
+            from_cache = self.cache[cache_key]
+            if self._is_expired(from_cache):
+                # Don't need to delete the cache entry,
+                # when we refresh via AssumeRole, we'll
+                # update the cache with the new entry.
+                logger.debug(
+                    "Credentials were found in cache, but they are expired.")
+                return None
+            else:
+                return self._create_creds_from_response(from_cache, client)
+        except KeyError:
+            return None
+
+    def _create_indirect_cache_key(self):
+        return self._create_cache_key(prefix='indirect---')
+
+    def _create_client_from_indirect_config(self, config):
+        source_cred_values = config['source_cred_values']
+        provider = AssumeRoleProvider(
+            load_config=lambda: self._loaded_config,
+            client_creator=self._client_creator,
+            cache=self.cache,
+            profile_name=self._loaded_config['profiles'][self._profile_name]['source_profile'],
+        )
+        source_profile_creds = provider.load()
+        client = self._client_creator(
+            'sts', aws_access_key_id=source_profile_creds.access_key,
+            aws_secret_access_key=source_profile_creds.secret_key,
+            aws_session_token=source_profile_creds.token,
+        )
+        return client
 
 
 class CredentialResolver(object):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -669,6 +669,10 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
     def setUp(self):
         self.fake_config = {
             'profiles': {
+                'development2': {
+                    'role_arn': 'myrole2',
+                    'source_profile': 'development',
+                },
                 'development': {
                     'role_arn': 'myrole',
                     'source_profile': 'longterm',
@@ -1051,6 +1055,109 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         # source_profile is required, we shoudl get an error.
         with self.assertRaises(botocore.exceptions.InvalidConfigError):
             provider.load()
+
+    def test_assume_indirect_role_with_no_cache(self):
+        responses = [
+            {
+                'Credentials': {
+                    'AccessKeyId': 'foo0',
+                    'SecretAccessKey': 'bar0',
+                    'SessionToken': 'baz0',
+                    'Expiration': self.some_future_time().isoformat()
+                },
+            },
+            {
+                'Credentials': {
+                    'AccessKeyId': 'foo1',
+                    'SecretAccessKey': 'bar1',
+                    'SessionToken': 'baz1',
+                    'Expiration': self.some_future_time().isoformat()
+                },
+            },
+        ]
+        client_creator = self.create_client_creator(with_response=responses)
+        provider = credentials.AssumeRoleProvider(
+            self.create_config_loader(),
+            client_creator, cache={}, profile_name='development2')
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo1')
+        self.assertEqual(creds.secret_key, 'bar1')
+        self.assertEqual(creds.token, 'baz1')
+
+    def test_assume_indirect_role_retrieves_from_cache(self):
+        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        utc_timestamp = date_in_future.isoformat() + 'Z'
+        self.fake_config['profiles']['development']['role_arn'] = 'myrole'
+        cache = {
+            'development--myrole': {
+                'Credentials': {
+                    'AccessKeyId': 'foo-dev-cached',
+                    'SecretAccessKey': 'bar-dev-cached',
+                    'SessionToken': 'baz-dev-cached',
+                    'Expiration': utc_timestamp,
+                }
+            },
+            'indirect---development2--myrole2': {
+                'Credentials': {
+                    'AccessKeyId': 'foo-dev2-cached',
+                    'SecretAccessKey': 'bar-dev2-cached',
+                    'SessionToken': 'baz-dev2-cached',
+                    'Expiration': utc_timestamp,
+                }
+            }
+        }
+        provider = credentials.AssumeRoleProvider(
+            self.create_config_loader(), mock.Mock(),
+            cache=cache, profile_name='development2')
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo-dev2-cached')
+        self.assertEqual(creds.secret_key, 'bar-dev2-cached')
+        self.assertEqual(creds.token, 'baz-dev2-cached')
+
+    def test_assume_indirect_role_in_cache_but_expired(self):
+        expired_creds = datetime.utcnow()
+        valid_creds = expired_creds + timedelta(seconds=60)
+        utc_timestamp = expired_creds.isoformat() + 'Z'
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': valid_creds.isoformat() + 'Z',
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        cache = {
+            'development--myrole': {
+                'Credentials': {
+                    'AccessKeyId': 'foo-dev-cached',
+                    'SecretAccessKey': 'bar-dev-cached',
+                    'SessionToken': 'baz-dev-cached',
+                    'Expiration': valid_creds.isoformat() + 'Z'
+                }
+            },
+            'indirect---development2--myrole2': {
+                'Credentials': {
+                    'AccessKeyId': 'foo-dev2-cached',
+                    'SecretAccessKey': 'bar-dev2-cached',
+                    'SessionToken': 'baz-dev2-cached',
+                    'Expiration': utc_timestamp,
+                }
+            }
+        }
+        provider = credentials.AssumeRoleProvider(
+            self.create_config_loader(), client_creator,
+            cache=cache, profile_name='development2')
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
 
 
 class TestRefreshLogic(unittest.TestCase):


### PR DESCRIPTION
This change will allow a profile to use a profile that uses a role as a
source profile. This will allow hierarchies of profiles where a user is
used to assume a role which is then used to assume another role. This is
useful for when another account grants cross account access and the role
that can assume the other role is assumable by users. Here's an example.

``` ~/.aws/credentials:
[default]
aws_access_key_id = <blah_id>
aws_secreet_access_key = <blah_secret>

~/.aws/config
[profile customer_accessor_role]
role_arn=arn:aws:iam:<my_acct_number>:role/customer_accessor_role
source_profile=default

[profile customer_role]
role_arn=arn:aws:iam:<customer_acct_number>:role/customer_role
source_profile=customer_accessor_role
external_id=<whatever>
```

Now I can do things like the following:

```
aws --profile customer_role s3 ls
```
