### PR TITLE
Iam string to dict

### DIFF
--- a/botocore/docs/shape.py
+++ b/botocore/docs/shape.py
@@ -16,6 +16,21 @@
 # ``traverse_and_document_shape`` method called directly. It should be
 # inherited from a Documenter class with the appropriate methods
 # and attributes.
+
+# Some shapes have their types remapped for before being exposed to the
+# user for convenience. A common example would be a shape that has a string
+# type being remapped to a dictionary because the string is simply a serialized
+# json object. This dictionary overrides a particular shape's documented type.
+# In addition shape names are not unique between services, there are over 2200
+# duplicated shape names between services, so this mapping needs to take into
+# account which service the shape being remapped belongs to.
+SHAPE_TYPE_REMAPPINGS = {
+    'iam': {
+        'policyDocumentType': 'dict'
+    }
+}
+
+
 class ShapeDocumenter(object):
     EVENT_NAME = ''
 
@@ -55,6 +70,10 @@ class ShapeDocumenter(object):
 
         :param is_required: If the shape is a required member.
         """
+        if self._service_name in SHAPE_TYPE_REMAPPINGS:
+            shape_remappings = SHAPE_TYPE_REMAPPINGS[self._service_name]
+            if shape.name in shape_remappings:
+                shape.type_name = shape_remappings[shape.name]
         param_type = shape.type_name
         if shape.name in history:
             self.document_recursive_shape(section, shape, name=name)

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -284,16 +284,22 @@ def add_expect_header(model, params, **kwargs):
 
 def change_iam_assumerolepolicydocument_type(section, event_name, **kwargs):
     if 'response-params' in event_name:
-        template_body_section = section.get_section('AssumeRolePolicyDocument')
-        type_section = template_body_section.get_section('param-type')
+        role_section = section.get_section('Role')
+        policy_document_section = role_section.get_section(
+            'AssumeRolePolicyDocument')
+        type_section = policy_document_section.get_section('param-type')
         type_section.clear_text()
-        type_section.write('(*dict*) --')
+        type_section.write('*(dict) --*')
     elif 'response-example' in event_name:
         parent = section.get_section('structure-value')
-        param_line = parent.get_section('AssumeRolePolicyDocument')
-        value_portion = param_line.get_section('member-value')
-        value_portion.clear_text()
-        value_portion.write('{}')
+        role = parent.get_section('Role')
+        role_member = role.get_section('member-value')
+        role_structure = role_member.get_section('structure-value')
+        assume_role_policy_document = role_structure.get_section(
+            'AssumeRolePolicyDocument')
+        value = assume_role_policy_document.get_section('member-value')
+        value.clear_text()
+        value.write('{ ... }')
 
 
 def document_copy_source_form(section, event_name, **kwargs):
@@ -808,7 +814,7 @@ BUILTIN_HANDLERS = [
     ('creating-client-class.s3', add_generate_presigned_post),
     ('creating-client-class.iot-data', check_openssl_supports_tls_version_1_2),
     ('after-call.iam', json_decode_policies),
-    ('docs.*.iam.AssumeRolePolicyDocument.complete-section',
+    ('docs.*.iam.GetRole.complete-section',
      change_iam_assumerolepolicydocument_type),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),
     ('after-call.cloudformation.GetTemplate', json_decode_template_body),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -282,26 +282,6 @@ def add_expect_header(model, params, **kwargs):
             params['headers']['Expect'] = '100-continue'
 
 
-def change_iam_assumerolepolicydocument_type(section, event_name, **kwargs):
-    if 'response-params' in event_name:
-        role_section = section.get_section('Role')
-        policy_document_section = role_section.get_section(
-            'AssumeRolePolicyDocument')
-        type_section = policy_document_section.get_section('param-type')
-        type_section.clear_text()
-        type_section.write('*(dict) --*')
-    elif 'response-example' in event_name:
-        parent = section.get_section('structure-value')
-        role = parent.get_section('Role')
-        role_member = role.get_section('member-value')
-        role_structure = role_member.get_section('structure-value')
-        assume_role_policy_document = role_structure.get_section(
-            'AssumeRolePolicyDocument')
-        value = assume_role_policy_document.get_section('member-value')
-        value.clear_text()
-        value.write('{ ... }')
-
-
 def document_copy_source_form(section, event_name, **kwargs):
     if 'request-example' in event_name:
         parent = section.get_section('structure-value')
@@ -814,8 +794,6 @@ BUILTIN_HANDLERS = [
     ('creating-client-class.s3', add_generate_presigned_post),
     ('creating-client-class.iot-data', check_openssl_supports_tls_version_1_2),
     ('after-call.iam', json_decode_policies),
-    ('docs.*.iam.GetRole.complete-section',
-     change_iam_assumerolepolicydocument_type),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),
     ('after-call.cloudformation.GetTemplate', json_decode_template_body),
     ('after-call.s3.GetBucketLocation', parse_get_bucket_location),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -282,6 +282,20 @@ def add_expect_header(model, params, **kwargs):
             params['headers']['Expect'] = '100-continue'
 
 
+def change_iam_assumerolepolicydocument_type(section, event_name, **kwargs):
+    if 'response-params' in event_name:
+        template_body_section = section.get_section('AssumeRolePolicyDocument')
+        type_section = template_body_section.get_section('param-type')
+        type_section.clear_text()
+        type_section.write('(*dict*) --')
+    elif 'response-example' in event_name:
+        parent = section.get_section('structure-value')
+        param_line = parent.get_section('AssumeRolePolicyDocument')
+        value_portion = param_line.get_section('member-value')
+        value_portion.clear_text()
+        value_portion.write('{}')
+
+
 def document_copy_source_form(section, event_name, **kwargs):
     if 'request-example' in event_name:
         parent = section.get_section('structure-value')
@@ -794,7 +808,8 @@ BUILTIN_HANDLERS = [
     ('creating-client-class.s3', add_generate_presigned_post),
     ('creating-client-class.iot-data', check_openssl_supports_tls_version_1_2),
     ('after-call.iam', json_decode_policies),
-
+    ('docs.*.iam.AssumeRolePolicyDocument.complete-section',
+     change_iam_assumerolepolicydocument_type),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),
     ('after-call.cloudformation.GetTemplate', json_decode_template_body),
     ('after-call.s3.GetBucketLocation', parse_get_bucket_location),

--- a/tests/functional/docs/test_iam.py
+++ b/tests/functional/docs/test_iam.py
@@ -1,0 +1,24 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.functional.docs import BaseDocsFunctionalTest
+
+
+class TestIamDocs(BaseDocsFunctionalTest):
+    def test_get_role_assumerolepolicydocument_type(self):
+        content = self.get_docstring_for_method('iam', 'get_role')
+        self.assert_contains_line(
+            '- **AssumeRolePolicyDocument** *(dict) --*',
+            content)
+        self.assert_contains_line(
+            "'AssumeRolePolicyDocument': { ... }",
+            content)

--- a/tests/functional/docs/test_iam.py
+++ b/tests/functional/docs/test_iam.py
@@ -20,5 +20,5 @@ class TestIamDocs(BaseDocsFunctionalTest):
             '- **AssumeRolePolicyDocument** *(dict) --*',
             content)
         self.assert_contains_line(
-            "'AssumeRolePolicyDocument': { ... }",
+            "'AssumeRolePolicyDocument': ...",
             content)


### PR DESCRIPTION
https://github.com/boto/boto3/issues/978

We decode the string for the AssumeRolePolicyDocument field in the response from get_role in iam.
https://github.com/boto/botocore/blob/develop/botocore/handlers.py#L428-L456

The documentation currently cites its type as a string

cc @dstufft @kyleknap @jamesls @JordonPhillips 

### Changes to example:
<img width="566" alt="screen shot 2017-02-15 at 5 37 06 pm" src="https://cloud.githubusercontent.com/assets/1010634/23003394/6fdd3222-f3a5-11e6-8def-a4108dbb209b.png">


### Changes to parameter docs:
<img width="488" alt="screen shot 2017-02-15 at 5 29 32 pm" src="https://cloud.githubusercontent.com/assets/1010634/23003395/6fe35e72-f3a5-11e6-8a0b-3fc197076b8c.png">



