### PR TITLE
Add compat function to ensure a type is text like

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -68,6 +68,13 @@ if six.PY3:
         # changes when using getargspec with functools.partials.
         return inspect.getfullargspec(func)[2]
 
+    def ensure_text_type(s, encoding='utf-8', errors='strict'):
+        if isinstance(s, str):
+            return s
+        if isinstance(s, bytes):
+            return s.decode(encoding, errors)
+        raise ValueError("Expected str or bytes, recieved %s." % type(s))
+
     def ensure_unicode(s, encoding=None, errors=None):
         # NOOP in Python 3, because every string is already unicode
         return s
@@ -126,6 +133,11 @@ else:
 
     def accepts_kwargs(func):
         return inspect.getargspec(func)[2]
+
+    def ensure_text_type(s, encoding='utf-8', errors='strict'):
+        if isinstance(s, basestring):
+            return s
+        return six.text_type(s)
 
     def ensure_unicode(s, encoding='utf-8', errors='strict'):
         if isinstance(s, six.text_type):

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -135,9 +135,11 @@ else:
         return inspect.getargspec(func)[2]
 
     def ensure_text_type(s, encoding='utf-8', errors='strict'):
-        if isinstance(s, basestring):
+        if isinstance(s, six.text_type):
             return s
-        return six.text_type(s)
+        if isinstance(s, six.binary_type):
+            return s.decode(encoding, errors)
+        raise ValueError("Expected str or unicode, received %s." % type(s))
 
     def ensure_unicode(s, encoding='utf-8', errors='strict'):
         if isinstance(s, six.text_type):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -16,7 +16,7 @@ import mock
 
 from botocore.exceptions import MD5UnavailableError
 from botocore.compat import (
-    total_seconds, unquote_str, six, ensure_bytes, get_md5
+    total_seconds, unquote_str, six, ensure_bytes, get_md5, ensure_text_type
 )
 
 from tests import BaseEnvVar, unittest
@@ -82,6 +82,37 @@ class TestEnsureBytes(unittest.TestCase):
         value = 500
         with self.assertRaises(ValueError):
             ensure_bytes(value)
+
+
+class TestEnsureText(unittest.TestCase):
+    def test_string(self):
+        value = 'foo'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, 'foo')
+
+    def test_binary(self):
+        value = b'bar'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, 'bar')
+
+    def test_unicode(self):
+        value = u'baz'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, 'baz')
+
+    def test_non_ascii(self):
+        value = b'\xe2\x9c\x93'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, u'\u2713')
+
+    def test_non_string_or_bytes_raises_error(self):
+        value = 500
+        with self.assertRaises(ValueError):
+            ensure_text_type(value)
 
 
 class TestGetMD5(unittest.TestCase):


### PR DESCRIPTION
Not entirely sure this is the right approach in both versions.