### PR TITLE
Enforce ordering on CloudFormation get_template TemplateBody

### DIFF
--- a/.changes/next-release/enhancement-cloudformationgettemplatetemplatebodyordering-86054.json
+++ b/.changes/next-release/enhancement-cloudformationgettemplatetemplatebodyordering-86054.json
@@ -1,0 +1,5 @@
+{
+  "category": "cloudformation get_template template body ordering",
+  "type": "enhancement",
+  "description": "fixes boto/boto3`#1378 <https://github.com/boto/boto3/issues/1378>`__"
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -25,7 +25,7 @@ import warnings
 import uuid
 
 from botocore.compat import unquote, json, six, unquote_str, \
-    ensure_bytes, get_md5, MD5_AVAILABLE
+    ensure_bytes, get_md5, MD5_AVAILABLE, OrderedDict
 from botocore.docs.utils import AutoPopulatedParam
 from botocore.docs.utils import HideParamFromOperations
 from botocore.docs.utils import AppendParamDocumentation
@@ -163,7 +163,8 @@ def decode_quoted_jsondoc(value):
 def json_decode_template_body(parsed, **kwargs):
     if 'TemplateBody' in parsed:
         try:
-            value = json.loads(parsed['TemplateBody'])
+            value = json.loads(
+                parsed['TemplateBody'], object_pairs_hook=OrderedDict)
             parsed['TemplateBody'] = value
         except (ValueError, TypeError):
             logger.debug('error loading JSON', exc_info=True)


### PR DESCRIPTION
The TemplateBody is loaded from a string into a JSON dictionary which
did not preserve order. Instead use an OrderedDict to prserve the
template ordering.


cc @jamesls @kyleknap @dstufft @JordonPhillips @joguSD 