### PR TITLE
Fixed test to not rely on getting the __repr__ in the error

### DIFF
--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -140,8 +140,7 @@ class TestValidateJSONValueTrait(BaseTestValidate):
                 'json': {'date': datetime(2017, 4, 27, 0, 0)}
             },
             errors=[
-                ('Invalid parameter json must be json serializable: datetime'
-                 '.datetime(2017, 4, 27, 0, 0) is not JSON serializable')
+                ('Invalid parameter json must be json serializable: ')
             ])
 
 


### PR DESCRIPTION
3.6 json error no longer reports __repr__ of the failed object, instead it just shows the type.

cc @jamesls @kyleknap @JordonPhillips @dstufft 