### PR TITLE
Add back missing fast fail states to create/update cfn waiters

### DIFF
--- a/.changes/next-release/bugfix-Waiters-383.json
+++ b/.changes/next-release/bugfix-Waiters-383.json
@@ -1,0 +1,5 @@
+{
+  "category": "Waiters", 
+  "type": "bugfix", 
+  "description": "Add back missing fail fail states to cloudformation waiters (`#1056 <https://github.com/boto/botocore/issues/1056>`__)"
+}

--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -141,6 +141,12 @@
           "state": "failure"
         },
         {
+          "expected": "UPDATE_ROLLBACK_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "Stacks[].StackStatus"
+        },
+        {
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"

--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -55,6 +55,12 @@
           "state": "failure"
         },
         {
+          "argument": "Stacks[].StackStatus",
+          "expected": "ROLLBACK_COMPLETE",
+          "matcher": "pathAny",
+          "state": "failure"
+        },
+        {
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"


### PR DESCRIPTION
Add back ROLLBACK_COMPLETE as a terminal failure state

StackCreateComplete can transition to a ROLLBACK_COMPLETE
when waiting for stack creation to complete.  The only action
upon reaching this state is to delete the stack.


Add back UPDATE_ROLLBACK_COMPLETE as fast fail case in waiter

For the update stack complete waiter, a failed update can result in
an UPDATE_ROLLEBACK_COMPLETE.  The unfortunate part here you
cannot use this waiter until you call UpdateStack, which is the
only cfn waiter that has this restriction.  This means a previous
UpateStack failed, calling the StackUpdateComplete waiter
before calling UpdateStack will immediately trigger the fast
fail case.


cc @kyleknap @JordonPhillips 