### PR TITLE
Fix Route 53 pagination when string MaxItems is expected

### DIFF
--- a/.changes/next-release/bugfix-Paginator-68981.json
+++ b/.changes/next-release/bugfix-Paginator-68981.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "Ensure that the page size type matches the type expected by the service. Fixes `#1063 <https://github.com/boto/botocore/issues/1063>`__."
+}

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -681,9 +681,11 @@ class BaseClient(object):
             documented_paginator_cls = type(
                 paginator_class_name, (Paginator,), {'paginate': paginate})
 
+            operation_model = self._service_model.operation_model(actual_operation_name)
             paginator = documented_paginator_cls(
                 getattr(self, operation_name),
-                paginator_config)
+                paginator_config,
+                operation_model)
             return paginator
 
     def can_paginate(self, operation_name):

--- a/tests/functional/test_route53.py
+++ b/tests/functional/test_route53.py
@@ -1,0 +1,51 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+
+import botocore.session
+from botocore.stub import Stubber
+
+class TestRoute53Pagination(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client('route53', 'us-west-2')
+        self.stubber = Stubber(self.client)
+        # response has required fields
+        self.response = {
+            'HostedZones': [],
+            'Marker': '',
+            'IsTruncated': True,
+            'MaxItems': '1'
+        }
+        self.operation_name = 'list_hosted_zones'
+
+    def test_paginate_with_max_items_int(self):
+        # Route53 has a string type for MaxItems.  We need to ensure that this
+        # still works with integers as the cli auto converts the page size
+        # argument to an integer.
+        self.stubber.add_response(self.operation_name, self.response)
+        paginator = self.client.get_paginator('list_hosted_zones')
+        with self.stubber:
+            config={'PageSize': 1}
+            results = list(paginator.paginate(PaginationConfig=config))
+            self.assertTrue(len(results) >= 0)
+
+    def test_paginate_with_max_items_str(self):
+        # Route53 has a string type for MaxItems.  We need to ensure that this
+        # still works with strings as that's the expected type for this key.
+        self.stubber.add_response(self.operation_name, self.response)
+        paginator = self.client.get_paginator('list_hosted_zones')
+        with self.stubber:
+            config={'PageSize': '1'}
+            results = list(paginator.paginate(PaginationConfig=config))
+            self.assertTrue(len(results) >= 0)

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from tests import unittest
+from botocore import model
 from botocore.paginate import Paginator
 from botocore.paginate import PaginatorModel
 from botocore.paginate import TokenDecoder
@@ -95,12 +96,13 @@ class TestPaginatorModel(unittest.TestCase):
 class TestPagination(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         self.paginate_config = {
             'output_token': 'NextToken',
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_result_key_available(self):
         self.assertEqual(
@@ -134,7 +136,7 @@ class TestPagination(unittest.TestCase):
             "result_key": "Users",
             "limit_key": "MaxKeys",
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -173,7 +175,7 @@ class TestPagination(unittest.TestCase):
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(self.method, self.pagination_config)
+        self.paginator = Paginator(self.method, self.pagination_config, self.model)
         # Verify that despite varying between NextToken and NextToken2
         # we still can extract the right next tokens.
         responses = [
@@ -203,7 +205,7 @@ class TestPagination(unittest.TestCase):
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {'Foo': [1], 'IsTruncated': True, 'NextToken': 'token1'},
             {'Foo': [2], 'IsTruncated': True, 'NextToken': 'token2'},
@@ -225,7 +227,7 @@ class TestPagination(unittest.TestCase):
             'input_token': 'NextToken',
             'result_key': 'Bar',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {'Foo': {'IsTruncated': True}, 'NextToken': 'token1'},
             {'Foo': {'IsTruncated': False}, 'NextToken': 'token2'},
@@ -244,7 +246,7 @@ class TestPagination(unittest.TestCase):
             "result_key": "Users",
             "limit_key": "MaxKeys",
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -285,7 +287,7 @@ class TestPagination(unittest.TestCase):
             "result_key": "Users",
             "limit_key": "MaxKeys",
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -303,7 +305,7 @@ class TestPagination(unittest.TestCase):
             "result_key": "Users",
             "limit_key": "MaxKeys",
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
         max_items = 3
         page_size = 2
@@ -343,13 +345,14 @@ class TestPagination(unittest.TestCase):
 class TestPaginatorPageSize(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         self.paginate_config = {
             "output_token": "Marker",
             "input_token": "Marker",
             "result_key": ["Users", "Groups"],
             'limit_key': 'MaxKeys',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         self.endpoint = mock.Mock()
 
     def test_no_page_size(self):
@@ -374,14 +377,16 @@ class TestPaginatorPageSize(unittest.TestCase):
         kwargs = {'arg1': 'foo', 'arg2': 'bar',
                   'PaginationConfig': {'PageSize': 5}}
         del self.paginate_config['limit_key']
+        paginator = Paginator(self.method, self.paginate_config, self.model)
 
         with self.assertRaises(PaginationError):
-            self.paginator.paginate(**kwargs)
+            paginator.paginate(**kwargs)
 
 
 class TestPaginatorWithPathExpressions(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         # This is something we'd see in s3 pagination.
         self.paginate_config = {
             'output_token': [
@@ -389,7 +394,7 @@ class TestPaginatorWithPathExpressions(unittest.TestCase):
             'input_token': 'next_marker',
             'result_key': 'Contents',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_s3_list_objects(self):
         responses = [
@@ -422,12 +427,13 @@ class TestPaginatorWithPathExpressions(unittest.TestCase):
 class TestBinaryTokens(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         self.paginate_config = {
             "output_token": "Marker",
             "input_token": "Marker",
             "result_key": "Users"
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_build_full_result_with_bytes(self):
         responses = [
@@ -592,6 +598,7 @@ class TestBinaryTokens(unittest.TestCase):
 class TestMultipleTokens(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         # This is something we'd see in s3 pagination.
         self.paginate_config = {
             "output_token": ["ListBucketResults.NextKeyMarker",
@@ -599,7 +606,7 @@ class TestMultipleTokens(unittest.TestCase):
             "input_token": ["key_marker", "upload_id_marker"],
             "result_key": 'Foo',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_s3_list_multipart_uploads(self):
         responses = [
@@ -633,6 +640,7 @@ class TestOptionalTokens(unittest.TestCase):
     """
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         # This is based on Route53 pagination.
         self.paginate_config = {
             "output_token": ["NextRecordName",
@@ -643,7 +651,7 @@ class TestOptionalTokens(unittest.TestCase):
                             "StartRecordIdentifier"],
             "result_key": 'Foo',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_clean_token(self):
         responses = [
@@ -673,13 +681,14 @@ class TestOptionalTokens(unittest.TestCase):
 class TestKeyIterators(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         # This is something we'd see in s3 pagination.
         self.paginate_config = {
             "output_token": "Marker",
             "input_token": "Marker",
             "result_key": "Users"
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_result_key_iters(self):
         responses = [
@@ -706,7 +715,7 @@ class TestKeyIterators(unittest.TestCase):
         self.assertEqual(complete, {'Users': ['User1', 'User2', 'User3']})
 
     def test_max_items_can_be_specified(self):
-        paginator = Paginator(self.method, self.paginate_config)
+        paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -722,7 +731,7 @@ class TestKeyIterators(unittest.TestCase):
     def test_max_items_as_strings(self):
         # Some services (route53) model MaxItems as a string type.
         # We need to be able to handle this case.
-        paginator = Paginator(self.method, self.paginate_config)
+        paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -737,7 +746,7 @@ class TestKeyIterators(unittest.TestCase):
             {'Users': ['User1'], 'NextToken': expected_token})
 
     def test_next_token_on_page_boundary(self):
-        paginator = Paginator(self.method, self.paginate_config)
+        paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -754,7 +763,7 @@ class TestKeyIterators(unittest.TestCase):
         # We're saying we only want 4 items, but notice that the second
         # page of results returns users 4-6 so we have to truncated
         # part of that second page.
-        paginator = Paginator(self.method, self.paginate_config)
+        paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1", "User2", "User3"], "Marker": "m1"},
             {"Users": ["User4", "User5", "User6"], "Marker": "m2"},
@@ -774,7 +783,7 @@ class TestKeyIterators(unittest.TestCase):
         # from test_MaxItems_can_be_specified_truncates_response
         # We got the first 4 users, when we pick up we should get
         # User5 - User7.
-        paginator = Paginator(self.method, self.paginate_config)
+        paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User4", "User5", "User6"], "Marker": "m2"},
             {"Users": ["User7"]},
@@ -795,7 +804,7 @@ class TestKeyIterators(unittest.TestCase):
     def test_max_items_exceeds_actual_amount(self):
         # Because MaxItems=10 > number of users (3), we should just return
         # all of the users.
-        paginator = Paginator(self.method, self.paginate_config)
+        paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {"Users": ["User1"], "Marker": "m1"},
             {"Users": ["User2"], "Marker": "m2"},
@@ -823,13 +832,14 @@ class TestKeyIterators(unittest.TestCase):
 class TestMultipleResultKeys(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         # This is something we'd see in s3 pagination.
         self.paginate_config = {
             "output_token": "Marker",
             "input_token": "Marker",
             "result_key": ["Users", "Groups"],
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_build_full_result_with_multiple_result_keys(self):
         responses = [
@@ -944,6 +954,7 @@ class TestMultipleResultKeys(unittest.TestCase):
 class TestMultipleInputKeys(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         # Probably the most complicated example we'll see:
         # multiple input/output/result keys.
         self.paginate_config = {
@@ -951,7 +962,7 @@ class TestMultipleInputKeys(unittest.TestCase):
             "input_token": ["InMarker1", "InMarker2"],
             "result_key": ["Users", "Groups"],
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_build_full_result_with_multiple_input_keys(self):
         responses = [
@@ -1022,6 +1033,7 @@ class TestMultipleInputKeys(unittest.TestCase):
 class TestExpressionKeyIterators(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         # This is something like what we'd see in RDS.
         self.paginate_config = {
             "input_token": "Marker",
@@ -1029,7 +1041,7 @@ class TestExpressionKeyIterators(unittest.TestCase):
             "limit_key": "MaxRecords",
             "result_key": "EngineDefaults.Parameters"
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         self.responses = [
             {"EngineDefaults": {"Parameters": ["One", "Two"]},
              "Marker": "m1"},
@@ -1060,12 +1072,13 @@ class TestExpressionKeyIterators(unittest.TestCase):
 class TestIncludeResultKeys(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         self.paginate_config = {
             'output_token': 'Marker',
             'input_token': 'Marker',
             'result_key': ['ResultKey', 'Count', 'Log'],
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_different_kinds_of_result_key(self):
         self.method.side_effect = [
@@ -1097,13 +1110,14 @@ class TestIncludeNonResultKeys(unittest.TestCase):
 
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         self.paginate_config = {
             'output_token': 'NextToken',
             'input_token': 'NextToken',
             'result_key': 'ResultKey',
             'non_aggregate_keys': ['NotResultKey'],
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_include_non_aggregate_keys(self):
         self.method.side_effect = [
@@ -1122,7 +1136,7 @@ class TestIncludeNonResultKeys(unittest.TestCase):
 
     def test_include_with_multiple_result_keys(self):
         self.paginate_config['result_key'] = ['ResultKey1', 'ResultKey2']
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         self.method.side_effect = [
             {'ResultKey1': ['a', 'b'], 'ResultKey2': ['u', 'v'],
              'NotResultKey': 'a', 'NextToken': 'token1'},
@@ -1145,7 +1159,7 @@ class TestIncludeNonResultKeys(unittest.TestCase):
         self.paginate_config['non_aggregate_keys'] = [
             'Outer', 'Result.Inner',
         ]
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         self.method.side_effect = [
             # The non result keys shows hypothetical
             # example.  This doesn't actually happen,
@@ -1173,13 +1187,14 @@ class TestIncludeNonResultKeys(unittest.TestCase):
 class TestSearchOverResults(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
         self.paginate_config = {
             'more_results': 'IsTruncated',
             'output_token': 'NextToken',
             'input_token': 'NextToken',
             'result_key': 'Foo',
         }
-        self.paginator = Paginator(self.method, self.paginate_config)
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
         responses = [
             {'Foo': [{'a': 1}, {'b': 2}],
              'IsTruncated': True, 'NextToken': '1'},
@@ -1209,6 +1224,7 @@ class TestSearchOverResults(unittest.TestCase):
 class TestDeprecatedStartingToken(unittest.TestCase):
     def setUp(self):
         self.method = mock.Mock()
+        self.model = mock.Mock()
 
     def create_paginator(self, multiple_tokens=False):
         if multiple_tokens:
@@ -1223,7 +1239,7 @@ class TestDeprecatedStartingToken(unittest.TestCase):
                 'input_token': 'Marker',
                 'result_key': 'Users',
             }
-        return Paginator(self.method, paginator_config)
+        return Paginator(self.method, paginator_config, self.model)
 
     def assert_pagination_result(self, expected, pagination_config,
                                  multiple_tokens=False):
@@ -1331,6 +1347,73 @@ class TestDeprecatedStartingToken(unittest.TestCase):
             actual = paginator.paginate(
                 PaginationConfig=pagination_config).build_full_result()
             self.assertEqual(actual, expected)
+
+
+class TestStringPageSize(unittest.TestCase):
+    def setUp(self):
+        self.service_model = {
+            'metadata': {
+                'protocol': 'query',
+                'endpointPrefix': 'prefix'
+            },
+            'documentation': 'best service ever',
+            'operations': {
+                'ListStuff': {
+                    'name': 'ListStuff',
+                    'http': {
+                        'method': 'GET',
+                        'requestUri': '/things'
+                    },
+                    'input': {'shape': 'ListStuffInputShape'},
+                    'output': {'shape': 'ListStuffOutputShape'},
+                    'errors': [],
+                    'documentation': 'Lists stuff'
+                }
+            },
+            'shapes': {
+                'String': {'type': 'string'},
+                'ListOfStuff': {
+                    'type': 'list',
+                    'member': {'type': 'string'}
+                },
+                'ListStuffInputShape': {
+                    'type': 'structure',
+                    'required': [],
+                    'members': {
+                        'NextToken': {'shape': 'String'},
+                        'MaxItems': {'shape': 'String'}
+                    }
+                },
+                'ListStuffOutputShape': {
+                    'type': 'structure',
+                    'required': [],
+                    'members': {
+                        'NextToken': {'shape': 'String'},
+                        'Stuff': {'shape': 'ListOfStuff'},
+                        'IsTruncated': {'type': 'boolean'}
+                    },
+                }
+            }
+        }
+        self.paginate_config = {
+            'input_token': 'NextToken',
+            'output_token': 'NextToken',
+            'limit_key': 'MaxItems',
+            'result_key': 'Stuff',
+        }
+        self.service = model.ServiceModel(self.service_model)
+        self.model = self.service.operation_model('ListStuff')
+        self.method = mock.Mock()
+        self.method.side_effect = []
+        self.paginator = Paginator(self.method, self.paginate_config, self.model)
+
+    def test_int_page_size(self):
+        res = list(self.paginator.paginate(PaginationConfig={'PageSize': 1}))
+        self.method.assert_called_with(MaxItems='1')
+
+    def test_str_page_size(self):
+        res = list(self.paginator.paginate(PaginationConfig={'PageSize': '1'}))
+        self.method.assert_called_with(MaxItems='1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Route 53 has defined their `MaxItems` pagination field as a string which leads to issues when passing the `page-size` flag to the cli as it will convert the value to an integer. This PR adds a hook to automatically convert the `MaxItems` field back into a string in the case that the operation expects it to be a string.

Fixes: https://github.com/boto/botocore/issues/1063

@JordonPhillips @stealthycoin @kyleknap @jamesls @dstufft 