### PR TITLE
Sanitize sigv4 canonical host header

### DIFF
--- a/.changes/next-release/bugfix-sigv4-42389.json
+++ b/.changes/next-release/bugfix-sigv4-42389.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "sigv4",
+  "description": "Strip out the default port and http auth info when computing the host header for sigv4 signing."
+}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -185,7 +185,12 @@ class SigV4Auth(BaseSigner):
 
     def _canonical_host(self, url):
         url_parts = urlsplit(url)
-        if url_parts.port == 80:
+        default_ports = {
+            'http': 80,
+            'https': 443
+        }
+        if any(url_parts.scheme == scheme and url_parts.port == port
+               for scheme, port in default_ports.items()):
             # No need to include the port if it's the default port.
             return url_parts.hostname
         # Strip out auth if it's present in the netloc.

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -559,6 +559,24 @@ class TestSigV4(unittest.TestCase):
         headers = auth.canonical_headers(original)
         self.assertEqual(headers, 'foo:leading and trailing')
 
+    def test_strips_default_port(self):
+        request = AWSRequest()
+        request.url = 'https://s3.us-west-2.amazonaws.com:80/'
+        request.method = 'GET'
+        auth = self.create_signer('s3', 'us-west-2')
+        actual = auth.headers_to_sign(request)['host']
+        expected = 's3.us-west-2.amazonaws.com'
+        self.assertEqual(actual, expected)
+
+    def test_strips_http_auth(self):
+        request = AWSRequest()
+        request.url = 'https://username:password@s3.us-west-2.amazonaws.com/'
+        request.method = 'GET'
+        auth = self.create_signer('s3', 'us-west-2')
+        actual = auth.headers_to_sign(request)['host']
+        expected = 's3.us-west-2.amazonaws.com'
+        self.assertEqual(actual, expected)
+
 
 class TestSigV4Resign(BaseTestWithFixedDate):
 

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -577,6 +577,15 @@ class TestSigV4(unittest.TestCase):
         expected = 's3.us-west-2.amazonaws.com'
         self.assertEqual(actual, expected)
 
+    def test_strips_default_port_and_http_auth(self):
+        request = AWSRequest()
+        request.url = 'https://username:password@s3.us-west-2.amazonaws.com:80'
+        request.method = 'GET'
+        auth = self.create_signer('s3', 'us-west-2')
+        actual = auth.headers_to_sign(request)['host']
+        expected = 's3.us-west-2.amazonaws.com'
+        self.assertEqual(actual, expected)
+
 
 class TestSigV4Resign(BaseTestWithFixedDate):
 

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -559,9 +559,18 @@ class TestSigV4(unittest.TestCase):
         headers = auth.canonical_headers(original)
         self.assertEqual(headers, 'foo:leading and trailing')
 
-    def test_strips_default_port(self):
+    def test_strips_http_default_port(self):
         request = AWSRequest()
-        request.url = 'https://s3.us-west-2.amazonaws.com:80/'
+        request.url = 'http://s3.us-west-2.amazonaws.com:80/'
+        request.method = 'GET'
+        auth = self.create_signer('s3', 'us-west-2')
+        actual = auth.headers_to_sign(request)['host']
+        expected = 's3.us-west-2.amazonaws.com'
+        self.assertEqual(actual, expected)
+
+    def test_strips_https_default_port(self):
+        request = AWSRequest()
+        request.url = 'https://s3.us-west-2.amazonaws.com:443/'
         request.method = 'GET'
         auth = self.create_signer('s3', 'us-west-2')
         actual = auth.headers_to_sign(request)['host']
@@ -579,7 +588,7 @@ class TestSigV4(unittest.TestCase):
 
     def test_strips_default_port_and_http_auth(self):
         request = AWSRequest()
-        request.url = 'https://username:password@s3.us-west-2.amazonaws.com:80'
+        request.url = 'http://username:password@s3.us-west-2.amazonaws.com:80/'
         request.method = 'GET'
         auth = self.create_signer('s3', 'us-west-2')
         actual = auth.headers_to_sign(request)['host']


### PR DESCRIPTION
This strips out the port on the host header if using the default port
80. It also strips out the http username and password. That was being
included because urlsplit returns it as part of the netloc.

Fixes aws/aws-cli#2883