### PR TITLE
Optimize bucket names in integration tests

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -37,7 +37,7 @@ from botocore.exceptions import ClientError
 
 
 def random_bucketname():
-    return 'botocoretest-' + random_chars(10)
+    return random_chars(10) + '-botocoretest'
 
 
 LOG = logging.getLogger('botocore.tests.integration')


### PR DESCRIPTION
Having entropy at the front of bucket names reduces the number of
SlowDown responses we will receive.

cc @kyleknap @jamesls @dstufft @stealthycoin