### PR TITLE
Remove content-type from presigned query requests

### DIFF
--- a/.changes/next-release/bugfix-presignedurl-90814.json
+++ b/.changes/next-release/bugfix-presignedurl-90814.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "presigned-url",
+  "description": "Fixes a bug where content-type would be set on presigned requests for query services."
+}

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -575,7 +575,8 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
 
     # Prepare the request dict by including the client's endpoint url.
     prepare_request_dict(
-        request_dict, endpoint_url=self.meta.endpoint_url)
+        request_dict, endpoint_url=self.meta.endpoint_url
+    )
 
     # Generate the presigned url.
     return request_signer.generate_presigned_url(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,9 +34,13 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
+from nose.tools import assert_equal
 
 import botocore.loaders
 import botocore.session
+from botocore.compat import six
+from botocore.compat import urlparse
+from botocore.compat import parse_qs
 from botocore import utils
 from botocore import credentials
 
@@ -331,3 +335,27 @@ class IntegerRefresher(credentials.RefreshableCredentials):
 
     def _current_datetime(self):
         return datetime.datetime.now(tzlocal())
+
+
+def _urlparse(url):
+    if isinstance(url, six.binary_type):
+        # Not really necessary, but it helps to reduce noise on Python 2.x
+        url = url.decode('utf8')
+    return urlparse(url)
+
+def assert_url_equal(url1, url2):
+    parts1 = _urlparse(url1)
+    parts2 = _urlparse(url2)
+
+    # Because the query string ordering isn't relevant, we have to parse
+    # every single part manually and then handle the query string.
+    assert_equal(parts1.scheme, parts2.scheme)
+    assert_equal(parts1.netloc, parts2.netloc)
+    assert_equal(parts1.path, parts2.path)
+    assert_equal(parts1.params, parts2.params)
+    assert_equal(parts1.fragment, parts2.fragment)
+    assert_equal(parts1.username, parts2.username)
+    assert_equal(parts1.password, parts2.password)
+    assert_equal(parts1.hostname, parts2.hostname)
+    assert_equal(parts1.port, parts2.port)
+    assert_equal(parse_qs(parts1.query), parse_qs(parts2.query))

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -1,0 +1,45 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from datetime import datetime
+
+import mock
+
+from tests import BaseSessionTest
+from tests import assert_url_equal
+from botocore.stub import Stubber
+
+
+class TestSTSPresignedUrl(BaseSessionTest):
+    def setUp(self):
+        super(TestSTSPresignedUrl, self).setUp()
+        self.client = self.session.create_client('sts', 'us-west-2')
+        # Makes sure that no requests will go through
+        self.stubber = Stubber(self.client)
+        self.stubber.activate()
+
+    def test_presigned_url_contains_no_content_type(self):
+        timestamp = datetime(2017, 3, 22, 0, 0)
+        with mock.patch('botocore.auth.datetime') as _datetime:
+            _datetime.datetime.utcnow.return_value = timestamp
+            url = self.client.generate_presigned_url('get_caller_identity', {})
+
+        # There should be no 'content-type' in x-amz-signedheaders
+        expected_url = (
+            'https://sts.amazonaws.com/?Action=GetCallerIdentity&'
+            'Version=2011-06-15&X-Amz-Algorithm=AWS4-HMAC-SHA256&'
+            'X-Amz-Credential=access_key%2F20170322%2Fus-east-1%2Fsts%2F'
+            'aws4_request&X-Amz-Date=20170322T000000Z&X-Amz-Expires=3600&'
+            'X-Amz-SignedHeaders=host&X-Amz-Signature=767845d2ee858069a598d5f'
+            '8b497b75c7d57356885b1b3dba46dbbc0fc62bf5a'
+        )
+        assert_url_equal(url, expected_url)

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -877,6 +877,18 @@ class TestSigV4Presign(BasePresignTest):
         }
         self.assertEqual(query_string, expected_query_string)
 
+    def test_presign_content_type_form_encoded_not_signed(self):
+        request = AWSRequest()
+        request.method = 'GET'
+        request.url = 'https://myservice.us-east-1.amazonaws.com/'
+        request.headers['Content-Type'] = (
+            'application/x-www-form-urlencoded; charset=utf-8'
+        )
+        self.auth.add_auth(request)
+        query_string = self.get_parsed_query_string(request)
+        signed_headers = query_string.get('X-Amz-SignedHeaders')
+        self.assertNotIn('content-type', signed_headers)
+
 
 class BaseS3PresignPostTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This deletes the content-type header from query requests which are
being presigned. Specifically it removes the auto-set value
"application/x-www-form-urlencoded; charset=utf-8" because that
value is not valid for presigned urls.