### PR TITLE
Add `readlines()` generator to response body streams

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -80,6 +80,21 @@ class StreamingBody(object):
             self._verify_content_length()
         return chunk
 
+    def readlines(self, delimiter='\n'):
+        """Generator that streams lines. The default delimiter
+        is the newline character.
+
+        If the delimiter argument is specified, it will
+        override the default.
+        """
+        line_buffer = ''
+        for byte in self.read():
+            byte = line_buffer + str(byte)
+            lines = byte.split(delimiter)
+            line_buffer = lines.pop()
+            for line in lines:
+                yield line
+
     def _verify_content_length(self):
         # See: https://github.com/kennethreitz/requests/issues/1855
         # Basically, our http library doesn't do this for us, so we have

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -46,6 +46,13 @@ class TestStreamWrapper(unittest.TestCase):
         stream = response.StreamingBody(body, content_length=10)
         self.assertEqual(stream.read(), b'1234567890')
 
+    def test_streaming_wrapper_generates_line_streams(self):
+        body = six.BytesIO(b'1234567890\n1234567890')
+        stream = response.StreamingBody(body, content_length=21)
+        lines = stream.readlines()
+        for line in lines:
+            self.assertEqual(line, b'1234567890')
+
     def test_streaming_body_with_invalid_length(self):
         body = six.BytesIO(b'123456789')
         stream = response.StreamingBody(body, content_length=10)


### PR DESCRIPTION
This interface allows file streams to be converted to streams delimited by specified delimiters, instead of the deafult fixed width byte streams returned by `read()`.

See http://stackoverflow.com/a/16890018/119765 for the motivation for this pull request and use-case justification.
