### PR TITLE
Remove unsupported paginator

### DIFF
--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -38,12 +38,6 @@
         "events",
         "searchedLogStreams"
       ]
-    },
-    "GetLogEvents": {
-      "input_token": "nextToken",
-      "output_token": "nextForwardToken",
-      "limit_key": "limit",
-      "result_key": "events"
     }
   }
 }


### PR DESCRIPTION
Caught by downstream CLI tests: https://github.com/aws/aws-cli/blob/develop/tests/functional/logs/test_get_log_events.py. I also ran the test for the CLI and that passed locally.

We will probably will have to stop paginating on repeated next tokens.