### PR TITLE
Fix regression in stubber

### DIFF
--- a/.changes/next-release/bugfix-Stubber-31703.json
+++ b/.changes/next-release/bugfix-Stubber-31703.json
@@ -1,0 +1,5 @@
+{
+  "category": "Stubber", 
+  "type": "bugfix", 
+  "description": "Fix regression in comparing multiple expected parameters"
+}

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -329,7 +329,7 @@ class Stubber(object):
                         pformat(expected_params), pformat(params)))
 
         # Ensure there are no extra params hanging around
-        if expected_params.keys() != params.keys():
+        if sorted(expected_params.keys()) != sorted(params.keys()):
             raise StubAssertionError(
                 operation_name=model.name,
                 reason='Expected parameters:\n%s,\nbut received:\n%s' % (

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -194,3 +194,20 @@ class TestStubber(unittest.TestCase):
         # Throw an error for invalid parameters
         with self.assertRaises(StubAssertionError):
             self.client.list_objects(Buck='bar')
+
+    def test_many_expected_params(self):
+        service_response = {}
+        expected_params = {
+            'Bucket': 'mybucket',
+            'Prefix': 'myprefix',
+            'Delimiter': '/',
+            'EncodingType': 'url'
+        }
+        self.stubber.add_response(
+            'list_objects', service_response, expected_params)
+        try:
+            with self.stubber:
+                self.client.list_objects(**expected_params)
+        except StubAssertionError:
+            self.fail(
+                "Stubber inappropriately raised error for same parameters.")


### PR DESCRIPTION
Sometimes the list returned from dict.keys() will not be in the same order
which will cause the equality of keys check to fail:
```
    >>> ['key1', 'key2'] == ['key2', 'key1']
    False
```
To fix it, the keys need to be sorted.

Noticed it because of failing tests here: https://github.com/boto/s3transfer/pull/15

cc @jamesls @JordonPhillips 