### PR TITLE
Allow reads of zero in StreamingBody

### DIFF
--- a/.changes/next-release/enhancement-Response-34923.json
+++ b/.changes/next-release/enhancement-Response-34923.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "description": "Allow reads of zero on streaming bodies, fixes `#1309 <https://github.com/boto/botocore/issues/1309>`__.",
+  "category": "Response"
+}

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -73,7 +73,7 @@ class StreamingBody(object):
         """
         chunk = self._raw_stream.read(amt)
         self._amount_read += len(chunk)
-        if not chunk or amt is None:
+        if amt is None or (not chunk and amt > 0):
             # If the server sends empty contents or
             # we ask to read all of the contents, then we know
             # we need to verify the content length.

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -55,6 +55,13 @@ class TestStreamWrapper(unittest.TestCase):
             # an IncompleteReadError because we were expectd 10 bytes, not 9.
             stream.read()
 
+    def test_streaming_body_with_zero_read(self):
+        body = six.BytesIO(b'1234567890')
+        stream = response.StreamingBody(body, content_length=10)
+        chunk = stream.read(0)
+        self.assertEqual(chunk, b'')
+        self.assertEqual(stream.read(), b'1234567890')
+
     def test_streaming_body_with_single_read(self):
         body = six.BytesIO(b'123456789')
         stream = response.StreamingBody(body, content_length=10)


### PR DESCRIPTION
Fixes #1309 

We currently throw an exception if you attempt to read zero bytes from the StreamingBody wrapper. This fixes the validation conditional to only validate the content length if we received an empty chunk and the amount requested was greater than zero.