### PR TITLE
Change result_key for kinesis to StreamDescription

### DIFF
--- a/botocore/data/kinesis/2013-12-02/paginators-1.json
+++ b/botocore/data/kinesis/2013-12-02/paginators-1.json
@@ -5,7 +5,7 @@
       "limit_key": "Limit",
       "more_results": "StreamDescription.HasMoreShards",
       "output_token": "StreamDescription.Shards[-1].ShardId",
-      "result_key": "StreamDescription.Shards",
+      "result_key": "StreamDescription",
       "non_aggregate_keys": [
         "StreamDescription.StreamARN",
         "StreamDescription.StreamName",


### PR DESCRIPTION
I'm not sure if this change is preferred behavior, but it should fix this issue: https://github.com/aws/aws-cli/issues/2001

When result_key is StreamDescription.Shards, you can't query for the ARN with "--output text" without "--no-paginate" but you can with "--output json", so I figured this was a paginating issue.