### PR TITLE
Added exponential backoff functionality for elastic mapreduce clusters

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -125,6 +125,26 @@
         }
       }
     },
+    "elasticmapreduce": {
+      "__default__": {
+        "max_attempts": 10,
+        "delay": {
+          "type": "exponential",
+          "base": 0.8,
+          "growth_factor": 2
+        },
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "ThrottlingException",
+                "http_status_code": 400
+              }
+            }
+          }
+        }
+      }
+    },
     "cloudsearch": {
       "__default__": {
         "policies": {


### PR DESCRIPTION
I was experiencing throttling exceptions using the boto3 EMR API. I noticed no configuration in `_retry.json` for EMR, so I added it.

Issue: https://github.com/boto/botocore/issues/1193