### PR TITLE
Fixed percent_encode when handing it bytes.

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -319,10 +319,18 @@ def percent_encode(input_str, safe=SAFE_CHARS):
     producing a percent encoded string, this function deals only with
     taking a string (not a dict/sequence) and percent encoding it.
 
+    If given the binary type, will simply URL encode it. If given the
+    text type, will produce the binary type by UTF-8 encoding the
+    text. If given something else, will convert it to the the text type
+    first.
     """
+    # If its not a binary or text string, make it a text string.
     if not isinstance(input_str, string_types):
         input_str = text_type(input_str)
-    return quote(text_type(input_str).encode('utf-8'), safe=safe)
+    # If it's not bytes, make it bytes by UTF-8 encoding it.
+    if not isinstance(input_str, binary_type):
+        input_str = input_str.encode('utf-8')
+    return quote(input_str, safe=safe)
 
 
 def parse_timestamp(value):


### PR DESCRIPTION
`percent_encode` fails when handed a string that's already been encoded into bytes. Have it just URL-quote that instead.

This fixes an error I'm running into when using S3 via the "django storages" package. I have a few keys with non-ASCII characters. Django storages handles this by encoding them as UTF-8 and handing the bytes off to boto. On Python 2 this fails with a UnicodeDecodeError, and on Python 3 I don't think it will raise an exception, but will return a url-encoded repr of the string passed in (which is probably not what you would want).