### PR TITLE
Fix escaped characters in shared example doc generation

### DIFF
--- a/botocore/docs/sharedexample.py
+++ b/botocore/docs/sharedexample.py
@@ -13,6 +13,7 @@
 import re
 import numbers
 from botocore.utils import parse_timestamp
+from botocore.docs.utils import escape_controls
 from botocore.compat import six
 
 
@@ -165,7 +166,8 @@ class SharedExampleDocumenter(object):
     def _document_str(self, section, value, path):
         # We do the string conversion because this might accept a type that
         # we don't specifically address.
-        section.write(u"'%s'," % six.text_type(value))
+        safe_value = escape_controls(value)
+        section.write(u"'%s'," % six.text_type(safe_value))
 
     def _document_number(self, section, value, path):
         section.write("%s," % str(value))

--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import re
 from collections import namedtuple
 
 
@@ -177,3 +178,20 @@ class AppendParamDocumentation(object):
             description_section = section.get_section(
                 'param-documentation')
             description_section.writeln(self._doc_string)
+
+
+_CONTROLS = {
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+    '\b': '\\b',
+    '\f': '\\f',
+}
+# Combines all CONTROLS keys into a big or regular expression
+_ESCAPE_CONTROLS_RE = re.compile('|'.join(map(re.escape, _CONTROLS)))
+# Based on the match get the appropriate replacement from CONTROLS
+_CONTROLS_MATCH_HANDLER = lambda match: _CONTROLS[match.group(0)]
+
+
+def escape_controls(value):
+    return _ESCAPE_CONTROLS_RE.sub(_CONTROLS_MATCH_HANDLER, value)

--- a/tests/unit/docs/test_sharedexample.py
+++ b/tests/unit/docs/test_sharedexample.py
@@ -299,3 +299,22 @@ class TestSharedExampleDocumenter(BaseDocsTest):
             u"    foo='\u2713'",
             u")"
         ])
+
+    def test_escape_character_example(self):
+        self.add_shape_to_params('foo', 'String')
+        self.documenter.document_shared_example(
+            example={
+                'output': {
+                    'foo': 'good\n\rintentions!\n\r'
+                }
+            },
+            prefix='foo.bar',
+            section=self.doc_structure,
+            operation_model=self.operation_model
+        )
+        self.assert_contains_lines_in_order([
+            "Expected Output:",
+            "  {",
+            "      'foo': 'good\\n\\rintentions!\\n\\r',",
+            "  }",
+        ])

--- a/tests/unit/docs/test_utils.py
+++ b/tests/unit/docs/test_utils.py
@@ -18,6 +18,7 @@ from botocore.docs.utils import get_official_service_name
 from botocore.docs.utils import AutoPopulatedParam
 from botocore.docs.utils import HideParamFromOperations
 from botocore.docs.utils import AppendParamDocumentation
+from botocore.docs.utils import escape_controls
 
 
 class TestPythonTypeName(unittest.TestCase):
@@ -217,3 +218,10 @@ class TestAppendParamDocumentation(BaseDocsTest):
             'docs.request-params', self.doc_structure)
         self.assert_contains_line('foo\n')
         self.assert_contains_line('hello!')
+
+
+class TestEscapeControls(unittest.TestCase):
+    def test_escapes_controls(self):
+        escaped = escape_controls('\na\rb\tc\fd\be')
+        self.assertEquals(escaped, '\\na\\rb\\tc\\fd\\be')
+


### PR DESCRIPTION
Some shared examples have escape characters in them that get interpolated and rendered into the generated documentation which causes issues when we hand it off to sphinx.

Before:
<img width="956" alt="screen shot 2017-07-28 at 2 03 44 pm" src="https://user-images.githubusercontent.com/1935727/28736445-aeaadb66-739e-11e7-804c-1f66718661b0.png">

After:
<img width="838" alt="screen shot 2017-07-28 at 2 10 04 pm" src="https://user-images.githubusercontent.com/1935727/28736457-b2bd102a-739e-11e7-9e0f-b8e34f36ae68.png">
