### PR TITLE
Add max_pool_connections to client config

### DIFF
--- a/.changes/next-release/feature-Config-99817.json
+++ b/.changes/next-release/feature-Config-99817.json
@@ -1,0 +1,5 @@
+{
+  "category": "Config", 
+  "type": "feature", 
+  "description": "Add `max_pool_connections` to client config (`#773 <https://github.com/boto/botocore/issues/773>`__, `#766 <https://github.com/boto/botocore/issues/766>`__, `#1026 <https://github.com/boto/botocore/issues/1026>`__)"
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -69,6 +69,7 @@ class ClientArgsCreator(object):
             service_model, region_name=endpoint_config['region_name'],
             endpoint_url=endpoint_config['endpoint_url'], verify=verify,
             response_parser_factory=self._response_parser_factory,
+            max_pool_connections=new_config.max_pool_connections,
             timeout=(new_config.connect_timeout, new_config.read_timeout))
 
         serializer = botocore.serialize.create_serializer(
@@ -119,7 +120,9 @@ class ClientArgsCreator(object):
         if client_config is not None:
             config_kwargs.update(
                 connect_timeout=client_config.connect_timeout,
-                read_timeout=client_config.read_timeout)
+                read_timeout=client_config.read_timeout,
+                max_pool_connections=client_config.max_pool_connections,
+            )
         s3_config = self.compute_s3_config(scoped_config,
                                            client_config)
         return {

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -13,7 +13,7 @@
 import copy
 from botocore.compat import OrderedDict
 
-from botocore.endpoint import DEFAULT_TIMEOUT
+from botocore.endpoint import DEFAULT_TIMEOUT, MAX_POOL_CONNECTIONS
 from botocore.exceptions import InvalidS3AddressingStyleError
 
 
@@ -48,6 +48,11 @@ class Config(object):
         when serializing requests. The default is True.  You can disable
         parameter validation for performance reasons.  Otherwise, it's
         recommended to leave parameter validation enabled.
+
+    :type max_pool_connections: int
+    :param max_pool_connections: The maximum number of connections to
+        keep in a connection pool.  If this value is not set, the default
+        value of 10 is used.
 
     :type s3: dict
     :param s3: A dictionary of s3 specific configurations.
@@ -86,6 +91,7 @@ class Config(object):
         ('connect_timeout', DEFAULT_TIMEOUT),
         ('read_timeout', DEFAULT_TIMEOUT),
         ('parameter_validation', True),
+        ('max_pool_connections', MAX_POOL_CONNECTIONS),
         ('s3', None)
     ])
 

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -17,6 +17,7 @@ import logging
 import time
 import threading
 
+from botocore.vendored.requests.adapters import HTTPAdapter
 from botocore.vendored.requests.sessions import Session
 from botocore.vendored.requests.utils import get_environ_proxies
 from botocore.vendored.requests.exceptions import ConnectionError
@@ -35,6 +36,7 @@ from botocore import parsers
 
 logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 60
+MAX_POOL_CONNECTIONS = 10
 filter_ssl_warnings()
 
 try:
@@ -75,7 +77,26 @@ def convert_to_response_dict(http_response, operation_model):
 
 
 class PreserveAuthSession(Session):
+    """Internal session class used to workaround requests behavior.
+
+    This class is intended to be used only by the Endpoint class.
+
+    """
+    def __init__(self, max_pool_connections=MAX_POOL_CONNECTIONS,
+                 http_adapter_cls=HTTPAdapter):
+        super(PreserveAuthSession, self).__init__()
+        # In order to support a user provided "max_pool_connections", we need
+        # to recreate the HTTPAdapter and pass in our max_pool_connections
+        # value.
+        adapter = http_adapter_cls(pool_maxsize=max_pool_connections)
+        # requests uses an HTTPAdapter for mounting both http:// and https://
+        self.mount('https://', adapter)
+        self.mount('http://', adapter)
+
     def rebuild_auth(self, prepared_request, response):
+        # Keep the existing auth information from the original prepared request.
+        # Normally this method would be where auth is regenerated as needed.
+        # By making this a noop, we're keeping the existing auth info.
         pass
 
 
@@ -92,7 +113,8 @@ class Endpoint(object):
 
     def __init__(self, host, endpoint_prefix,
                  event_emitter, proxies=None, verify=True,
-                 timeout=DEFAULT_TIMEOUT, response_parser_factory=None):
+                 timeout=DEFAULT_TIMEOUT, response_parser_factory=None,
+                 max_pool_connections=MAX_POOL_CONNECTIONS):
         self._endpoint_prefix = endpoint_prefix
         self._event_emitter = event_emitter
         self.host = host
@@ -100,8 +122,10 @@ class Endpoint(object):
         if proxies is None:
             proxies = {}
         self.proxies = proxies
-        self.http_session = PreserveAuthSession()
+        self.http_session = PreserveAuthSession(
+            max_pool_connections=max_pool_connections)
         self.timeout = timeout
+        self.max_pool_connections = max_pool_connections
         logger.debug('Setting %s timeout as %s', endpoint_prefix, self.timeout)
         self._lock = threading.Lock()
         if response_parser_factory is None:
@@ -241,8 +265,10 @@ class EndpointCreator(object):
 
     def create_endpoint(self, service_model, region_name, endpoint_url,
                         verify=None, response_parser_factory=None,
-                        timeout=DEFAULT_TIMEOUT):
+                        timeout=DEFAULT_TIMEOUT,
+                        max_pool_connections=MAX_POOL_CONNECTIONS):
         if not is_valid_endpoint_url(endpoint_url):
+
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
         return Endpoint(
             endpoint_url,
@@ -251,6 +277,7 @@ class EndpointCreator(object):
             proxies=self._get_proxies(endpoint_url),
             verify=self._get_verify_value(verify),
             timeout=timeout,
+            max_pool_connections=max_pool_connections,
             response_parser_factory=response_parser_factory)
 
     def _get_proxies(self, url):

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -76,7 +76,7 @@ def convert_to_response_dict(http_response, operation_model):
     return response_dict
 
 
-class PreserveAuthSession(Session):
+class BotocoreHTTPSession(Session):
     """Internal session class used to workaround requests behavior.
 
     This class is intended to be used only by the Endpoint class.
@@ -84,7 +84,7 @@ class PreserveAuthSession(Session):
     """
     def __init__(self, max_pool_connections=MAX_POOL_CONNECTIONS,
                  http_adapter_cls=HTTPAdapter):
-        super(PreserveAuthSession, self).__init__()
+        super(BotocoreHTTPSession, self).__init__()
         # In order to support a user provided "max_pool_connections", we need
         # to recreate the HTTPAdapter and pass in our max_pool_connections
         # value.
@@ -122,7 +122,7 @@ class Endpoint(object):
         if proxies is None:
             proxies = {}
         self.proxies = proxies
-        self.http_session = PreserveAuthSession(
+        self.http_session = BotocoreHTTPSession(
             max_pool_connections=max_pool_connections)
         self.timeout = timeout
         self.max_pool_connections = max_pool_connections

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -21,7 +21,7 @@ from botocore.compat import six
 from botocore.awsrequest import AWSRequest
 from botocore.endpoint import Endpoint, DEFAULT_TIMEOUT
 from botocore.endpoint import EndpointCreator
-from botocore.endpoint import PreserveAuthSession
+from botocore.endpoint import BotocoreHTTPSession
 from botocore.exceptions import EndpointConnectionError
 from botocore.exceptions import ConnectionClosedError
 from botocore.exceptions import BaseEndpointResolverError
@@ -361,7 +361,7 @@ class TestAWSSession(unittest.TestCase):
         success_response.raw._original_response = None
         success_response.is_redirect = False
         success_response.status_code = 200
-        session = PreserveAuthSession()
+        session = BotocoreHTTPSession()
         session.send = Mock(return_value=success_response)
 
         list(session.resolve_redirects(
@@ -376,7 +376,7 @@ class TestAWSSession(unittest.TestCase):
 
     def test_max_pool_conns_injects_custom_adapter(self):
         http_adapter_cls = Mock(return_value=sentinel.HTTP_ADAPTER)
-        session = PreserveAuthSession(max_pool_connections=20,
+        session = BotocoreHTTPSession(max_pool_connections=20,
                                       http_adapter_cls=http_adapter_cls)
         http_adapter_cls.assert_called_with(pool_maxsize=20)
         self.assertEqual(session.adapters['https://'], sentinel.HTTP_ADAPTER)

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -41,7 +41,7 @@ class TestS3Addressing(BaseSessionTest):
                              force_hmacv1=False):
         if force_hmacv1:
             self.session.register('choose-signer', self.enable_hmacv1)
-        with patch('botocore.endpoint.PreserveAuthSession') as \
+        with patch('botocore.endpoint.BotocoreHTTPSession') as \
                 mock_http_session:
             mock_send = mock_http_session.return_value.send
             mock_send.return_value = self.mock_response


### PR DESCRIPTION
This config value allows you to control the size of the
connection pools used in urllib3.  We were previously using the
hardcoded value of 10 (from requests).

I ended up not touching the `pool_connections` based on the
discussion from #766.

There ends up being quite a noticeable difference whenever
`num_threads > max_pool_connection`, so I think this will
help people running requests with a large number of threads.

As an aside, the implementation for this was much more complicated
than necessary.  I'm thinking on sending a few follow up PRs that
start to clean up some of this technical debt.

Closes #773
Closes #766

cc @kyleknap @JordonPhillips 