### PR TITLE
Fix SigV2Auth for GET requests

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -109,7 +109,7 @@ class SigV2Auth(BaseSigner):
             params = request.data
         else:
             # GET
-            params = request.param
+            params = request.params
         params['AWSAccessKeyId'] = self.credentials.access_key
         params['SignatureVersion'] = '2'
         params['SignatureMethod'] = 'HmacSHA256'

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -226,6 +226,20 @@ class TestSigV2(unittest.TestCase):
             result, ('Foo=%E2%9C%93',
                      u'VCtWuwaOL0yMffAT8W4y0AFW3W4KUykBqah9S40rB+Q='))
 
+    def test_get(self):
+        request = Request()
+        request.url = '/'
+        request.method = 'GET'
+        request.params = {'Foo': u'\u2713'}
+        self.signer.add_auth(request)
+        self.assertEqual(request.params['AWSAccessKeyId'], 'foo')
+        self.assertEqual(request.params['Foo'], u'\u2713')
+        self.assertEqual(request.params['Timestamp'], '2014-06-20T08:40:23Z')
+        self.assertEqual(request.params['Signature'],
+                         u'Un97klqZCONP65bA1+Iv4H3AcB2I40I4DBvw5ZERFPw=')
+        self.assertEqual(request.params['SignatureMethod'], 'HmacSHA256')
+        self.assertEqual(request.params['SignatureVersion'], '2')
+
 
 class TestSigV3(unittest.TestCase):
 


### PR DESCRIPTION
The add_auth() method references request.param rather than
request.params which causes it to thow an AttributeError when invoked on
a GET request.

This fix is required to access the Alexa Top Sites API using botocore.

```python
from botocore.auth import SigV2Auth
from botocore.awsrequest import AWSRequest
from botocore.endpoint import BotocoreHTTPSession
from botocore.session import get_session

request = AWSRequest()
request.method = 'GET'
request.url = 'https://ats.amazonaws.com'
request.params['Action'] = 'TopSites'
request.params['ResponseGroup'] = 'Country'

credentials = get_session().get_credentials()
auth = SigV2Auth(credentials)
auth.add_auth(request)

session = BotocoreHTTPSession()
session.send(request.prepare())
```