### PR TITLE
Support loading json extra files

### DIFF
--- a/.changes/next-release/feature-Loader-97471.json
+++ b/.changes/next-release/feature-Loader-97471.json
@@ -1,0 +1,5 @@
+{
+  "category": "Loader",
+  "description": "Support loading json extra files.",
+  "type": "feature"
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -820,6 +820,24 @@ def _get_new_endpoint(original_endpoint, new_endpoint, use_new_scheme=True):
     return final_endpoint
 
 
+def deep_merge(base, extra):
+    """Deeply two dictionaries, overriding existing keys in the base.
+
+    :param base: The base dictionary which will be merged into.
+    :param extra: The dictionary to merge into the base. Keys from this
+        dictionary will take precedence.
+    """
+    for key in extra:
+        # If the key represents a dict on both given dicts, merge the sub-dicts
+        if key in base and isinstance(base[key], dict)\
+                and isinstance(extra[key], dict):
+            deep_merge(base[key], extra[key])
+            continue
+
+        # Otherwise, set the key on the base to be the value of the extra.
+        base[key] = extra[key]
+
+
 class S3RegionRedirector(object):
     def __init__(self, endpoint_bridge, client, cache=None):
         self._endpoint_resolver = endpoint_bridge

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -47,6 +47,7 @@ from botocore.utils import merge_dicts
 from botocore.utils import get_service_module_name
 from botocore.utils import percent_encode_sequence
 from botocore.utils import switch_host_s3_accelerate
+from botocore.utils import deep_merge
 from botocore.utils import S3RegionRedirector
 from botocore.utils import ContainerMetadataFetcher
 from botocore.model import DenormalizedStructureBuilder
@@ -1014,6 +1015,98 @@ class TestSwitchHostS3Accelerate(unittest.TestCase):
         self.assertEqual(
             self.request.url,
             'https://s3-accelerate.dualstack.amazonaws.com/foo/key.txt')
+
+
+class TestDeepMerge(unittest.TestCase):
+    def test_simple_merge(self):
+        a = {'key': 'value'}
+        b = {'otherkey': 'othervalue'}
+        deep_merge(a, b)
+
+        expected = {'key': 'value', 'otherkey': 'othervalue'}
+        self.assertEqual(a, expected)
+
+    def test_merge_list(self):
+        # Lists are treated as opaque data and so no effort should be made to
+        # combine them.
+        a = {'key': ['original']}
+        b = {'key': ['new']}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': ['new']})
+
+    def test_merge_number(self):
+        # The value from b is always taken
+        a = {'key': 10}
+        b = {'key': 45}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': 45})
+
+        a = {'key': 45}
+        b = {'key': 10}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': 10})
+
+    def test_merge_boolean(self):
+        # The value from b is always taken
+        a = {'key': False}
+        b = {'key': True}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': True})
+
+        a = {'key': True}
+        b = {'key': False}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': False})
+
+    def test_merge_string(self):
+        a = {'key': 'value'}
+        b = {'key': 'othervalue'}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': 'othervalue'})
+
+    def test_merge_overrides_value(self):
+        # The value from b is always taken, even when it's a different type
+        a = {'key': 'original'}
+        b = {'key': {'newkey': 'newvalue'}}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': {'newkey': 'newvalue'}})
+
+        a = {'key': {'anotherkey': 'value'}}
+        b = {'key': 'newvalue'}
+        deep_merge(a, b)
+        self.assertEqual(a, {'key': 'newvalue'})
+
+    def test_deep_merge(self):
+        a = {
+            'first': {
+                'second': {
+                    'key': 'value',
+                    'otherkey': 'othervalue'
+                },
+                'key': 'value'
+            }
+        }
+        b = {
+            'first': {
+                'second': {
+                    'otherkey': 'newvalue',
+                    'yetanotherkey': 'yetanothervalue'
+                }
+            }
+        }
+        deep_merge(a, b)
+
+        expected = {
+            'first': {
+                'second': {
+                    'key': 'value',
+                    'otherkey': 'newvalue',
+                    'yetanotherkey': 'yetanothervalue'
+                },
+                'key': 'value'
+            }
+        }
+        self.assertEqual(a, expected)
 
 
 class TestS3RegionRedirector(unittest.TestCase):


### PR DESCRIPTION
These files will define extra data to be added into the service model
upon loading. These will be used to make additive changes to the
model which reflect sdk-specific information that is not sent over
the wire.

The deep merge is, of course, quite expensive. In a worst case scenario
(a very large service model and an equally sized extras file) client creation
takes ~4x as long on python 2 and ~2x as long on python 3. However, these extra
files will never be more than adding a few parameters. The impact given a
small extra file is negligible.

cc @kyleknap @jamesls @stealthycoin