### PR TITLE
Add argument passing to tests

### DIFF
--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -4,17 +4,34 @@
 # binary package not from the CWD.
 
 import os
+import sys
 from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
 
-def run(command):
-    return check_call(command, shell=True)
+def main():
+    os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
+    command = [
+        'nosetests',
+        '--with-coverage',
+        '--cover-erase',
+        '--cover-package', 'botocore',
+        '--cover-xml',
+        '--with-xunit',
+        '-v',
+    ]
 
-run('nosetests --with-coverage --cover-erase --cover-package botocore '
-    '--with-xunit --cover-xml -v unit/ functional/')
+    extra_args = sys.argv[1:]
+    if extra_args:
+        command.extend(extra_args)
+    else:
+        command.extend(['unit/', 'functional/'])
+
+    return check_call(' '.join(command), shell=True)
+
+if __name__ == '__main__':
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ skipsdist = True
 [testenv]
 commands =
     {toxinidir}/scripts/ci/install
-    {toxinidir}/scripts/ci/run-tests
+    {toxinidir}/scripts/ci/run-tests {posargs}


### PR DESCRIPTION
This allows e.g. `tox -e py27 -- functional/test_stub.py` to just run that one test file, making the red-green-refactor cycle faster.
