### PR TITLE
Make links anonymous

### DIFF
--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -227,11 +227,11 @@ class ReSTStyle(BaseStyle):
                 # case then there was no link text.  We should just
                 # use an inline link.  The syntax of this is
                 # `<http://url>`_
-                self.doc.push_write('`<%s>`_' % self.a_href)
+                self.doc.push_write('`<%s>`__' % self.a_href)
             else:
                 self.doc.push_write(self.a_href)
                 self.doc.hrefs[self.a_href] = self.a_href
-                self.doc.write('`_')
+                self.doc.write('`__')
             self.a_href = None
         self.doc.write(' ')
 

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -220,7 +220,7 @@ class ReSTStyle(BaseStyle):
                 if ':' in last_write:
                     last_write = last_write.replace(':', r'\:')
                 self.doc.push_write(last_write)
-                self.doc.push_write(' <%s>`_' % self.a_href)
+                self.doc.push_write(' <%s>`__' % self.a_href)
             elif last_write == '`':
                 # Look at start_a().  It will do a self.doc.write('`')
                 # which is the start of the link title.  If that is the

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -170,7 +170,7 @@ class TestStyle(unittest.TestCase):
         style.start_a(attrs=[('href', 'http://example.org')])
         style.end_a()
         self.assertEqual(style.doc.getvalue(),
-                         six.b('`<http://example.org>`_ '))
+                         six.b('`<http://example.org>`__ '))
 
     def test_sphinx_reference_label_html(self):
         style = ReSTStyle(ReSTDocument())

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -153,7 +153,7 @@ class TestStyle(unittest.TestCase):
         style.end_a()
         self.assertEqual(
             style.doc.getvalue(),
-            six.b('`example <http://example.org>`_ ')
+            six.b('`example <http://example.org>`__ ')
         )
 
     def test_escape_href_link(self):
@@ -163,7 +163,7 @@ class TestStyle(unittest.TestCase):
         style.end_a()
         self.assertEqual(
             style.doc.getvalue(),
-            six.b('`foo\\: the next bar <http://example.org>`_ '))
+            six.b('`foo\\: the next bar <http://example.org>`__ '))
 
     def test_handle_no_text_hrefs(self):
         style = ReSTStyle(ReSTDocument())


### PR DESCRIPTION
Sphinx will throw warnings if you have two uri's with the same name
but different targets because it helpfully assumes your intent was
to make an embedded uri global. This add an additional underscore to
the end of those links to make Sphinx treat them as 'anonymous'.

The links do still work properly without this change, but the CLI
will spit out warnings without it, which is not a great customer
experience.

Fixes #1268
Fixes aws/aws-cli#2786