### PR TITLE
Discard starting_truncation after first request

### DIFF
--- a/.changes/next-release/bugfix-Paginator-57048.json
+++ b/.changes/next-release/bugfix-Paginator-57048.json
@@ -1,0 +1,5 @@
+{
+  "category": "Paginator",
+  "description": "Fixed a bug causing running `build_full_results` multiple times to incorrectly generate the `NextToken` value.",
+  "type": "bugfix"
+}

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -257,6 +257,11 @@ class PageIterator(object):
                         parsed, primary_result_key, starting_truncation)
                 first_request = False
                 self._record_non_aggregate_key_values(parsed)
+            else:
+                # If this isn't the first request, we have already sliced into
+                # the first request and had to make additional requests after.
+                # We no longer need to add this to truncation.
+                starting_truncation = 0
             current_response = primary_result_key.search(parsed)
             if current_response is None:
                 current_response = []


### PR DESCRIPTION
This fixes a bug where we were not discarding the starting truncation
value in the paginator after the first request was made and truncated.
This resulted in having an inflated `boto_truncate_amount` value in
the pagination token. Successive calls would begin to drop results
starting at the third call.

cc @stealthycoin @dstufft