### PR TITLE
Save operation_name on ClientError exception object

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -339,6 +339,7 @@ class ClientError(Exception):
             operation_name=operation_name)
         super(ClientError, self).__init__(msg)
         self.response = error_response
+        self.operation_name = operation_name
 
 
 class UnsupportedTLSVersionWarning(Warning):


### PR DESCRIPTION
The operation name could be useful when working with exceptions raised by boto, currently you'll have to match on the error message which is far from optimal.