### PR TITLE
Avoid noisy logging on INFO level.

### DIFF
--- a/botocore/vendored/requests/packages/urllib3/connectionpool.py
+++ b/botocore/vendored/requests/packages/urllib3/connectionpool.py
@@ -199,7 +199,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         Return a fresh :class:`HTTPConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTP connection (%d): %s" %
+        log.debug("Starting new HTTP connection (%d): %s" %
                  (self.num_connections, self.host))
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
@@ -731,7 +731,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         Return a fresh :class:`httplib.HTTPSConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTPS connection (%d): %s"
+        log.debug("Starting new HTTPS connection (%d): %s"
                  % (self.num_connections, self.host))
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:


### PR DESCRIPTION
Log starting new HTTP connection on `DEBUG` level, but not `INFO`.
Logging such things for every connection, which can be hundreds per second, as `INFO` is a noisy trash in the logs and even an unnecessary information.

See also boto/boto3#1208