### PR TITLE
Always use embedded URIs

### DIFF
--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -220,8 +220,7 @@ class ReSTStyle(BaseStyle):
                 if ':' in last_write:
                     last_write = last_write.replace(':', r'\:')
                 self.doc.push_write(last_write)
-                self.doc.hrefs[last_write] = self.a_href
-                self.doc.write('`_')
+                self.doc.push_write(' <%s>`_' % self.a_href)
             elif last_write == '`':
                 # Look at start_a().  It will do a self.doc.write('`')
                 # which is the start of the link title.  If that is the

--- a/tests/unit/docs/bcdoc/test_document.py
+++ b/tests/unit/docs/bcdoc/test_document.py
@@ -41,13 +41,19 @@ class TestReSTDocument(unittest.TestCase):
         doc = ReSTDocument()
         doc.include_doc_string('<p>this is a <code>test</code></p>')
         self.assertEqual(doc.getvalue(), six.b('\n\nthis is a ``test`` \n\n'))
-        
+
     def test_remove_doc_string(self):
         doc = ReSTDocument()
         doc.writeln('foo')
         doc.include_doc_string('<p>this is a <code>test</code></p>')
         doc.remove_last_doc_string()
         self.assertEqual(doc.getvalue(), six.b('foo\n'))
+
+    def test_add_links(self):
+        doc = ReSTDocument()
+        doc.hrefs['foo'] = 'https://example.com/'
+        self.assertEqual(
+            doc.getvalue(), six.b('\n\n.. _foo: https://example.com/\n'))
 
 
 class TestDocumentStructure(unittest.TestCase):

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -146,6 +146,16 @@ class TestStyle(unittest.TestCase):
             style.doc.getvalue(),
             six.b(''))
 
+    def test_href_link(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_a(attrs=[('href', 'http://example.org')])
+        style.doc.write('example')
+        style.end_a()
+        self.assertEqual(
+            style.doc.getvalue(),
+            six.b('`example <http://example.org>`_ ')
+        )
+
     def test_escape_href_link(self):
         style = ReSTStyle(ReSTDocument())
         style.start_a(attrs=[('href', 'http://example.org')])
@@ -153,8 +163,7 @@ class TestStyle(unittest.TestCase):
         style.end_a()
         self.assertEqual(
             style.doc.getvalue(),
-            six.b('`foo\\: the next bar`_ \n\n.. _foo\\: the next '
-                  'bar: http://example.org\n'))
+            six.b('`foo\\: the next bar <http://example.org>`_ '))
 
     def test_handle_no_text_hrefs(self):
         style = ReSTStyle(ReSTDocument())


### PR DESCRIPTION
rst typically has links offloaded to another part of the document to
improve readability, but also allows directly embedded URIs. This
changes our doc behavior to always use embedded URIs because there
are several cases where the same string will have different targets
throughout a page. Since these rst files are immediately converted
to html or some other format, it isn't important to make them super
pretty.

Fixes #863

cc @stealthycoin @dstufft @joguSD