### PR TITLE
Cloudformation documentation update

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -586,14 +586,13 @@ def document_cloudformation_get_template_return_type(section, event_name, **kwar
         template_body_section = section.get_section('TemplateBody')
         type_section = template_body_section.get_section('param-type')
         type_section.clear_text()
-        type_section.write(':type TemplateBody: dict')
+        type_section.write('(*dict*) --')
     elif 'response-example' in event_name:
         parent = section.get_section('structure-value')
         param_line = parent.get_section('TemplateBody')
         value_portion = param_line.get_section('member-value')
         value_portion.clear_text()
         value_portion.write('{}')
-        
 
 def switch_host_machinelearning(request, **kwargs):
     switch_host_with_param(request, 'PredictEndpoint')

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -581,6 +581,27 @@ def document_glacier_tree_hash_checksum():
     return AppendParamDocumentation('checksum', doc).append_documentation
 
 
+def document_cloudformation_get_template_return_type(section, event_name, **kwargs):
+    if 'response-params' in event_name:
+        template_body_section = section.get_section('TemplateBody')
+        type_section = template_body_section.get_section('param-type')
+        type_section.clear_text()
+        type_section.write(':type TemplateBody: dict')
+    elif 'response-example' in event_name:
+        parent = section.get_section('structure-value')
+        param_line = parent.get_section('TemplateBody')
+        value_portion = param_line.get_section('member-value')
+        value_portion.clear_text()
+        value_portion.write('{"AWSTemplateFormatVersion" : "version date", '
+                            '"Description" : "JSON string", '
+                            '"Metadata" : { template metadata }, '
+                            '"Parameters" : { set of parameters }, '
+                            '"Mappings" : { set of mappings }, '
+                            '"Conditions" : { set of conditions }, '
+                            '"Resources" : { set of resources }, '
+                            '"Outputs" : { set of outputs } }')
+        
+
 def switch_host_machinelearning(request, **kwargs):
     switch_host_with_param(request, 'PredictEndpoint')
 
@@ -848,7 +869,10 @@ BUILTIN_HANDLERS = [
      AutoPopulatedParam('checksum').document_auto_populated_param),
     ('docs.request-params.glacier.CompleteMultipartUpload.complete-section',
      document_glacier_tree_hash_checksum()),
-
+    # Cloudformation documentation customizations
+    ('docs.*.cloudformation.GetTemplate.complete-section',
+     document_cloudformation_get_template_return_type),
+    
     # UserData base64 encoding documentation customizations
     ('docs.*.ec2.RunInstances.complete-section',
      document_base64_encoding('UserData')),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -592,14 +592,7 @@ def document_cloudformation_get_template_return_type(section, event_name, **kwar
         param_line = parent.get_section('TemplateBody')
         value_portion = param_line.get_section('member-value')
         value_portion.clear_text()
-        value_portion.write('{"AWSTemplateFormatVersion" : "version date", '
-                            '"Description" : "JSON string", '
-                            '"Metadata" : { template metadata }, '
-                            '"Parameters" : { set of parameters }, '
-                            '"Mappings" : { set of mappings }, '
-                            '"Conditions" : { set of conditions }, '
-                            '"Resources" : { set of resources }, '
-                            '"Outputs" : { set of outputs } }')
+        value_portion.write('{}')
         
 
 def switch_host_machinelearning(request, **kwargs):

--- a/tests/functional/test_cloudformation.py
+++ b/tests/functional/test_cloudformation.py
@@ -24,13 +24,4 @@ class TestCloudFormationDocs(BaseDocsFunctionalTest):
         self.assert_contains_line(
             "TemplateBody: dict", content)
         # Check the specifics of the returned dict
-        self.assert_contains_lines_in_order([
-            '"AWSTemplateFormatVersion" : "version date"',
-            '"Description" : "JSON string"',
-            '"Metadata" : { template metadata }',
-            '"Parameters" : { set of parameters }',
-            '"Mappings" : { set of mappings }',
-            '"Conditions" : { set of conditions }',
-            '"Resources" : { set of resources }',
-            '"Outputs" : { set of outputs }',
-        ], content)
+        self.assert_contains_line('{}', content)

--- a/tests/functional/test_cloudformation.py
+++ b/tests/functional/test_cloudformation.py
@@ -17,11 +17,11 @@ from botocore.docs.service import ServiceDocumenter
 class TestCloudFormationDocs(BaseDocsFunctionalTest):
     def test_get_template_response_documented_as_dict(self):
         content = self.get_docstring_for_method('cloudformation', 'get_template')
-        # Should not say the return type of template body is a string
+        # String return type should be gone
         self.assert_not_contains_line(
-            "TemplateBody: string", content)
+            "(*string*) --", content)
         # Check for template body returning a dict
         self.assert_contains_line(
-            "TemplateBody: dict", content)
+            "(*dict*) --", content)
         # Check the specifics of the returned dict
         self.assert_contains_line('{}', content)

--- a/tests/functional/test_cloudformation.py
+++ b/tests/functional/test_cloudformation.py
@@ -1,0 +1,36 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.functional.docs import BaseDocsFunctionalTest
+from botocore.docs.service import ServiceDocumenter
+
+
+class TestCloudFormationDocs(BaseDocsFunctionalTest):
+    def test_get_template_response_documented_as_dict(self):
+        content = self.get_docstring_for_method('cloudformation', 'get_template')
+        # Should not say the return type of template body is a string
+        self.assert_not_contains_line(
+            "TemplateBody: string", content)
+        # Check for template body returning a dict
+        self.assert_contains_line(
+            "TemplateBody: dict", content)
+        # Check the specifics of the returned dict
+        self.assert_contains_lines_in_order([
+            '"AWSTemplateFormatVersion" : "version date"',
+            '"Description" : "JSON string"',
+            '"Metadata" : { template metadata }',
+            '"Parameters" : { set of parameters }',
+            '"Mappings" : { set of mappings }',
+            '"Conditions" : { set of conditions }',
+            '"Resources" : { set of resources }',
+            '"Outputs" : { set of outputs }',
+        ], content)


### PR DESCRIPTION
Updated cloud formation documentation, changes get_template return type from string to dict.

Fixes #1058 

cc @kyleknap @jamesls @JordonPhillips 