### PR TITLE
Make ClientError a subclass of BotoCoreError and allow pickling of exception classes

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -23,9 +23,12 @@ class BotoCoreError(Exception):
     """
     fmt = 'An unspecified error occurred'
 
-    def __init__(self, **kwargs):
-        msg = self.fmt.format(**kwargs)
+    def __init__(self, msg=None, **kwargs):
+        # The  msg parameter is to ensure this class remains picklable
+        if not msg:
+            msg = self.fmt.format(**kwargs)
         Exception.__init__(self, msg)
+        self.msg = msg
         self.kwargs = kwargs
 
 
@@ -343,7 +346,7 @@ class UnsupportedSignatureVersionError(BotoCoreError):
     fmt = 'Signature version is not supported: {signature_version}'
 
 
-class ClientError(Exception):
+class ClientError(BotoCoreError):
     MSG_TEMPLATE = (
         'An error occurred ({error_code}) when calling the {operation_name} '
         'operation{retry_info}: {error_message}')

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -31,6 +31,15 @@ class BotoCoreError(Exception):
         self.msg = msg
         self.kwargs = kwargs
 
+    def __reduce__(self):
+        return (
+            self.__class__,
+            # pass in the message again
+            (self.msg,),
+            # setting self.kwargs again
+            {'args': self.args, 'msg': self.msg, 'kwargs': self.kwargs},
+        )
+
 
 class DataNotFoundError(BotoCoreError):
     """
@@ -372,6 +381,15 @@ class ClientError(BotoCoreError):
                     retry_info = (' (reached max retries: %s)' %
                                   metadata['RetryAttempts'])
         return retry_info
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self.response, self.operation_name),
+            # args is set by the base Exception class
+            # kwargs is set by BotoCoreError
+            {'args': self.args, 'kwargs': self.kwargs},
+        )
 
 
 class UnsupportedTLSVersionWarning(Warning):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -11,6 +11,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pickle
+
 from nose.tools import assert_equals
 
 from botocore import exceptions
@@ -39,6 +41,15 @@ def test_client_error_set_correct_operation_name():
     response = {'Error': {}}
     exception = exceptions.ClientError(response, 'blackhole')
     assert_equals(exception.operation_name, 'blackhole')
+
+
+def test_client_error_can_be_pickled():
+    response = {'Error': {}}
+    exception = exceptions.ClientError(response, 'blackhole')
+
+    pickled = pickle.dumps(exception)
+    unpickled = pickle.loads(pickled)
+    assert exception.args == unpickled.args
 
 
 def test_retry_info_added_when_present():

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -16,6 +16,13 @@ from nose.tools import assert_equals
 from botocore import exceptions
 
 
+def test_client_error_is_subclass_of_botocoreerror():
+    response = {'Error': {}}
+    exception = exceptions.ClientError(response, 'blackhole')
+
+    assert isinstance(exception, exceptions.BotoCoreError)
+
+
 def test_client_error_can_handle_missing_code_or_message():
     response = {'Error': {}}
     expect = 'An error occurred (Unknown) when calling the blackhole operation: Unknown'


### PR DESCRIPTION
Fix #834, fix #899.