### PR TITLE
Coerce headers stored in dict to be lowercase.

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -215,7 +215,8 @@ class ResponseParser(object):
         if isinstance(parsed, dict):
             response_metadata = parsed.get('ResponseMetadata', {})
             response_metadata['HTTPStatusCode'] = response['status_code']
-            response_metadata['HTTPHeaders'] = dict(response['headers'])
+            response_metadata['HTTPHeaders'] = dict(
+                (k.lower(), v) for k, v in response['headers'].items())
             parsed['ResponseMetadata'] = response_metadata
         return parsed
 

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -373,7 +373,7 @@ class TestHeaderResponseInclusion(unittest.TestCase):
         headers = {
             'x-amzn-requestid': 'request-id',
             'Header1': 'foo',
-            'Header2': 'bar',
+            'HEADER2': 'bar',
         }
         output_shape = self.create_arbitary_output_shape()
         parsed = parser.parse(
@@ -381,13 +381,18 @@ class TestHeaderResponseInclusion(unittest.TestCase):
              'status_code': 200}, output_shape)
         # Response headers should be mapped as HTTPHeaders.
         self.assertEqual(
-            parsed['ResponseMetadata']['HTTPHeaders'], headers)
+            parsed['ResponseMetadata']['HTTPHeaders'],
+            {
+                'x-amzn-requestid': 'request-id',
+                'header1': 'foo',
+                'header2': 'bar',
+            })
 
     def test_can_always_json_serialize_headers(self):
         parser = self.create_parser()
         original_headers = {
             'x-amzn-requestid': 'request-id',
-            'Header1': 'foo',
+            'header1': 'foo',
         }
         headers = CustomHeaderDict(original_headers)
         output_shape = self.create_arbitary_output_shape()
@@ -399,7 +404,7 @@ class TestHeaderResponseInclusion(unittest.TestCase):
         # response.  So we want to ensure that despite using a CustomHeaderDict
         # we can always JSON dumps the response metadata.
         self.assertEqual(
-            json.loads(json.dumps(metadata))['HTTPHeaders']['Header1'], 'foo')
+            json.loads(json.dumps(metadata))['HTTPHeaders']['header1'], 'foo')
 
 
 class TestResponseParsingDatetimes(unittest.TestCase):


### PR DESCRIPTION
Make sure that the headers when converted to `dict` are in lower case.

This change is needed to support case-insensitive `CIMultiDict` that is provided with `aiohttp` responses. When `dict()`'ed, the keys of `CIMultiDict` are in Camel-Case.