### PR TITLE
Split properly on Windows

### DIFF
--- a/.changes/next-release/bugfix-Credentials-49467.json
+++ b/.changes/next-release/bugfix-Credentials-49467.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Fixed a bug causing issues in configuring the process provider on windows when paths were used."
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -18,7 +18,6 @@ import os
 import getpass
 import threading
 import subprocess
-import shlex
 from collections import namedtuple
 from copy import deepcopy
 from hashlib import sha256
@@ -30,6 +29,7 @@ from dateutil.tz import tzlocal
 import botocore.configloader
 import botocore.compat
 from botocore.compat import total_seconds
+from botocore.compat import compat_shell_split
 from botocore.exceptions import UnknownCredentialError
 from botocore.exceptions import PartialCredentialsError
 from botocore.exceptions import ConfigNotFound
@@ -742,7 +742,7 @@ class ProcessProvider(CredentialProvider):
     def _retrieve_credentials_using(self, credential_process):
         # We're not using shell=True, so we need to pass the
         # command and all arguments as a list.
-        process_list = shlex.split(credential_process)
+        process_list = compat_shell_split(credential_process)
         p = self._popen(process_list,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -10,15 +10,15 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
 import datetime
 import mock
 
+from nose.tools import assert_equal, assert_raises
+
 from botocore.exceptions import MD5UnavailableError
 from botocore.compat import (
-    total_seconds, unquote_str, six, ensure_bytes, get_md5
+    total_seconds, unquote_str, six, ensure_bytes, get_md5, compat_shell_split
 )
-
 from tests import BaseEnvVar, unittest
 
 
@@ -95,3 +95,68 @@ class TestGetMD5(unittest.TestCase):
         with mock.patch('botocore.compat.MD5_AVAILABLE', False):
             with self.assertRaises(MD5UnavailableError):
                 get_md5()
+
+
+def test_compat_shell_split_windows():
+    windows_cases = {
+        r'': [],
+        r'spam \\': [r'spam', '\\\\'],
+        r'spam ': [r'spam'],
+        r' spam': [r'spam'],
+        'spam eggs': [r'spam', r'eggs'],
+        'spam\teggs': [r'spam', r'eggs'],
+        'spam\neggs': ['spam\neggs'],
+        '""': [''],
+        '" "': [' '],
+        '"\t"': ['\t'],
+        '\\\\': ['\\\\'],
+        # The following four test cases are official test cases given in
+        # Microsoft's documentation.
+        r'"abc" d e': [r'abc', r'd', r'e'],
+        r'a\\b d"e f"g h': [r'a\\b', r'de fg', r'h'],
+        r'a\\\"b c d': [r'a\"b', r'c', r'd'],
+        r'a\\\\"b c" d e': [r'a\\b c', r'd', r'e']
+    }
+    runner = ShellSplitTestRunner()
+    for input_string, expected_output in windows_cases.items():
+        yield runner.assert_equal, input_string, expected_output, "win32"
+
+    yield runner.assert_raises, r'"', ValueError, "win32"
+
+
+def test_compat_shell_split_unix():
+    unix_cases = {
+        r'': [],
+        r'spam \\': [r'spam', '\\'],
+        r'spam ': [r'spam'],
+        r' spam': [r'spam'],
+        'spam eggs': [r'spam', r'eggs'],
+        'spam\teggs': [r'spam', r'eggs'],
+        'spam\neggs': ['spam', 'eggs'],
+        '""': [''],
+        '" "': [' '],
+        '"\t"': ['\t'],
+        '\\\\': ['\\'],
+        # The following four test cases are official test cases given in
+        # Microsoft's documentation, but adapted to unix shell splitting.
+        r'"abc" d e': [r'abc', r'd', r'e'],
+        r'a\\b d"e f"g h': [r'a\b', r'de fg', r'h'],
+        r'a\\\"b c d': [r'a\"b', r'c', r'd'],
+        r'a\\\\"b c" d e': [r'a\\b c', r'd', r'e']
+    }
+    runner = ShellSplitTestRunner()
+    for input_string, expected_output in unix_cases.items():
+        yield runner.assert_equal, input_string, expected_output, "linux2"
+        yield runner.assert_equal, input_string, expected_output, "darwin"
+
+    yield runner.assert_raises, r'"', ValueError, "linux2"
+    yield runner.assert_raises, r'"', ValueError, "darwin"
+
+
+class ShellSplitTestRunner(object):
+    def assert_equal(self, s, expected, platform):
+        assert_equal(compat_shell_split(s, platform), expected)
+
+    def assert_raises(self, s, exception_cls, platform):
+        with assert_raises(exception_cls):
+            compat_shell_split(s, platform)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -110,6 +110,8 @@ def test_compat_shell_split_windows():
         '" "': [' '],
         '"\t"': ['\t'],
         '\\\\': ['\\\\'],
+        '\\\\ ': ['\\\\'],
+        '\\\\\t': ['\\\\'],
         # The following four test cases are official test cases given in
         # Microsoft's documentation.
         r'"abc" d e': [r'abc', r'd', r'e'],
@@ -137,6 +139,8 @@ def test_compat_shell_split_unix():
         '" "': [' '],
         '"\t"': ['\t'],
         '\\\\': ['\\'],
+        '\\\\ ': ['\\'],
+        '\\\\\t': ['\\'],
         # The following four test cases are official test cases given in
         # Microsoft's documentation, but adapted to unix shell splitting.
         r'"abc" d e': [r'abc', r'd', r'e'],

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -112,6 +112,7 @@ def test_compat_shell_split_windows():
         '\\\\': ['\\\\'],
         '\\\\ ': ['\\\\'],
         '\\\\\t': ['\\\\'],
+        r'\"': ['"'],
         # The following four test cases are official test cases given in
         # Microsoft's documentation.
         r'"abc" d e': [r'abc', r'd', r'e'],
@@ -141,6 +142,7 @@ def test_compat_shell_split_unix():
         '\\\\': ['\\'],
         '\\\\ ': ['\\'],
         '\\\\\t': ['\\'],
+        r'\"': ['"'],
         # The following four test cases are official test cases given in
         # Microsoft's documentation, but adapted to unix shell splitting.
         r'"abc" d e': [r'abc', r'd', r'e'],

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -158,5 +158,4 @@ class ShellSplitTestRunner(object):
         assert_equal(compat_shell_split(s, platform), expected)
 
     def assert_raises(self, s, exception_cls, platform):
-        with assert_raises(exception_cls):
-            compat_shell_split(s, platform)
+        assert_raises(exception_cls, compat_shell_split, s, platform)


### PR DESCRIPTION
This implements splitting on Windows properly, as shelex.split only
works correctly for posix systems.