### PR TITLE
Make s3 integ test more resilient

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -75,7 +75,9 @@ class BaseS3ClientTest(unittest.TestCase):
             }
         response = bucket_client.create_bucket(**bucket_kwargs)
         self.assert_status_code(response, 200)
-        self.addCleanup(recursive_delete, self.client, bucket_name)
+        waiter = bucket_client.get_waiter('bucket_exists')
+        waiter.wait(Bucket=bucket_name)
+        self.addCleanup(recursive_delete, bucket_client, bucket_name)
         return bucket_name
 
     def make_tempdir(self):


### PR DESCRIPTION
Use bucket_client instead of self.client.
Also, use a waiter to ensure the bucket exists.  There are times
when this test can fail with a bucket does not exist.

cc @kyleknap @JordonPhillips 