### PR TITLE
Fix failing rds test

### DIFF
--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -10,3 +10,31 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
+import uuid
+
+_ORIGINAL = os.environ.copy()
+# These are environment variables that allow users to control
+# the location of config files used by botocore.
+_CONFIG_FILE_ENV_VARS = [
+    'AWS_CONFIG_FILE',
+    'AWS_SHARED_CREDENTIALS_FILE',
+    'BOTO_CONFIG',
+]
+_CREDENTIAL_ENV_VARS = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+]
+
+
+def setup_package():
+    random_file = str(uuid.uuid4())
+    for varname in _CONFIG_FILE_ENV_VARS:
+        os.environ[varname] = random_file
+    for credvar in _CREDENTIAL_ENV_VARS:
+        os.environ.pop(credvar, None)
+
+
+def teardown_package():
+    os.environ = _ORIGINAL

--- a/tests/functional/test_rds.py
+++ b/tests/functional/test_rds.py
@@ -13,15 +13,13 @@
 import mock
 
 import botocore.session
-from tests import unittest
+from tests import BaseSessionTest
 
 
-class TestRDSPresign(unittest.TestCase):
-    def setUp(self):
-        self.session = botocore.session.get_session()
-        self.client = self.session.create_client('rds', 'us-west-2')
+class TestRDSPresign(BaseSessionTest):
 
     def test_inject_presigned_url(self):
+        client = self.session.create_client('rds', 'us-west-2')
         params = {
             'SourceDBSnapshotIdentifier': 'source-db',
             'TargetDBSnapshotIdentifier': 'target-db',
@@ -34,7 +32,7 @@ class TestRDSPresign(unittest.TestCase):
                     b'<CopyDBSnapshotResult></CopyDBSnapshotResult>'
                     b'</CopyDBSnapshotResponse>'
                 ))
-            self.client.copy_db_snapshot(**params)
+            client.copy_db_snapshot(**params)
             sent_request = _send.call_args[0][0]
 
         self.assertIn('PreSignedUrl', sent_request.body)


### PR DESCRIPTION
Our travis tests are failing due to a recent RDS functional test that was added.  I added two things:

1. Fix the test (tests that need credentials should subclass BaseSessionTest)
2. Add package setup/teardown that more closely resembles the travis environment.  This likely went unnoticed because if you have credentials configured locally the test will pass.  With this change, the original test would have failed on a dev laptop.