### PR TITLE
Update git urls to use HTTPS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ mock==1.3.0
 wheel==0.24.0
 docutils>=0.10
 behave==1.2.5
--e git://github.com/boto/jmespath.git@develop#egg=jmespath
+-e git+https://github.com/boto/jmespath.git@develop#egg=jmespath


### PR DESCRIPTION
This appears to be recommended by pypa since it is the only scheme they document: https://pip.pypa.io/en/stable/user_guide/#requirements-files

cc @kyleknap @jamesls