### PR TITLE
Add an external_link method

### DIFF
--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -387,3 +387,9 @@ class ReSTStyle(BaseStyle):
         docstring_lines = docstring.splitlines()
         for docstring_line in docstring_lines:
             self.doc.writeln(docstring_line)
+
+    def external_link(self, title, link):
+        if self.doc.target == 'html':
+            self.doc.write('`%s <%s>`_' % (title, link))
+        else:
+            self.doc.write(title)

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -279,3 +279,17 @@ class TestStyle(unittest.TestCase):
 
         self.assertEqual(style.doc.getvalue(),
                          six.b("\n\n\n* foo\n\n\n  \n  * bar\n  "))
+
+    def test_external_link(self):
+        style = ReSTStyle(ReSTDocument())
+        style.doc.target = 'html'
+        style.external_link('MyLink', 'http://example.com/foo')
+        self.assertEqual(style.doc.getvalue(),
+                         six.b('`MyLink <http://example.com/foo>`_'))
+
+
+    def test_external_link_in_man_page(self):
+        style = ReSTStyle(ReSTDocument())
+        style.doc.target = 'man'
+        style.external_link('MyLink', 'http://example.com/foo')
+        self.assertEqual(style.doc.getvalue(), six.b('MyLink'))


### PR DESCRIPTION
This generates an inlink external link.  This is modeled off of the [sphinx_reference_label](https://github.com/boto/botocore/blob/develop/botocore/docs/bcdoc/style.py#L206)