### PR TITLE
Always strip / from cache file names

### DIFF
--- a/.changes/next-release/bugfix-Credentials-62433.json
+++ b/.changes/next-release/bugfix-Credentials-62433.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Fixes a bug causing cached credentials to break in the CLI on Windows. Fixes aws/aws-cli`#2978 <https://github.com/boto/botocore/issues/2978>`__"
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -495,6 +495,11 @@ class CachedCredentialFetcher(object):
     def _create_cache_key(self):
         raise NotImplementedError('_create_cache_key()')
 
+    def _make_file_safe(self, filename):
+        # Replace :, path sep, and / to make it the string filename safe.
+        filename = filename.replace(':', '_').replace(os.path.sep, '_')
+        return filename.replace('/', '_')
+
     def _get_credentials(self):
         raise NotImplementedError('_get_credentials()')
 
@@ -625,11 +630,8 @@ class AssumeRoleCredentialFetcher(CachedCredentialFetcher):
 
         args = json.dumps(args, sort_keys=True)
         argument_hash = sha256(args.encode('utf-8')).hexdigest()
-
-        # Prefix the cache key with the role arn to aid human-readability.
-        # Replace : and path sep to make it file safe.
-        arn = self._role_arn.replace(':', '_').replace(os.path.sep, '_')
-        return '%s--%s' % (arn, argument_hash)
+        cache_key = '%s--%s' % (self._role_arn, argument_hash)
+        return self._make_file_safe(cache_key)
 
     def _get_credentials(self):
         """Get credentials by calling assume role."""

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -180,9 +180,9 @@ class TestDeferredRefreshableCredentials(unittest.TestCase):
         self.assertEqual(self.refresher.call_count, 1)
 
 
-class TestAssumeRoleCredentialRefresher(BaseEnvVar):
+class TestAssumeRoleCredentialFetcher(BaseEnvVar):
     def setUp(self):
-        super(TestAssumeRoleCredentialRefresher, self).setUp()
+        super(TestAssumeRoleCredentialFetcher, self).setUp()
         self.source_creds = credentials.Credentials('a', 'b', 'c')
         self.role_arn = 'myrole'
 
@@ -296,7 +296,7 @@ class TestAssumeRoleCredentialRefresher(BaseEnvVar):
         cache = {}
         client_creator = self.create_client_creator(with_response=response)
 
-        role_arn = 'arn:aws:iam::foo-role'
+        role_arn = 'arn:aws:iam::role/foo-role'
         refresher = credentials.AssumeRoleCredentialFetcher(
             client_creator, self.source_creds, role_arn, cache=cache
         )
@@ -306,8 +306,8 @@ class TestAssumeRoleCredentialRefresher(BaseEnvVar):
         # On windows, you cannot use a a ':' in the filename, so
         # we need to make sure that it doesn't make it into the cache key.
         cache_key = (
-            'arn_aws_iam__foo-role--'
-            '2658f5f4e4ba3dce28e1c7eaf23dc91ccf512a3cface8cf9b48fed7dfc81a2db'
+            'arn_aws_iam__role_foo-role--'
+            'a812859ff24fa3e52c0f5f3e02bf7ee35d37d994268ed246b7565432feaa9b8c'
         )
         self.assertIn(cache_key, cache)
         self.assertEqual(cache[cache_key], response)


### PR DESCRIPTION
Previously we had just been stripping colon and path sep, but forward
slash will also break on Windows.

Fixes aws/aws-cli#2978

cc @kyleknap