### PR TITLE
Improve functional test for waiter config validation

### DIFF
--- a/botocore/data/ec2/2016-04-01/waiters-2.json
+++ b/botocore/data/ec2/2016-04-01/waiters-2.json
@@ -301,7 +301,7 @@
       "acceptors": [
         {
           "expected": true,
-          "matcher": "pathAll",
+          "matcher": "path",
           "state": "success",
           "argument": "length(KeyPairs[].KeyName) > `0`"
         },

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -366,6 +366,23 @@ class TestArgumentGenerator(unittest.TestCase):
             }
         )
 
+    def test_will_use_member_names_for_string_values(self):
+        self.arg_generator = ArgumentGenerator(use_member_names=True)
+        self.assert_skeleton_from_model_is(
+            model={
+                'A': {'type': 'string'},
+                'B': {'type': 'integer'},
+                'C': {'type': 'float'},
+                'D': {'type': 'boolean'},
+            },
+            generated_skeleton={
+                'A': 'A',
+                'B': 0,
+                'C': 0.0,
+                'D': True,
+            }
+        )
+
     def test_generate_nested_structure(self):
         self.assert_skeleton_from_model_is(
             model={


### PR DESCRIPTION
This improves the waiter config validation to check a few additional cases, primarily related to JMESPath including:

* Verify the JMESPath expression matches something in the output
* Verify the JMESPath expression returns list types for `pathAll` and `pathAny`
* Verify the operation referenced actually produces output.

In order to do this, I made one change to the `ArgumentGenerator` utility class.  In order to rely on the "truth" value of the jmespath search result, I didn't want empty strings being generated.  To account for this, I added the ability for the placeholder strings to optionally use the member names for the values.

As part of this change, I had to update one of the waiter configs as it was now failing the tests:

```
AssertionError: Attempted to use 'pathAll' matcher in waiter 'KeyPairExists' with \
 non list result in JMESPath expression: length(KeyPairs[].KeyName) > `0`
```

I also moved around when we create a waiter so we now get better error messages from pre-existing validation.  Here's what some of the error messages now look like:

```
AssertionError: JMESPath expression did not match anything for \
  waiter 'ConversionTaskCancelled': ConversionTasks[].WillNeverMatch

AssertionError: Could not create waiter 'bundle_task_complete': \
  Invalid jmespath expression: Incomplete expression: "BadJMESPath("

AssertionError: Could not create waiter 'nat_gateway_available': \
  Error processing waiter config: Unknown acceptor: pathUnknown

AssertionError: Waiter 'UserExists' has JMESPath expression with \
  no output shape: OperationModel(name=DeleteUser)
```

cc @kyleknap @JordonPhillips 