### PR TITLE
Save operation_name on ClientError exception object

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -339,6 +339,7 @@ class ClientError(Exception):
             operation_name=operation_name)
         super(ClientError, self).__init__(msg)
         self.response = error_response
+        self.operation_name = operation_name
 
 
 class UnsupportedTLSVersionWarning(Warning):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -24,4 +24,9 @@ def test_client_error_can_handle_missing_code_or_message():
 def test_client_error_has_operation_name_set():
     response = {'Error': {}}
     exception = exceptions.ClientError(response, 'blackhole')
+    assert(hasattr(exception, 'operation_name'))
+
+def test_client_error_set_correct_operation_name():
+    response = {'Error': {}}
+    exception = exceptions.ClientError(response, 'blackhole')
     assert_equals(exception.operation_name, 'blackhole')

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -20,3 +20,8 @@ def test_client_error_can_handle_missing_code_or_message():
     response = {'Error': {}}
     expect = 'An error occurred (Unknown) when calling the blackhole operation: Unknown'
     assert_equals(str(exceptions.ClientError(response, 'blackhole')), expect)
+
+def test_client_error_has_operation_name_set():
+    response = {'Error': {}}
+    exception = exceptions.ClientError(response, 'blackhole')
+    assert_equals(exception.operation_name, 'blackhole')


### PR DESCRIPTION
The operation name could be useful when working with exceptions raised by boto, currently you'll have to match on the error message which is far from optimal.