### PR TITLE
Decode file paths in config loader

### DIFF
--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -14,8 +14,9 @@
 import os
 import shlex
 import copy
+import sys
 
-from six.moves import configparser
+from botocore.compat import six
 
 import botocore.exceptions
 
@@ -142,12 +143,13 @@ def raw_config_parse(config_filename, parse_subsections=True):
         path = os.path.expandvars(path)
         path = os.path.expanduser(path)
         if not os.path.isfile(path):
-            raise botocore.exceptions.ConfigNotFound(path=path)
-        cp = configparser.RawConfigParser()
+            raise botocore.exceptions.ConfigNotFound(path=_unicode_path(path))
+        cp = six.moves.configparser.RawConfigParser()
         try:
             cp.read(path)
-        except configparser.Error:
-            raise botocore.exceptions.ConfigParseError(path=path)
+        except six.moves.configparser.Error:
+            raise botocore.exceptions.ConfigParseError(
+                path=_unicode_path(path))
         else:
             for section in cp.sections():
                 config[section] = {}
@@ -161,9 +163,15 @@ def raw_config_parse(config_filename, parse_subsections=True):
                             config_value = _parse_nested(config_value)
                         except ValueError:
                             raise botocore.exceptions.ConfigParseError(
-                                path=path)
+                                path=_unicode_path(path))
                     config[section][option] = config_value
     return config
+
+
+def _unicode_path(path):
+    if isinstance(path, six.text_type):
+        return path
+    return path.decode(sys.getfilesystemencoding(), 'replace')
 
 
 def _parse_nested(config_value):

--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -146,7 +146,7 @@ def raw_config_parse(config_filename, parse_subsections=True):
             raise botocore.exceptions.ConfigNotFound(path=_unicode_path(path))
         cp = six.moves.configparser.RawConfigParser()
         try:
-            cp.read(path)
+            cp.read([path])
         except six.moves.configparser.Error:
             raise botocore.exceptions.ConfigParseError(
                 path=_unicode_path(path))

--- a/tests/unit/cfg/aws_config_unicode✓
+++ b/tests/unit/cfg/aws_config_unicode✓
@@ -1,0 +1,8 @@
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = bar
+
+[profile "personal"]
+aws_access_key_id = fie
+aws_secret_access_key = baz
+aws_security_token = fiebaz

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -14,13 +14,19 @@
 # language governing permissions and limitations under the License.
 from tests import unittest, BaseEnvVar
 import os
+import mock
+
 import botocore.exceptions
 from botocore.configloader import raw_config_parse, load_config, \
     multi_file_load_config
+from botocore.compat import six
 
 
 def path(filename):
-    return os.path.join(os.path.dirname(__file__), 'cfg', filename)
+    directory = os.path.join(os.path.dirname(__file__), 'cfg')
+    if isinstance(filename, six.binary_type):
+        directory = six.b(directory)
+    return os.path.join(directory, filename)
 
 
 class TestConfigLoader(BaseEnvVar):
@@ -102,6 +108,20 @@ class TestConfigLoader(BaseEnvVar):
         self.assertEqual(third_config['aws_access_key_id'], 'third_fie')
         self.assertEqual(third_config['aws_secret_access_key'], 'third_baz')
         self.assertEqual(third_config['aws_security_token'], 'third_fiebaz')
+
+    def test_unicode_bytes_path_not_found(self):
+        with self.assertRaises(botocore.exceptions.ConfigNotFound):
+            with mock.patch('sys.getfilesystemencoding') as encoding:
+                encoding.return_value = 'utf-8'
+                load_config(path(b'\xe2\x9c\x93'))
+
+    def test_unicode_bytes_path(self):
+        filename = path(b'aws_config_unicode\xe2\x9c\x93')
+        with mock.patch('sys.getfilesystemencoding') as encoding:
+            encoding.return_value = 'utf-8'
+            loaded_config = load_config(filename)
+        self.assertIn('default', loaded_config['profiles'])
+        self.assertIn('personal', loaded_config['profiles'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This decodes the path in config parser before throwing errors.

Fixes aws/aws-cli#2395

cc @kyleknap @jamesls @stealthycoin @dstufft