### PR TITLE
Make copying UNSIGNED return the same instance

### DIFF
--- a/.changes/next-release/bugfix-Config-76988.json
+++ b/.changes/next-release/bugfix-Config-76988.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fixes a bug resulting from copy/deepcopy not returning the same object for botocore.UNSIGNED. Fixes boto/boto3`#1144 <https://github.com/boto/botocore/issues/1144>`__",
+  "category": "Config",
+  "type": "bugfix"
+}

--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -62,7 +62,7 @@ BOTOCORE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 # Used to specify anonymous (unsigned) request signature
-class _UNSIGNED(object):
+class UNSIGNED(object):
     def __copy__(self):
         return self
 
@@ -70,7 +70,7 @@ class _UNSIGNED(object):
         return self
 
 
-UNSIGNED = _UNSIGNED()
+UNSIGNED = UNSIGNED()
 
 
 def xform_name(name, sep='_', _xform_cache=_xform_cache,

--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -60,8 +60,17 @@ ScalarTypes = ('string', 'integer', 'boolean', 'timestamp', 'float', 'double')
 
 BOTOCORE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
+
 # Used to specify anonymous (unsigned) request signature
-UNSIGNED = object()
+class _UNSIGNED(object):
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memodict={}):
+        return self
+
+
+UNSIGNED = _UNSIGNED()
 
 
 def xform_name(name, sep='_', _xform_cache=_xform_cache,

--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -66,7 +66,7 @@ class UNSIGNED(object):
     def __copy__(self):
         return self
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict):
         return self
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,9 +15,11 @@ from tests import unittest
 from dateutil.tz import tzutc, tzoffset
 import datetime
 from botocore.compat import six
+import copy
 
 import mock
 
+import botocore
 from botocore import xform_name
 from botocore.compat import OrderedDict, json
 from botocore.awsrequest import AWSRequest
@@ -1634,6 +1636,14 @@ class TestContainerMetadataFetcher(unittest.TestCase):
 
     def test_external_host_not_allowed_if_https(self):
         self.assert_host_is_not_allowed('https://somewhere.com/foo')
+
+
+class TestUnsigned(unittest.TestCase):
+    def test_copy_returns_same_object(self):
+        self.assertIs(botocore.UNSIGNED, copy.copy(botocore.UNSIGNED))
+
+    def test_deepcopy_returns_same_object(self):
+        self.assertIs(botocore.UNSIGNED, copy.deepcopy(botocore.UNSIGNED))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
botocore.UNSIGNED is meant as a sentinal value like None, so copying
it should always return the same instance. This implements that
behavior.

Fixes boto/boto3#1144

cc @kyleknap @jamesls @dstufft @stealthycoin