### PR TITLE
Add retry information to ResponseMetadata

### DIFF
--- a/.changes/next-release/feature-ResponseMetadata-68727.json
+++ b/.changes/next-release/feature-ResponseMetadata-68727.json
@@ -1,0 +1,5 @@
+{
+  "category": "ResponseMetadata", 
+  "type": "feature", 
+  "description": "Add MaxAttemptsReached and RetryAttempts keys to the returned ResonseMetadata dictionary (`#1024 <https://github.com/boto/botocore/issues/1024>`__, `#965 <https://github.com/boto/botocore/issues/965>`__, `#926 <https://github.com/boto/botocore/issues/926>`__)"
+}

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -142,9 +142,14 @@ class Endpoint(object):
         request = self.create_request(request_dict, operation_model)
         success_response, exception = self._get_response(
             request, operation_model, attempts)
+        retries = []
         while self._needs_retry(attempts, operation_model, request_dict,
                                 success_response, exception):
             attempts += 1
+            # add retry information to response
+            if success_response is not None and \
+                'Error' in success_response[1]:
+                retries.append(success_response[1]['Error'])
             # If there is a stream associated with the request, we need
             # to reset it before attempting to send the request again.
             # This will ensure that we resend the entire contents of the
@@ -155,6 +160,10 @@ class Endpoint(object):
                 request_dict, operation_model)
             success_response, exception = self._get_response(
                 request, operation_model, attempts)
+        # this *should* be None or a tuple
+        if success_response is not None and \
+            'ResponseMetadata' in success_response[1]:
+            success_response[1]['ResponseMetadata']['Retries'] = retries
         if exception is not None:
             raise exception
         else:

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -342,16 +342,29 @@ class UnsupportedSignatureVersionError(BotoCoreError):
 class ClientError(Exception):
     MSG_TEMPLATE = (
         'An error occurred ({error_code}) when calling the {operation_name} '
-        'operation: {error_message}')
+        'operation{retry_info}: {error_message}')
 
     def __init__(self, error_response, operation_name):
+        retry_info = self._get_retry_info(error_response)
         msg = self.MSG_TEMPLATE.format(
             error_code=error_response['Error'].get('Code', 'Unknown'),
             error_message=error_response['Error'].get('Message', 'Unknown'),
-            operation_name=operation_name)
+            operation_name=operation_name,
+            retry_info=retry_info,
+        )
         super(ClientError, self).__init__(msg)
         self.response = error_response
         self.operation_name = operation_name
+
+    def _get_retry_info(self, response):
+        retry_info = ''
+        if 'ResponseMetadata' in response:
+            metadata = response['ResponseMetadata']
+            if metadata.get('MaxAttemptsReached', False):
+                if 'RetryAttempts' in metadata:
+                    retry_info = (' (max_retries=%s reached)' %
+                                  metadata['RetryAttempts'])
+        return retry_info
 
 
 class UnsupportedTLSVersionWarning(Warning):

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -362,7 +362,7 @@ class ClientError(Exception):
             metadata = response['ResponseMetadata']
             if metadata.get('MaxAttemptsReached', False):
                 if 'RetryAttempts' in metadata:
-                    retry_info = (' (max_retries=%s reached)' %
+                    retry_info = (' (reached max retries: %s)' %
                                   metadata['RetryAttempts'])
         return retry_info
 

--- a/botocore/retryhandler.py
+++ b/botocore/retryhandler.py
@@ -251,6 +251,9 @@ class MaxAttemptsDecorator(BaseChecker):
                                           caught_exception)
         if should_retry:
             if attempt_number >= self._max_attempts:
+                # explicitly set MaxAttemptsReached
+                if response is not None and 'ResponseMetadata' in response[1]:
+                    response[1]['ResponseMetadata']['MaxAttemptsReached'] = True
                 logger.debug("Reached the maximum number of retry "
                              "attempts: %s", attempt_number)
                 return False

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -21,12 +21,44 @@ def test_client_error_can_handle_missing_code_or_message():
     expect = 'An error occurred (Unknown) when calling the blackhole operation: Unknown'
     assert_equals(str(exceptions.ClientError(response, 'blackhole')), expect)
 
+
 def test_client_error_has_operation_name_set():
     response = {'Error': {}}
     exception = exceptions.ClientError(response, 'blackhole')
-    assert(hasattr(exception, 'operation_name'))
+    assert hasattr(exception, 'operation_name')
+
 
 def test_client_error_set_correct_operation_name():
     response = {'Error': {}}
     exception = exceptions.ClientError(response, 'blackhole')
     assert_equals(exception.operation_name, 'blackhole')
+
+
+def test_retry_info_added_when_present():
+    response = {
+        'Error': {},
+        'ResponseMetadata': {
+            'MaxAttemptsReached': True,
+            'RetryAttempts': 3,
+        }
+    }
+    error_msg = str(exceptions.ClientError(response, 'operation'))
+    if '(max_retries=3 reached)' not in error_msg:
+        raise AssertionError("retry information not inject into error "
+                             "message: %s" % error_msg)
+
+
+def test_retry_info_not_added_if_retry_attempts_not_present():
+    response = {
+        'Error': {},
+        'ResponseMetadata': {
+            'MaxAttemptsReached': True,
+        }
+    }
+    # Because RetryAttempts is missing, retry info is not
+    # in the error message.
+    error_msg = str(exceptions.ClientError(response, 'operation'))
+    if 'max_retries' in error_msg:
+        raise AssertionError("Retry information should not be in exception "
+                             "message when retry attempts not in response "
+                             "metadata: %s" % error_msg)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -43,7 +43,7 @@ def test_retry_info_added_when_present():
         }
     }
     error_msg = str(exceptions.ClientError(response, 'operation'))
-    if '(max_retries=3 reached)' not in error_msg:
+    if '(reached max retries: 3)' not in error_msg:
         raise AssertionError("retry information not inject into error "
                              "message: %s" % error_msg)
 
@@ -58,7 +58,7 @@ def test_retry_info_not_added_if_retry_attempts_not_present():
     # Because RetryAttempts is missing, retry info is not
     # in the error message.
     error_msg = str(exceptions.ClientError(response, 'operation'))
-    if 'max_retries' in error_msg:
+    if 'max retries' in error_msg:
         raise AssertionError("Retry information should not be in exception "
                              "message when retry attempts not in response "
                              "metadata: %s" % error_msg)

--- a/tests/unit/test_retryhandler.py
+++ b/tests/unit/test_retryhandler.py
@@ -53,16 +53,18 @@ class TestRetryCheckers(unittest.TestCase):
     def test_max_attempts(self):
         self.checker = retryhandler.MaxAttemptsDecorator(
             retryhandler.HTTPStatusCodeChecker(500), max_attempts=3)
+        response = {'ResponseMetadata': {}}
 
         # Retry up to three times.
         self.assert_should_be_retried(
-            (HTTP_500_RESPONSE, {}), attempt_number=1)
+            (HTTP_500_RESPONSE, response), attempt_number=1)
         self.assert_should_be_retried(
             (HTTP_500_RESPONSE, {}), attempt_number=2)
         # On the third failed response, we've reached the
         # max attempts so we should return False.
         self.assert_should_not_be_retried(
-            (HTTP_500_RESPONSE, {}), attempt_number=3)
+            (HTTP_500_RESPONSE, response), attempt_number=3)
+        self.assertTrue(response['ResponseMetadata']['MaxAttemptsReached'])
 
     def test_max_attempts_successful(self):
         self.checker = retryhandler.MaxAttemptsDecorator(


### PR DESCRIPTION
This pulls in https://github.com/boto/botocore/pull/965 with the following changes:

* Replace `Retries` list with the number of retry attempts.
* Update `ClientError` messages to include retry information when max attempts are reached.

More context [here](https://github.com/boto/botocore/pull/965#issuecomment-243618656).

A few examples:

Client error messages:

```
An error occurred (NotFound) when calling the DescribeInstances operation (max_retries=4 reached): The instance ID 'i-1234' does not exist
```

ResponseMetadata on error:

```
 'ResponseMetadata': {'HTTPHeaders': {'connection': 'close',
                                      'date': 'Wed, 31 Aug 2016 17:41:51 GMT',
                                      'server': 'AmazonEC2',
                                      'transfer-encoding': 'chunked'},
                      'HTTPStatusCode': 400,
                      'MaxAttemptsReached': True,
                      'RequestId': 'abcd',
                      'RetryAttempts': 4}}
```

ResponseMetadata on success:

```
 'ResponseMetadata': {'HTTPHeaders': {'content-type': 'text/xml;charset=UTF-8',
                                      'date': 'Wed, 31 Aug 2016 17:42:19 GMT',
                                      'server': 'AmazonEC2',
                                      'transfer-encoding': 'chunked',
                                      'vary': 'Accept-Encoding'},
                      'HTTPStatusCode': 200,
                      'RequestId': '25587b14-963b-4357-bc13-56c0acd52d0e',
                      'RetryAttempts': 0}}
```

cc @kyleknap @JordonPhillips 