### PR TITLE
tests: pass all env vars to cmd-runner

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -145,6 +145,7 @@ class BaseClientDriverTest(unittest.TestCase):
         if self.INJECT_DUMMY_CREDS:
             env = {'AWS_ACCESS_KEY_ID': 'foo',
                    'AWS_SECRET_ACCESS_KEY': 'bar'}
+        env.update(os.environ)
         self.driver.start(env=env)
 
     def cmd(self, *args):


### PR DESCRIPTION
cmd-runner was started with no environment variables inherited.
This breaks tests when run with custom PYTHONPATH, which is useful for
testing botocore while not being installed in standard locations.

One case when this is important is performing tests before installing
the package in Gentoo Linux.

Link: https://bugs.gentoo.org/640726