### PR TITLE
Fix S3 SignatureDoesNotMatch with Unicode params

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -572,7 +572,7 @@ class HmacV1Auth(BaseSigner):
         if len(nv) == 1:
             return nv
         else:
-            return (nv[0], unquote(nv[1]))
+            return (nv[0], unquote(nv[1].encode('ascii')).decode('utf-8'))
 
     def canonical_resource(self, split, auth_path=None):
         # don't include anything after the first ? in the resource...


### PR DESCRIPTION
Boto can cause S3 to return an error from S3:

```
<Error>
<Code>SignatureDoesNotMatch</Code>
<Message>
The request signature we calculated does not match the signature you provided. Check your key and signing method.
</Message>
…
```

This was because of an asymmetry in the URL handling for HmacV1Auth signing.

The URL the signing algorithm starts with has been escaped using `botocore.utils.percent_encode` which uses `urllib.quote` on `input_str.encode('utf-8')` and ends up as a `u""` type string before the canonical string processing. But the `unquote_v` method of `botocore.auth.HmacV1Auth` only did half of this, using `urllib.unquote` but *not* decoding back from utf-8. So it would end up with a unicode-type string containing *two code points* for the single original code point, which then get separately **re**-encoded by the `new_hmac.update(string_to_sign.encode('utf-8'))` call in the `sign_string` method.

This adds logic an existing little hook to force the string back to its original form. I'm not sure if there are other places where a `percent_encode` is improperly balanced by a plain `unquote` but this fixes the S3 SignatureDoesNotMatch error.

Note that S3 still can get unhappy with the value itself (InvalidArgument: Header value cannot be represented using ISO-8859-1) depending on what characters are used, so e.g. in the case of the content-disposition header you'd want to [follow best practices](https://tools.ietf.org/html/rfc6266#appendix-D) which would also serve to work **around** this issue — but seems the signing should still be made correct for non-ASCII characters regardless.