### PR TITLE
Allow expected params to be passed to add_client_error

### DIFF
--- a/.changes/next-release/feature-Stubber-16169.json
+++ b/.changes/next-release/feature-Stubber-16169.json
@@ -1,0 +1,5 @@
+{
+  "category": "Stubber", 
+  "type": "feature", 
+  "description": "Add ability to specify expected params when using `add_client_error` (`#1025 <https://github.com/boto/botocore/issues/1025>`__)"
+}

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -235,7 +235,7 @@ class Stubber(object):
 
     def add_client_error(self, method, service_error_code='',
                          service_message='', http_status_code=400,
-                         service_error_meta=None):
+                         service_error_meta=None, expected_params=None):
         """
         Adds a ``ClientError`` to the response queue.
 
@@ -256,6 +256,13 @@ class Stubber(object):
         :param service_error_meta: Additional keys to be added to the
             service Error
         :type service_error_meta: dict
+
+        :param expected_params: A dictionary of the expected parameters to
+            be called for the provided service response. The parameters match
+            the names of keyword arguments passed to that client call. If
+            any of the parameters differ a ``StubResponseError`` is thrown.
+            You can use stub.ANY to indicate a particular parameter to ignore
+            in validation. stub.ANY is only valid for top level params.
         """
         http_response = Response()
         http_response.status_code = http_status_code
@@ -280,7 +287,7 @@ class Stubber(object):
         response = {
             'operation_name': operation_name,
             'response': (http_response, parsed_response),
-            'expected_params': None
+            'expected_params': expected_params
         }
         self._queue.append(response)
 

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -287,7 +287,7 @@ class Stubber(object):
         response = {
             'operation_name': operation_name,
             'response': (http_response, parsed_response),
-            'expected_params': expected_params
+            'expected_params': expected_params,
         }
         self._queue.append(response)
 

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -77,6 +77,27 @@ class TestStubber(unittest.TestCase):
         with self.assertRaises(ClientError):
             self.client.list_objects(Bucket='foo')
 
+    def test_can_add_expected_params_to_client_error(self):
+        self.stubber.add_client_error(
+            'list_objects', 'Error', 'error',
+            expected_params={'Bucket': 'foo'}
+        )
+        self.stubber.activate()
+        with self.assertRaises(ClientError):
+            self.client.list_objects(Bucket='foo')
+
+    def test_can_expected_param_fails_in_client_error(self):
+        self.stubber.add_client_error(
+            'list_objects', 'Error', 'error',
+            expected_params={'Bucket': 'foo'}
+        )
+        self.stubber.activate()
+        # We expect an AssertionError instead of a ClientError
+        # because we're calling the operation with the wrong
+        # param value.
+        with self.assertRaises(AssertionError):
+            self.client.list_objects(Bucket='wrong-argument-value')
+
     def test_expected_params_success(self):
         service_response = {}
         expected_params = {'Bucket': 'foo'}


### PR DESCRIPTION
This way you can still verify that your client method is being called as expected before raising a `ClientError`.

This pulls in https://github.com/boto/botocore/pull/1025 and adds tests for the change.

cc @kyleknap @JordonPhillips 