### PR TITLE
Expose waiter configuration

### DIFF
--- a/.changes/next-release/feature-Waiter-54293.json
+++ b/.changes/next-release/feature-Waiter-54293.json
@@ -1,0 +1,5 @@
+{
+  "category": "Waiter",
+  "type": "feature",
+  "description": "Expose configurable waiter interface"
+}

--- a/botocore/docs/waiter.py
+++ b/botocore/docs/waiter.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore import xform_name
+from botocore.compat import OrderedDict
+from botocore.docs.utils import DocumentedShape
 from botocore.utils import get_service_module_name
 from botocore.docs.method import document_model_driven_method
 
@@ -82,6 +84,29 @@ def document_wait_method(section, waiter_name, event_emitter,
     operation_model = service_model.operation_model(
         waiter_model.operation)
 
+    waiter_config_members = OrderedDict()
+
+    waiter_config_members['Delay'] = DocumentedShape(
+        name='Delay', type_name='integer',
+        documentation=(
+            '<p>The amount of time in seconds to wait between '
+            'attempts. Default: {0}</p>'.format(waiter_model.delay)))
+
+    waiter_config_members['MaxAttempts'] = DocumentedShape(
+        name='MaxAttempts', type_name='integer',
+        documentation=(
+            '<p>The maximum number of attempts to be made. '
+            'Default: {0}</p>'.format(waiter_model.max_attempts)))
+
+    botocore_waiter_params = [
+        DocumentedShape(
+            name='WaiterConfig', type_name='structure',
+            documentation=(
+                '<p>A dictionary that provides parameters to control '
+                'waiting behavior.</p>'),
+            members=waiter_config_members)
+    ]
+
     wait_description = (
         'Polls :py:meth:`{0}.Client.{1}` every {2} '
         'seconds until a successful state is reached. An error is '
@@ -96,6 +121,7 @@ def document_wait_method(section, waiter_name, event_emitter,
         event_emitter=event_emitter,
         method_description=wait_description,
         example_prefix='waiter.wait',
+        include_input=botocore_waiter_params,
         document_output=False,
         include_signature=include_signature
     )

--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -287,9 +287,11 @@ class Waiter(object):
     def wait(self, **kwargs):
         acceptors = list(self.config.acceptors)
         current_state = 'waiting'
-        sleep_amount = self.config.delay
+        # pop the invocation specific config
+        config = kwargs.pop('WaiterConfig', {})
+        sleep_amount = config.get('Delay', self.config.delay)
+        max_attempts = config.get('MaxAttempts', self.config.max_attempts)
         num_attempts = 0
-        max_attempts = self.config.max_attempts
 
         while True:
             response = self._operation_method(**kwargs)

--- a/tests/unit/docs/test_waiter.py
+++ b/tests/unit/docs/test_waiter.py
@@ -47,5 +47,14 @@ class TestWaiterDocumenter(BaseDocsTest):
             '      )',
             '    :type Biz: string',
             '    :param Biz:',
+            '    :type WaiterConfig: dict',
+            '    :param WaiterConfig:',
+            ('A dictionary that provides parameters to control waiting '
+             'behavior.'),
+            '     - **Delay** *(integer) --*',
+            ('        The amount of time in seconds to wait between attempts. '
+             'Default: 15'),
+            '      - **MaxAttempts** *(integer) --*',
+            '        The maximum number of attempts to be made. Default: 40',
             '    :returns: None'
         ])


### PR DESCRIPTION
Adding so we can properly address https://github.com/aws/aws-cli/pull/2761

This will allow `WaiterConfig` to be passed to `waiter.wait()` calls allowing customers to adjust waiter's `maxAttempts` and `delay` settings. This is based on how `PaginationConfig` works. The current keys are formatted to match the waiter models.

```
waiter.wait(WaiterConfig={
    'delay': 5,
    'maxAttempts': 5,
})
```