### PR TITLE
Add internal link support to doc generator

### DIFF
--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -402,3 +402,9 @@ class ReSTStyle(BaseStyle):
             self.doc.write('`%s <%s>`_' % (title, link))
         else:
             self.doc.write(title)
+
+    def internal_link(self, title, page):
+        if self.doc.target == 'html':
+            self.doc.write(':doc:`%s <%s>`' % (title, page))
+        else:
+            self.doc.write(title)

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -317,9 +317,23 @@ class TestStyle(unittest.TestCase):
         self.assertEqual(style.doc.getvalue(),
                          six.b('`MyLink <http://example.com/foo>`_'))
 
-
     def test_external_link_in_man_page(self):
         style = ReSTStyle(ReSTDocument())
         style.doc.target = 'man'
         style.external_link('MyLink', 'http://example.com/foo')
+        self.assertEqual(style.doc.getvalue(), six.b('MyLink'))
+
+    def test_internal_link(self):
+        style = ReSTStyle(ReSTDocument())
+        style.doc.target = 'html'
+        style.internal_link('MyLink', '/index')
+        self.assertEqual(
+            style.doc.getvalue(),
+            six.b(':doc:`MyLink </index>`')
+        )
+
+    def test_internal_link_in_man_page(self):
+        style = ReSTStyle(ReSTDocument())
+        style.doc.target = 'man'
+        style.internal_link('MyLink', '/index')
         self.assertEqual(style.doc.getvalue(), six.b('MyLink'))


### PR DESCRIPTION
This adds support for linking to internal pages using the doc
directive for html, with a text fallback for other formats such
as manpages where that isn't supported.