### PR TITLE
Add line iterator to StreamingBody

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -122,7 +122,7 @@ class StreamingBody(object):
         while True:
             current_chunk = self.read(chunk_size)
             if current_chunk == b"":
-                raise StopIteration()
+                break
             yield current_chunk
 
     def _verify_content_length(self):

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -85,11 +85,11 @@ class StreamingBody(object):
         """
         # Reading 1024 bytes at a time seems a sane choice [citation needed].
         # If the user needs to specify something different they can always call
-        # streaming_body.iter_lines(<other-chunk-size>)
+        # streaming_body._iter_lines(<other-chunk-size>)
         default_chunk_size = 1024
-        return self.iter_lines(default_chunk_size)
+        return self._iter_lines(default_chunk_size)
 
-    def iter_lines(self, chunk_size):
+    def _iter_lines(self, chunk_size):
         """Return an iterator to yield lines from the raw stream.
 
         This is achieved by reading chunk of bytes (of size chunk_size) at a

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -102,9 +102,7 @@ class StreamingBody(object):
 
             lines = chunk.splitlines()
 
-            chunk_ends_with_newline = chunk[-1] == b"\n"
-
-            if lines and lines[-1] and chunk and not chunk_ends_with_newline:
+            if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]:
                 # We might be in the 'middle' of a line. Hence we keep the
                 # last line as pending.
                 pending = lines.pop()

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -89,7 +89,7 @@ class TestStreamWrapper(unittest.TestCase):
             body = six.BytesIO(b'1234567890\n1234567890\n12345')
             stream = response.StreamingBody(body, content_length=27)
             self._assert_lines(
-                stream.iter_lines(chunk_size),
+                stream._iter_lines(chunk_size),
                 [b'1234567890', b'1234567890', b'12345'],
             )
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -68,6 +68,26 @@ class TestStreamWrapper(unittest.TestCase):
         stream.close()
         self.assertTrue(body.closed)
 
+    def test_streaming_line_iterator(self):
+        body = six.BytesIO(b'1234567890\n1234567890\n12345')
+        stream = response.StreamingBody(body, content_length=27)
+        lines = iter(stream)
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'12345')
+        with self.assertRaises(StopIteration):
+            next(lines)
+
+    def test_streaming_line_iterator_ends_newline(self):
+        body = six.BytesIO(b'1234567890\n1234567890\n12345\n')
+        stream = response.StreamingBody(body, content_length=28)
+        lines = iter(stream)
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'12345')
+        with self.assertRaises(StopIteration):
+            next(lines)
+
 
 class TestGetResponse(BaseResponseTest):
     maxDiff = None


### PR DESCRIPTION
This way, we can readlines from a streaming body (without having to load
all bytes into memory!)

This will allow us to use StreamingBody in places where a Python
file-like object is expected.
(E.g. csv.reader!)