### PR TITLE
Add support for timestamp in ArgumentGenerator

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -563,6 +563,8 @@ class ArgumentGenerator(object):
                 return 0.0
             elif shape.type_name == 'boolean':
                 return True
+            elif shape.type_name == 'timestamp':
+                return datetime.datetime(1970, 1, 1, 0, 0, 0)
         finally:
             stack.pop()
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -371,12 +371,14 @@ class TestArgumentGenerator(unittest.TestCase):
                 'B': {'type': 'integer'},
                 'C': {'type': 'float'},
                 'D': {'type': 'boolean'},
+                'E': {'type': 'timestamp'}
             },
             generated_skeleton={
                 'A': '',
                 'B': 0,
                 'C': 0.0,
                 'D': True,
+                'E': datetime.datetime(1970, 1, 1, 0, 0, 0)
             }
         )
 


### PR DESCRIPTION
Uses epoch time as a ``datetime`` for its default value. Right now it defaults to ``None`` which is in appropriate representation of the ``timestamp`` type in our models.

This is needed for this PR: https://github.com/aws/aws-cli/pull/2293

cc @jamesls @JordonPhillips @stealthycoin 