### PR TITLE
Finer grained stub error handling

### DIFF
--- a/.changes/next-release/bugfix-Stubber-65181.json
+++ b/.changes/next-release/bugfix-Stubber-65181.json
@@ -1,0 +1,5 @@
+{
+  "category": "Stubber", 
+  "type": "bugfix", 
+  "description": "This change makes the error handling more verbose in the case where  a stubbed method has been called, but the Stubber is not expecting a call."
+}

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -420,8 +420,10 @@ class StubResponseError(BotoCoreError):
 
 
 class StubAssertionError(StubResponseError, AssertionError):
-    fmt = 'Error getting response stub for operation {operation_name}: {reason}'
+    pass
 
+class UnStubbedResponseError(StubResponseError):
+    pass
 
 class InvalidConfigError(BotoCoreError):
     fmt = '{error_msg}'

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -16,7 +16,7 @@ from pprint import pformat
 
 from botocore.validate import validate_parameters
 from botocore.exceptions import ParamValidationError, \
-    StubResponseError, StubAssertionError
+    StubResponseError, StubAssertionError, UnStubbedResponseError
 from botocore.vendored.requests.models import Response
 
 
@@ -317,10 +317,13 @@ class Stubber(object):
 
     def _assert_expected_call_order(self, model, params):
         if not self._queue:
-            raise StubResponseError(
+            raise UnStubbedResponseError(
                 operation_name=model.name,
-                reason=('Unexpected API Call: called with parameters:\n%s' %
-                        pformat(params)))
+                reason=(
+                        'Unexpected API Call: A call was made but no additional calls expected.'
+                        'Either the API Call was not stubbed or it was called multiple times.'
+                        )
+            )
 
         name = self._queue[0]['operation_name']
         if name != model.name:

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -18,7 +18,7 @@ import botocore.session
 import botocore.stub as stub
 from botocore.stub import Stubber
 from botocore.exceptions import StubResponseError, ClientError, \
-    StubAssertionError
+    StubAssertionError, UnStubbedResponseError
 from botocore.exceptions import ParamValidationError
 import botocore.client
 import botocore.retryhandler
@@ -51,8 +51,8 @@ class TestStubber(unittest.TestCase):
     def test_activated_stubber_errors_with_no_registered_stubs(self):
         self.stubber.activate()
         # Params one per line for readability.
-        with self.assertRaisesRegexp(StubResponseError,
-                                     "'Bucket': 'asdfasdfasdfasdf',\n"):
+        with self.assertRaisesRegexp(UnStubbedResponseError,
+                                     "Unexpected API Call"):
             self.client.list_objects(
                 Bucket='asdfasdfasdfasdf',
                 Delimiter='asdfasdfasdfasdf',
@@ -64,7 +64,7 @@ class TestStubber(unittest.TestCase):
         self.stubber.activate()
         self.client.list_objects(Bucket='foo')
 
-        with self.assertRaises(StubResponseError):
+        with self.assertRaises(UnStubbedResponseError):
             self.client.list_objects(Bucket='foo')
 
     def test_client_error_response(self):

--- a/tests/unit/test_stub.py
+++ b/tests/unit/test_stub.py
@@ -15,7 +15,7 @@ from tests import unittest
 import mock
 
 from botocore.stub import Stubber
-from botocore.exceptions import ParamValidationError, StubResponseError
+from botocore.exceptions import ParamValidationError, StubResponseError, UnStubbedResponseError
 from botocore.model import ServiceModel
 from botocore import hooks
 
@@ -177,7 +177,7 @@ class TestStubber(unittest.TestCase):
 
     def test_get_response_errors_with_no_stubs(self):
         self.stubber.activate()
-        with self.assertRaises(StubResponseError):
+        with self.assertRaises(UnStubbedResponseError):
             self.emit_get_response_event()
 
     def test_assert_no_responses_remaining(self):


### PR DESCRIPTION
This PR introduces an `UnStubbedResponseError` class which is raised when an instance of the Stubber class's  stub queue is exhausted.  This came about as a result of writing tests, and receiving an unhelpful message informing me that there was an unexpected API call.  

I found this unhelpful because it masked the fact that the `stubber` instance had no additional requests it was expecting.  This change gives a more specific error message as to why the request failed.