### PR TITLE
Add keyring support to config credential provider

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -733,9 +733,16 @@ class ConfigProvider(CredentialProvider):
                         logger.error("The keyring module could not be imported."
                             " For keyring support, install the keyring module.")
                         raise
-                    access_key = project_config[self.ACCESS_KEY]
+                    try:
+                        access_key = profile_config[self.ACCESS_KEY]
+                    except KeyError:
+                        raise PartialCredentialsError(provider=self.METHOD,
+                                                      cred_var=self.ACCESS_KEY)
                     secret_key = keyring.get_password(self._profile_name,
                                                       access_key)
+                    if secret_key is None:
+                        raise PartialCredentialsError(provider=self.METHOD,
+                                                      cred_var=self.SECRET_KEY)
                 else:
                     access_key, secret_key = self._extract_creds_from_mapping(
                         profile_config, self.ACCESS_KEY, self.SECRET_KEY)

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -25,6 +25,7 @@ if python_version == '2.6':
 
 run('pip install -r requirements.txt')
 run('pip install coverage')
+run('pip install keyring')
 if os.path.isdir('dist') and os.listdir('dist'):
     shutil.rmtree('dist')
 run('python setup.py bdist_wheel')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,7 +24,16 @@ import platform
 import select
 import datetime
 from subprocess import Popen, PIPE
-import keyring
+
+try:
+    import keyring
+    from keyring.backend import KeyringBackend
+    HAS_KEYRING = True
+except ImportError:
+    class KeyringBackend(object):
+        pass
+
+    HAS_KEYRING = False
 
 from dateutil.tz import tzlocal
 # The unittest module got a significant overhaul
@@ -79,6 +88,8 @@ def create_session(**kwargs):
 
 @contextlib.contextmanager
 def temporary_set_keyring_backend(keyring_backend):
+    if not HAS_KEYRING:
+        return
     orig_keyring_backend = keyring.get_keyring()
     keyring.set_keyring(keyring_backend)
     yield
@@ -258,7 +269,7 @@ class ClientDriver(object):
                 "Error from command '%s': %s" % (cmd, result))
 
 
-class DummyKeyringBackend(keyring.backend.KeyringBackend):
+class DummyKeyringBackend(KeyringBackend):
     priority = 1
 
     def __init__(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -537,6 +537,7 @@ class TestConfigFileProvider(BaseEnvVar):
             provider.load()
 
     # Pretend that the keyring package is not installed
+    @unittest.skipIf(sys.version_info < (2, 7), "Keyring package does not support python2.6")
     @mock.patch.dict(sys.modules, {"keyring": None})
     def test_keyring_import_error(self):
         profile_config = {
@@ -550,6 +551,7 @@ class TestConfigFileProvider(BaseEnvVar):
         with self.assertRaises(ImportError):
             provider.load()
 
+    @unittest.skipIf(sys.version_info < (2, 7), "Keyring package does not support python2.6")
     def test_secret_key_from_keyring(self):
         keyring_backend = DummyKeyringBackend()
         keyring_backend.set_password('default', 'a', 'b')
@@ -570,6 +572,7 @@ class TestConfigFileProvider(BaseEnvVar):
         self.assertEqual(creds.secret_key, 'b')
         self.assertEqual(creds.method, 'config-file')
 
+    @unittest.skipIf(sys.version_info < (2, 7), "Keyring package does not support python2.6")
     def test_secret_key_not_in_keyring(self):
         keyring_backend = DummyKeyringBackend()
 


### PR DESCRIPTION
This adds support for the keyring module to the config credential provider. This allows users to store just the access key in a config file while keeping the secret key in a more secure storage facility. The excellent keyring module handles all of the cross-platform code required to make this work.

There have been numerous discussions about this in the past, including some currently open feature requests. Support for it was in boto2, but never made it across to boto3/botocore. Despite a lot of work being put in for #72, that PR was never merged due to the belief that it would make more sense for the
keyring to be set up as an external credential provider plugin.

I don't believe this is the optimal approach. The point of having keyring support at all is to automate the process of retrieving the credentials while still keeping the secret key in a secure storage facility. This process still requires some configuration - namely, the profile name and the access key. This
configuration still has to go somewhere, and the AWS config file is the best choice as far as I can tell. It follows that integrating keyring support into the config credential provider makes the most sense.

The other reason for having this go into the core config credential provider rather than act as a third party plugin is down to the fact that a lot of the time users are not interacting with botocore directly. Rather, they are using the AWS CLI tool, or through ansible's various modules, or some other
integration on top of botocore.

The issue of integrating keyring support so it can be used automatically by AWS CLI was raised again [last year](https://github.com/boto/boto3/issues/629#issuecomment-221467941). Unfortunately, it appears no answer was provided by any of the boto maintainers. I definitely agree with @handlerbot that having this integrated into one of the projects as core functionality would make everyones' lives easier.

Please note that at this stage I have only added support for the AWS config file, due to the documentation stating that the boto config file is mainly for backwards compatibility with boto2. However I would be happy to update the PR and extend to the boto config file too if that is desired.