### PR TITLE
Support paginating with tokens that contain bytes

### DIFF
--- a/.changes/next-release/bugfix-Paginator-39515.json
+++ b/.changes/next-release/bugfix-Paginator-39515.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "Fixes bug where pagination would fail if the pagination token contained bytes."
+}

--- a/tests/functional/test_paginate.py
+++ b/tests/functional/test_paginate.py
@@ -10,8 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from nose.tools import assert_equal
+
 from tests import unittest
 from botocore.stub import Stubber, StubAssertionError
+from botocore.paginate import TokenDecoder, TokenEncoder
+from botocore.compat import six
 import botocore.session
 
 
@@ -58,3 +62,23 @@ class TestRDSPagination(unittest.TestCase):
         except StubAssertionError as e:
             self.fail(str(e))
 
+
+def test_token_encoding():
+    cases = [
+        {'foo': 'bar'},
+        {'foo': b'bar'},
+        {'foo': {'bar': b'baz'}},
+        {'foo': ['bar', b'baz']},
+        {'foo': b'\xff'},
+        {'foo': {'bar': b'baz', 'bin': [b'bam']}},
+    ]
+
+    for token_dict in cases:
+        yield assert_token_encodes_and_decodes, token_dict
+
+
+def assert_token_encodes_and_decodes(token_dict):
+    encoded = TokenEncoder().encode(token_dict)
+    assert isinstance(encoded, six.string_types)
+    decoded = TokenDecoder().decode(encoded)
+    assert_equal(decoded, token_dict)


### PR DESCRIPTION
Some services (such as dynamodb) may use bytes in their pagination tokens, so this adds fallback support for that.

The solution in this PR is to attempt to encode as before, but if it fails to traverse the token dict encoding any bytes found and noting the path to those values.

Another option considered was using pickle, but the concern there was that we couldn't easily limit it to json+bytes and therefore we'd be exposing ourselves to code execution issues.