### PR TITLE
Revert "Decode file paths in config loader"

### DIFF
--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -14,9 +14,8 @@
 import os
 import shlex
 import copy
-import sys
 
-from botocore.compat import six
+from six.moves import configparser
 
 import botocore.exceptions
 
@@ -143,13 +142,12 @@ def raw_config_parse(config_filename, parse_subsections=True):
         path = os.path.expandvars(path)
         path = os.path.expanduser(path)
         if not os.path.isfile(path):
-            raise botocore.exceptions.ConfigNotFound(path=_unicode_path(path))
-        cp = six.moves.configparser.RawConfigParser()
+            raise botocore.exceptions.ConfigNotFound(path=path)
+        cp = configparser.RawConfigParser()
         try:
-            cp.read([path])
-        except six.moves.configparser.Error:
-            raise botocore.exceptions.ConfigParseError(
-                path=_unicode_path(path))
+            cp.read(path)
+        except configparser.Error:
+            raise botocore.exceptions.ConfigParseError(path=path)
         else:
             for section in cp.sections():
                 config[section] = {}
@@ -163,15 +161,9 @@ def raw_config_parse(config_filename, parse_subsections=True):
                             config_value = _parse_nested(config_value)
                         except ValueError:
                             raise botocore.exceptions.ConfigParseError(
-                                path=_unicode_path(path))
+                                path=path)
                     config[section][option] = config_value
     return config
-
-
-def _unicode_path(path):
-    if isinstance(path, six.text_type):
-        return path
-    return path.decode(sys.getfilesystemencoding(), 'replace')
 
 
 def _parse_nested(config_value):

--- a/tests/unit/cfg/aws_config_unicode✓
+++ b/tests/unit/cfg/aws_config_unicode✓
@@ -1,8 +1,0 @@
-[default]
-aws_access_key_id = foo
-aws_secret_access_key = bar
-
-[profile "personal"]
-aws_access_key_id = fie
-aws_secret_access_key = baz
-aws_security_token = fiebaz

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -14,19 +14,13 @@
 # language governing permissions and limitations under the License.
 from tests import unittest, BaseEnvVar
 import os
-import mock
-
 import botocore.exceptions
 from botocore.configloader import raw_config_parse, load_config, \
     multi_file_load_config
-from botocore.compat import six
 
 
 def path(filename):
-    directory = os.path.join(os.path.dirname(__file__), 'cfg')
-    if isinstance(filename, six.binary_type):
-        directory = six.b(directory)
-    return os.path.join(directory, filename)
+    return os.path.join(os.path.dirname(__file__), 'cfg', filename)
 
 
 class TestConfigLoader(BaseEnvVar):
@@ -108,20 +102,6 @@ class TestConfigLoader(BaseEnvVar):
         self.assertEqual(third_config['aws_access_key_id'], 'third_fie')
         self.assertEqual(third_config['aws_secret_access_key'], 'third_baz')
         self.assertEqual(third_config['aws_security_token'], 'third_fiebaz')
-
-    def test_unicode_bytes_path_not_found(self):
-        with self.assertRaises(botocore.exceptions.ConfigNotFound):
-            with mock.patch('sys.getfilesystemencoding') as encoding:
-                encoding.return_value = 'utf-8'
-                load_config(path(b'\xe2\x9c\x93'))
-
-    def test_unicode_bytes_path(self):
-        filename = path(b'aws_config_unicode\xe2\x9c\x93')
-        with mock.patch('sys.getfilesystemencoding') as encoding:
-            encoding.return_value = 'utf-8'
-            loaded_config = load_config(filename)
-        self.assertIn('default', loaded_config['profiles'])
-        self.assertIn('personal', loaded_config['profiles'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts boto/botocore#1144

The tests were failing on our Windows test boxes. Reverting until we can get it fixed.