### PR TITLE
Add last_response attr to WaiterError

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -295,6 +295,10 @@ class WaiterError(BotoCoreError):
     """Waiter failed to reach desired state."""
     fmt = 'Waiter {name} failed: {reason}'
 
+    def __init__(self, name, reason, last_response):
+        super(WaiterError, self).__init__(name=name, reason=reason)
+        self.last_response = last_response
+
 
 class IncompleteReadError(BotoCoreError):
     """HTTP response did not return expected number of bytes."""

--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -303,11 +303,11 @@ class Waiter(object):
                 # transition to the failure state if an error
                 # response was received.
                 if 'Error' in response:
-                    # Transition to the failure state, which we can
-                    # just handle here by raising an exception.
-                    raise WaiterError(
-                        name=self.name,
-                        reason=response['Error'].get('Message', 'Unknown'))
+                    # This was a ClientError that was not handled in an
+                    # acceptor. Raise a ClientError again
+                    raise ClientError(
+                        error_response=response,
+                        operation_name=self.config.operation)
             if current_state == 'success':
                 logger.debug("Waiting complete, waiter matched the "
                              "success state.")

--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -303,11 +303,13 @@ class Waiter(object):
                 # transition to the failure state if an error
                 # response was received.
                 if 'Error' in response:
-                    # This was a ClientError that was not handled in an
-                    # acceptor. Raise a ClientError again
-                    raise ClientError(
-                        error_response=response,
-                        operation_name=self.config.operation)
+                    # Transition to a failure state, which we
+                    # can just handle here by raising an exception.
+                    raise WaiterError(
+                        name=self.name,
+                        reason=response['Error'].get('Message', 'Unknown'),
+                        last_response=response
+                    )
             if current_state == 'success':
                 logger.debug("Waiting complete, waiter matched the "
                              "success state.")
@@ -315,8 +317,13 @@ class Waiter(object):
             if current_state == 'failure':
                 raise WaiterError(
                     name=self.name,
-                    reason='Waiter encountered a terminal failure state')
+                    reason='Waiter encountered a terminal failure state',
+                    last_response=response,
+                )
             if num_attempts >= max_attempts:
-                raise WaiterError(name=self.name,
-                                  reason='Max attempts exceeded')
+                raise WaiterError(
+                    name=self.name,
+                    reason='Max attempts exceeded',
+                    last_response=response
+                )
             time.sleep(sleep_amount)

--- a/tests/unit/test_waiters.py
+++ b/tests/unit/test_waiters.py
@@ -358,7 +358,7 @@ class TestWaitersObjects(unittest.TestCase):
             for_operation=operation_method
         )
         waiter = Waiter('MyWaiter', config, operation_method)
-        with self.assertRaises(WaiterError):
+        with self.assertRaises(ClientError):
             waiter.wait()
 
     def test_unspecified_errors_propagate_error_code(self):
@@ -378,7 +378,7 @@ class TestWaitersObjects(unittest.TestCase):
         )
         waiter = Waiter('MyWaiter', config, operation_method)
 
-        with self.assertRaisesRegexp(WaiterError, error_message):
+        with self.assertRaisesRegexp(ClientError, error_message):
             waiter.wait()
 
     def test_waiter_transitions_to_failure_state(self):


### PR DESCRIPTION
The rationale behind just adding a last_response instead of exposing some sort
of error_code and error_message is that a WaiterError can also be thrown in
non-error states (transitioning to a failure state, hitting max-attempts), and
while we can always guarantee a last response, we can't necessarily guarantee
that response is a "error" response.

Closes https://github.com/boto/botocore/pull/957