### PR TITLE
Allow underscore in endpoint urls

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -604,7 +604,7 @@ def is_valid_endpoint_url(endpoint_url):
     if hostname[-1] == ".":
         hostname = hostname[:-1]
     allowed = re.compile(
-        "^((?!-)[A-Z\d-]{1,63}(?<!-)\.)*((?!-)[A-Z\d-]{1,63}(?<!-))$",
+        "^((?!-)[A-Z\d-_]{1,63}(?<!-)\.)*((?!-)[A-Z\d-_]{1,63}(?<!-))$",
         re.IGNORECASE)
     return allowed.match(hostname)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -541,6 +541,8 @@ class TestIsValidEndpointURL(unittest.TestCase):
     def test_hostname_no_dots(self):
         self.assertTrue(is_valid_endpoint_url('https://foo/'))
 
+    def test_hostname_can_have_underscores(self):
+        self.assertTrue(is_valid_endpoint_url('https://dev-dynamodb_1/'))
 
 class TestFixS3Host(unittest.TestCase):
     def test_fix_s3_host_initial(self):


### PR DESCRIPTION
I dont see any reason why these should be excluded.

A perfectly reasonably hostname to have in your `/etc/hosts` file for example is `dev-dynamodb_1`. Currently this fails with an invalid endpoint url error.