### PR TITLE
Add generated files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ pip-log.txt
 env
 env2
 env3
+
+docs/source/reference/services
+tests/coverage.xml
+tests/nosetests.xml


### PR DESCRIPTION
These files are generated by running `make html` for the docs or `tox` for tests.