### PR TITLE
Add paginators for several services

### DIFF
--- a/.changes/next-release/enhancment-Paginator-15272.json
+++ b/.changes/next-release/enhancment-Paginator-15272.json
@@ -1,0 +1,5 @@
+{
+  "description": "Added paginators for a number of services where the result key is unambiguous.",
+  "category": "Paginator",
+  "type": "enhancment"
+}

--- a/botocore/data/alexaforbusiness/2017-11-09/paginators-1.json
+++ b/botocore/data/alexaforbusiness/2017-11-09/paginators-1.json
@@ -1,3 +1,46 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListSkills": {
+      "result_key": "SkillSummaries",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "SearchUsers": {
+      "result_key": "Users",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListTags": {
+      "result_key": "Tags",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "SearchProfiles": {
+      "result_key": "Profiles",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "SearchSkillGroups": {
+      "result_key": "SkillGroups",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "SearchDevices": {
+      "result_key": "Devices",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "SearchRooms": {
+      "result_key": "Rooms",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/cloud9/2017-09-23/paginators-1.json
+++ b/botocore/data/cloud9/2017-09-23/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeEnvironmentMemberships": {
+      "result_key": "memberships",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListEnvironments": {
+      "result_key": "environmentIds",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    }
+  }
 }

--- a/botocore/data/clouddirectory/2016-05-10/paginators-1.json
+++ b/botocore/data/clouddirectory/2016-05-10/paginators-1.json
@@ -1,3 +1,100 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListObjectParentPaths": {
+      "result_key": "PathToObjectIdentifiersList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListFacetNames": {
+      "result_key": "FacetNames",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListPublishedSchemaArns": {
+      "result_key": "SchemaArns",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListDirectories": {
+      "result_key": "Directories",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListDevelopmentSchemaArns": {
+      "result_key": "SchemaArns",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListTypedLinkFacetNames": {
+      "result_key": "FacetNames",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListIndex": {
+      "result_key": "IndexAttachments",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListFacetAttributes": {
+      "result_key": "Attributes",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListObjectPolicies": {
+      "result_key": "AttachedPolicyIds",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListTagsForResource": {
+      "result_key": "Tags",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListAttachedIndices": {
+      "result_key": "IndexAttachments",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "LookupPolicy": {
+      "result_key": "PolicyToPathList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListPolicyAttachments": {
+      "result_key": "ObjectIdentifiers",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListObjectAttributes": {
+      "result_key": "Attributes",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListAppliedSchemaArns": {
+      "result_key": "SchemaArns",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListTypedLinkFacetAttributes": {
+      "result_key": "Attributes",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/cloudhsmv2/2017-04-28/paginators-1.json
+++ b/botocore/data/cloudhsmv2/2017-04-28/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeBackups": {
+      "result_key": "Backups",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "DescribeClusters": {
+      "result_key": "Clusters",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListTags": {
+      "result_key": "TagList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/codecommit/2015-04-13/paginators-1.json
+++ b/botocore/data/codecommit/2015-04-13/paginators-1.json
@@ -9,6 +9,36 @@
       "input_token": "nextToken",
       "output_token": "nextToken",
       "result_key": "repositories"
+    },
+    "GetCommentsForComparedCommit": {
+      "result_key": "commentsForComparedCommitData",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "DescribePullRequestEvents": {
+      "result_key": "pullRequestEvents",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetCommentsForPullRequest": {
+      "result_key": "commentsForPullRequestData",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListPullRequests": {
+      "result_key": "pullRequestIds",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetDifferences": {
+      "result_key": "differences",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
     }
   }
 }

--- a/botocore/data/comprehend/2017-11-27/paginators-1.json
+++ b/botocore/data/comprehend/2017-11-27/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListTopicsDetectionJobs": {
+      "result_key": "TopicsDetectionJobPropertiesList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/dms/2016-01-01/paginators-1.json
+++ b/botocore/data/dms/2016-01-01/paginators-1.json
@@ -1,3 +1,82 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeSchemas": {
+      "result_key": "Schemas",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeCertificates": {
+      "result_key": "Certificates",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEndpoints": {
+      "result_key": "Endpoints",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEventSubscriptions": {
+      "result_key": "EventSubscriptionsList",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEndpointTypes": {
+      "result_key": "SupportedEndpointTypes",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeReplicationInstances": {
+      "result_key": "ReplicationInstances",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeTableStatistics": {
+      "result_key": "TableStatistics",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeConnections": {
+      "result_key": "Connections",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeReplicationTaskAssessmentResults": {
+      "result_key": "ReplicationTaskAssessmentResults",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEvents": {
+      "result_key": "Events",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeOrderableReplicationInstances": {
+      "result_key": "OrderableReplicationInstances",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeReplicationSubnetGroups": {
+      "result_key": "ReplicationSubnetGroups",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeReplicationTasks": {
+      "result_key": "ReplicationTasks",
+      "output_token": "Marker",
+      "input_token": "Marker",
+      "limit_key": "MaxRecords"
+    }
+  }
 }

--- a/botocore/data/ds/2015-04-16/paginators-1.json
+++ b/botocore/data/ds/2015-04-16/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeDomainControllers": {
+      "result_key": "DomainControllers",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "Limit"
+    }
+  }
 }

--- a/botocore/data/es/2015-01-01/paginators-1.json
+++ b/botocore/data/es/2015-01-01/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListElasticsearchInstanceTypes": {
+      "result_key": "ElasticsearchInstanceTypes",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListElasticsearchVersions": {
+      "result_key": "ElasticsearchVersions",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/glue/2017-03-31/paginators-1.json
+++ b/botocore/data/glue/2017-03-31/paginators-1.json
@@ -1,3 +1,82 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetJobs": {
+      "result_key": "Jobs",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetPartitions": {
+      "result_key": "Partitions",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetDatabases": {
+      "result_key": "DatabaseList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetClassifiers": {
+      "result_key": "Classifiers",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetTableVersions": {
+      "result_key": "TableVersions",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetCrawlers": {
+      "result_key": "Crawlers",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetDevEndpoints": {
+      "result_key": "DevEndpoints",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetJobRuns": {
+      "result_key": "JobRuns",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetTriggers": {
+      "result_key": "Triggers",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetTables": {
+      "result_key": "TableList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetUserDefinedFunctions": {
+      "result_key": "UserDefinedFunctions",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetCrawlerMetrics": {
+      "result_key": "CrawlerMetricsList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetConnections": {
+      "result_key": "ConnectionList",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/inspector/2016-02-16/paginators-1.json
+++ b/botocore/data/inspector/2016-02-16/paginators-1.json
@@ -1,3 +1,52 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListFindings": {
+      "result_key": "findingArns",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListAssessmentTemplates": {
+      "result_key": "assessmentTemplateArns",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "PreviewAgents": {
+      "result_key": "agentPreviews",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListEventSubscriptions": {
+      "result_key": "subscriptions",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListRulesPackages": {
+      "result_key": "rulesPackageArns",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListAssessmentRunAgents": {
+      "result_key": "assessmentRunAgents",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListAssessmentRuns": {
+      "result_key": "assessmentRunArns",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListAssessmentTargets": {
+      "result_key": "assessmentTargetArns",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    }
+  }
 }

--- a/botocore/data/lex-models/2017-04-19/paginators-1.json
+++ b/botocore/data/lex-models/2017-04-19/paginators-1.json
@@ -1,3 +1,64 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetSlotTypeVersions": {
+      "result_key": "slotTypes",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetSlotTypes": {
+      "result_key": "slotTypes",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetIntents": {
+      "result_key": "intents",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetBotChannelAssociations": {
+      "result_key": "botChannelAssociations",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetBots": {
+      "result_key": "bots",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetBuiltinSlotTypes": {
+      "result_key": "slotTypes",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetIntentVersions": {
+      "result_key": "intents",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetBotAliases": {
+      "result_key": "BotAliases",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetBuiltinIntents": {
+      "result_key": "intents",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "GetBotVersions": {
+      "result_key": "bots",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    }
+  }
 }

--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -38,12 +38,6 @@
         "events",
         "searchedLogStreams"
       ]
-    },
-    "GetLogEvents": {
-      "result_key": "events",
-      "output_token": "nextForwardToken",
-      "input_token": "nextToken",
-      "limit_key": "limit"
     }
   }
 }

--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -38,6 +38,12 @@
         "events",
         "searchedLogStreams"
       ]
+    },
+    "GetLogEvents": {
+      "result_key": "events",
+      "output_token": "nextForwardToken",
+      "input_token": "nextToken",
+      "limit_key": "limit"
     }
   }
 }

--- a/botocore/data/mobile/2017-07-01/paginators-1.json
+++ b/botocore/data/mobile/2017-07-01/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListBundles": {
+      "result_key": "bundleList",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    },
+    "ListProjects": {
+      "result_key": "projects",
+      "output_token": "nextToken",
+      "input_token": "nextToken",
+      "limit_key": "maxResults"
+    }
+  }
 }

--- a/botocore/data/mturk/2017-01-17/paginators-1.json
+++ b/botocore/data/mturk/2017-01-17/paginators-1.json
@@ -1,3 +1,58 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListAssignmentsForHIT": {
+      "result_key": "Assignments",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListQualificationTypes": {
+      "result_key": "QualificationTypes",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListHITs": {
+      "result_key": "HITs",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListWorkerBlocks": {
+      "result_key": "WorkerBlocks",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListReviewableHITs": {
+      "result_key": "HITs",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListHITsForQualificationType": {
+      "result_key": "HITs",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListQualificationRequests": {
+      "result_key": "QualificationRequests",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListWorkersWithQualificationType": {
+      "result_key": "Qualifications",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListBonusPayments": {
+      "result_key": "BonusPayments",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/organizations/2016-11-28/paginators-1.json
+++ b/botocore/data/organizations/2016-11-28/paginators-1.json
@@ -71,6 +71,12 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults",
       "result_key": "Targets"
+    },
+    "ListAWSServiceAccessForOrganization": {
+      "result_key": "EnabledServicePrincipals",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
     }
   }
 }

--- a/botocore/data/rekognition/2016-06-27/paginators-1.json
+++ b/botocore/data/rekognition/2016-06-27/paginators-1.json
@@ -17,6 +17,12 @@
       "non_aggregate_keys": [
         "FaceModelVersion"
       ]
+    },
+    "ListStreamProcessors": {
+      "result_key": "StreamProcessors",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
     }
   }
 }

--- a/botocore/data/resource-groups/2017-11-27/paginators-1.json
+++ b/botocore/data/resource-groups/2017-11-27/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListGroups": {
+      "result_key": "Groups",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "SearchResources": {
+      "result_key": "ResourceIdentifiers",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListGroupResources": {
+      "result_key": "ResourceIdentifiers",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/sagemaker/2017-07-24/paginators-1.json
+++ b/botocore/data/sagemaker/2017-07-24/paginators-1.json
@@ -1,3 +1,40 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListTrainingJobs": {
+      "result_key": "TrainingJobSummaries",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListEndpoints": {
+      "result_key": "Endpoints",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListEndpointConfigs": {
+      "result_key": "EndpointConfigs",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListNotebookInstances": {
+      "result_key": "NotebookInstances",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListTags": {
+      "result_key": "Tags",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListModels": {
+      "result_key": "Models",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/servicecatalog/2015-12-10/paginators-1.json
+++ b/botocore/data/servicecatalog/2015-12-10/paginators-1.json
@@ -1,3 +1,58 @@
 {
-  "pagination": {}
+  "pagination": {
+    "SearchProductsAsAdmin": {
+      "result_key": "ProductViewDetails",
+      "output_token": "NextPageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListAcceptedPortfolioShares": {
+      "result_key": "PortfolioDetails",
+      "output_token": "NextPageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListPortfolios": {
+      "result_key": "PortfolioDetails",
+      "output_token": "NextPageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListConstraintsForPortfolio": {
+      "result_key": "ConstraintDetails",
+      "output_token": "NextPageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListLaunchPaths": {
+      "result_key": "LaunchPathSummaries",
+      "output_token": "NextPageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListTagOptions": {
+      "result_key": "TagOptionDetails",
+      "output_token": "PageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListPortfoliosForProduct": {
+      "result_key": "PortfolioDetails",
+      "output_token": "NextPageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListPrincipalsForPortfolio": {
+      "result_key": "Principals",
+      "output_token": "NextPageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListResourcesForTagOption": {
+      "result_key": "ResourceDetails",
+      "output_token": "PageToken",
+      "input_token": "PageToken",
+      "limit_key": "PageSize"
+    }
+  }
 }

--- a/botocore/data/servicediscovery/2017-03-14/paginators-1.json
+++ b/botocore/data/servicediscovery/2017-03-14/paginators-1.json
@@ -1,3 +1,28 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListServices": {
+      "result_key": "Services",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListInstances": {
+      "result_key": "Instances",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListNamespaces": {
+      "result_key": "Namespaces",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListOperations": {
+      "result_key": "Operations",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }

--- a/botocore/data/ses/2010-12-01/paginators-1.json
+++ b/botocore/data/ses/2010-12-01/paginators-1.json
@@ -5,6 +5,12 @@
       "output_token": "NextToken",
       "limit_key": "MaxItems",
       "result_key": "Identities"
+    },
+    "ListCustomVerificationEmailTemplates": {
+      "result_key": "CustomVerificationEmailTemplates",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
     }
   }
 }

--- a/botocore/data/ssm/2014-11-06/paginators-1.json
+++ b/botocore/data/ssm/2014-11-06/paginators-1.json
@@ -47,6 +47,18 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults",
       "result_key": "Parameters"
+    },
+    "GetParameterHistory": {
+      "result_key": "Parameters",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "GetParametersByPath": {
+      "result_key": "Parameters",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
     }
   }
 }

--- a/botocore/data/workmail/2017-10-01/paginators-1.json
+++ b/botocore/data/workmail/2017-10-01/paginators-1.json
@@ -1,3 +1,40 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListUsers": {
+      "result_key": "Users",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListGroupMembers": {
+      "result_key": "Members",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListOrganizations": {
+      "result_key": "OrganizationSummaries",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListGroups": {
+      "result_key": "Groups",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListResources": {
+      "result_key": "Resources",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListAliases": {
+      "result_key": "Aliases",
+      "output_token": "NextToken",
+      "input_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
 }


### PR DESCRIPTION
This adds paginators for a number of services where it was possible
to conclusively determine what the result key was. This only covers
cases where the result key was the only list in the operation
response and there were no structures or maps in the response.