### PR TITLE
reading 0 bytes from StreamingBody does not return IncompleteReadError

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -73,7 +73,7 @@ class StreamingBody(object):
         """
         chunk = self._raw_stream.read(amt)
         self._amount_read += len(chunk)
-        if not chunk or amt is None:
+        if not chunk and amt != 0 or amt is None:
             # If the server sends empty contents or
             # we ask to read all of the contents, then we know
             # we need to verify the content length.

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -61,6 +61,11 @@ class TestStreamWrapper(unittest.TestCase):
         with self.assertRaises(IncompleteReadError):
             stream.read()
 
+    def test_streaming_body_with_zero_read(self):
+        body = six.BytesIO(b'1234567890')
+        stream = response.StreamingBody(body, content_length=10)
+        self.assertEqual(stream.read(0), '')
+
     def test_streaming_body_closes(self):
         body = six.BytesIO(b'1234567890')
         stream = response.StreamingBody(body, content_length=10)

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -64,7 +64,7 @@ class TestStreamWrapper(unittest.TestCase):
     def test_streaming_body_with_zero_read(self):
         body = six.BytesIO(b'1234567890')
         stream = response.StreamingBody(body, content_length=10)
-        self.assertEqual(stream.read(0), '')
+        self.assertEqual(stream.read(0), b'')
 
     def test_streaming_body_closes(self):
         body = six.BytesIO(b'1234567890')


### PR DESCRIPTION
I kept running into unexplained IncompleteReadErrors and realized the source came from reading 0 bytes from a StreamingBody object. I cross referenced with the Python documentation [here](https://docs.python.org/2/library/stdtypes.html#file.read) and [here](https://docs.python.org/2/tutorial/inputoutput.html#methods-of-file-objects), and Python does not throw an error for this, so I don't think botocore should either (especially since it supports negative num bytes as an argument as well, so zero is the only exception).

I just added a quick AND statement to the code to encompass this use case & wrote a test case to assert the error is no longer thrown.