### PR TITLE
unquote string value in parse_timestamp

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -27,7 +27,7 @@ import botocore
 from botocore.exceptions import InvalidExpressionError, ConfigNotFound
 from botocore.exceptions import InvalidDNSNameError, ClientError
 from botocore.exceptions import MetadataRetrievalError
-from botocore.compat import json, quote, zip_longest, urlsplit, urlunsplit
+from botocore.compat import json, quote, unquote, zip_longest, urlsplit, urlunsplit
 from botocore.vendored import requests
 from botocore.compat import OrderedDict, six
 
@@ -357,7 +357,7 @@ def parse_timestamp(value):
         # In certain cases, a timestamp marked with GMT can be parsed into a
         # different time zone, so here we provide a context which will
         # enforce that GMT == UTC.
-        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
+        return dateutil.parser.parse(unquote(value), tzinfos={'GMT': tzutc()})
     except (TypeError, ValueError) as e:
         raise ValueError('Invalid timestamp "%s": %s' % (value, e))
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -317,6 +317,11 @@ class TestParseTimestamps(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_timestamp('invalid date')
 
+    def test_parse_quoted_timestamp(self):
+        self.assertEqual(
+            parse_timestamp('Thu,%2031%20Dec%202099%2020:00:00%20GMT'),
+            datetime.datetime(2099, 12, 31, 20, 0, tzinfo=tzutc()))
+
 
 class TestDatetime2Timestamp(unittest.TestCase):
     def test_datetime2timestamp_naive(self):


### PR DESCRIPTION
Hi, I have a django project which uses django-storages with boto3 backend to handle images on s3, and sometime botocore raise an exception because the 'expires' header is quoted.

```python
{
  'body': b'',
  'headers': {'content-length': '1874986', 'expires': 'Thu,%2031%20Dec%202099%2020:00:00%20GMT'},
  'status_code': 200,
}
```

For this case I try to be sure that the value is validated before trying to convert to a datetime object.

(
As a micro optimization could be done only in case of error, but I don't think it is really worth it

```python
    try:
        # In certain cases, a timestamp marked with GMT can be parsed into a
        # different time zone, so here we provide a context which will
        # enforce that GMT == UTC.
        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
    except (TypeError, ValueError) as e:
        return dateutil.parser.parse(unquote(value), tzinfos={'GMT': tzutc()})
    except (TypeError, ValueError) as e:
        raise ValueError('Invalid timestamp "%s": %s' % (value, e))
```

)