### PR TITLE
Allow underscores in endpoint_url hostname

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -602,9 +602,9 @@ def is_valid_endpoint_url(endpoint_url):
     if hostname[-1] == ".":
         hostname = hostname[:-1]
     allowed = re.compile(
-        "^((?!-)[A-Z\d-]{1,63}(?<!-)\.)*((?!-)[A-Z\d-]{1,63}(?<!-))$",
+        "^((?!-)[_A-Z\d-]{1,63}(?<!-)\.)*((?!-)[_A-Z\d-]{1,63}(?<!-))$",
         re.IGNORECASE)
-    return allowed.match(hostname)
+    return bool(allowed.match(hostname))
 
 
 def check_dns_name(bucket_name):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -522,6 +522,9 @@ class TestIsValidEndpointURL(unittest.TestCase):
     def test_cannot_have_spaces(self):
         self.assertFalse(is_valid_endpoint_url('https://my invalid name/'))
 
+    def test_can_have_underscores(self):
+        self.assertTrue(is_valid_endpoint_url('https://foo_bar/'))
+
     def test_missing_scheme(self):
         self.assertFalse(is_valid_endpoint_url('foo.bar.com'))
 


### PR DESCRIPTION
Currently `is_valid_endpoint` in `botocore.utils` doesn't allow for underscores in the `endpoint_url`. 

We weren't able to specify docker containers names using underscores as endpoints, so we wrote the following fix.

It also adds an explicit call to `bool()` in the `is_valid_endpoint` return statement to conform to the function contract stating that it returns `True` or `False`.