### PR TITLE
sigv4 presigned urls should preserve blank params

### DIFF
--- a/.changes/next-release/bugfix-s3-27146.json
+++ b/.changes/next-release/bugfix-s3-27146.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3", 
+  "type": "bugfix", 
+  "description": "fixes `#1059 <https://github.com/boto/botocore/issues/1059>`__ (presigned s3v4 URL bug related to blank query parameters being filtered incorrectly)"
+}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -443,7 +443,8 @@ class SigV4QueryAuth(SigV4Auth):
         # have repeated keys so we know we have single element lists which we
         # can convert back to scalar values.
         query_dict = dict(
-            [(k, v[0]) for k, v in parse_qs(url_parts.query).items()])
+            [(k, v[0]) for k, v in
+             parse_qs(url_parts.query, keep_blank_values=True).items()])
         # The spec is particular about this.  It *has* to be:
         # https://<endpoint>?<operation params>&<auth params>
         # You can't mix the two types of params together, i.e just keep doing

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -680,6 +680,15 @@ class TestSigV4Presign(BasePresignTest):
         # Verify we encode spaces as '%20, and we don't use '+'.
         self.assertIn('Description=With%20Spaces', request.url)
 
+    def test_presign_with_empty_param_value(self):
+        request = AWSRequest()
+        request.method = 'POST'
+        # actual URL format for creating a multipart upload
+        request.url = 'https://s3.amazonaws.com/mybucket/mykey?uploads'
+        self.auth.add_auth(request)
+        # verify that uploads param is still in URL
+        self.assertIn('uploads', request.url)
+
     def test_s3_sigv4_presign(self):
         auth = botocore.auth.S3SigV4QueryAuth(
             self.credentials, self.service_name, self.region_name, expires=60)


### PR DESCRIPTION
A unit test and fix for #1059, which is a sigv4 bug related to presigned urls where the base url contains a query parameter without a value, such as '/bucket/key?uploads' for an s3 create_multipart_upload url.

The first commit contains a unit test that fails, and the second commit updates SigV4QueryAuth._modify_request_before_signing to use the keep_blank_values param of parse_qs in order to preserve parameters with no value.
