### PR TITLE
Remove unnecessary terminal states from cloudformation waiters

### DIFF
--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -44,31 +44,13 @@
         },
         {
           "argument": "Stacks[].StackStatus",
-          "expected": "DELETE_IN_PROGRESS",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
           "expected": "DELETE_FAILED",
           "matcher": "pathAny",
           "state": "failure"
         },
         {
           "argument": "Stacks[].StackStatus",
-          "expected": "ROLLBACK_COMPLETE",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
           "expected": "ROLLBACK_FAILED",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "ROLLBACK_IN_PROGRESS",
           "matcher": "pathAny",
           "state": "failure"
         },
@@ -104,67 +86,13 @@
         },
         {
           "argument": "Stacks[].StackStatus",
-          "expected": "CREATE_COMPLETE",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
           "expected": "CREATE_FAILED",
           "matcher": "pathAny",
           "state": "failure"
         },
         {
           "argument": "Stacks[].StackStatus",
-          "expected": "CREATE_IN_PROGRESS",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "ROLLBACK_COMPLETE",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
           "expected": "ROLLBACK_FAILED",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "ROLLBACK_IN_PROGRESS",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_COMPLETE",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_IN_PROGRESS",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_ROLLBACK_COMPLETE",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
           "matcher": "pathAny",
           "state": "failure"
         },
@@ -202,25 +130,7 @@
         },
         {
           "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_ROLLBACK_COMPLETE",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
           "expected": "UPDATE_ROLLBACK_FAILED",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
-          "matcher": "pathAny",
-          "state": "failure"
-        },
-        {
-          "argument": "Stacks[].StackStatus",
-          "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
           "matcher": "pathAny",
           "state": "failure"
         },


### PR DESCRIPTION
This removes two types of failure states from the cloudformation
waiters:

* Transitional states, e.g. delete_in_progress->delete_completed
* Any state which can still be transitioned to a success state

The first point aids in fast fails, but is otherwise unnecessary.
The latter point is the most interesting one.  Consider two operations:

* cfn.DeleteStacks()
* cfn.WaitDeleteStackComplete()

With the current approach, you *have* to call DeleteStacks before
WaitDeleteStackComplete.  However, one should be able to call
WaitDeleteStackComplete() in one process/thread, and then subsequently
call DeleteStacks().  This latter behavior is possible in other waiters.
Consider:

* Calling ec2.WaitInstanceTerminated, then terminating an instance
* Calling dynamodb.WaitTableNotExists, then deleting the table

This update brings that same behavior to cloudformation waiters.

cc @kyleknap @JordonPhillips 