### PR TITLE
Adding SSE related fields to Kinesis non_aggregate_keys

### DIFF
--- a/botocore/data/kinesis/2013-12-02/paginators-1.json
+++ b/botocore/data/kinesis/2013-12-02/paginators-1.json
@@ -11,7 +11,9 @@
         "StreamDescription.StreamName",
         "StreamDescription.StreamStatus",
         "StreamDescription.RetentionPeriodHours",
-        "StreamDescription.EnhancedMonitoring"
+        "StreamDescription.EnhancedMonitoring",
+        "StreamDescription.EncryptionType",
+        "StreamDescription.KeyId"
       ]
     },
     "ListStreams": {


### PR DESCRIPTION
Kinesis Streams recently introduced server-side encryption:

https://aws.amazon.com/blogs/big-data/under-the-hood-of-server-side-encryption-for-amazon-kinesis-streams/

but its new fields are not displayed from `describe-stream` output.

# How to reproduce

1. Go to AWS Console
2. Create a stream `foo`
3. From stream's detail page, enable server-side encryption(select "(Default)aws/kinesis" for master key)
4. From CLI, run `$ aws kinesis describe-stream --stream-name foo  --debug`

# What to expect

Response body contains newely added 
- EncryptionType
- KeyId

```
{"StreamDescription":{"EncryptionType":"KMS","EnhancedMonitoring":[{"ShardLevelMetrics":[]}],"HasMoreShards":false,"KeyId":"arn:aws:kms:eu-west-1:...
```

but it's not displayed from CLI output.

Once this PR merged, the output should contain them

```
$ aws kinesis describe-stream --stream-name foo
{
    "StreamDescription": {
        "KeyId": "arn:aws:kms:eu-west-1:...",   <- NEW
        "EncryptionType": "KMS",                <- NEW
        "StreamStatus": "ACTIVE",
        "StreamName": "foo",
...
```