### PR TITLE
Change credential log statement to INFO from DEBUG

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -488,7 +488,7 @@ class InstanceMetadataProvider(CredentialProvider):
         metadata = fetcher.retrieve_iam_role_credentials()
         if not metadata:
             return None
-        logger.info('Found credentials from IAM Role: %s',
+        logger.debug('Found credentials from IAM Role: %s',
                     metadata['role_name'])
         # We manually set the data here, since we already made the request &
         # have it. When the expiry is hit, the credentials will auto-refresh


### PR DESCRIPTION
When logger is defined anywhere in the program Botocore is mostly silent with its logging statements except for this single logger. This commit changes it to be more in-line with other logging statement levels.