### PR TITLE
Move all uses of six to the vendored version

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 if six.PY3:
-    from six.moves import http_client
+    from botocore.vendored.six.moves import http_client
 
     class HTTPHeaders(http_client.HTTPMessage):
         pass

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -19,7 +19,6 @@ import botocore.session
 from botocore.client import ClientError
 from botocore.compat import six
 from botocore.exceptions import EndpointConnectionError
-from six import StringIO
 
 
 class TestBucketWithVersions(unittest.TestCase):
@@ -93,7 +92,7 @@ class TestResponseLog(unittest.TestCase):
         # lose this feature.
         session = botocore.session.get_session()
         client = session.create_client('s3', region_name='us-west-2')
-        debug_log = StringIO()
+        debug_log = six.StringIO()
         session.set_stream_logger('', logging.DEBUG, debug_log)
         client.list_buckets()
         debug_log_contents = debug_log.getvalue()

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -27,8 +27,6 @@ import logging
 import io
 import datetime
 from botocore.compat import six
-from six import BytesIO
-from six.moves import BaseHTTPServer
 
 import nose.tools as t
 from nose import with_setup
@@ -78,11 +76,11 @@ if not six.PY3:
 log = logging.getLogger(__name__)
 
 
-class RawHTTPRequest(BaseHTTPServer.BaseHTTPRequestHandler):
+class RawHTTPRequest(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
     def __init__(self, raw_request):
         if isinstance(raw_request, six.text_type):
             raw_request = raw_request.encode('utf-8')
-        self.rfile = BytesIO(raw_request)
+        self.rfile = six.BytesIO(raw_request)
         self.raw_requestline = self.rfile.readline()
         self.error_code = None
         self.error_message = None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,7 +14,7 @@
 from tests import unittest
 from dateutil.tz import tzutc, tzoffset
 import datetime
-import six
+from botocore.compat import six
 
 import mock
 


### PR DESCRIPTION
As botocore does not include six as a dependency, it should never
reference the globally installed six. Always use the vendored version
instead.

Helps ensure there is not an ImportError at runtime.