### PR TITLE
adding missing SecurityGroups paginator

### DIFF
--- a/botocore/data/ec2/2016-11-15/paginators-1.json
+++ b/botocore/data/ec2/2016-11-15/paginators-1.json
@@ -23,6 +23,12 @@
       "output_token": "NextToken",
       "result_key": "ReservedInstancesModifications"
     },
+    "DescribeSecurityGroups": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "SecurityGroups"
+    },
     "DescribeSnapshots": {
       "input_token": "NextToken",
       "output_token": "NextToken",


### PR DESCRIPTION
This PR adds the paginator for DescribeSecurityGroups. Right now it looks like a couple tests in boto3 are failing because this paginator is missing.