### PR TITLE
Allow parsing of json error responses with non-json bodies.

### DIFF
--- a/.changes/next-release/bugfix-Exceptions-99181.json
+++ b/.changes/next-release/bugfix-Exceptions-99181.json
@@ -1,0 +1,5 @@
+{
+  "description": "Allow parsing of json error responses with non-json bodies.",
+  "type": "bugfix",
+  "category": "Exceptions"
+}

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -551,7 +551,10 @@ class BaseJSONParser(ResponseParser):
         # so we need to check for both.
         error['Error']['Message'] = body.get('message',
                                              body.get('Message', ''))
-        code = body.get('__type')
+        # if the message did not contain an error code
+        # include the response status code
+        response_code = response.get('status_code')
+        code = body.get('__type', response_code and str(response_code))
         if code is not None:
             # code has a couple forms as well:
             # * "com.aws.dynamodb.vAPI#ProvisionedThroughputExceededException"
@@ -571,8 +574,13 @@ class BaseJSONParser(ResponseParser):
         if not body_contents:
             return {}
         body = body_contents.decode(self.DEFAULT_ENCODING)
-        original_parsed = json.loads(body)
-        return original_parsed
+        try:
+            original_parsed = json.loads(body)
+            return original_parsed
+        except ValueError:
+            # if the body cannot be parsed, include
+            # the literal string as the message
+            return { 'message': body }
 
 
 class JSONParser(BaseJSONParser):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -618,7 +618,7 @@ class TestParseErrorResponses(unittest.TestCase):
         self.assertIn('Error', parsed)
         self.assertEqual(parsed['Error'], {
             'Code': '413',
-            'Message': response
+            'Message': response.decode('utf-8')
         })
         self.assertEqual(parsed['ResponseMetadata'], {
             'HTTPStatusCode': 413,
@@ -640,7 +640,7 @@ class TestParseErrorResponses(unittest.TestCase):
         self.assertIn('Error', parsed)
         self.assertEqual(parsed['Error'], {
             'Code': '403',
-            'Message': response
+            'Message': response.decode('utf-8')
         })
         self.assertEqual(parsed['ResponseMetadata'], {
             'HTTPStatusCode': 403,

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -607,6 +607,46 @@ class TestParseErrorResponses(unittest.TestCase):
             'HTTPHeaders': headers
         })
 
+    def test_error_response_with_string_body_rest_json(self):
+        parser = parsers.RestJSONParser()
+        response = b'HTTP content length exceeded 1049600 bytes.'
+        headers = {'content-length': '0', 'connection': 'keep-alive'}
+        output_shape = None
+        parsed = parser.parse({'body': response, 'headers': headers,
+                               'status_code': 413}, output_shape)
+
+        self.assertIn('Error', parsed)
+        self.assertEqual(parsed['Error'], {
+            'Code': '413',
+            'Message': response
+        })
+        self.assertEqual(parsed['ResponseMetadata'], {
+            'HTTPStatusCode': 413,
+            'HTTPHeaders': headers
+        })
+
+    def test_error_response_with_xml_body_rest_json(self):
+        parser = parsers.RestJSONParser()
+        response = (
+            '<AccessDeniedException>'
+            '   <Message>Unable to determine service/operation name to be authorized</Message>'
+            '</AccessDeniedException>'
+        ).encode('utf-8')
+        headers = {'content-length': '0', 'connection': 'keep-alive'}
+        output_shape = None
+        parsed = parser.parse({'body': response, 'headers': headers,
+                               'status_code': 403}, output_shape)
+
+        self.assertIn('Error', parsed)
+        self.assertEqual(parsed['Error'], {
+            'Code': '403',
+            'Message': response
+        })
+        self.assertEqual(parsed['ResponseMetadata'], {
+            'HTTPStatusCode': 403,
+            'HTTPHeaders': headers
+        })
+
     def test_s3_error_response(self):
         body = (
             '<Error>'


### PR DESCRIPTION
Fixes Issue #908

By catching ValueErrors on json.loads when parsing the error's message body,
the raw message can be included as a string. This is not the common case,
but errors in an invalid format have been seen in Api Gateway, SWF and Dynamo
