### PR TITLE
Add waiters for athena

### DIFF
--- a/botocore/data/athena/2017-05-18/waiters-2.json
+++ b/botocore/data/athena/2017-05-18/waiters-2.json
@@ -1,0 +1,43 @@
+{
+  "version": 2,
+  "waiters": {
+    "QuerySucceeded": {
+      "delay": 15,
+      "operation": "GetQueryExecution",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": "SUCCEEDED",
+          "matcher": "path",
+          "state": "success",
+          "argument": "QueryExecution.Status.State"
+        },
+        {
+          "expected": "FAILED",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "QueryExecution.Status.State"
+        },
+        {
+          "expected": "CANCELED",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "QueryExecution.Status.State"
+        }
+      ]
+    },
+    "QueriesFinished": {
+      "delay": 15,
+      "operation": "BatchGetQueryExecution",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": 0,
+          "matcher": "path",
+          "state": "success",
+          "argument": "length(QueryExecutions[?Status.State == `RUNNING`])"
+        }
+      ]
+    }
+  }
+}

--- a/botocore/data/athena/2017-05-18/waiters-2.json
+++ b/botocore/data/athena/2017-05-18/waiters-2.json
@@ -32,10 +32,10 @@
       "maxAttempts": 40,
       "acceptors": [
         {
-          "expected": 0,
+          "expected": true,
           "matcher": "path",
           "state": "success",
-          "argument": "length(QueryExecutions[?Status.State == `RUNNING`])"
+          "argument": "length(QueryExecutions[?Status.State == `RUNNING`]) == `0`"
         }
       ]
     }

--- a/tests/integration/test_waiters.py
+++ b/tests/integration/test_waiters.py
@@ -130,10 +130,7 @@ class TestWaiterForAthena(unittest.TestCase):
             waiter.wait(QueryExecutionId=query_id)
 
     def test_waiter_queries_finished(self):
-        """
-        Test queries_finished waiter. It comes back after all queries either
-        processed or can't be processed.
-        """
+        """Test queries_finished waiter."""
         query_1 = self.client.start_query_execution(
             QueryString='SELECT current_date',
             ResultConfiguration={
@@ -149,6 +146,7 @@ class TestWaiterForAthena(unittest.TestCase):
         )
         query_ids = [query_1['QueryExecutionId'], query_2['QueryExecutionId']]
         waiter = self.client.get_waiter('queries_finished')
+        # It comes back after all queries either processed or can't be processed.
         waiter.wait(QueryExecutionIds=query_ids)
         execution = self.client.batch_get_query_execution(QueryExecutionIds=query_ids)
         self.assertNotEqual(execution['QueryExecutions'][0]['Status']['State'], 'RUNNING')


### PR DESCRIPTION
I added two waiters for athena(https://github.com/boto/boto3/issues/1212).

For single query, `query_succeeded` only comes back without error iff query succeeded. Otherwise, `WaitError` is raised and one may call `get_query_execution` to examine the details.

For multiple queries, `queries_finished` is used. When it comes back, it means none of the queries is in `RUNNING` state. One should call `batch_get_query_execution` to examine the details.
