### PR TITLE
Add a waiter to Athena

### DIFF
--- a/botocore/data/athena/2017-05-18/waiters-2.json
+++ b/botocore/data/athena/2017-05-18/waiters-2.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "waiters": {
+    "QuerySucceeded": {
+      "delay": 5,
+      "operation": "GetQueryExecution",
+      "maxAttempts": 30,
+      "acceptors": [
+        {
+          "expected": "SUCCEEDED",
+          "matcher": "path",
+          "argument": "QueryExecution.Status",
+          "state": "success"
+        },
+        {
+          "expected": "CANCELLED",
+          "matcher": "path",
+          "argument": "QueryExecution.Status",
+          "state": "failure"
+        },
+        {
+          "expected": "FAILED",
+          "matcher": "path",
+          "argument": "QueryExecution.Status",
+          "state": "failure"
+        }
+      ]
+    }
+  }
+}

--- a/botocore/data/athena/2017-05-18/waiters-2.json
+++ b/botocore/data/athena/2017-05-18/waiters-2.json
@@ -9,19 +9,19 @@
         {
           "expected": "SUCCEEDED",
           "matcher": "path",
-          "argument": "QueryExecution.Status",
+          "argument": "QueryExecution.Status.State",
           "state": "success"
         },
         {
           "expected": "CANCELLED",
           "matcher": "path",
-          "argument": "QueryExecution.Status",
+          "argument": "QueryExecution.Status.State",
           "state": "failure"
         },
         {
           "expected": "FAILED",
           "matcher": "path",
-          "argument": "QueryExecution.Status",
+          "argument": "QueryExecution.Status.State",
           "state": "failure"
         }
       ]


### PR DESCRIPTION
Hello 👋 
I've been recently working with Athena, and I found it useful to create a waiter for the query to be successful (so the results can be accessed and used in one script).

Changes:
- Add a waiter called `QuerySucceeded` to Athena's waiters.
- Success: `QueryExecution.Status.State` = `SUCCEEDED`
- Failure: `QueryExecution.Status.State` = `CANCELLED` or `FAILED`
- Keep waiting (implicit): `QueryExecution.Status.State` = `QUEUED` or `RUNNING`

The way I see it there's no change to the actual logic, so no tests are required. But please let me know if I missed that.

Have a great day!