### PR TITLE
Fix order of credential providers

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -82,7 +82,6 @@ def create_credential_resolver(session, cache=None):
     )
     providers = [
         env_provider,
-        assume_role_provider,
         SharedCredentialProvider(
             creds_filename=credential_file,
             profile_name=profile_name
@@ -92,6 +91,7 @@ def create_credential_resolver(session, cache=None):
         # The new config file has precedence over the legacy
         # config file.
         ConfigProvider(config_filename=config_file, profile_name=profile_name),
+        assume_role_provider,
         OriginalEC2Provider(),
         BotoProvider(),
         container_provider,


### PR DESCRIPTION
According to the [Credentials Configuration documentation for Boto 3](https://boto3.readthedocs.io/en/latest/guide/configuration.html):

```
The order in which Boto3 searches for credentials is:

  1. Passing credentials as parameters in the boto.client() method
  2. Passing credentials as parameters when creating a Session object
  3. Environment variables
  4. Shared credential file (~/.aws/credentials)
  5. AWS config file (~/.aws/config)
  6. Assume Role provider
  7. Boto2 config file (/etc/boto.cfg and ~/.boto)
  8. Instance metadata service on an Amazon EC2 instance that has an IAM role configured.
```

However, looking at the definition of [`create_credential_resolver()`](https://github.com/boto/botocore/blob/4c6a23cbe39a3c54f96e3574278b3a164f2e4d30/botocore/credentials.py#L44-L82), the `AssumeRoleProvider` (_#_*6* above) is loaded _before_ the `SharedCredentialProvider` (_#_*4*) and `ConfigProvider` (_#_*5*). This PR fixes the ordering of these providers to reflect the documentation.

Supposing you're using temporary credentials through AWS's STS/assume-role facilities, before this change you may be prompted for an MFA code (even when valid credentials exist):
```
$ python
>>> import boto3, botocore
>>> botocore.session.Session().get_credentials()
Enter MFA code:
```

After this change, credentials are loaded automatically from the shared file, as expected:
```
$ python
>>> import boto3, botocore
>>> botocore.session.Session().get_credentials()
<botocore.credentials.Credentials object at 0x105192d90>
>>>
```

Environment information:
```
$ env | grep AWS
AWS_PROFILE=foobar
$ python --version
Python 2.7.13
$ pip --version
pip 9.0.1 from /usr/local/lib/python2.7/site-packages (python 2.7)
$ pip list | grep boto
boto (2.45.0)
boto3 (1.4.4)
botocore (1.5.5)
```