### PR TITLE
Generate example enum

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -18,6 +18,7 @@ import hashlib
 import binascii
 import functools
 import weakref
+import random
 
 import dateutil.parser
 from dateutil.tz import tzlocal, tzutc
@@ -578,6 +579,8 @@ class ArgumentGenerator(object):
             elif shape.type_name == 'string':
                 if self._use_member_names:
                     return name
+                if shape.enum:
+                    return random.choice(shape.enum)
                 return ''
             elif shape.type_name in ['integer', 'long']:
                 return 0

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -416,6 +416,17 @@ class TestArgumentGenerator(unittest.TestCase):
             }
         )
 
+    def test_generate_string_enum(self):
+        enum_values = ['A', 'B', 'C']
+        model = {
+            'A': {'type': 'string', 'enum': enum_values}
+        }
+        shape = DenormalizedStructureBuilder().with_members(
+            model).build_model()
+        actual = self.arg_generator.generate_skeleton(shape)
+
+        self.assertIn(actual['A'], enum_values)
+
     def test_generate_scalars(self):
         self.assert_skeleton_from_model_is(
             model={


### PR DESCRIPTION
This causes generated skeletons to populate an example value for
enums that matches known possible values.

cc @stealthycoin @dstufft