### PR TITLE
add CodeDeploy waiters for deployments

### DIFF
--- a/botocore/data/codedeploy/2014-10-06/waiters-2.json
+++ b/botocore/data/codedeploy/2014-10-06/waiters-2.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "waiters": {
+    "DeploymentSuccessful": {
+      "delay": 15,
+      "operation": "GetDeployment",
+      "maxAttempts": 120,
+      "acceptors": [
+        {
+          "expected": "Succeeded",
+          "matcher": "path",
+          "state": "success",
+          "argument": "deploymentInfo.status"
+        },
+        {
+          "expected": "Failed",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "deploymentInfo.status"
+        },
+        {
+          "expected": "Stopped",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "deploymentInfo.status"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR implements waiters for CodeDeploy' s most basic deployment flows.
 

Deployment state as a whole can take Created/Queued/InProgress/Succeeded/Failed/Stopped.
http://docs.aws.amazon.com/codedeploy/latest/APIReference/API_DeploymentInfo.html#CodeDeploy-Type-DeploymentInfo-deploymentOverview

This waiter waits until deployments Succeeded/Failed/Stopped..

![codedeploy-waiter-flow](https://cloud.githubusercontent.com/assets/266641/16707997/2c196ad0-45e3-11e6-8dff-014abb0903bb.png)

Closes boto/boto3#708

## Usage
```
$ aws deploy create-deployment \
  --application-name foo \
  --deployment-config-name CodeDeployDefault.OneAtATime \
  --deployment-group-name bar \
  --description "baz" \
  --s3-location bucket=YOUR-BUCKET,bundleType=zip,key=YOUR/KEY.zip
{
    "deploymentId": "d-123456789"
}

$ aws deploy wait deployment-successful --deployment-id d-123456789
```


## API names

OpsWorks has wait/deployment-successful API, so I followed this naming conventions.
http://docs.aws.amazon.com/cli/latest/reference/opsworks/wait/deployment-successful.html