### PR TITLE
Update waiters-2.json

### DIFF
--- a/botocore/data/emr/2009-03-31/waiters-2.json
+++ b/botocore/data/emr/2009-03-31/waiters-2.json
@@ -41,7 +41,7 @@
     "ClusterTerminated": {
       "delay": 30,
       "operation": "DescribeCluster",
-      "maxAttempts": 600,
+      "maxAttempts": 60,
       "acceptors": [
         {
           "state": "success",

--- a/botocore/data/emr/2009-03-31/waiters-2.json
+++ b/botocore/data/emr/2009-03-31/waiters-2.json
@@ -37,6 +37,25 @@
           "expected": "TERMINATED_WITH_ERRORS"
         }
       ]
+    },
+    "ClusterTerminated": {
+      "delay": 30,
+      "operation": "DescribeCluster",
+      "maxAttempts": 600,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "path",
+          "argument": "Cluster.Status.State",
+          "expected": "TERMINATED"
+        },
+        {
+          "state": "failure",
+          "matcher": "path",
+          "argument": "Cluster.Status.State",
+          "expected": "TERMINATED_WITH_ERRORS"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds a waiter for EMR cluster termination. The waiter waits for up to 300 minutes.