### PR TITLE
Update s3.Bucket CreationDate docstring

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.json
+++ b/botocore/data/s3/2006-03-01/service-2.json
@@ -1021,7 +1021,7 @@
         },
         "CreationDate":{
           "shape":"CreationDate",
-          "documentation":"Date the bucket was created."
+          "documentation":"Date the bucket was created. This will be <code>null</code> if the bucket is owned by another account or you do not have permissions to ListBuckets"
         }
       }
     },


### PR DESCRIPTION
Adding this as followup to boto/boto3#1064.

Existing docs are a little inconsistent in their usage of `null` vs `None`, but `null` seems slightly more in keeping with existing style?

(Ref boto/boto3#1063)