### PR TITLE
Use member names in lists for ArgumentGenerator

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -580,8 +580,11 @@ class ArgumentGenerator(object):
     def _generate_type_list(self, shape, stack):
         # For list elements we've arbitrarily decided to
         # return two elements for the skeleton list.
+        name = ''
+        if self._use_member_names:
+            name = shape.member.name
         return [
-            self._generate_skeleton(shape.member, stack),
+            self._generate_skeleton(shape.member, stack, name),
         ]
 
     def _generate_type_map(self, shape, stack):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -399,6 +399,33 @@ class TestArgumentGenerator(unittest.TestCase):
             }
         )
 
+    def test_will_use_member_names_for_string_values_of_list(self):
+        self.arg_generator = ArgumentGenerator(use_member_names=True)
+        # We're not using assert_skeleton_from_model_is
+        # because we can't really control the name of strings shapes
+        # being used in the DenormalizedStructureBuilder. We can only
+        # control the name of structures and list shapes.
+        shape_map = ShapeResolver({
+            'InputShape': {
+                'type': 'structure',
+                'members': {
+                    'StringList': {'shape': 'StringList'},
+                }
+            },
+            'StringList': {
+                'type': 'list',
+                'member': {'shape': 'StringType'},
+            },
+            'StringType': {
+                'type': 'string',
+            }
+        })
+        shape = shape_map.get_shape_by_name('InputShape')
+        actual = self.arg_generator.generate_skeleton(shape)
+
+        expected = {'StringList': ['StringType']}
+        self.assertEqual(actual, expected)
+
     def test_generate_nested_structure(self):
         self.assert_skeleton_from_model_is(
             model={


### PR DESCRIPTION
Use the member name for strings in lists. Catches and edge case pointed out by @jamesls in this PR: https://github.com/aws/aws-cli/pull/2293

cc @jamesls @JordonPhillips @stealthycoin 