### PR TITLE
Fix exceptions picklability

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -24,9 +24,11 @@ class BotoCoreError(Exception):
     fmt = 'An unspecified error occurred'
 
     def __init__(self, **kwargs):
-        msg = self.fmt.format(**kwargs)
-        Exception.__init__(self, msg)
+        self.message = self.fmt.format(**kwargs)
         self.kwargs = kwargs
+
+    def __str__(self):
+        return self.message
 
 
 class DataNotFoundError(BotoCoreError):
@@ -350,13 +352,12 @@ class ClientError(Exception):
 
     def __init__(self, error_response, operation_name):
         retry_info = self._get_retry_info(error_response)
-        msg = self.MSG_TEMPLATE.format(
+        self.message = self.MSG_TEMPLATE.format(
             error_code=error_response['Error'].get('Code', 'Unknown'),
             error_message=error_response['Error'].get('Message', 'Unknown'),
             operation_name=operation_name,
             retry_info=retry_info,
         )
-        super(ClientError, self).__init__(msg)
         self.response = error_response
         self.operation_name = operation_name
 
@@ -369,6 +370,9 @@ class ClientError(Exception):
                     retry_info = (' (reached max retries: %s)' %
                                   metadata['RetryAttempts'])
         return retry_info
+
+    def __str__(self):
+        return self.message
 
 
 class UnsupportedTLSVersionWarning(Warning):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -11,6 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pickle
 from nose.tools import assert_equals
 
 from botocore import exceptions
@@ -47,6 +48,26 @@ def test_retry_info_added_when_present():
         raise AssertionError("retry information not inject into error "
                              "message: %s" % error_msg)
 
+def test_waiter_error_is_pickleable():
+    exception = exceptions.WaiterError('object_available', 'timeout', {})
+    exception2 = pickle.loads(pickle.dumps(exception))
+
+    assert_equals(exception.__repr__(), exception2.__repr__())
+    assert_equals(str(exception), str(exception2))
+    assert_equals(type(exception), type(exception2))
+    assert_equals(exception.kwargs, exception2.kwargs)
+
+def test_client_error_is_pickleable():
+    response = {'Error': {}}
+
+    exception = exceptions.ClientError(response, 'blackhole')
+    exception2 = pickle.loads(pickle.dumps(exception))
+
+    assert_equals(exception.__repr__(), exception2.__repr__())
+    assert_equals(str(exception), str(exception2))
+    assert_equals(type(exception), type(exception2))
+    assert_equals(exception.response, exception2.response)
+    assert_equals(exception.operation_name, exception2.operation_name)
 
 def test_retry_info_not_added_if_retry_attempts_not_present():
     response = {


### PR DESCRIPTION
Currently exceptions created by botocore fail when sent through `pickle.loads(pickle.dumps(err))`. `pickle` is a module commonly used for serialization of python objects sent between runs or processes. One notable usage example is in `multiprocessing` module which in turn is used in Django's parallel test suite.

Any user who currently performs boto3 operations inside Django's test runner risks that his test suite blows up without running appropriate teardown operations. I've filed a separate fix for Django in django/django#7325.

These commits fix picklability of botocore exception classes. The culprit seemed to be calling parent `Exception.__init__` for defining exception's string representation instead of implementing our own more specialized `__str__` method.


One unrelated thing that surprised me while going through the code is that `ClientError` does not inherit `BotoCoreError`. I was 100% expecting to be able to catch all AWS-related errors with a single error class, but it seems that I would have to write something like this instead:

```
try:
    s3_object.load()
except (BotoCoreError, ClientError) as e:
    ...
```

Is the reason for this to shift blame between AWS/Client? If so I think there would be a room here for another error class that would be parent for both of these.