### PR TITLE
allow bytearray in calculating md5 from bytes

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -130,7 +130,7 @@ def calculate_md5(params, **kwargs):
     request_dict = params
     if request_dict['body'] and 'Content-MD5' not in params['headers']:
         body = request_dict['body']
-        if isinstance(body, bytes):
+        if isinstance(body, (bytes, bytearray)):
             binary_md5 = _calculate_md5_from_bytes(body)
         else:
             binary_md5 = _calculate_md5_from_file(body)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -866,6 +866,17 @@ class TestAddMD5(BaseMD5Test):
             request_dict['headers']['Content-MD5'],
             'OFj2IjCsPJFfMAxmQxLGPw==')
 
+    def test_add_md5_with_bytearray_object(self):
+        request_dict = {
+            'body': bytearray('foobar'),
+            'headers': {}
+        }
+        self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
+        handlers.calculate_md5(request_dict)
+        self.assertEqual(
+            request_dict['headers']['Content-MD5'],
+            'OFj2IjCsPJFfMAxmQxLGPw==')
+
 
 class TestParameterAlias(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -868,7 +868,7 @@ class TestAddMD5(BaseMD5Test):
 
     def test_add_md5_with_bytearray_object(self):
         request_dict = {
-            'body': bytearray('foobar'),
+            'body': bytearray(b'foobar'),
             'headers': {}
         }
         self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'


### PR DESCRIPTION
Passing `bytearray` to S3 multipart upload fails when calculating md5. Having the below code, it fails w/o the modification.
https://gist.github.com/foobarna/913a84136a4357bbdc4112c924c0c41e

https://docs.python.org/2/whatsnew/2.6.html#pep-3112-byte-literals
