### PR TITLE
Do not generate 100-continue expectation with no body.

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -115,6 +115,12 @@ class AWSConnection(object):
                 break
 
     def _send_request(self, method, url, body, headers, *args, **kwargs):
+        if headers.get('Content-Length') == '0':
+            # From RFC: https://tools.ietf.org/html/rfc7231#section-5.1.1
+            # Requirement for clients:
+            # - A client MUST NOT generate a 100-continue expectation
+            #   in a request that does not include a message body.
+            headers.pop('Expect', None)
         self._response_received = False
         if headers.get('Expect', b'') == b'100-continue':
             self._expect_header_set = True
@@ -230,7 +236,7 @@ class AWSConnection(object):
 
     def send(self, str):
         if self._response_received:
-            logger.debug("send() called, but reseponse already received. "
+            logger.debug("send() called, but response already received. "
                          "Not sending data.")
             return
         return super(AWSConnection, self).send(str)

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -436,6 +436,14 @@ class TestAWSHTTPConnection(unittest.TestCase):
         response = conn.getresponse()
         self.assertEqual(response.status, 200)
 
+    def test_no_expect_header_set_no_body(self):
+        s = FakeSocket(b'HTTP/1.1 200 OK\r\n')
+        conn = AWSHTTPConnection('s3.amazonaws.com', 443)
+        conn.sock = s
+        conn.request('PUT', '/bucket/foo', b'')
+        response = conn.getresponse()
+        self.assertEqual(response.status, 200)
+
     def test_tunnel_readline_none_bugfix(self):
         # Tests whether ``_tunnel`` function is able to work around the
         # py26 bug of avoiding infinite while loop if nothing is returned.


### PR DESCRIPTION
HTTP RFC explicitly states that 100-continue should
not be set when there is no message body.

https://tools.ietf.org/html/rfc7231#section-5.1.1

> A client MUST NOT generate a 100-continue expectation in
> a request that does not include a message body.

This is a mandatory requirement, this PR Fixes the current
implementation behavior by not sending `100-continue`
when content-length is '0' which means there is no message
body

Fixes boto/boto3#1341