### PR TITLE
Allow Zero for passwordUsePreventionType minimum value

### DIFF
--- a/botocore/data/iam/2010-05-08/service-2.json
+++ b/botocore/data/iam/2010-05-08/service-2.json
@@ -6633,7 +6633,7 @@
       "type":"integer",
       "box":true,
       "max":24,
-      "min":1
+      "min":0
     },
     "passwordType":{
       "type":"string",


### PR DESCRIPTION
Zero is a valid value for PasswordReusePrevention. It disables reuse checking and is the default.  From line 6011 in the same file:
> Specifies the number of previous passwords that IAM users are prevented from reusing. The default value of 0 means IAM users are not prevented from reusing previous passwords. Default value: 0.