### PR TITLE
Default to 'Unknown' when Error key is missing in response

### DIFF
--- a/.changes/next-release/bugfix-Exceptions-23441.json
+++ b/.changes/next-release/bugfix-Exceptions-23441.json
@@ -1,0 +1,5 @@
+{
+  "category": "Exceptions", 
+  "type": "bugfix", 
+  "description": "Default to 'Unknown' when error response is missing 'Error' key"
+}

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -350,9 +350,10 @@ class ClientError(Exception):
 
     def __init__(self, error_response, operation_name):
         retry_info = self._get_retry_info(error_response)
+        error = error_response.get('Error', {})
         msg = self.MSG_TEMPLATE.format(
-            error_code=error_response['Error'].get('Code', 'Unknown'),
-            error_message=error_response['Error'].get('Message', 'Unknown'),
+            error_code=error.get('Code', 'Unknown'),
+            error_message=error.get('Message', 'Unknown'),
             operation_name=operation_name,
             retry_info=retry_info,
         )

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -62,3 +62,19 @@ def test_retry_info_not_added_if_retry_attempts_not_present():
         raise AssertionError("Retry information should not be in exception "
                              "message when retry attempts not in response "
                              "metadata: %s" % error_msg)
+
+
+def test_can_handle_when_response_missing_error_key():
+    response = {
+        'ResponseMetadata': {
+            'HTTPHeaders': {},
+            'HTTPStatusCode': 503,
+            'MaxAttemptsReached': True,
+            'RetryAttempts': 4
+        }
+    }
+    e = exceptions.ClientError(response, 'SomeOperation')
+    if 'An error occurred (Unknown)' not in str(e):
+        raise AssertionError(
+            "Error code should default to 'Unknown' "
+            "when missing error response, instead got: %s" % str(e))


### PR DESCRIPTION
Fixes #1254.