### PR TITLE
Bug fix for _get_response receives 'bytes' instead of  text

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -982,7 +982,7 @@ class ContainerMetadataFetcher(object):
                     error_msg="Received non 200 response (%s) from ECS metadata: %s"
                     % (response.status_code, response.content))
             try:
-                return json.loads(response.content)
+                return json.loads(response.text)
             except ValueError:
                 raise MetadataRetrievalError(
                     error_msg=("Unable to parse JSON returned from "


### PR DESCRIPTION
Fixing a bug that when requests module returns a byte response instead of text _get_response crashes
requests module can grantee a text response and handles the encoding when using the text method