### PR TITLE
Adding persistent caching of temporary credentials

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -17,6 +17,7 @@ import logging
 import os
 import getpass
 import threading
+import json
 from collections import namedtuple
 
 from dateutil.parser import parse
@@ -61,7 +62,7 @@ def create_credential_resolver(session):
         AssumeRoleProvider(
             load_config=lambda: session.full_config,
             client_creator=session.create_client,
-            cache={},
+            cache=JSONFileCache(),
             profile_name=profile_name,
         ),
         SharedCredentialProvider(
@@ -150,6 +151,51 @@ def create_mfa_serial_refresher():
         # when the temp creds expire.
         raise RefreshWithMFAUnsupportedError()
     return _refresher
+
+
+class JSONFileCache(object):
+    """JSON file cache.
+    This provides a dict like interface that stores JSON serializable
+    objects.
+    The objects are serialized to JSON and stored in a file.  These
+    values can be retrieved at a later time.
+    """
+
+    CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
+
+    def __init__(self, working_dir=CACHE_DIR):
+        self._working_dir = working_dir
+
+    def __contains__(self, cache_key):
+        actual_key = self._convert_cache_key(cache_key)
+        return os.path.isfile(actual_key)
+
+    def __getitem__(self, cache_key):
+        """Retrieve value from a cache key."""
+        actual_key = self._convert_cache_key(cache_key)
+        try:
+            with open(actual_key) as f:
+                return json.load(f)
+        except (OSError, ValueError, IOError):
+            raise KeyError(cache_key)
+
+    def __setitem__(self, cache_key, value):
+        full_key = self._convert_cache_key(cache_key)
+        try:
+            file_content = json.dumps(value)
+        except (TypeError, ValueError):
+            raise ValueError("Value cannot be cached, must be "
+                             "JSON serializable: %s" % value)
+        if not os.path.isdir(self._working_dir):
+            os.makedirs(self._working_dir)
+        with os.fdopen(os.open(full_key,
+                               os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
+            f.truncate()
+            f.write(file_content)
+
+    def _convert_cache_key(self, cache_key):
+        full_path = os.path.join(self._working_dir, cache_key + '.json')
+        return full_path
 
 
 class Credentials(object):
@@ -854,7 +900,7 @@ class AssumeRoleProvider(CredentialProvider):
         return cache_key.replace('/', '-')
 
     def _write_cached_credentials(self, creds, cache_key):
-        self.cache[cache_key] = creds
+        self.cache[cache_key] = _serialize_if_needed(creds)
 
     def _get_role_config_values(self):
         # This returns the role related configuration.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -57,6 +57,19 @@ def skip_unless_has_memory_collection(cls):
     return cls
 
 
+def skip_if_windows(reason):
+    """Decorator to skip tests that should not be run on windows.
+    Example usage:
+        @skip_if_windows("Not valid")
+        def test_some_non_windows_stuff(self):
+            self.assertEqual(...)
+    """
+    def decorator(func):
+        return unittest.skipIf(
+            platform.system() not in ['Darwin', 'Linux'], reason)(func)
+    return decorator
+
+
 def random_chars(num_chars):
     """Returns random hex characters.
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -14,6 +14,8 @@
 from datetime import datetime, timedelta
 import mock
 import os
+import tempfile
+import shutil
 
 from dateutil.tz import tzlocal, tzutc
 
@@ -22,7 +24,7 @@ from botocore.utils import ContainerMetadataFetcher
 from botocore.credentials import EnvProvider, create_assume_role_refresher
 import botocore.exceptions
 import botocore.session
-from tests import unittest, BaseEnvVar, IntegerRefresher
+from tests import unittest, BaseEnvVar, IntegerRefresher, skip_if_windows
 
 
 # Passed to session to keep it from finding default config file
@@ -1052,6 +1054,67 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         # source_profile is required, we shoudl get an error.
         with self.assertRaises(botocore.exceptions.InvalidConfigError):
             provider.load()
+
+
+class TestJSONCache(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.cache = credentials.JSONFileCache(self.tempdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_supports_contains_check(self):
+        # By default the cache is empty because we're
+        # using a new temp dir everytime.
+        self.assertTrue('mykey' not in self.cache)
+
+    def test_add_key_and_contains_check(self):
+        self.cache['mykey'] = {'foo': 'bar'}
+        self.assertTrue('mykey' in self.cache)
+
+    def test_added_key_can_be_retrieved(self):
+        self.cache['mykey'] = {'foo': 'bar'}
+        self.assertEqual(self.cache['mykey'], {'foo': 'bar'})
+
+    def test_only_accepts_json_serializable_data(self):
+        with self.assertRaises(ValueError):
+            # set()'s cannot be serialized to a JSON string.
+            self.cache['mykey'] = set()
+
+    def test_can_override_existing_values(self):
+        self.cache['mykey'] = {'foo': 'bar'}
+        self.cache['mykey'] = {'baz': 'newvalue'}
+        self.assertEqual(self.cache['mykey'], {'baz': 'newvalue'})
+
+    def test_can_add_multiple_keys(self):
+        self.cache['mykey'] = {'foo': 'bar'}
+        self.cache['mykey2'] = {'baz': 'qux'}
+        self.assertEqual(self.cache['mykey'], {'foo': 'bar'})
+        self.assertEqual(self.cache['mykey2'], {'baz': 'qux'})
+
+    def test_working_dir_does_not_exist(self):
+        working_dir = os.path.join(self.tempdir, 'foo')
+        cache = credentials.JSONFileCache(working_dir)
+        cache['foo'] = {'bar': 'baz'}
+        self.assertEqual(cache['foo'], {'bar': 'baz'})
+
+    def test_key_error_raised_when_cache_key_does_not_exist(self):
+        with self.assertRaises(KeyError):
+            self.cache['foo']
+
+    def test_file_is_truncated_before_writing(self):
+        self.cache['mykey'] = {
+            'really long key in the cache': 'really long value in cache'}
+        # Now overwrite it with a smaller value.
+        self.cache['mykey'] = {'a': 'b'}
+        self.assertEqual(self.cache['mykey'], {'a': 'b'})
+
+    @skip_if_windows('File permissions tests not supported on Windows.')
+    def test_permissions_for_file_restricted(self):
+        self.cache['mykey'] = {'foo': 'bar'}
+        filename = os.path.join(self.tempdir, 'mykey.json')
+        self.assertEqual(os.stat(filename).st_mode & 0xFFF, 0o600)
 
 
 class TestRefreshLogic(unittest.TestCase):


### PR DESCRIPTION
Adding persistent caching of temporary credentials from aws/aws-cli@22932e53c7085bd8e53b22904b326c426e2e60fc

This PR addresses #1148 by porting the code present in awscli into botocore to make it available to boto3. Having the code in both awscli and botocore until it's removed from awscli doesn't appear to have any negative impact.

One thing I'd like guidance on is:

* The `RefreshableCredentials` class stores the `_expiry_time` natively in `datetime` format.
* The `AssumeRoleProvider` class expects the possibility that the `response['Credentials']['Expiration']` value which may come from the cache may need to be [parsed from a string back into a `datetime`](https://github.com/boto/botocore/blob/8ec77d0b1683cd01e1b62506c4c1ea53ccda6daf/botocore/credentials.py#L904-L905)
* By my searches it appears to me that `awscli` doesn't have any special logic (not present in botocore) to ensure that the expiration `datetime` is serialized to a string before it's passed to `JSONFileCache`
* When I use the existing [`assumerole` customization](https://github.com/aws/aws-cli/blob/02ead4f0f2f5be1e91903aaf97a9669db228bc49/awscli/customizations/assumerole.py) in `awscli` the expiration `datetime` is correctly serialized to a string when stored in the `JSONFileCache`
* When I use this new functionality that I've moved into botocore in this PR *without* and explicit serialization call, the expiration `datetime` is passed to `JSONFileCache` un-serialized (which `JSONFileCache` rightly rejects). As a result I've [added a serialization step](https://github.com/boto/botocore/compare/develop...gene1wood:add-persistent-credential-cache?expand=1#diff-dcd72ae45553af71f1ceafb2d4ee5dcfR903) and I don't understand why this step isn't also required for awscli to work.

@jamesls Can you provide any insight on this question about serialization? If there's any way I can remove that serialization call and have the expiration `datetime` serialized through whatever method awscli accomplishes it I'd prefer it.