### PR TITLE
Implemented NoSuchBucketError

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -371,6 +371,10 @@ class ClientError(Exception):
         return retry_info
 
 
+class NoSuchBucketError(ClientError):
+    pass
+
+
 class UnsupportedTLSVersionWarning(Warning):
     """Warn when an openssl version that uses TLS 1.2 is required"""
     pass

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -17,8 +17,10 @@ import botocore
 import botocore.session
 import botocore.stub as stub
 from botocore.stub import Stubber
-from botocore.exceptions import StubResponseError, ClientError, \
-    StubAssertionError
+from botocore.exceptions import ClientError
+from botocore.exceptions import NoSuchBucketError
+from botocore.exceptions import StubResponseError
+from botocore.exceptions import StubAssertionError
 from botocore.exceptions import ParamValidationError
 import botocore.client
 import botocore.retryhandler
@@ -75,6 +77,16 @@ class TestStubber(unittest.TestCase):
         self.stubber.activate()
 
         with self.assertRaises(ClientError):
+            self.client.list_objects(Bucket='foo')
+
+    def test_client_error_response__no_such_bucket(self):
+        error_code = 'NoSuchBucket'
+        error_message = "An error message"
+        self.stubber.add_client_error(
+            'list_objects', error_code, error_message)
+        self.stubber.activate()
+
+        with self.assertRaises(NoSuchBucketError):
             self.client.list_objects(Bucket='foo')
 
     def test_can_add_expected_params_to_client_error(self):

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -17,6 +17,7 @@ from tests import unittest, random_chars
 
 import botocore.session
 from botocore.client import ClientError
+from botocore.client import NoSuchBucketError
 from botocore.compat import six
 from botocore.exceptions import EndpointConnectionError
 from six import StringIO
@@ -35,6 +36,10 @@ class TestBucketWithVersions(unittest.TestCase):
         for version in versions['Versions']:
             version_ids.append(version['VersionId'])
         return version_ids
+
+    def test_delete_non_existent_bucket(self):
+        with self.assertRaises(NoSuchBucketError):
+            self.client.delete_bucket(Bucket='name_of_no_existent_bucket')
 
     def test_create_versioned_bucket(self):
         # Verifies we can:


### PR DESCRIPTION
This will be very useful when doing error handling in boto3. Instead of catching the generic ClientError and trying to parse the error code, I can now catch NoSuchBucketError and be sure that I caught the specific error.

I designed this by starting from what the test_s3_error_response() is testing.

And the how ClientError forms its msg compared to what I receive from boto3: `botocore.exceptions.ClientError: An error occurred (NoSuchBucket) when calling the ListObjects operation: The specified bucket does not exist`