### PR TITLE
Add iterator support to streaming body

### DIFF
--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -75,6 +75,18 @@ class TestStreamWrapper(unittest.TestCase):
         stream.close()
         self.assertTrue(body.closed)
 
+    def test_streaming_body_iterator(self):
+        body = six.BytesIO(b'123456789\n' * 10)
+        stream = response.StreamingBody(body, content_length=100)
+        for line in stream:
+            self.assertEqual(line, b'123456789\n')
+
+    def test_streaming_body_iterator(self):
+        body = six.BytesIO(b'123456789\r\n' * 10)
+        stream = response.StreamingBody(body, content_length=100)
+        for line in stream:
+            self.assertEqual(line, b'123456789\r\n')
+
 
 class TestGetResponse(BaseResponseTest):
     maxDiff = None

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -81,9 +81,9 @@ class TestStreamWrapper(unittest.TestCase):
         for line in stream:
             self.assertEqual(line, b'123456789\n')
 
-    def test_streaming_body_iterator(self):
+    def test_streaming_body_iterator_dos_newlines(self):
         body = six.BytesIO(b'123456789\r\n' * 10)
-        stream = response.StreamingBody(body, content_length=100)
+        stream = response.StreamingBody(body, content_length=110)
         for line in stream:
             self.assertEqual(line, b'123456789\r\n')
 


### PR DESCRIPTION
This will allow the common pattern of iterating over lines
like in file like objects. 

For example:
```
for line in streaming_body:
    # do something with line
```

Implemented using the underlying raw stream
readline. This can clean up code looking to read newline delimited
data while keeping the streaming behavior (rather than reading bytes
and implementing newline detection).

This change also implements the read length verification from the read()
method as well to mirror the behavior.
