### PR TITLE
Switch from absolute imports to relative imports

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -19,10 +19,10 @@ considered internal, and *not* a public API.
 import copy
 import logging
 
-import botocore.serialize
-from botocore.signers import RequestSigner
-from botocore.config import Config
-from botocore.endpoint import EndpointCreator
+from . import serialize, parsers
+from .signers import RequestSigner
+from .config import Config
+from .endpoint import EndpointCreator
 
 
 logger = logging.getLogger(__name__)
@@ -78,9 +78,9 @@ class ClientArgsCreator(object):
             proxies=new_config.proxies,
             timeout=(new_config.connect_timeout, new_config.read_timeout))
 
-        serializer = botocore.serialize.create_serializer(
+        serializer = serialize.create_serializer(
             protocol, parameter_validation)
-        response_parser = botocore.parsers.create_parser(protocol)
+        response_parser = parsers.create_parser(protocol)
         return {
             'serializer': serializer,
             'endpoint': endpoint,

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -24,16 +24,16 @@ import time
 import calendar
 import json
 
-from botocore.exceptions import NoCredentialsError
-from botocore.utils import normalize_url_path, percent_encode_sequence
-from botocore.compat import HTTPHeaders
-from botocore.compat import quote, unquote, urlsplit, parse_qs
-from botocore.compat import urlunsplit
-from botocore.compat import encodebytes
-from botocore.compat import six
-from botocore.compat import json
-from botocore.compat import MD5_AVAILABLE
-from botocore.compat import ensure_unicode
+from .exceptions import NoCredentialsError
+from .utils import normalize_url_path, percent_encode_sequence
+from .compat import HTTPHeaders
+from .compat import quote, unquote, urlsplit, parse_qs
+from .compat import urlunsplit
+from .compat import encodebytes
+from .compat import six
+from .compat import json
+from .compat import MD5_AVAILABLE
+from .compat import ensure_unicode
 
 logger = logging.getLogger(__name__)
 

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -18,20 +18,18 @@ import functools
 import socket
 import inspect
 
-from botocore.compat import six
-from botocore.compat import HTTPHeaders, HTTPResponse, urlunsplit, urlsplit,\
-    urlparse
-from botocore.exceptions import UnseekableStreamError
-from botocore.utils import percent_encode_sequence
-from botocore.vendored.requests import models
-from botocore.vendored.requests.sessions import REDIRECT_STATI
-from botocore.vendored.requests.packages.urllib3.connection import \
+from .compat import six
+from .compat import HTTPHeaders, HTTPResponse, urlunsplit, urlsplit, urlparse
+from .exceptions import UnseekableStreamError
+from .utils import percent_encode_sequence
+from .vendored.requests import models
+from .vendored.requests.sessions import REDIRECT_STATI
+from .vendored.requests.packages.urllib3.connection import \
     VerifiedHTTPSConnection
-from botocore.vendored.requests.packages.urllib3.connection import \
-    HTTPConnection
-from botocore.vendored.requests.packages.urllib3.connectionpool import \
+from .vendored.requests.packages.urllib3.connection import HTTPConnection
+from .vendored.requests.packages.urllib3.connectionpool import \
     HTTPConnectionPool
-from botocore.vendored.requests.packages.urllib3.connectionpool import \
+from .vendored.requests.packages.urllib3.connectionpool import \
     HTTPSConnectionPool
 
 

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -13,30 +13,30 @@
 import logging
 import functools
 
-from botocore import waiter, xform_name
-from botocore.auth import AUTH_TYPE_MAPS
-from botocore.awsrequest import prepare_request_dict
-from botocore.docs.docstring import ClientMethodDocstring
-from botocore.docs.docstring import PaginatorDocstring
-from botocore.exceptions import ClientError, DataNotFoundError
-from botocore.exceptions import OperationNotPageableError
-from botocore.exceptions import UnknownSignatureVersionError
-from botocore.hooks import first_non_none_response
-from botocore.model import ServiceModel
-from botocore.paginate import Paginator
-from botocore.utils import CachedProperty
-from botocore.utils import get_service_module_name
-from botocore.utils import switch_host_s3_accelerate
-from botocore.utils import S3RegionRedirector
-from botocore.utils import fix_s3_host
-from botocore.utils import switch_to_virtual_host_style
-from botocore.utils import S3_ACCELERATE_WHITELIST
-from botocore.args import ClientArgsCreator
-from botocore.compat import urlsplit
-from botocore import UNSIGNED
+from . import waiter, xform_name
+from .auth import AUTH_TYPE_MAPS
+from .awsrequest import prepare_request_dict
+from .docs.docstring import ClientMethodDocstring
+from .docs.docstring import PaginatorDocstring
+from .exceptions import ClientError, DataNotFoundError
+from .exceptions import OperationNotPageableError
+from .exceptions import UnknownSignatureVersionError
+from .hooks import first_non_none_response
+from .model import ServiceModel
+from .paginate import Paginator
+from .utils import CachedProperty
+from .utils import get_service_module_name
+from .utils import switch_host_s3_accelerate
+from .utils import S3RegionRedirector
+from .utils import fix_s3_host
+from .utils import switch_to_virtual_host_style
+from .utils import S3_ACCELERATE_WHITELIST
+from .args import ClientArgsCreator
+from .compat import urlsplit
+from . import UNSIGNED
 # Keep this imported.  There's pre-existing code that uses
 # "from botocore.client import Config".
-from botocore.config import Config
+from .config import Config
 
 
 logger = logging.getLogger(__name__)

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -19,15 +19,15 @@ import warnings
 import hashlib
 import logging
 
-from botocore.vendored import six
-from botocore.exceptions import MD5UnavailableError
-from botocore.vendored.requests.packages.urllib3 import exceptions
+from .vendored import six
+from .exceptions import MD5UnavailableError
+from .vendored.requests.packages.urllib3 import exceptions
 
 logger = logging.getLogger(__name__)
 
 
 if six.PY3:
-    from botocore.vendored.six.moves import http_client
+    from .vendored.six.moves import http_client
 
     class HTTPHeaders(http_client.HTTPMessage):
         pass

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -11,12 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import copy
-from botocore.compat import OrderedDict
+from .compat import OrderedDict
 
-from botocore.endpoint import DEFAULT_TIMEOUT, MAX_POOL_CONNECTIONS
-from botocore.exceptions import InvalidS3AddressingStyleError
-from botocore.exceptions import InvalidRetryConfigurationError
-from botocore.exceptions import InvalidMaxRetryAttemptsError
+from .endpoint import DEFAULT_TIMEOUT, MAX_POOL_CONNECTIONS
+from .exceptions import InvalidS3AddressingStyleError
+from .exceptions import InvalidRetryConfigurationError
+from .exceptions import InvalidMaxRetryAttemptsError
 
 
 class Config(object):

--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -16,9 +16,9 @@ import shlex
 import copy
 import sys
 
-from botocore.compat import six
+from .compat import six
 
-import botocore.exceptions
+from . import exceptions
 
 
 def multi_file_load_config(*filenames):
@@ -74,7 +74,7 @@ def multi_file_load_config(*filenames):
     for filename in filenames:
         try:
             loaded = load_config(filename)
-        except botocore.exceptions.ConfigNotFound:
+        except exceptions.ConfigNotFound:
             continue
         profiles.append(loaded.pop('profiles'))
         configs.append(loaded)
@@ -143,12 +143,12 @@ def raw_config_parse(config_filename, parse_subsections=True):
         path = os.path.expandvars(path)
         path = os.path.expanduser(path)
         if not os.path.isfile(path):
-            raise botocore.exceptions.ConfigNotFound(path=_unicode_path(path))
+            raise exceptions.ConfigNotFound(path=_unicode_path(path))
         cp = six.moves.configparser.RawConfigParser()
         try:
             cp.read([path])
         except six.moves.configparser.Error:
-            raise botocore.exceptions.ConfigParseError(
+            raise exceptions.ConfigParseError(
                 path=_unicode_path(path))
         else:
             for section in cp.sections():
@@ -162,7 +162,7 @@ def raw_config_parse(config_filename, parse_subsections=True):
                         try:
                             config_value = _parse_nested(config_value)
                         except ValueError:
-                            raise botocore.exceptions.ConfigParseError(
+                            raise exceptions.ConfigParseError(
                                 path=_unicode_path(path))
                     config[section][option] = config_value
     return config

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -22,18 +22,18 @@ from collections import namedtuple
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
 
-import botocore.configloader
-import botocore.compat
-from botocore.compat import total_seconds
-from botocore.exceptions import UnknownCredentialError
-from botocore.exceptions import PartialCredentialsError
-from botocore.exceptions import ConfigNotFound
-from botocore.exceptions import InvalidConfigError
-from botocore.exceptions import RefreshWithMFAUnsupportedError
-from botocore.exceptions import MetadataRetrievalError
-from botocore.exceptions import CredentialRetrievalError
-from botocore.utils import InstanceMetadataFetcher, parse_key_val_file
-from botocore.utils import ContainerMetadataFetcher
+from . import configloader
+from . import compat
+from .compat import total_seconds
+from .exceptions import UnknownCredentialError
+from .exceptions import PartialCredentialsError
+from .exceptions import ConfigNotFound
+from .exceptions import InvalidConfigError
+from .exceptions import RefreshWithMFAUnsupportedError
+from .exceptions import MetadataRetrievalError
+from .exceptions import CredentialRetrievalError
+from .utils import InstanceMetadataFetcher, parse_key_val_file
+from .utils import ContainerMetadataFetcher
 
 
 logger = logging.getLogger(__name__)
@@ -182,8 +182,8 @@ class Credentials(object):
         #
         # Eventually the service will decide whether to accept the credential.
         # This also complies with the behavior in Python 3.
-        self.access_key = botocore.compat.ensure_unicode(self.access_key)
-        self.secret_key = botocore.compat.ensure_unicode(self.secret_key)
+        self.access_key = compat.ensure_unicode(self.access_key)
+        self.secret_key = compat.ensure_unicode(self.secret_key)
 
     def get_frozen_credentials(self):
         return ReadOnlyCredentials(self.access_key,
@@ -227,8 +227,8 @@ class RefreshableCredentials(Credentials):
         self._normalize()
 
     def _normalize(self):
-        self._access_key = botocore.compat.ensure_unicode(self._access_key)
-        self._secret_key = botocore.compat.ensure_unicode(self._secret_key)
+        self._access_key = compat.ensure_unicode(self._access_key)
+        self._secret_key = compat.ensure_unicode(self._secret_key)
 
     @classmethod
     def create_from_metadata(cls, metadata, refresh_using, method):
@@ -659,7 +659,7 @@ class SharedCredentialProvider(CredentialProvider):
             profile_name = 'default'
         self._profile_name = profile_name
         if ini_parser is None:
-            ini_parser = botocore.configloader.raw_config_parse
+            ini_parser = configloader.raw_config_parse
         self._ini_parser = ini_parser
 
     def load(self):
@@ -707,7 +707,7 @@ class ConfigProvider(CredentialProvider):
         self._config_filename = config_filename
         self._profile_name = profile_name
         if config_parser is None:
-            config_parser = botocore.configloader.load_config
+            config_parser = configloader.load_config
         self._config_parser = config_parser
 
     def load(self):
@@ -750,7 +750,7 @@ class BotoProvider(CredentialProvider):
         if environ is None:
             environ = os.environ
         if ini_parser is None:
-            ini_parser = botocore.configloader.raw_config_parse
+            ini_parser = configloader.raw_config_parse
         self._environ = environ
         self._ini_parser = ini_parser
 

--- a/botocore/docs/__init__.py
+++ b/botocore/docs/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 
-from botocore.docs.service import ServiceDocumenter
+from .service import ServiceDocumenter
 
 
 def generate_docs(root_dir, session):

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -12,11 +12,11 @@
 # language governing permissions and limitations under the License.
 import inspect
 
-from botocore.docs.utils import get_official_service_name
-from botocore.docs.method import document_custom_method
-from botocore.docs.method import document_model_driven_method
-from botocore.docs.method import get_instance_public_methods
-from botocore.docs.sharedexample import document_shared_examples
+from .utils import get_official_service_name
+from .method import document_custom_method
+from .method import document_model_driven_method
+from .method import get_instance_public_methods
+from .sharedexample import document_shared_examples
 
 
 class ClientDocumenter(object):

--- a/botocore/docs/docstring.py
+++ b/botocore/docs/docstring.py
@@ -10,10 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.docs.method import document_model_driven_method
-from botocore.docs.waiter import document_wait_method
-from botocore.docs.paginator import document_paginate_method
-from botocore.docs.bcdoc.restdoc import DocumentStructure
+from .method import document_model_driven_method
+from .waiter import document_wait_method
+from .paginator import document_paginate_method
+from .bcdoc.restdoc import DocumentStructure
 
 
 class LazyLoadedDocstring(str):

--- a/botocore/docs/example.py
+++ b/botocore/docs/example.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.docs.shape import ShapeDocumenter
-from botocore.docs.utils import py_default
+from .shape import ShapeDocumenter
+from .utils import py_default
 
 
 class BaseExampleDocumenter(ShapeDocumenter):

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -12,10 +12,10 @@
 # language governing permissions and limitations under the License.
 import inspect
 
-from botocore.docs.params import RequestParamsDocumenter
-from botocore.docs.params import ResponseParamsDocumenter
-from botocore.docs.example import ResponseExampleDocumenter
-from botocore.docs.example import RequestExampleDocumenter
+from .params import RequestParamsDocumenter
+from .params import ResponseParamsDocumenter
+from .example import ResponseExampleDocumenter
+from .example import RequestExampleDocumenter
 
 
 AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI'

--- a/botocore/docs/paginator.py
+++ b/botocore/docs/paginator.py
@@ -10,11 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore import xform_name
-from botocore.compat import OrderedDict
-from botocore.docs.utils import DocumentedShape
-from botocore.utils import get_service_module_name
-from botocore.docs.method import document_model_driven_method
+from .. import xform_name
+from ..compat import OrderedDict
+from .utils import DocumentedShape
+from ..utils import get_service_module_name
+from .method import document_model_driven_method
 
 
 class PaginatorDocumenter(object):

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.docs.shape import ShapeDocumenter
-from botocore.docs.utils import py_type_name
+from .shape import ShapeDocumenter
+from .utils import py_type_name
 
 
 class BaseParamsDocumenter(ShapeDocumenter):

--- a/botocore/docs/service.py
+++ b/botocore/docs/service.py
@@ -10,12 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.exceptions import DataNotFoundError
-from botocore.docs.utils import get_official_service_name
-from botocore.docs.client import ClientDocumenter
-from botocore.docs.waiter import WaiterDocumenter
-from botocore.docs.paginator import PaginatorDocumenter
-from botocore.docs.bcdoc.restdoc import DocumentStructure
+from ..exceptions import DataNotFoundError
+from .utils import get_official_service_name
+from .client import ClientDocumenter
+from .waiter import WaiterDocumenter
+from .paginator import PaginatorDocumenter
+from .bcdoc.restdoc import DocumentStructure
 
 
 class ServiceDocumenter(object):

--- a/botocore/docs/shape.py
+++ b/botocore/docs/shape.py
@@ -16,7 +16,7 @@
 # ``traverse_and_document_shape`` method called directly. It should be
 # inherited from a Documenter class with the appropriate methods
 # and attributes.
-from botocore.utils import is_json_value_header
+from ..utils import is_json_value_header
 
 
 class ShapeDocumenter(object):

--- a/botocore/docs/sharedexample.py
+++ b/botocore/docs/sharedexample.py
@@ -12,9 +12,9 @@
 # language governing permissions and limitations under the License.
 import re
 import numbers
-from botocore.utils import parse_timestamp
-from botocore.docs.utils import escape_controls
-from botocore.compat import six
+from ..utils import parse_timestamp
+from .utils import escape_controls
+from ..compat import six
 
 
 class SharedExampleDocumenter(object):

--- a/botocore/docs/waiter.py
+++ b/botocore/docs/waiter.py
@@ -10,11 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore import xform_name
-from botocore.compat import OrderedDict
-from botocore.docs.utils import DocumentedShape
-from botocore.utils import get_service_module_name
-from botocore.docs.method import document_model_driven_method
+from .. import xform_name
+from ..compat import OrderedDict
+from .utils import DocumentedShape
+from ..utils import get_service_module_name
+from .method import document_model_driven_method
 
 
 class WaiterDocumenter(object):

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -17,21 +17,21 @@ import logging
 import time
 import threading
 
-from botocore.vendored.requests.adapters import HTTPAdapter
-from botocore.vendored.requests.sessions import Session
-from botocore.vendored.requests.utils import get_environ_proxies
-from botocore.vendored.requests.exceptions import ConnectionError
-from botocore.vendored import six
+from .vendored.requests.adapters import HTTPAdapter
+from .vendored.requests.sessions import Session
+from .vendored.requests.utils import get_environ_proxies
+from .vendored.requests.exceptions import ConnectionError
+from .vendored import six
 
-from botocore.awsrequest import create_request_object
-from botocore.exceptions import UnknownEndpointError
-from botocore.exceptions import EndpointConnectionError
-from botocore.exceptions import ConnectionClosedError
-from botocore.compat import filter_ssl_warnings
-from botocore.utils import is_valid_endpoint_url
-from botocore.hooks import first_non_none_response
-from botocore.response import StreamingBody
-from botocore import parsers
+from .awsrequest import create_request_object
+from .exceptions import UnknownEndpointError
+from .exceptions import EndpointConnectionError
+from .exceptions import ConnectionClosedError
+from .compat import filter_ssl_warnings
+from .utils import is_valid_endpoint_url
+from .hooks import first_non_none_response
+from .response import StreamingBody
+from . import parsers
 
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ MAX_POOL_CONNECTIONS = 10
 filter_ssl_warnings()
 
 try:
-    from botocore.vendored.requests.packages.urllib3.contrib import pyopenssl
+    from .vendored.requests.packages.urllib3.contrib import pyopenssl
     pyopenssl.extract_from_urllib3()
 except ImportError:
     pass

--- a/botocore/errorfactory.py
+++ b/botocore/errorfactory.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.exceptions import ClientError
-from botocore.utils import get_service_module_name
+from .exceptions import ClientError
+from .utils import get_service_module_name
 
 
 class BaseClientExceptions(object):

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -12,7 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import unicode_literals
-from botocore.vendored.requests.exceptions import ConnectionError
+from .vendored.requests.exceptions import ConnectionError
 
 
 class BotoCoreError(Exception):

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -24,25 +24,25 @@ import re
 import warnings
 import uuid
 
-from botocore.compat import unquote, json, six, unquote_str, \
+from .compat import unquote, json, six, unquote_str, \
     ensure_bytes, get_md5, MD5_AVAILABLE
-from botocore.docs.utils import AutoPopulatedParam
-from botocore.docs.utils import HideParamFromOperations
-from botocore.docs.utils import AppendParamDocumentation
-from botocore.signers import add_generate_presigned_url
-from botocore.signers import add_generate_presigned_post
-from botocore.signers import add_generate_db_auth_token
-from botocore.exceptions import ParamValidationError
-from botocore.exceptions import AliasConflictParameterError
-from botocore.exceptions import UnsupportedTLSVersionWarning
-from botocore.utils import percent_encode, SAFE_CHARS
-from botocore.utils import switch_host_with_param
+from .docs.utils import AutoPopulatedParam
+from .docs.utils import HideParamFromOperations
+from .docs.utils import AppendParamDocumentation
+from .signers import add_generate_presigned_url
+from .signers import add_generate_presigned_post
+from .signers import add_generate_db_auth_token
+from .exceptions import ParamValidationError
+from .exceptions import AliasConflictParameterError
+from .exceptions import UnsupportedTLSVersionWarning
+from .utils import percent_encode, SAFE_CHARS
+from .utils import switch_host_with_param
 
-from botocore import retryhandler
-from botocore import utils
-from botocore import translate
-import botocore
-import botocore.auth
+from . import retryhandler
+from . import utils
+from . import translate
+from . import UNSIGNED
+from . import auth
 
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ def set_operation_specific_signer(context, signing_name, **kwargs):
     # Auth type will be the string value 'none' if the operation should not
     # be signed at all.
     if auth_type == 'none':
-        return botocore.UNSIGNED
+        return UNSIGNED
 
     if auth_type.startswith('v4'):
         signature_version = 'v4'
@@ -309,7 +309,7 @@ def disable_signing(**kwargs):
     This handler disables request signing by setting the signer
     name to a special sentinel value.
     """
-    return botocore.UNSIGNED
+    return UNSIGNED
 
 
 def add_expect_header(model, params, **kwargs):

--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -13,7 +13,7 @@
 import copy
 import logging
 from collections import defaultdict, deque, namedtuple
-from botocore.compat import accepts_kwargs, six
+from .compat import accepts_kwargs, six
 
 logger = logging.getLogger(__name__)
 

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -104,11 +104,11 @@ which don't represent the actual service api.
 import os
 import logging
 
-from botocore import BOTOCORE_ROOT
-from botocore.compat import json
-from botocore.compat import OrderedDict
-from botocore.exceptions import DataNotFoundError, UnknownServiceError
-from botocore.utils import deep_merge
+from . import BOTOCORE_ROOT
+from .compat import json
+from .compat import OrderedDict
+from .exceptions import DataNotFoundError, UnknownServiceError
+from .utils import deep_merge
 
 
 logger = logging.getLogger(__name__)

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -13,8 +13,8 @@
 """Abstractions to interact with service models."""
 from collections import defaultdict
 
-from botocore.utils import CachedProperty, instance_cache
-from botocore.compat import OrderedDict
+from .utils import CachedProperty, instance_cache
+from .compat import OrderedDict
 
 
 NOT_SET = object()

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -13,15 +13,15 @@
 
 from itertools import tee
 
-from botocore.compat import six
+from .compat import six
 
 import jmespath
 import json
 import base64
 import logging
-from botocore.exceptions import PaginationError
-from botocore.compat import zip
-from botocore.utils import set_value_from_jmespath, merge_dicts
+from .exceptions import PaginationError
+from .compat import zip
+from .utils import set_value_from_jmespath, merge_dicts
 
 
 log = logging.getLogger(__name__)

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -96,9 +96,9 @@ import json
 import xml.etree.cElementTree
 import logging
 
-from botocore.compat import six, XMLParseError
+from .compat import six, XMLParseError
 
-from botocore.utils import parse_timestamp, merge_dicts, \
+from .utils import parse_timestamp, merge_dicts, \
     is_json_value_header
 
 LOG = logging.getLogger(__name__)

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -19,7 +19,7 @@ in a specific AWS partition.
 import logging
 import re
 
-from botocore.exceptions import NoRegionError
+from .exceptions import NoRegionError
 
 LOG = logging.getLogger(__name__)
 DEFAULT_URI_TEMPLATE = '{service}.{region}.{dnsSuffix}'

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -16,11 +16,11 @@ import sys
 import xml.etree.cElementTree
 import logging
 
-from botocore import ScalarTypes
-from botocore.hooks import first_non_none_response
-from botocore.compat import json, set_socket_timeout, XMLParseError
-from botocore.exceptions import IncompleteReadError
-from botocore import parsers
+from . import ScalarTypes
+from .hooks import first_non_none_response
+from .compat import json, set_socket_timeout, XMLParseError
+from .exceptions import IncompleteReadError
+from . import parsers
 
 
 logger = logging.getLogger(__name__)

--- a/botocore/retryhandler.py
+++ b/botocore/retryhandler.py
@@ -17,10 +17,10 @@ import functools
 import logging
 from binascii import crc32
 
-from botocore.vendored.requests import ConnectionError, Timeout
-from botocore.vendored.requests.packages.urllib3.exceptions import ClosedPoolError
+from .vendored.requests import ConnectionError, Timeout
+from .vendored.requests.packages.urllib3.exceptions import ClosedPoolError
 
-from botocore.exceptions import ChecksumError, EndpointConnectionError
+from .exceptions import ChecksumError, EndpointConnectionError
 
 
 logger = logging.getLogger(__name__)

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -42,13 +42,13 @@ import base64
 from xml.etree import ElementTree
 import calendar
 
-from botocore.compat import six
+from .compat import six
 
-from botocore.compat import json, formatdate
-from botocore.utils import parse_to_aware_datetime
-from botocore.utils import percent_encode
-from botocore.utils import is_json_value_header
-from botocore import validate
+from .compat import json, formatdate
+from .utils import parse_to_aware_datetime
+from .utils import percent_encode
+from .utils import is_json_value_header
+from . import validate
 
 
 # From the spec, the default timestamp format if not specified is iso8601.

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -21,10 +21,10 @@ import logging
 import os
 import platform
 
-from botocore import __version__
-import botocore.configloader
-import botocore.credentials
-import botocore.client
+from . import __version__
+from . import configloader
+from . import credentials as botocore_credentials
+from . import client as botocore_client
 from botocore.exceptions import ConfigNotFound, ProfileNotFound
 from botocore.exceptions import UnknownServiceError, PartialCredentialsError
 from botocore.errorfactory import ClientExceptionsFactory
@@ -176,7 +176,7 @@ class Session(object):
     def _register_credential_provider(self):
         self._components.lazy_register_component(
             'credential_provider',
-            lambda:  botocore.credentials.create_credential_resolver(self))
+            lambda:  botocore_credentials.create_credential_resolver(self))
 
     def _register_data_loader(self):
         self._components.lazy_register_component(
@@ -397,7 +397,7 @@ class Session(object):
         if self._config is None:
             try:
                 config_file = self.get_config_variable('config_file')
-                self._config = botocore.configloader.load_config(config_file)
+                self._config = configloader.load_config(config_file)
             except ConfigNotFound:
                 self._config = {'profiles': {}}
             try:
@@ -407,7 +407,7 @@ class Session(object):
                 # can validate the user is not referring to a nonexistent
                 # profile.
                 cred_file = self.get_config_variable('credentials_file')
-                cred_profiles = botocore.configloader.raw_config_parse(
+                cred_profiles = configloader.raw_config_parse(
                     cred_file)
                 for profile in cred_profiles:
                     cred_vars = cred_profiles[profile]
@@ -456,7 +456,7 @@ class Session(object):
         :param token: An option session token used by STS session
             credentials.
         """
-        self._credentials = botocore.credentials.Credentials(access_key,
+        self._credentials = botocore_credentials.Credentials(access_key,
                                                              secret_key,
                                                              token)
 
@@ -836,7 +836,7 @@ class Session(object):
         response_parser_factory = self.get_component(
             'response_parser_factory')
         if aws_access_key_id is not None and aws_secret_access_key is not None:
-            credentials = botocore.credentials.Credentials(
+            credentials = botocore_credentials.Credentials(
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,
                 token=aws_session_token)
@@ -850,7 +850,7 @@ class Session(object):
             credentials = self.get_credentials()
         endpoint_resolver = self.get_component('endpoint_resolver')
         exceptions_factory = self.get_component('exceptions_factory')
-        client_creator = botocore.client.ClientCreator(
+        client_creator = botocore_client.ClientCreator(
             loader, endpoint_resolver, self.user_agent(), event_emitter,
             retryhandler, translate, response_parser_factory,
             exceptions_factory)

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -14,10 +14,10 @@ import copy
 from collections import deque
 from pprint import pformat
 
-from botocore.validate import validate_parameters
-from botocore.exceptions import ParamValidationError, \
+from .validate import validate_parameters
+from .exceptions import ParamValidationError, \
     StubResponseError, StubAssertionError
-from botocore.vendored.requests.models import Response
+from .vendored.requests.models import Response
 
 
 class _ANY(object):

--- a/botocore/translate.py
+++ b/botocore/translate.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 import copy
 
-from botocore.utils import merge_dicts
+from .utils import merge_dicts
 
 
 def build_retry_config(endpoint_prefix, retry_model, definitions,

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -23,13 +23,13 @@ import random
 import dateutil.parser
 from dateutil.tz import tzlocal, tzutc
 
-import botocore
-from botocore.exceptions import InvalidExpressionError, ConfigNotFound
-from botocore.exceptions import InvalidDNSNameError, ClientError
-from botocore.exceptions import MetadataRetrievalError
-from botocore.compat import json, quote, zip_longest, urlsplit, urlunsplit
-from botocore.vendored import requests
-from botocore.compat import OrderedDict, six
+from .exceptions import InvalidExpressionError, ConfigNotFound
+from .exceptions import InvalidDNSNameError, ClientError
+from .exceptions import MetadataRetrievalError
+from .compat import json, quote, zip_longest, urlparse, urlsplit, urlunsplit
+from .vendored import requests
+from .compat import OrderedDict, six
+from . import UNSIGNED
 
 
 logger = logging.getLogger(__name__)
@@ -684,7 +684,7 @@ def fix_s3_host(request, signature_version, region_name,
     """
     # By default we do not use virtual hosted style addressing when
     # signed with signature version 4.
-    if signature_version is not botocore.UNSIGNED and \
+    if signature_version is not UNSIGNED and \
             's3v4' in signature_version:
         return
     elif not _allowed_region(region_name):
@@ -1025,7 +1025,7 @@ class ContainerMetadataFetcher(object):
         return self._retrieve_credentials(full_url, headers)
 
     def _validate_allowed_url(self, full_url):
-        parsed = botocore.compat.urlparse(full_url)
+        parsed = urlparse(full_url)
         is_whitelisted_host = self._check_if_whitelisted_host(
             parsed.hostname)
         if not is_whitelisted_host:

--- a/botocore/validate.py
+++ b/botocore/validate.py
@@ -13,14 +13,14 @@ Validation Errors
 
 """
 
-from botocore.compat import six
+from .compat import six
 import decimal
 import json
 from datetime import datetime
 
-from botocore.utils import parse_to_aware_datetime
-from botocore.utils import is_json_value_header
-from botocore.exceptions import ParamValidationError
+from .utils import parse_to_aware_datetime
+from .utils import is_json_value_header
+from .exceptions import ParamValidationError
 
 
 def validate_parameters(params, shape):

--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -14,8 +14,8 @@ import jmespath
 import logging
 import time
 
-from botocore.utils import get_service_module_name
-from botocore.docs.docstring import WaiterDocstring
+from .utils import get_service_module_name
+from .docs.docstring import WaiterDocstring
 from .exceptions import WaiterError, ClientError, WaiterConfigError
 from . import xform_name
 


### PR DESCRIPTION
This PR replaces the existing absolute imports of botocore modules with relative imports. This was done to
* Use a consistent approach to importing local modules
* Increase portability and vendoring of botocore code

By switching to a relative import scheme, botocore is considerably more portable, particularly when vendoring botocore code within an application.