### PR TITLE
Add support disabling subsection parsing

### DIFF
--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -113,9 +113,9 @@ def raw_config_parse(config_filename, parse_subsections=True):
 
     :param config_filename: The name of the INI file to parse
 
-    :param parse_subsections: If True, parse subsections: turn the value
-       into a dictionary with keys and values of its own if the entire value
-       is a indented block. For example, if the file had the value::
+    :param parse_subsections: If True, parse indented blocks as
+       subsections that represent their own configuration dictionary.
+       For example, if the config file had the contents::
 
            s3 =
               signature_version = s3v4
@@ -125,8 +125,8 @@ def raw_config_parse(config_filename, parse_subsections=True):
 
             {'s3': {'signature_version': 's3v4', 'addressing_style': 'path'}}
 
-       If False, do not try try to preserve the value and return the literal
-       value::
+       If False, do not try to parse subsections and return the indented
+       block as its literal value::
 
             {'s3': '\nsignature_version = s3v4\naddressing_style = path'}
 

--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -106,10 +106,29 @@ def load_config(config_filename):
     return build_profile_map(parsed)
 
 
-def raw_config_parse(config_filename):
+def raw_config_parse(config_filename, parse_subsections=True):
     """Returns the parsed INI config contents.
 
     Each section name is a top level key.
+
+    :param config_filename: The name of the INI file to parse
+
+    :param parse_subsections: If True, parse subsections: turn the value
+       into a dictionary with keys and values of its own if the entire value
+       is a indented block. For example, if the file had the value::
+
+           s3 =
+              signature_version = s3v4
+              addressing_style = path
+
+        The resulting ``raw_config_parse`` would be::
+
+            {'s3': {'signature_version': 's3v4', 'addressing_style': 'path'}}
+
+       If False, do not try try to preserve the value and return the literal
+       value::
+
+            {'s3': '\nsignature_version = s3v4\naddressing_style = path'}
 
     :returns: A dict with keys for each profile found in the config
         file and the value of each key being a dict containing name
@@ -134,7 +153,7 @@ def raw_config_parse(config_filename):
                 config[section] = {}
                 for option in cp.options(section):
                     config_value = cp.get(section, option)
-                    if config_value.startswith('\n'):
+                    if parse_subsections and config_value.startswith('\n'):
                         # Then we need to parse the inner contents as
                         # hierarchical.  We support a single level
                         # of nesting for now.

--- a/tests/unit/cfg/aws_config_nested
+++ b/tests/unit/cfg/aws_config_nested
@@ -3,6 +3,7 @@ aws_access_key_id = foo
 aws_secret_access_key = bar
 s3 =
     signature_version = s3v4
+    addressing_style = path
 cloudwatch =
     signature_version = v4
 region=us-west-2

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -62,6 +62,23 @@ class TestConfigLoader(BaseEnvVar):
         self.assertEqual(config['s3']['signature_version'], 's3v4')
         self.assertEqual(config['cloudwatch']['signature_version'], 'v4')
 
+    def test_nested_hierarchy_with_no_subsection_parsing(self):
+        filename = path('aws_config_nested')
+        raw_config = raw_config_parse(filename, False)['default']
+        self.assertEqual(raw_config['aws_access_key_id'], 'foo')
+        self.assertEqual(raw_config['region'], 'us-west-2')
+        # Specifying False for pase_subsections in raw_config_parse
+        # will make sure that indented sections such as singature_version
+        # will not be treated as another subsection but rather
+        # its literal value.
+        self.assertEqual(
+            raw_config['cloudwatch'], '\nsignature_version = v4')
+        self.assertEqual(
+            raw_config['s3'],
+            '\nsignature_version = s3v4'
+            '\naddressing_style = path'
+        )
+
     def test_nested_bad_config(self):
         filename = path('aws_config_nested_bad')
         with self.assertRaises(botocore.exceptions.ConfigParseError):


### PR DESCRIPTION
This useful for retrieving the literal value of an option instead of possibly treating it as its own subsection.

cc @jamesls @JordonPhillips @stealthycoin 