### PR TITLE
Enforce ISO8601 format in cached refresher

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -132,8 +132,10 @@ def _parse_if_needed(value):
     return parse(value)
 
 
-def _serialize_if_needed(value):
+def _serialize_if_needed(value, iso=False):
     if isinstance(value, datetime.datetime):
+        if iso:
+            return value.isoformat()
         return value.strftime('%Y-%m-%dT%H:%M:%S%Z')
     return value
 
@@ -509,7 +511,7 @@ class CachedCredentialFetcher(object):
             logger.debug("Credentials for role retrieved from cache.")
 
         creds = response['Credentials']
-        expiration = _serialize_if_needed(creds['Expiration'])
+        expiration = _serialize_if_needed(creds['Expiration'], iso=True)
         return {
             'access_key': creds['AccessKeyId'],
             'secret_key': creds['SecretAccessKey'],

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -197,7 +197,7 @@ class TestAssumeRoleCredentialRefresher(BaseEnvVar):
     def get_expected_creds_from_response(self, response):
         expiration = response['Credentials']['Expiration']
         if isinstance(expiration, datetime):
-            expiration = expiration.strftime('%Y-%m-%dT%H:%M:%S%Z')
+            expiration = expiration.isoformat()
         return {
             'access_key': response['Credentials']['AccessKeyId'],
             'secret_key': response['Credentials']['SecretAccessKey'],


### PR DESCRIPTION
This moves the cached credential fetcher to enforcing iso format
rather than relying on a hand-rolled format string. This is important
on Windows, where our format string can produce strings that we
can't parse.