### PR TITLE
Do not sign trace header

### DIFF
--- a/.changes/next-release/bugfix-sigv4-897.json
+++ b/.changes/next-release/bugfix-sigv4-897.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "sigv4",
+  "description": "Do not sign x-amzn-trace-id as it can be mutated along the way."
+}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -47,7 +47,8 @@ ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 SIGV4_TIMESTAMP = '%Y%m%dT%H%M%SZ'
 SIGNED_HEADERS_BLACKLIST = [
     'expect',
-    'user-agent'
+    'user-agent',
+    'x-amzn-trace-id',
 ]
 
 

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -341,6 +341,10 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
     def test_blacklist_expect_headers(self):
         self._test_blacklist_header('expect', '100-continue')
 
+    def test_blacklist_trace_id(self):
+        self._test_blacklist_header('x-amzn-trace-id',
+                                    'Root=foo;Parent=bar;Sampleid=1')
+
     def test_blacklist_headers(self):
         self._test_blacklist_header('user-agent', 'botocore/1.4.11')
 


### PR DESCRIPTION
The trace header can be mutated along the way, so it should be blacklisted.

cc @kyleknap @jamesls @stealthycoin