### PR TITLE
fixes #926 - expose retry information in exceptions

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -142,9 +142,14 @@ class Endpoint(object):
         request = self.create_request(request_dict, operation_model)
         success_response, exception = self._get_response(
             request, operation_model, attempts)
+        retries = []
         while self._needs_retry(attempts, operation_model, request_dict,
                                 success_response, exception):
             attempts += 1
+            # add retry information to response
+            if success_response is not None and \
+                'Error' in success_response[1]:
+                retries.append(success_response[1]['Error'])
             # If there is a stream associated with the request, we need
             # to reset it before attempting to send the request again.
             # This will ensure that we resend the entire contents of the
@@ -155,6 +160,10 @@ class Endpoint(object):
                 request_dict, operation_model)
             success_response, exception = self._get_response(
                 request, operation_model, attempts)
+        # this *should* be None or a tuple
+        if success_response is not None and \
+            'ResponseMetadata' in success_response[1]:
+            success_response[1]['ResponseMetadata']['Retries'] = retries
         if exception is not None:
             raise exception
         else:

--- a/botocore/retryhandler.py
+++ b/botocore/retryhandler.py
@@ -251,6 +251,9 @@ class MaxAttemptsDecorator(BaseChecker):
                                           caught_exception)
         if should_retry:
             if attempt_number >= self._max_attempts:
+                # explicitly set MaxAttemptsReached
+                if response is not None and 'ResponseMetadata' in response[1]:
+                    response[1]['ResponseMetadata']['MaxAttemptsReached'] = True
                 logger.debug("Reached the maximum number of retry "
                              "attempts: %s", attempt_number)
                 return False

--- a/tests/unit/test_retryhandler.py
+++ b/tests/unit/test_retryhandler.py
@@ -53,16 +53,18 @@ class TestRetryCheckers(unittest.TestCase):
     def test_max_attempts(self):
         self.checker = retryhandler.MaxAttemptsDecorator(
             retryhandler.HTTPStatusCodeChecker(500), max_attempts=3)
+        response = {'ResponseMetadata': {}}
 
         # Retry up to three times.
         self.assert_should_be_retried(
-            (HTTP_500_RESPONSE, {}), attempt_number=1)
+            (HTTP_500_RESPONSE, response), attempt_number=1)
         self.assert_should_be_retried(
             (HTTP_500_RESPONSE, {}), attempt_number=2)
         # On the third failed response, we've reached the
         # max attempts so we should return False.
         self.assert_should_not_be_retried(
-            (HTTP_500_RESPONSE, {}), attempt_number=3)
+            (HTTP_500_RESPONSE, response), attempt_number=3)
+        self.assertTrue(response['ResponseMetadata']['MaxAttemptsReached'])
 
     def test_max_attempts_successful(self):
         self.checker = retryhandler.MaxAttemptsDecorator(


### PR DESCRIPTION
This is my attempt at fixing #926 by providing information on retries in ``ResponseMetadata``, which is returned as part of the exceptions that are raised to the user.

* in botocore.retryhandler.MaxAttemptsDecorator.__call__(), add a MaxAttemptsReached=True element to ResponseMetadata if the maximum number of attempts is reached
* in botocore.endpoint.Endpoint._send_request(), add a NumAttempts element to ResponseMetadata, containing the attempt number

An example of this in action:

```python
#!/usr/bin/env python

import boto3
from mock import patch, Mock
from botocore.vendored.requests.models import Response

ec2 = boto3.resource('ec2')
i = ec2.Instance('i-0')

def mock_get_response(self, request, operation_model, attempts):
    headers = {
        'transfer-encoding': 'chunked',
        'date': 'Thu, 23 Jun 2016 11:32:42 GMT',
        'connection': 'close',
        'server': 'AmazonEC2'
    }
    mock_resp = Mock(spec_set=Response)
    type(mock_resp).content = '<?xml version="1.0" encoding="UTF-8"?>\n<Response><Errors><Error><Type>Sender</Type><Code>Throttling</Code><Message>Rate exceeded</Message></Error></Errors><RequestID>44c0f570-e338-48dd-9953-6684fa586dcb</RequestID></Response>'
    type(mock_resp).headers = headers
    type(mock_resp).status_code = 400
    parsed = {
        'ResponseMetadata': {
            'HTTPStatusCode': 400,
            'RequestId': '44c0f570-e338-48dd-9953-6684fa586dcb',
            'HTTPHeaders': headers
        },
        'Error': {
            'Message': "Rate exceeded",
            'Code': 'Throttling'
        }
    }
    return (mock_resp, parsed), None


with patch('botocore.endpoint.Endpoint._get_response', side_effect=mock_get_response, autospec=True):
    try:
        x = i.hypervisor
    except Exception as ex:
        print(ex.response)
```

```console
(botocore)jantman@phoenix:pts/14:~/GIT/botocore (issue926_retry_info %=)$ time python ~/tmp/test.py 
{'ResponseMetadata': {'NumAttempts': 5, 'HTTPStatusCode': 400, 'MaxAttemptsReached': True, 'RequestId': '44c0f570-e338-48dd-9953-6684fa586dcb', 'HTTPHeaders': {'transfer-encoding': 'chunked', 'date': 'Thu, 23 Jun 2016 11:32:42 GMT', 'connection': 'close', 'server': 'AmazonEC2'}}, 'Error': {'Message': 'Rate exceeded', 'Code': 'Throttling'}}

real    0m13.479s
user    0m0.340s
sys     0m0.043s
```