### PR TITLE
Use weakref for client in S3 redirector

### DIFF
--- a/.changes/next-release/bugfix-S3-4368.json
+++ b/.changes/next-release/bugfix-S3-4368.json
@@ -1,0 +1,5 @@
+{
+  "category": "S3",
+  "description": "Fixed a bug where the S3 region redirector was potentially causing a memory leak on python 2.6.",
+  "type": "bugfix"
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -16,9 +16,7 @@ import datetime
 import hashlib
 import binascii
 import functools
-import threading
-
-from collections import MutableMapping
+import weakref
 
 from six import string_types, text_type
 import dateutil.parser
@@ -815,7 +813,10 @@ class S3RegionRedirector(object):
         self._cache = cache
         if self._cache is None:
             self._cache = {}
-        self._client = client
+
+        # This needs to be a weak ref in order to prevent memory leaks on
+        # python 2.6
+        self._client = weakref.proxy(client)
 
     def register(self, event_emitter=None):
         emitter = event_emitter or self._client.meta.events


### PR DESCRIPTION
The S3RegionRedirector holds a reference to the client, which was
causing memory leaks on python 2.6. We didn't notice this previously
because our tests give us a certain tolerance and we were still
falling under that tolerance. If more events are added to the
event emitter by default, it can cause the amount of memory leaked
to go past our tolerance.

This fixes the issue by making the S3 redirector hold a weakref to
the client instead of a strong reference. We don't have to worry
about it being GC'd because customers will be holding a strong ref
to the client for us.

cc @jamesls @kyleknap