### PR TITLE
Add retry for Glacier RequestTimeoutException

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -198,6 +198,20 @@
         }
       }
     },
+    "glacier": {
+      "__default__": {
+        "policies": {
+          "timeouts": {
+            "applies_when": {
+              "response": {
+                "http_status_code": 408,
+                "service_error_code": "RequestTimeoutException"
+              }
+            }
+          }
+        }
+      }
+    },
     "route53": {
       "__default__": {
         "policies": {


### PR DESCRIPTION
According to http://docs.aws.amazon.com/amazonglacier/latest/dev/api-error-responses.html, Glacier replies with a RequestTimeoutException when the upload takes too long. Since this could be due to network conditions, it makes sense to retry in this case.