### PR TITLE
Use shell=True in process provider

### DIFF
--- a/.changes/next-release/bugfix-Credentials-34257.json
+++ b/.changes/next-release/bugfix-Credentials-34257.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Fixed an issue where paths were being corrupted on windows when using the process provider."
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -18,7 +18,6 @@ import os
 import getpass
 import threading
 import subprocess
-import shlex
 from collections import namedtuple
 from copy import deepcopy
 from hashlib import sha256
@@ -740,12 +739,13 @@ class ProcessProvider(CredentialProvider):
         )
 
     def _retrieve_credentials_using(self, credential_process):
-        # We're not using shell=True, so we need to pass the
-        # command and all arguments as a list.
-        process_list = shlex.split(credential_process)
-        p = self._popen(process_list,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE)
+        # We have to use shell=True to make Windows work
+        p = self._popen(
+            credential_process,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True
+        )
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             raise CredentialRetrievalError(

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -2455,8 +2455,8 @@ class TestProcessProvider(BaseEnvVar):
         self.assertEqual(creds.token, 'baz')
         self.assertEqual(creds.method, 'custom-process')
         self.popen_mock.assert_called_with(
-            ['my-process'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            'my-process',
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
         )
 
     def test_can_pass_arguments_through(self):
@@ -2477,8 +2477,8 @@ class TestProcessProvider(BaseEnvVar):
         creds = provider.load()
         self.assertIsNotNone(creds)
         self.popen_mock.assert_called_with(
-            ['my-process', '--foo', '--bar', 'one two'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            'my-process --foo --bar "one two"',
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
         )
 
     def test_can_refresh_credentials(self):


### PR DESCRIPTION
Using shell=False is nice and fast, but it means we have to split the
commands manually, which is just not feasible on Windows.