### PR TITLE
Honor old scheme when redirecting S3 requests

### DIFF
--- a/.changes/next-release/bugfix-s3-36114.json
+++ b/.changes/next-release/bugfix-s3-36114.json
@@ -1,0 +1,5 @@
+{
+  "description": "S3 region redirector will now honor the orginial url scheme.",
+  "category": "s3",
+  "type": "bugfix"
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -922,7 +922,7 @@ class S3RegionRedirector(object):
     def set_request_url(self, params, context, **kwargs):
         endpoint = context.get('signing', {}).get('endpoint', None)
         if endpoint is not None:
-            params['url'] = _get_new_endpoint(params['url'], endpoint)
+            params['url'] = _get_new_endpoint(params['url'], endpoint, False)
 
     def redirect_from_cache(self, params, context, **kwargs):
         """

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1000,6 +1000,15 @@ class TestS3RegionRedirector(unittest.TestCase):
         self.assertEqual(
             params['url'], 'https://us-west-2.amazonaws.com/foo')
 
+    def test_set_request_url_keeps_old_scheme(self):
+        params = {'url': 'http://us-west-2.amazonaws.com/foo'}
+        context = {'signing': {
+            'endpoint': 'https://eu-central-1.amazonaws.com'
+        }}
+        self.redirector.set_request_url(params, context)
+        self.assertEqual(
+            params['url'], 'http://eu-central-1.amazonaws.com/foo')
+
     def test_sets_signing_context_from_cache(self):
         signing_context = {'endpoint': 'bar'}
         self.cache['foo'] = signing_context


### PR DESCRIPTION
If the old URL was using http over https, we will no continue to
use http.

Fixes #976
Closes #984

cc @kyleknap @jamesls