### PR TITLE
ECS: use 'response.decode' to convert bytes -> string on python3

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -980,13 +980,13 @@ class ContainerMetadataFetcher(object):
             if response.status_code != 200:
                 raise MetadataRetrievalError(
                     error_msg="Received non 200 response (%s) from ECS metadata: %s"
-                    % (response.status_code, response.content))
+                    % (response.status_code, response.text))
             try:
-                return json.loads(response.content)
+                return json.loads(response.content.decode('utf-8'))
             except ValueError:
                 raise MetadataRetrievalError(
                     error_msg=("Unable to parse JSON returned from "
-                               "ECS metadata: %s" % response.content))
+                               "ECS metadata: %s" % response.text))
         except RETRYABLE_HTTP_ERRORS as e:
             error_msg = ("Received error when attempting to retrieve "
                          "ECS metadata: %s" % e)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -19,7 +19,7 @@ import six
 import mock
 
 from botocore import xform_name
-from botocore.compat import OrderedDict, json
+from botocore.compat import OrderedDict, json, ensure_bytes
 from botocore.awsrequest import AWSRequest
 from botocore.exceptions import InvalidExpressionError, ConfigNotFound
 from botocore.exceptions import ClientError
@@ -1190,7 +1190,7 @@ class TestContainerMetadataFetcher(unittest.TestCase):
     def fake_response(self, status_code, body):
         response = mock.Mock()
         response.status_code = status_code
-        response.content = body
+        response.content = ensure_bytes(body)  # requests.Response.content is bytes
         return response
 
     def set_http_responses_to(self, *responses):


### PR DESCRIPTION
Use 'response.text' for more flexible decoding on error; this uses errors='replace'
and tries to auto-detect encoding. Makes sense since an error may not be
generated by AWS and might not always be UTF-8.

This is a bug in how the ECS ContainerMetadataFetcher gets the credentials when running inside a task.