### PR TITLE
Add retry for apigateway TooManyRequestsException

### DIFF
--- a/.changes/next-release/bugfix-apigateway-27382.json
+++ b/.changes/next-release/bugfix-apigateway-27382.json
@@ -1,0 +1,5 @@
+{
+  "category": "apigateway",
+  "type": "bugfix",
+  "description": "Properly retry TooManyRequestsException."
+}

--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -84,6 +84,20 @@
           "too_many_requests": {"$ref": "too_many_requests"}
       }
     },
+    "apigateway": {
+      "__default__": {
+        "policies": {
+          "too_many_requests": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "TooManyRequestsException",
+                "http_status_code": 429
+              }
+            }
+          }
+        }
+      }
+    },
     "dynamodb": {
       "__default__": {
         "max_attempts": 10,


### PR DESCRIPTION
Based on the [apigateway docs](https://docs.aws.amazon.com/apigateway/api-reference/handling-errors/), `TooManyRequestsException` should be retried.

Fixes boto/boto3#876

cc @kyleknap @jamesls @stealthycoin