### PR TITLE
Fix bug with sigv4 signer with consecutive spaces

### DIFF
--- a/.changes/next-release/bugfix-Auth-55416.json
+++ b/.changes/next-release/bugfix-Auth-55416.json
@@ -1,0 +1,5 @@
+{
+  "category": "Auth", 
+  "type": "bugfix", 
+  "description": "Fix bug in Signature Version 4 signer when a header value has consecutive spaces"
+}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -239,7 +239,7 @@ class SigV4Auth(BaseSigner):
         #
         # The Trimall function removes excess white space before and after
         # values, and converts sequential spaces to a single space.
-        return ' '.join(value.strip().split())
+        return ' '.join(value.split())
 
     def signed_headers(self, headers_to_sign):
         l = ['%s' % n.lower().strip() for n in set(headers_to_sign)]

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -228,10 +228,18 @@ class SigV4Auth(BaseSigner):
         headers = []
         sorted_header_names = sorted(set(headers_to_sign))
         for key in sorted_header_names:
-            value = ','.join(v.strip() for v in
+            value = ','.join(self._header_value(v) for v in
                              sorted(headers_to_sign.get_all(key)))
             headers.append('%s:%s' % (key, value))
         return '\n'.join(headers)
+
+    def _header_value(self, value):
+        # From the sigv4 docs:
+        # Lowercase(HeaderName) + ':' + Trimall(HeaderValue)
+        #
+        # The Trimall function removes excess white space before and after
+        # values, and converts sequential spaces to a single space.
+        return ' '.join(value.strip().split())
 
     def signed_headers(self, headers_to_sign):
         l = ['%s' % n.lower().strip() for n in set(headers_to_sign)]

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -889,6 +889,14 @@ class TestS3SigV4Client(BaseS3ClientTest):
         # Make sure the upload id is as expected.
         self.assertEqual(response['Uploads'][0]['UploadId'], upload_id)
 
+    def test_can_add_double_space_metadata(self):
+        # Ensure we get no sigv4 errors when we send
+        # metadata with consecutive spaces.
+        response = self.client.put_object(
+            Bucket=self.bucket_name, Key='foo.txt',
+            Body=b'foobar', Metadata={'foo': '  multi    spaces  '})
+        self.assert_status_code(response, 200)
+
 
 class TestSSEKeyParamValidation(BaseS3ClientTest):
     def test_make_request_with_sse(self):

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -532,6 +532,20 @@ class TestSigV4(unittest.TestCase):
         sha_header = request.headers['X-Amz-Content-SHA256']
         self.assertEqual(sha_header, 'UNSIGNED-PAYLOAD')
 
+    def test_collapse_multiple_spaces(self):
+        auth = self.create_signer()
+        original = HTTPHeaders()
+        original['foo'] = 'double  space'
+        headers = auth.canonical_headers(original)
+        self.assertEqual(headers, 'foo:double space')
+
+    def test_trims_leading_trailing_spaces(self):
+        auth = self.create_signer()
+        original = HTTPHeaders()
+        original['foo'] = '  leading  and  trailing  '
+        headers = auth.canonical_headers(original)
+        self.assertEqual(headers, 'foo:leading and trailing')
+
 
 class TestSigV4Resign(BaseTestWithFixedDate):
 


### PR DESCRIPTION
See: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

Added integration test that fails without this change.
I verified that this affected glacier vault descriptions as well as s3
object metadata.