### PR TITLE
Fix a paginator bug involving optional tokens.

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -200,9 +200,10 @@ class PageIterator(object):
 
     def _inject_token_into_kwargs(self, op_kwargs, next_token):
         for name, token in next_token.items():
-            if token is None or token == 'None':
-                continue
-            op_kwargs[name] = token
+            if (token is not None) and (token != 'None'):
+                op_kwargs[name] = token
+            elif name in op_kwargs:
+                del op_kwargs[name]
 
     def _handle_first_request(self, parsed, primary_result_key,
                               starting_truncation):


### PR DESCRIPTION
This bug causes the route53 list_resource_record_sets paginator to skip over records in certain cases.

list_resource_record_sets uses a 3-tuple of pagination tokens, but one of them will be absent on some records. If the second page starts with a 3-token item and the third page starts with a 2-token item, the previous third token will get left in the request parameters, causing the backend to advance past the targeted item.
