### PR TITLE
Fix regression in assume role caching

### DIFF
--- a/.changes/next-release/bugfix-AssumeRole-9717.json
+++ b/.changes/next-release/bugfix-AssumeRole-9717.json
@@ -1,0 +1,5 @@
+{
+  "category": "AssumeRole", 
+  "type": "bugfix", 
+  "description": "Fix regression introduced in `#920 <https://github.com/boto/botocore/issues/920>`__ where assume role responses error out when attempting to cache a response. (`#961 <https://github.com/boto/botocore/issues/961>`__)"
+}

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -214,7 +214,7 @@ class ResponseParser(object):
         if isinstance(parsed, dict) and 'ResponseMetadata' in parsed:
             parsed['ResponseMetadata']['HTTPStatusCode'] = (
                 response['status_code'])
-            parsed['ResponseMetadata']['HTTPHeaders'] = response['headers']
+            parsed['ResponseMetadata']['HTTPHeaders'] = dict(response['headers'])
         return parsed
 
     def _is_generic_error_response(self, response):


### PR DESCRIPTION
This pulls in https://github.com/boto/botocore/pull/961 and adds tests for the change.

Right now you get an error:
```
$ aws ec2 describe-instances --profile some-role
Value cannot be cached, must be JSON serializable: {u'AssumedRole...
```

This was from a recent addition to botocore that added the HTTP headers into the response metadata returned from client calls.

I agree with the original change from @bashtoni to fix this in the parser.  We've had an implicit contract that you can JSON dump response metadata so while we could fix this in the assume role cacher, it's possible customer code could be relying on this property, in which case we would not be able to fix.

cc @kyleknap @JordonPhillips 