### PR TITLE
Athena GetQueryResults pagination fix

### DIFF
--- a/.changes/next-release/bugfix-Paginator-865.json
+++ b/.changes/next-release/bugfix-Paginator-865.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "Fix Athena GetQueryResults paginator"
+}

--- a/botocore/data/athena/2017-05-18/paginators-1.json
+++ b/botocore/data/athena/2017-05-18/paginators-1.json
@@ -16,7 +16,8 @@
       "input_token": "NextToken",
       "output_token": "NextToken",
       "limit_key": "MaxResults",
-      "result_key": "ResultSet"
+      "result_key": "ResultSet.Rows",
+      "non_aggregate_keys": ["ResultSet.ResultSetMetadata"]
     }
   }
 }


### PR DESCRIPTION
The paginator for Athena's GetQueryResults was pointing to the top level structure `ResultSet` rather than the aggregate key `ResultSet.Rows`. In fixing this I added a functional test that verifies all `result_key`s defined in a paginator config point to a type that we can support aggregation for. There are currently 3 paginators that have a `result_key` that point to a type that we do not support aggregation for, hence why the travis build fails. 

1) Apigateway's [GetUsage](https://github.com/boto/botocore/blob/8e809c053dcccb03b0a563392f2e4fcc6d992071/botocore/data/apigateway/2015-07-09/paginators-1.json#L51) `items`. [Return structure](http://botocore.readthedocs.io/en/latest/reference/services/apigateway.html#APIGateway.Client.get_usage)
2) Devicefarm's [ListUniqueProblems](https://github.com/boto/botocore/blob/8e809c053dcccb03b0a563392f2e4fcc6d992071/botocore/data/devicefarm/2015-06-23/paginators-1.json#L48) `uniqueProblems`. [Return structure](http://botocore.readthedocs.io/en/latest/reference/services/devicefarm.html#DeviceFarm.Client.list_unique_problems)
3) Devicefarm's [GetOfferingStatus](https://github.com/boto/botocore/blob/8e809c053dcccb03b0a563392f2e4fcc6d992071/botocore/data/devicefarm/2015-06-23/paginators-1.json#L58) `current`. [Return structure](http://botocore.readthedocs.io/en/latest/reference/services/devicefarm.html#DeviceFarm.Client.get_offering_status)

Any `result_key` that has a type that is not supported will drop any results after the first request, making no attempt to aggregate. Requests will continue to be made until the pagination is exhausted or errors. Effectively, you get the first page of results and no `NextToken` and is strictly a downgrade from not using pagination. We'll either need to figure out proper pagination support for these (whatever that means for a `Map` type) or remove the paginators for them as they do more harm than good.

For now I've split the PR into the athena pagination fix and the paginator config validation. Other PR: https://github.com/boto/botocore/pull/1264