### PR TITLE
Test with Python 3.5 in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34
+envlist = py26,py27,py33,py34,py35
 
 skipsdist = True
 


### PR DESCRIPTION
I only have Pythons 2.7 and 3.5 installed on my system, so the tox file wasn't good for me to run with 2 and 3.