### PR TITLE
Decode config file paths

### DIFF
--- a/.changes/next-release/bugfix-config-8651.json
+++ b/.changes/next-release/bugfix-config-8651.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fix a bug in loading config files from paths that contain non-ascii characters. Fixes aws/aws-cli`#2395 <https://github.com/boto/botocore/issues/2395>`__",
+  "category": "config",
+  "type": "bugfix"
+}


### PR DESCRIPTION
Fixes aws/aws-cli#2395

This was originally committed in #1144 but the tests failed on Windows due to some file system issues. This was resolved by creating the file on the fly and cleaning it up after.

I've run the tests (including integration) on several python versions on OSX, Linux, and Windows.

cc @kyleknap @jamesls @dstufft @stealthycoin 