### PR TITLE
Add Lifecyle Waiters for Autoscaling

### DIFF
--- a/botocore/data/autoscaling/2011-01-01/waiters-2.json
+++ b/botocore/data/autoscaling/2011-01-01/waiters-2.json
@@ -1,0 +1,31 @@
+{
+  "version": 2,
+  "waiters": {
+    "LifecycleStateInService": {
+      "operation": "DescribeAutoScalingInstances",
+      "maxAttempts": 40,
+      "delay": 15,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "pathAll",
+          "argument": "AutoScalingInstances[].LifecycleState",
+          "expected": "InService"
+        }
+      ]
+    },
+    "LifecycleStateStandby": {
+      "operation": "DescribeAutoScalingInstances",
+      "maxAttempts": 40,
+      "delay": 15,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "pathAll",
+          "argument": "AutoScalingInstances[].LifecycleState",
+          "expected": "Standby"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add Waiters for `enter_standby` and `exit_standby` results.