### PR TITLE
fix attribute error in sigv2 auth

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -107,7 +107,7 @@ class SigV2Auth(BaseSigner):
             params = request.data
         else:
             # GET
-            params = request.param
+            params = request.params
         params['AWSAccessKeyId'] = self.credentials.access_key
         params['SignatureVersion'] = '2'
         params['SignatureMethod'] = 'HmacSHA256'


### PR DESCRIPTION
head_object method will fail with sigv2:

Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/work/pixel/lib/s3.py", line 60, in head_key
    await client.head_object(Bucket=bucket, Key=key)
  File "/usr/local/lib/python3.5/dist-packages/aiobotocore/client.py", line 79, in _make_api_call
    operation_model, request_dict)
  File "/usr/local/lib/python3.5/dist-packages/aiobotocore/endpoint.py", line 180, in _send_request
    request = self.create_request(request_dict, operation_model)
  File "/usr/local/lib/python3.5/dist-packages/botocore/endpoint.py", line 150, in create_request
    operation_name=operation_model.name)
  File "/usr/local/lib/python3.5/dist-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/usr/local/lib/python3.5/dist-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/usr/local/lib/python3.5/dist-packages/botocore/signers.py", line 90, in handler
    return self.sign(operation_name, request)
  File "/usr/local/lib/python3.5/dist-packages/botocore/signers.py", line 147, in sign
    auth.add_auth(request)
  File "/usr/local/lib/python3.5/dist-packages/botocore/auth.py", line 109, in add_auth
    params = request.param

The reason is request has params attribute, not param