### PR TITLE
Expand expected assumerole exceptions

### DIFF
--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -225,7 +225,7 @@ class TestAssumeRoleCredentials(BaseEnvVar):
                 return result['Credentials']
             except ClientError as e:
                 code = e.response.get('Error', {}).get('Code')
-                if code == "InvalidClientTokenId":
+                if code in ["InvalidClientTokenId", "AccessDenied"]:
                     time.sleep(delay)
                 else:
                     raise


### PR DESCRIPTION
This adds 'AccessDenied' to the list of expected assumerole exceptions.
The api will *usually* return 'InvalidClientTokenId', but not always.