### PR TITLE
Stubber: made ANY usable for nested parameters

### DIFF
--- a/.changes/next-release/feature-Stub-87309.json
+++ b/.changes/next-release/feature-Stub-87309.json
@@ -1,0 +1,5 @@
+{
+  "category": "Stub",
+  "type": "feature",
+  "description": "Made ANY usable for nested parameters"
+}

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -20,7 +20,22 @@ from botocore.exceptions import ParamValidationError, \
 from botocore.vendored.requests.models import Response
 
 
-ANY = object()
+class _ANY(object):
+    """
+    A helper object that compares equal to everything. Copied from
+    unittest.mock
+    """
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+    def __repr__(self):
+        return '<ANY>'
+
+ANY = _ANY()
 
 
 class Stubber(object):
@@ -262,7 +277,7 @@ class Stubber(object):
             the names of keyword arguments passed to that client call. If
             any of the parameters differ a ``StubResponseError`` is thrown.
             You can use stub.ANY to indicate a particular parameter to ignore
-            in validation. stub.ANY is only valid for top level params.
+            in validation.
         """
         http_response = Response()
         http_response.status_code = http_status_code
@@ -326,10 +341,7 @@ class Stubber(object):
 
         # Validate the parameters are equal
         for param, value in expected_params.items():
-            if value is ANY:
-                continue
-            elif param not in params or \
-                    expected_params[param] != params[param]:
+            if param not in params or expected_params[param] != params[param]:
                 raise StubAssertionError(
                     operation_name=model.name,
                     reason='Expected parameters:\n%s,\nbut received:\n%s' % (

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -204,6 +204,44 @@ class TestStubber(unittest.TestCase):
         except StubAssertionError:
             self.fail("stub.ANY failed to ignore parameter for validation.")
 
+    def test_nested_any_param(self):
+        service_response = {}
+        expected_params = {
+            'Bucket': 'foo',
+            'Key': 'bar.txt',
+            'Metadata': {
+                'MyMeta': stub.ANY,
+            }
+        }
+
+        self.stubber.add_response(
+            'put_object', service_response, expected_params)
+        self.stubber.add_response(
+            'put_object', service_response, expected_params)
+
+        try:
+            with self.stubber:
+                self.client.put_object(
+                    Bucket='foo',
+                    Key='bar.txt',
+                    Metadata={
+                        'MyMeta': 'Foo',
+                    }
+                )
+                self.client.put_object(
+                    Bucket='foo',
+                    Key='bar.txt',
+                    Metadata={
+                        'MyMeta': 'Bar',
+                    }
+                )
+        except StubAssertionError:
+            self.fail(
+                "stub.ANY failed to ignore nested parameter for validation.")
+
+    def test_ANY_repr(self):
+        self.assertEqual(repr(stub.ANY), '<ANY>')
+
     def test_none_param(self):
         service_response = {}
         expected_params = {'Buck': None}


### PR DESCRIPTION
Use the same compare-all class that `unittest.mock.ANY` uses to enable deep comparisons to 'just work'.