### PR TITLE
Populate location constraint in integration tests

### DIFF
--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -41,7 +41,12 @@ class TestBucketWithVersions(unittest.TestCase):
         # 1. Create a bucket
         # 2. Enable versioning
         # 3. Put an Object
-        self.client.create_bucket(Bucket=self.bucket_name)
+        self.client.create_bucket(
+            Bucket=self.bucket_name,
+            CreateBucketConfiguration={
+                'LocationConstraint': 'us-west-2'
+            }
+        )
         self.addCleanup(self.client.delete_bucket, Bucket=self.bucket_name)
 
         self.client.put_bucket_versioning(


### PR DESCRIPTION
When switching to sigv4 by default, I missed this S3 test in the client
integration tests. I did a search of the other integration tests to
look for create bucket, and only found one in test_elastictranscoder
which was configured for us-east-1 and thus does not need that value
to be set.

cc @jamesls @phjordon