### PR TITLE
Hook more events into presign functionality

### DIFF
--- a/.changes/next-release/bugfix-Presign-62691.json
+++ b/.changes/next-release/bugfix-Presign-62691.json
@@ -1,0 +1,5 @@
+{
+  "category": "Presign", 
+  "type": "bugfix", 
+  "description": "Fix issue where some events were not fired during the presigning of a request thus not including a variety of customizations (`#1340 <https://github.com/boto/botocore/issues/1340>`__)"
+}

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -557,7 +557,9 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
         params = {}
     expires_in = ExpiresIn
     http_method = HttpMethod
-    context = {}
+    context = {
+        'is_presign_request': True
+    }
 
     request_signer = self._request_signer
     serializer = self._serializer

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -131,7 +131,9 @@ class RequestSigner(object):
             'before-sign.{0}.{1}'.format(self._service_name, operation_name),
             request=request, signing_name=signing_name,
             region_name=self._region_name,
-            signature_version=signature_version, request_signer=self)
+            signature_version=signature_version, request_signer=self,
+            operation_name=operation_name
+        )
 
         if signature_version != botocore.UNSIGNED:
             kwargs = {
@@ -551,8 +553,11 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     """
     client_method = ClientMethod
     params = Params
+    if params is None:
+        params = {}
     expires_in = ExpiresIn
     http_method = HttpMethod
+    context = {}
 
     request_signer = self._request_signer
     serializer = self._serializer
@@ -565,6 +570,8 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     operation_model = self.meta.service_model.operation_model(
         operation_name)
 
+    params = self._emit_api_params(params, operation_model, context)
+
     # Create a request dict based on the params to serialize.
     request_dict = serializer.serialize_to_request(
         params, operation_model)
@@ -575,8 +582,7 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
 
     # Prepare the request dict by including the client's endpoint url.
     prepare_request_dict(
-        request_dict, endpoint_url=self.meta.endpoint_url
-    )
+        request_dict, endpoint_url=self.meta.endpoint_url, context=context)
 
     # Generate the presigned url.
     return request_signer.generate_presigned_url(

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -23,6 +23,9 @@ class TestSTSPresignedUrl(BaseSessionTest):
     def setUp(self):
         super(TestSTSPresignedUrl, self).setUp()
         self.client = self.session.create_client('sts', 'us-west-2')
+        # Makes sure that no requests will go through
+        self.stubber = Stubber(self.client)
+        self.stubber.activate()
 
     def test_presigned_url_contains_no_content_type(self):
         timestamp = datetime(2017, 3, 22, 0, 0)

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -23,9 +23,6 @@ class TestSTSPresignedUrl(BaseSessionTest):
     def setUp(self):
         super(TestSTSPresignedUrl, self).setUp()
         self.client = self.session.create_client('sts', 'us-west-2')
-        # Makes sure that no requests will go through
-        self.stubber = Stubber(self.client)
-        self.stubber.activate()
 
     def test_presigned_url_contains_no_content_type(self):
         timestamp = datetime(2017, 3, 22, 0, 0)

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -28,9 +28,12 @@ import botocore.translate
 class TestStubber(unittest.TestCase):
     def setUp(self):
         session = botocore.session.get_session()
-        config = botocore.config.Config(signature_version=botocore.UNSIGNED)
-        self.client = session.create_client('s3', config=config)
-
+        config = botocore.config.Config(
+            signature_version=botocore.UNSIGNED,
+            s3={'addressing_style': 'path'}
+        )
+        self.client = session.create_client(
+            's3', region_name='us-east-1', config=config)
         self.stubber = Stubber(self.client)
 
     def test_stubber_returns_response(self):
@@ -270,3 +273,43 @@ class TestStubber(unittest.TestCase):
         except StubAssertionError:
             self.fail(
                 "Stubber inappropriately raised error for same parameters.")
+
+    def test_no_stub_for_presign_url(self):
+        try:
+            with self.stubber:
+                url = self.client.generate_presigned_url(
+                    ClientMethod='get_object',
+                    Params={
+                        'Bucket': 'mybucket',
+                        'Key': 'mykey'
+                    }
+                )
+                self.assertEqual(
+                    url, 'https://s3.amazonaws.com/mybucket/mykey')
+        except StubResponseError:
+            self.fail(
+                'Stubbed responses should not be required for generating '
+                'presigned requests'
+            )
+
+    def test_can_stub_with_presign_url_mixed_in(self):
+        desired_response = {}
+        expected_params = {
+            'Bucket': 'mybucket',
+            'Prefix': 'myprefix',
+        }
+        self.stubber.add_response(
+            'list_objects', desired_response, expected_params)
+        with self.stubber:
+            url = self.client.generate_presigned_url(
+                ClientMethod='get_object',
+                Params={
+                    'Bucket': 'myotherbucket',
+                    'Key': 'myotherkey'
+                }
+            )
+            self.assertEqual(
+                    url, 'https://s3.amazonaws.com/myotherbucket/myotherkey')
+            actual_response = self.client.list_objects(**expected_params)
+            self.assertEqual(desired_response, actual_response)
+        self.stubber.assert_no_pending_responses()

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -815,6 +815,22 @@ class TestGenerateUrl(unittest.TestCase):
             ]
         )
 
+    def test_generate_presign_url_emits_is_presign_in_context(self):
+        emitter = mock.Mock(HierarchicalEmitter)
+        emitter.emit.return_value = []
+        self.client.meta.events = emitter
+        self.client.generate_presigned_url(
+            'get_object', Params={'Bucket': self.bucket, 'Key': self.key})
+        kwargs_emitted = [
+            emit_call[1] for emit_call in emitter.emit.call_args_list
+        ]
+        for kwargs in kwargs_emitted:
+            self.assertTrue(
+                kwargs.get('context', {}).get('is_presign_request'),
+                'The context did not have is_presign_request set to True for '
+                'the following kwargs emitted: %s' % kwargs
+            )
+
 
 class TestGeneratePresignedPost(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -22,6 +22,7 @@ import botocore.auth
 from botocore.config import Config
 from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials
+from botocore.hooks import HierarchicalEmitter
 from botocore.exceptions import NoRegionError, UnknownSignatureVersionError
 from botocore.exceptions import UnknownClientMethodError, ParamValidationError
 from botocore.exceptions import UnsupportedSignatureVersionError
@@ -128,7 +129,7 @@ class TestSigner(BaseSignerTest):
             'before-sign.service_name.operation_name',
             request=mock.ANY, signing_name='signing_name',
             region_name='region_name', signature_version='v4',
-            request_signer=self.signer)
+            request_signer=self.signer, operation_name='operation_name')
 
     def test_disable_signing(self):
         # Returning botocore.UNSIGNED from choose-signer disables signing!
@@ -727,7 +728,7 @@ class TestGenerateUrl(unittest.TestCase):
             'query_string': {},
             'url_path': u'/mybucket/mykey',
             'method': u'GET',
-            'context': {}}
+            'context': mock.ANY}
         self.generate_url_mock.assert_called_with(
             request_dict=ref_request_dict, expires_in=3600,
             operation_name='GetObject')
@@ -748,7 +749,7 @@ class TestGenerateUrl(unittest.TestCase):
             'query_string': {u'response-content-disposition': disposition},
             'url_path': u'/mybucket/mykey',
             'method': u'GET',
-            'context': {}}
+            'context': mock.ANY}
         self.generate_url_mock.assert_called_with(
             request_dict=ref_request_dict, expires_in=3600,
             operation_name='GetObject')
@@ -772,7 +773,7 @@ class TestGenerateUrl(unittest.TestCase):
             'query_string': {},
             'url_path': u'/mybucket/mykey',
             'method': u'GET',
-            'context': {}}
+            'context': mock.ANY}
         self.generate_url_mock.assert_called_with(
             request_dict=ref_request_dict, expires_in=20,
             operation_name='GetObject')
@@ -788,10 +789,27 @@ class TestGenerateUrl(unittest.TestCase):
             'query_string': {},
             'url_path': u'/mybucket/mykey',
             'method': u'PUT',
-            'context': {}}
+            'context': mock.ANY}
         self.generate_url_mock.assert_called_with(
             request_dict=ref_request_dict, expires_in=3600,
             operation_name='GetObject')
+
+    def test_generate_presigned_url_emits_param_events(self):
+        emitter = mock.Mock(HierarchicalEmitter)
+        emitter.emit.return_value = []
+        self.client.meta.events = emitter
+        self.client.generate_presigned_url(
+            'get_object', Params={'Bucket': self.bucket, 'Key': self.key})
+        events_emitted = [
+            emit_call[0][0] for emit_call in emitter.emit.call_args_list
+        ]
+        self.assertEqual(
+            events_emitted,
+            [
+                'provide-client-params.s3.GetObject',
+                'before-parameter-build.s3.GetObject'
+            ]
+        )
 
 
 class TestGeneratePresignedPost(unittest.TestCase):

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -728,6 +728,10 @@ class TestGenerateUrl(unittest.TestCase):
             'query_string': {},
             'url_path': u'/mybucket/mykey',
             'method': u'GET',
+            # mock.ANY is used because client parameter related events
+            # inject values into the context. So using the context's exact
+            # value for these tests will be a maintenance burden if
+            # anymore customizations are added that inject into the context.
             'context': mock.ANY}
         self.generate_url_mock.assert_called_with(
             request_dict=ref_request_dict, expires_in=3600,


### PR DESCRIPTION
Specifically ensure the following:

* The emission of `provide-client-params` event to hook in injection of parameters
* The emission of `before-parameter-build` event event to hook in internal customizations related to parameters such as SSE-C MD5 injection.
* Registering s3 accelerate handler to `before-sign` so s3 accelerate presigned url's can be created. It is important to note that I decided not to move the `request-created` event to the presigner because the signers are already hooked up to that event so re-emitting that event will cause the signers to get triggered again. Furthermore, putting it at `before-sign` is consistent with the handlers we use to change addressing style.

Fixes https://github.com/boto/botocore/issues/978