### PR TITLE
Fix all invalid escape sequences discovered running tests

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -165,7 +165,7 @@ if sys.version_info[:2] == (2, 6):
             'ignore',
             message="Certificate has no.*subjectAltName.*",
             category=exceptions.SecurityWarning,
-            module=".*urllib3\.connection")
+            module=r".*urllib3\.connection")
 else:
     import xml.etree.cElementTree
     XMLParseError = xml.etree.cElementTree.ParseError
@@ -183,7 +183,7 @@ def filter_ssl_warnings():
         'ignore',
         message="A true SSLContext object is not available.*",
         category=exceptions.InsecurePlatformWarning,
-        module=".*urllib3\.util\.ssl_")
+        module=r".*urllib3\.util\.ssl_")
     filter_ssl_san_warnings()
 
 

--- a/botocore/docs/sharedexample.py
+++ b/botocore/docs/sharedexample.py
@@ -178,7 +178,7 @@ class SharedExampleDocumenter(object):
         section.write("datetime(%s)," % datetime_str)
 
     def _get_comment(self, path, comments):
-        key = re.sub('^\.', '', ''.join(path))
+        key = re.sub(r'^\.', '', ''.join(path))
         if comments and key in comments:
             return '# ' + comments[key]
         else:

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -54,7 +54,7 @@ REGISTER_LAST = object()
 # to be as long as 255 characters, and bucket names can contain any
 # combination of uppercase letters, lowercase letters, numbers, periods
 # (.), hyphens (-), and underscores (_).
-VALID_BUCKET = re.compile('^[a-zA-Z0-9.\-_]{1,255}$')
+VALID_BUCKET = re.compile(r'^[a-zA-Z0-9.\-_]{1,255}$')
 VERSION_ID_SUFFIX = re.compile(r'\?versionId=[^\s]+$')
 
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -39,7 +39,7 @@ METADATA_SECURITY_CREDENTIALS_URL = (
 # These are chars that do not need to be urlencoded.
 # Based on rfc2986, section 2.3
 SAFE_CHARS = '-._~'
-LABEL_RE = re.compile('[a-z0-9][a-z0-9\-]*[a-z0-9]')
+LABEL_RE = re.compile(r'[a-z0-9][a-z0-9\-]*[a-z0-9]')
 RESTRICTED_REGIONS = [
     'us-gov-west-1',
     'fips-us-gov-west-1',
@@ -79,7 +79,7 @@ def get_service_module_name(service_model):
             'serviceFullName', service_model.service_name))
     name = name.replace('Amazon', '')
     name = name.replace('AWS', '')
-    name = re.sub('\W+', '', name)
+    name = re.sub(r'\W+', '', name)
     return name
 
 
@@ -637,7 +637,7 @@ def is_valid_endpoint_url(endpoint_url):
     if hostname[-1] == ".":
         hostname = hostname[:-1]
     allowed = re.compile(
-        "^((?!-)[A-Z\d-]{1,63}(?<!-)\.)*((?!-)[A-Z\d-]{1,63}(?<!-))$",
+        r"^((?!-)[A-Z\d-]{1,63}(?<!-)\.)*((?!-)[A-Z\d-]{1,63}(?<!-))$",
         re.IGNORECASE)
     return allowed.match(hostname)
 

--- a/tests/unit/test_regions.py
+++ b/tests/unit/test_regions.py
@@ -27,7 +27,7 @@ class TestEndpointResolver(unittest.TestCase):
                 {
                     'partition': 'aws',
                     'dnsSuffix': 'amazonaws.com',
-                    'regionRegex': '^(us|eu)\-\w+$',
+                    'regionRegex': r'^(us|eu)\-\w+$',
                     'defaults': {
                         'hostname': '{service}.{region}.{dnsSuffix}'
                     },
@@ -90,7 +90,7 @@ class TestEndpointResolver(unittest.TestCase):
                 {
                     'partition': 'foo',
                     'dnsSuffix': 'foo.com',
-                    'regionRegex': '^(foo)\-\w+$',
+                    'regionRegex': r'^(foo)\-\w+$',
                     'defaults': {
                         'hostname': '{service}.{region}.{dnsSuffix}',
                         'protocols': ['http'],


### PR DESCRIPTION
Fixes warning of the form:

```
DeprecationWarning: invalid escape sequence \...
```

See:

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior