### PR TITLE
JSON load request data when presigning

### DIFF
--- a/.changes/next-release/bugfix-Presigner-33378.json
+++ b/.changes/next-release/bugfix-Presigner-33378.json
@@ -1,0 +1,5 @@
+{
+  "description": "Support presigning rest-json services.",
+  "type": "bugfix",
+  "category": "Presigner"
+}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -22,6 +22,7 @@ from operator import itemgetter
 import functools
 import time
 import calendar
+import json
 
 from botocore.exceptions import NoCredentialsError
 from botocore.utils import normalize_url_path, percent_encode_sequence
@@ -452,11 +453,9 @@ class SigV4QueryAuth(SigV4Auth):
         # percent_encode_sequence(new_query_params)
         operation_params = ''
         if request.data:
-            # We also need to move the body params into the query string.
-            # request.data will be populated, for example, with query services
-            # which normally form encode the params into the body.
-            # This means that request.data is a dict() of the operation params.
-            query_dict.update(request.data)
+            # We also need to move the body params into the query string. To
+            # do this, we first have to convert it to a dict.
+            query_dict.update(self._get_body_as_dict(request))
             request.data = ''
         if query_dict:
             operation_params = percent_encode_sequence(query_dict) + '&'
@@ -473,6 +472,18 @@ class SigV4QueryAuth(SigV4Auth):
         p = url_parts
         new_url_parts = (p[0], p[1], p[2], new_query_string, p[4])
         request.url = urlunsplit(new_url_parts)
+
+    def _get_body_as_dict(self, request):
+        # For query services, request.data is form-encoded and is already a
+        # dict, but for other services such as rest-json it could be a json
+        # string or bytes. In those cases we attempt to load the data as a
+        # dict.
+        data = request.data
+        if isinstance(data, six.binary_type):
+            data = json.loads(data.decode('utf-8'))
+        elif isinstance(data, six.string_types):
+            data = json.loads(data)
+        return data
 
     def _inject_signature_to_request(self, request, signature):
         # Rather than calculating an "Authorization" header, for the query

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -715,6 +715,48 @@ class TestSigV4Presign(BasePresignTest):
         self.assertEqual(
             query_string['X-Amz-Security-Token'], 'security-token')
 
+    def test_presign_where_body_is_json_bytes(self):
+        request = AWSRequest()
+        request.method = 'GET'
+        request.url = 'https://myservice.us-east-1.amazonaws.com/'
+        request.data = b'{"Param": "value"}'
+        self.auth.add_auth(request)
+        query_string = self.get_parsed_query_string(request)
+        expected_query_string = {
+            'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+            'X-Amz-Credential': (
+                'access_key/20140101/myregion/myservice/aws4_request'),
+            'X-Amz-Expires': '60',
+            'X-Amz-Date': '20140101T000000Z',
+            'X-Amz-Signature': (
+                '8e1d372d168d532313ce6df8f64a7dc51d'
+                'e6f312a9cfba6e5b345d8a771e839c'),
+            'X-Amz-SignedHeaders': 'host',
+            'Param': 'value'
+        }
+        self.assertEqual(query_string, expected_query_string)
+
+    def test_presign_where_body_is_json_string(self):
+        request = AWSRequest()
+        request.method = 'GET'
+        request.url = 'https://myservice.us-east-1.amazonaws.com/'
+        request.data = '{"Param": "value"}'
+        self.auth.add_auth(request)
+        query_string = self.get_parsed_query_string(request)
+        expected_query_string = {
+            'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+            'X-Amz-Credential': (
+                'access_key/20140101/myregion/myservice/aws4_request'),
+            'X-Amz-Expires': '60',
+            'X-Amz-Date': '20140101T000000Z',
+            'X-Amz-Signature': (
+                '8e1d372d168d532313ce6df8f64a7dc51d'
+                'e6f312a9cfba6e5b345d8a771e839c'),
+            'X-Amz-SignedHeaders': 'host',
+            'Param': 'value'
+        }
+        self.assertEqual(query_string, expected_query_string)
+
 
 class BaseS3PresignPostTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This attempts to json load request data that isn't already a dict
during presigning. As a result, rest-json services can now be
presigned.

cc @kyleknap @jamesls @stealthycoin