### PR TITLE
Fixes #976 by keeping old netloc field in new endpoint

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -799,7 +799,7 @@ def _get_new_endpoint(original_endpoint, new_endpoint, use_new_scheme=True):
         scheme = new_endpoint_components.scheme
     final_endpoint_components = (
         scheme,
-        new_endpoint_components.netloc,
+        original_endpoint_components.netloc,
         original_endpoint_components.path,
         original_endpoint_components.query,
         ''


### PR DESCRIPTION
Fixes https://github.com/boto/botocore/issues/976
The old `netloc` field was not being used when it should be:
```
>>> urlparse.urlsplit('http://s3.amazonaws.com/jamesls-test-sync')
SplitResult(scheme='http', netloc='s3.amazonaws.com', path='/jamesls-test-sync', query='', fragment='')
```
This will allow the scheme to be upgraded but won't change the endpoint location
@jamesls @kyleknap 