### PR TITLE
Enforce GMT == UTC

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -331,7 +331,10 @@ def parse_timestamp(value):
         except (TypeError, ValueError):
             pass
     try:
-        return dateutil.parser.parse(value)
+        # In certain cases, a timestamp marked with GMT can be parsed into a
+        # different time zone, so here we provide a context which will
+        # enforce that GMT == UTC.
+        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
     except (TypeError, ValueError) as e:
         raise ValueError('Invalid timestamp "%s": %s' % (value, e))
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -248,6 +248,18 @@ class TestParseTimestamps(unittest.TestCase):
             parse_timestamp('Wed, 02 Oct 2002 13:00:00 GMT'),
             datetime.datetime(2002, 10, 2, 13, 0, tzinfo=tzutc()))
 
+    def test_parse_gmt_in_uk_time(self):
+        # In the UK the time switches from GMT to BST and back as part of
+        # their daylight savings time. time.tzname will therefore report
+        # both time zones. dateutil sees that the time zone is a local time
+        # zone and so parses it as local time, but it ends up being BST
+        # instead of GMT. To remedy this issue we can provide a time zone
+        # context which will enforce GMT == UTC.
+        with mock.patch('time.tzname', ('GMT', 'BST')):
+            self.assertEqual(
+                parse_timestamp('Wed, 02 Oct 2002 13:00:00 GMT'),
+                datetime.datetime(2002, 10, 2, 13, 0, tzinfo=tzutc()))
+
     def test_parse_invalid_timestamp(self):
         with self.assertRaises(ValueError):
             parse_timestamp('invalid date')


### PR DESCRIPTION
In the UK the time switches from GMT to BST and back as part of
their daylight savings time. time.tzname will therefore report
both time zones. dateutil sees that the time zone is a local time
zone and so parses it as local time, but it ends up being BST
instead of GMT. To remedy this issue we can provide a time zone
context which will enforce GMT == UTC.

Fixes #1070

cc @kyleknap @jamesls @stealthycoin