### PR TITLE
Don't fail OpenSSL version check on 1.1.0

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -671,7 +671,7 @@ def check_openssl_supports_tls_version_1_2(**kwargs):
     import ssl
     try:
         openssl_version_tuple = ssl.OPENSSL_VERSION_INFO
-        if openssl_version_tuple[0] < 1 or openssl_version_tuple[2] < 1:
+        if openssl_version_tuple < (1, 0, 1):
             warnings.warn(
                 'Currently installed openssl version: %s does not '
                 'support TLS 1.2, which is required for use of iot-data. '


### PR DESCRIPTION
openssl_version_tuple[2] is 0 on OpenSSL 1.1.0, which fails the condition, but should be accepted. Simply comparing tuples should work.