### PR TITLE
Add support for process-based credential providers

### DIFF
--- a/.changes/next-release/feature-credentials-59288.json
+++ b/.changes/next-release/feature-credentials-59288.json
@@ -1,0 +1,5 @@
+{
+  "category": "credentials", 
+  "type": "feature", 
+  "description": "Adds support for the process credential provider, allowing users to specify a process to call to get credentials."
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -17,6 +17,8 @@ import logging
 import os
 import getpass
 import threading
+import subprocess
+import shlex
 from collections import namedtuple
 from copy import deepcopy
 from hashlib import sha256
@@ -82,6 +84,8 @@ def create_credential_resolver(session):
             creds_filename=credential_file,
             profile_name=profile_name
         ),
+        ProcessProvider(profile_name=profile_name,
+                        load_config=lambda: session.full_config),
         # The new config file has precedence over the legacy
         # config file.
         ConfigProvider(config_filename=config_file, profile_name=profile_name),
@@ -699,6 +703,76 @@ class CredentialProvider(object):
                 raise PartialCredentialsError(provider=self.METHOD,
                                               cred_var=key_name)
         return found
+
+
+class ProcessProvider(CredentialProvider):
+
+    METHOD = 'custom-process'
+
+    def __init__(self, profile_name, load_config, popen=subprocess.Popen):
+        self._profile_name = profile_name
+        self._load_config = load_config
+        self._loaded_config = None
+        self._popen = popen
+
+    def load(self):
+        credential_process = self._credential_process
+        if credential_process is None:
+            return
+
+        creds_dict = self._retrieve_credentials_using(credential_process)
+        if creds_dict.get('expiry_time') is not None:
+            return RefreshableCredentials.create_from_metadata(
+                creds_dict,
+                lambda: self._retrieve_credentials_using(credential_process),
+                self.METHOD
+            )
+
+        return Credentials(
+            access_key=creds_dict['access_key'],
+            secret_key=creds_dict['secret_key'],
+            token=creds_dict.get('token'),
+            method=self.METHOD
+        )
+
+    def _retrieve_credentials_using(self, credential_process):
+        # We're not using shell=True, so we need to pass the
+        # command and all arguments as a list.
+        process_list = shlex.split(credential_process)
+        p = self._popen(process_list,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        if p.returncode != 0:
+            raise CredentialRetrievalError(
+                provider=self.METHOD, error_msg=stderr.decode('utf-8'))
+        parsed = botocore.compat.json.loads(stdout.decode('utf-8'))
+        version = parsed.get('Version', '<Version key not provided>')
+        if version != 1:
+            raise CredentialRetrievalError(
+                provider=self.METHOD,
+                error_msg=("Unsupported version '%s' for credential process "
+                           "provider, supported versions: 1" % version))
+        try:
+            return {
+                'access_key': parsed['AccessKeyId'],
+                'secret_key': parsed['SecretAccessKey'],
+                'token': parsed.get('SessionToken'),
+                'expiry_time': parsed.get('Expiration'),
+            }
+        except KeyError as e:
+            raise CredentialRetrievalError(
+                provider=self.METHOD,
+                error_msg="Missing required key in response: %s" % e
+            )
+
+    @property
+    def _credential_process(self):
+        if self._loaded_config is None:
+            self._loaded_config = self._load_config()
+        profile_config = self._loaded_config.get(
+            'profiles', {}).get(self._profile_name, {})
+        return profile_config.get('credential_process')
 
 
 class InstanceMetadataProvider(CredentialProvider):

--- a/tests/functional/utils/__init__.py
+++ b/tests/functional/utils/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/utils/credentialprocess.py
+++ b/tests/functional/utils/credentialprocess.py
@@ -1,0 +1,35 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This is a dummy implementation of a credential provider process."""
+import argparse
+import json
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--raise-error', action='store_true', help=(
+        'If set, this will cause the process to return a non-zero exit code '
+        'and print to stderr.'
+    ))
+    args = parser.parse_args()
+    if args.raise_error:
+        raise Exception('Failed to fetch credentials.')
+    print(json.dumps({
+        'AccessKeyId': 'spam',
+        'SecretAccessKey': 'eggs',
+        'Version': 1
+    }))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows users to configure an external process to provide
credentials using the `credential_process` config variable.

Note that this is built on top of the assume role provider since
there is rebasing necessary.