### PR TITLE
Make output JSON serializable

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -214,7 +214,7 @@ class ResponseParser(object):
         if isinstance(parsed, dict) and 'ResponseMetadata' in parsed:
             parsed['ResponseMetadata']['HTTPStatusCode'] = (
                 response['status_code'])
-            parsed['ResponseMetadata']['HTTPHeaders'] = response['headers']
+            parsed['ResponseMetadata']['HTTPHeaders'] = dict(response['headers'])
         return parsed
 
     def _is_generic_error_response(self, response):


### PR DESCRIPTION
92568700ad1bd560d3f92213b52a6b11a1647d13 breaks assumed roles in AWS CLI because it adds HTTP headers in a `botocore.vendored.requests.structures.CaseInsensitiveDict`.  AWS CLI caches details to disk by serializing to JSON.

Resolve this by coercing into a normal dict.