### PR TITLE
Credentials provider based on STS.GetSessionToken

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1213,11 +1213,12 @@ class GetSessionTokenProvider(CredentialProvider):
 
     GET_SESSION_TOKEN_CONFIG_VAR = 'session_token_duration'
 
-    def __init__(self, load_config, client_creator, profile_name, cache):
+    def __init__(self, load_config, client_creator, profile_name, cache, prompter=getpass.getpass):
         self._load_config = load_config
         self._client_creator = client_creator
         self._profile_name = profile_name
-        self.cache=cache
+        self.cache = cache
+        self._prompter = prompter
 
     def load(self):
         self._loaded_config = self._load_config()
@@ -1237,10 +1238,17 @@ class GetSessionTokenProvider(CredentialProvider):
             profile=profile
         )
 
+        extra_args = {}
+        mfa_serial = role_config.get('mfa_serial')
+        if mfa_serial is not None:
+            extra_args['SerialNumber'] = mfa_serial
+
         fetcher = GetSessionTokenCredentialFetcher(
             client_creator=self._client_creator,
             source_credentials=source_credentials,
             cache=self.cache,
+            mfa_prompter=self._prompter,
+            extra_args=extra_args,
         )
         refresher = fetcher.fetch_credentials
 

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1578,12 +1578,12 @@ class AssumeRoleProvider(CredentialProvider):
 
         if not self._get_session_token_provider_creator and \
                 GetSessionTokenProvider.GET_SESSION_TOKEN_CONFIG_VAR in \
-                profiles[source_profile]:
+                source_profile:
             raise InvalidConfigError(error_msg=(
                     'The %s parameter is specified in profile "%s", '
                     'but no get session token provider was configured.' % (
                         GetSessionTokenProvider.GET_SESSION_TOKEN_CONFIG_VAR,
-                        parent_profile)
+                        parent_profile_name)
             ))
 
         # Make sure we aren't going into an infinite loop. If we haven't

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1532,11 +1532,21 @@ class AssumeRoleProvider(CredentialProvider):
         profile = profiles[profile_name]
 
         if self._has_static_credentials(profile):
-            return self._resolve_static_credentials_from_profile(profile)
+            return self._resolve_static_credentials_from_profile(profile, profile_name)
 
         return self._load_creds_via_assume_role(profile_name)
 
-    def _resolve_static_credentials_from_profile(self, profile):
+    def _resolve_static_credentials_from_profile(self, profile, profile_name):
+        get_session_token_provider = GetSessionTokenProvider(
+            load_config=self._load_config,
+            client_creator=self._client_creator,
+            profile_name=profile_name,
+            cache=self.cache,
+        )
+        get_session_token_credentials = get_session_token_provider.load()
+        if get_session_token_credentials:
+            return get_session_token_credentials
+
         try:
             return Credentials(
                 access_key=profile['aws_access_key_id'],

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1256,6 +1256,8 @@ class GetSessionTokenProvider(CredentialProvider):
             extra_args=extra_args,
         )
         refresher = fetcher.fetch_credentials
+        if mfa_serial is not None:
+            refresher = create_mfa_serial_refresher(refresher)
 
         return DeferredRefreshableCredentials(
             method=self.METHOD,
@@ -1269,7 +1271,16 @@ class GetSessionTokenProvider(CredentialProvider):
         profile = profiles[profile_name]
 
         mfa_serial = profile.get('mfa_serial')
-        session_token_duration = int(profile[self.GET_SESSION_TOKEN_CONFIG_VAR])
+        session_token_duration = profile[self.GET_SESSION_TOKEN_CONFIG_VAR]
+
+        if not session_token_duration.isdigit():
+            raise InvalidConfigError(
+                error_msg=(
+                    'session_token_duration must be an integer'
+                )
+            )
+
+        session_token_duration = int(session_token_duration)
 
         role_config = {
             'mfa_serial': mfa_serial,

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -733,6 +733,33 @@ class AssumeRoleCredentialFetcher(CachedCredentialFetcher):
 class GetSessionTokenCredentialFetcher(CachedCredentialFetcher):
     def __init__(self, client_creator, source_credentials, extra_args=None, mfa_prompter=None, cache=None,
                  expiry_window_seconds=60 * 15):
+        """
+        :type client_creator: callable
+        :param client_creator: A callable that creates a client taking
+            arguments like ``Session.create_client``.
+
+        :type source_credentials: Credentials
+        :param source_credentials: The credentials to use to create the
+            client for the call to GetSessionToken.
+
+        :type extra_args: dict
+        :param extra_args: Any additional arguments to add to the get session
+            token request using the format of the botocore operation.
+            Possible keys include, but may not be limited to,
+            DurationSeconds and SerialNumber.
+
+        :type mfa_prompter: callable
+        :param mfa_prompter: A callable that returns input provided by the
+            user (i.e raw_input, getpass.getpass, etc.).
+
+        :type cache: dict
+        :param cache: An object that supports ``__getitem__``,
+            ``__setitem__``, and ``__contains__``.  An example of this is
+            the ``JSONFileCache`` class in aws-cli.
+
+        :type expiry_window_seconds: int
+        :param expiry_window_seconds: The amount of time, in seconds,
+        """
         self._client_creator = client_creator
         self._source_credentials = source_credentials
 
@@ -770,7 +797,9 @@ class GetSessionTokenCredentialFetcher(CachedCredentialFetcher):
         return client.get_session_token(**kwargs)
 
     def _get_session_token_kwargs(self):
-        """Get the arguments for GetSessionToken based on current configuration."""
+        """Get the arguments for GetSessionToken based on
+        current configuration.
+        """
         get_session_token_kwargs = self._session_token_kwargs
         mfa_serial = get_session_token_kwargs.get('SerialNumber')
 
@@ -1226,7 +1255,31 @@ class GetSessionTokenProvider(CredentialProvider):
 
     GET_SESSION_TOKEN_CONFIG_VAR = 'session_token_duration'
 
-    def __init__(self, load_config, client_creator, profile_name, cache, prompter=getpass.getpass):
+    def __init__(self, load_config, client_creator, cache, profile_name,
+                 prompter=getpass.getpass):
+        """
+        :type load_config: callable
+        :param load_config: A function that accepts no arguments, and
+            when called, will return the full configuration dictionary
+            for the session (``session.full_config``).
+
+        :type client_creator: callable
+        :param client_creator: A factory function that will create
+            a client when called.  Has the same interface as
+            ``botocore.session.Session.create_client``.
+
+        :type cache: dict
+        :param cache: An object that supports ``__getitem__``,
+            ``__setitem__``, and ``__contains__``.  An example
+            of this is the ``JSONFileCache`` class in the CLI.
+
+        :type profile_name: str
+        :param profile_name: The name of the profile.
+
+        :type prompter: callable
+        :param prompter: A callable that returns input provided
+            by the user (i.e raw_input, getpass.getpass, etc.).
+        """
         self._load_config = load_config
         self._client_creator = client_creator
         self._profile_name = profile_name
@@ -1355,6 +1408,12 @@ class AssumeRoleProvider(CredentialProvider):
         :param credential_sourcer: A credential provider that takes a
             configuration, which is used to provide the source credentials
             for the STS call.
+
+        :type get_session_token_provider_creator: callable
+        :param get_session_token_provider_creator: A function that accepts a
+            profile name as an argument, and when called, will return a
+            GetSessionTokenProvider instance configured with the provided
+            profile name.
         """
         #: The cache used to first check for assumed credentials.
         #: This is checked before making the AssumeRole API

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1241,7 +1241,9 @@ class GetSessionTokenProvider(CredentialProvider):
             profile=profile
         )
 
-        extra_args = {}
+        extra_args = {
+            'DurationSeconds': role_config['session_token_duration']
+        }
         mfa_serial = role_config.get('mfa_serial')
         if mfa_serial is not None:
             extra_args['SerialNumber'] = mfa_serial

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -744,7 +744,10 @@ class GetSessionTokenCredentialFetcher(CachedCredentialFetcher):
 
         The cache key is intended to be compatible with file names.
         """
-        args = deepcopy({'a':'1'})
+        args = deepcopy(self._session_token_kwargs)
+        # access_key_id is added on top of DurationSeconds and SerialNumber
+        # in order to create a unique key
+        args['access_key_id'] = self._source_credentials.get_frozen_credentials().access_key
 
         args = json.dumps(args, sort_keys=True)
         argument_hash = sha1(args.encode('utf-8')).hexdigest()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -2358,7 +2358,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         provider = credentials.AssumeRoleProvider(
             self.create_config_loader(),
             mock.Mock(), cache={}, profile_name='development',
-            get_session_token_provider=None
+            get_session_token_provider_creator=None
         )
 
         with self.assertRaises(botocore.exceptions.InvalidConfigError):
@@ -2569,7 +2569,8 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         provider = credentials.AssumeRoleProvider(
             self.create_config_loader(),
             client_creator=client_creator, cache={}, profile_name='development',
-            get_session_token_provider=mock_get_session_token_provider
+            get_session_token_provider_creator=
+            lambda profile_name: mock_get_session_token_provider
         )
 
         # The credentials won't actually be assumed until they're requested.

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -617,375 +617,6 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         self.assertEqual(calls, expected_calls)
 
 
-class TestGetSessionTokenCredentialFetcher(BaseEnvVar):
-    def setUp(self):
-        super(TestGetSessionTokenCredentialFetcher, self).setUp()
-        self.source_creds = credentials.Credentials('a', 'b', 'c')
-
-    def create_client_creator(self, with_response):
-        # Create a mock sts client that returns a specific response
-        # for get_session_token.
-        client = mock.Mock()
-        if isinstance(with_response, list):
-            client.get_session_token.side_effect = with_response
-        else:
-            client.get_session_token.return_value = with_response
-        return mock.Mock(return_value=client)
-
-    def get_expected_creds_from_response(self, response):
-        expiration = response['Credentials']['Expiration']
-        if isinstance(expiration, datetime):
-            expiration = expiration.isoformat()
-        return {
-            'access_key': response['Credentials']['AccessKeyId'],
-            'secret_key': response['Credentials']['SecretAccessKey'],
-            'token': response['Credentials']['SessionToken'],
-            'expiry_time': expiration
-        }
-
-    def test_no_cache(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat()
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds
-        )
-
-        expected_response = self.get_expected_creds_from_response(response)
-        response = refresher.fetch_credentials()
-
-        self.assertEqual(response, expected_response)
-
-    def test_expiration_in_datetime_format(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                # Note the lack of isoformat(), we're using
-                # a datetime.datetime type.  This will ensure
-                # we test both parsing as well as serializing
-                # from a given datetime because the credentials
-                # are immediately expired.
-                'Expiration': self.some_future_time()
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds,
-        )
-
-        expected_response = self.get_expected_creds_from_response(response)
-        response = refresher.fetch_credentials()
-
-        self.assertEqual(response, expected_response)
-
-    def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
-        utc_timestamp = date_in_future.isoformat() + 'Z'
-        cache_key = (
-            '3828048bbba9e40538a9871551b2fdc0b21841ad'
-        )
-        cache = {
-            cache_key: {
-                'Credentials': {
-                    'AccessKeyId': 'foo-cached',
-                    'SecretAccessKey': 'bar-cached',
-                    'SessionToken': 'baz-cached',
-                    'Expiration': utc_timestamp,
-                }
-            }
-        }
-        client_creator = mock.Mock()
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds, cache=cache
-        )
-
-        expected_response = self.get_expected_creds_from_response(
-            cache[cache_key]
-        )
-        response = refresher.fetch_credentials()
-
-        self.assertEqual(response, expected_response)
-        client_creator.assert_not_called()
-
-    def test_cache_key_is_windows_safe(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat()
-            },
-        }
-        cache = {}
-        client_creator = self.create_client_creator(with_response=response)
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds, cache=cache
-        )
-
-        refresher.fetch_credentials()
-
-        # On windows, you cannot use a a ':' in the filename, so
-        # we need to make sure that it doesn't make it into the cache key.
-        cache_key = (
-            '3828048bbba9e40538a9871551b2fdc0b21841ad'
-        )
-        self.assertIn(cache_key, cache)
-        self.assertEqual(cache[cache_key], response)
-
-    def test_cache_key_with_duration_seconds(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat()
-            },
-        }
-        cache = {}
-        client_creator = self.create_client_creator(with_response=response)
-        duration_seconds = 3600
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds, cache=cache,
-            extra_args={'DurationSeconds': duration_seconds}
-        )
-        refresher.fetch_credentials()
-
-        # This is the sha256 hex digest of the expected get session token args.
-        cache_key = (
-            'f75848d46c00c54667d4f39b7e8d90000a82f141'
-        )
-        self.assertIn(cache_key, cache)
-        self.assertEqual(cache[cache_key], response)
-
-    def test_cache_key_with_serial_number(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat()
-            },
-        }
-        cache = {}
-        client_creator = self.create_client_creator(with_response=response)
-        serial_number = 'mfa'
-        token_code = 'token-code'
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds, cache=cache,
-            extra_args={'SerialNumber': serial_number}, mfa_prompter=mock.Mock(return_value=token_code)
-        )
-        refresher.fetch_credentials()
-
-        # This is the sha256 hex digest of the expected get session token args.
-        cache_key = (
-            'efa35a9b921539cc9036f5cfb13fc7733476af94'
-        )
-        self.assertIn(cache_key, cache)
-        self.assertEqual(cache[cache_key], response)
-
-    def test_get_session_token_in_cache_but_expired(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        cache = {
-            '3828048bbba9e40538a9871551b2fdc0b21841ad': {
-                'Credentials': {
-                    'AccessKeyId': 'foo-cached',
-                    'SecretAccessKey': 'bar-cached',
-                    'SessionToken': 'baz-cached',
-                    'Expiration': datetime.now(tzlocal()),
-                }
-            }
-        }
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds, cache=cache
-        )
-        expected = self.get_expected_creds_from_response(response)
-        response = refresher.fetch_credentials()
-
-        self.assertEqual(response, expected)
-
-    def test_duration_seconds_can_be_provided(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        duration_seconds = 10800
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds,
-            extra_args={'DurationSeconds': duration_seconds}
-        )
-        refresher.fetch_credentials()
-
-        client = client_creator.return_value
-        client.get_session_token.assert_called_with(
-            DurationSeconds=duration_seconds)
-
-    def test_serial_number_can_be_provided(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        serial_number = 'mfa'
-        token_code = 'token-code'
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds, mfa_prompter=mock.Mock(return_value=token_code),
-            extra_args={'SerialNumber': serial_number}
-        )
-        refresher.fetch_credentials()
-
-        client = client_creator.return_value
-        client.get_session_token.assert_called_with(
-            SerialNumber=serial_number,
-            TokenCode=token_code)
-
-    def test_mfa(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        prompter = mock.Mock(return_value='token-code')
-        mfa_serial = 'mfa'
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds,
-            extra_args={'SerialNumber': mfa_serial}, mfa_prompter=prompter
-        )
-        refresher.fetch_credentials()
-
-        client = client_creator.return_value
-        # In addition to the normal get session token args, we should also
-        # inject the serial number from the config as well as the
-        # token code that comes from prompting the user (the prompter
-        # object).
-        client.get_session_token.assert_called_with(
-            SerialNumber='mfa',
-            TokenCode='token-code')
-
-    def test_refreshes(self):
-        responses = [{
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                # We're creating an expiry time in the past so as
-                # soon as we try to access the credentials, the
-                # refresh behavior will be triggered.
-                'Expiration': (
-                        datetime.now(tzlocal()) -
-                        timedelta(seconds=100)).isoformat(),
-            },
-        }, {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            }
-        }]
-        client_creator = self.create_client_creator(with_response=responses)
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds
-        )
-
-        # The first call will simply use whatever credentials it is given.
-        # The second will check the cache, and only make a call if the
-        # cached credentials are expired.
-        refresher.fetch_credentials()
-        refresher.fetch_credentials()
-
-        client = client_creator.return_value
-        get_session_token_calls = client.get_session_token.call_args_list
-        self.assertEqual(len(get_session_token_calls), 2, get_session_token_calls)
-
-    def test_mfa_refresh_enabled(self):
-        responses = [{
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                # We're creating an expiry time in the past so as
-                # soon as we try to access the credentials, the
-                # refresh behavior will be triggered.
-                'Expiration': (
-                        datetime.now(tzlocal()) -
-                        timedelta(seconds=100)).isoformat(),
-            },
-        }, {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            }
-        }]
-        client_creator = self.create_client_creator(with_response=responses)
-
-        token_code = 'token-code-1'
-        prompter = mock.Mock(side_effect=[token_code])
-        mfa_serial = 'mfa'
-
-        refresher = credentials.GetSessionTokenCredentialFetcher(
-            client_creator, self.source_creds,
-            extra_args={'SerialNumber': mfa_serial}, mfa_prompter=prompter
-        )
-
-        # This is will refresh credentials if they're expired. Because
-        # we set the expiry time to something in the past, this will
-        # trigger the refresh behavior.
-        refresher.fetch_credentials()
-
-        get_session_token = client_creator.return_value.get_session_token
-        calls = [c[1] for c in get_session_token.call_args_list]
-        expected_calls = [
-            {
-                'SerialNumber': mfa_serial,
-                'TokenCode': token_code
-            }
-        ]
-        self.assertEqual(calls, expected_calls)
-
-    def some_future_time(self):
-        timeobj = datetime.now(tzlocal())
-        return timeobj + timedelta(hours=24)
-
-
 class TestEnvVar(BaseEnvVar):
 
     def test_envvars_are_found_no_token(self):
@@ -2584,426 +2215,6 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         )
 
 
-class TestGetSessionTokenCredentialProvider(unittest.TestCase):
-    def setUp(self):
-        self.fake_config = {
-            'profiles': {
-                'development': {
-                    'aws_access_key_id': 'akid',
-                    'aws_secret_access_key': 'skid',
-                    'session_token_duration': '3600',
-                },
-            }
-        }
-
-    def create_config_loader(self, with_config=None):
-        if with_config is None:
-            with_config = self.fake_config
-        load_config = mock.Mock()
-        load_config.return_value = with_config
-        return load_config
-
-    def create_client_creator(self, with_response):
-        # Create a mock sts client that returns a specific response
-        # for get_session_token.
-        client = mock.Mock()
-        if isinstance(with_response, list):
-            client.get_session_token.side_effect = with_response
-        else:
-            client.get_session_token.return_value = with_response
-        return mock.Mock(return_value=client)
-
-    def some_future_time(self):
-        timeobj = datetime.now(tzlocal())
-        return timeobj + timedelta(hours=24)
-
-    def test_get_session_token_with_no_cache(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat()
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            client_creator, cache={}, profile_name='development')
-
-        creds = provider.load()
-
-        self.assertEqual(creds.access_key, 'foo')
-        self.assertEqual(creds.secret_key, 'bar')
-        self.assertEqual(creds.token, 'baz')
-
-    def test_get_session_token_with_datetime(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                # Note the lack of isoformat(), we're using
-                # a datetime.datetime type.  This will ensure
-                # we test both parsing as well as serializing
-                # from a given datetime because the credentials
-                # are immediately expired.
-                'Expiration': datetime.now(tzlocal()) + timedelta(hours=20)
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            client_creator, cache={}, profile_name='development')
-
-        creds = provider.load()
-
-        self.assertEqual(creds.access_key, 'foo')
-        self.assertEqual(creds.secret_key, 'bar')
-        self.assertEqual(creds.token, 'baz')
-
-    def test_get_session_token_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
-        utc_timestamp = date_in_future.isoformat() + 'Z'
-        self.fake_config['profiles']['development']['session_token_duration'] \
-            = '10800'
-
-        cache_key = (
-            '442c2e4543b38cc9453c5a946b152ae6714c83db'
-        )
-        cache = {
-            cache_key: {
-                'Credentials': {
-                    'AccessKeyId': 'foo-cached',
-                    'SecretAccessKey': 'bar-cached',
-                    'SessionToken': 'baz-cached',
-                    'Expiration': utc_timestamp,
-                }
-            }
-        }
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(), mock.Mock(),
-            cache=cache, profile_name='development')
-
-        creds = provider.load()
-
-        self.assertEqual(creds.access_key, 'foo-cached')
-        self.assertEqual(creds.secret_key, 'bar-cached')
-        self.assertEqual(creds.token, 'baz-cached')
-
-    def test_cache_key_is_windows_safe(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat()
-            },
-        }
-        cache = {}
-        self.fake_config['profiles']['development']['session_token_duration'] \
-            = '10800'
-
-        client_creator = self.create_client_creator(with_response=response)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            client_creator, cache=cache, profile_name='development')
-
-        provider.load().get_frozen_credentials()
-        # On windows, you cannot use a a ':' in the filename, so
-        # we need to make sure it doesn't come up in the cache key.
-        cache_key = (
-            '442c2e4543b38cc9453c5a946b152ae6714c83db'
-        )
-        self.assertIn(cache_key, cache)
-        self.assertEqual(cache[cache_key], response)
-
-    def test_cache_key_with_mfa_serial(self):
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat()
-            },
-        }
-        cache = {}
-        self.fake_config['profiles']['development']['session_token_duration'] \
-            = '10800'
-        self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
-
-        token_code = 'token-code'
-
-        client_creator = self.create_client_creator(with_response=response)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            client_creator, cache=cache, profile_name='development',
-            prompter=mock.Mock(return_value=token_code))
-
-        # The credentials won't actually be assumed until they're requested.
-        provider.load().get_frozen_credentials()
-
-        cache_key = (
-            '4a99f5bf3fdf2d26a8dbe0aeb976c357d9a4c9b4'
-        )
-        self.assertIn(cache_key, cache)
-        self.assertEqual(cache[cache_key], response)
-
-    def test_get_session_token_in_cache_but_expired(self):
-        expired_creds = datetime.now(tzlocal())
-        valid_creds = expired_creds + timedelta(hours=1)
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': valid_creds,
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        cache = {
-            '3bde8d90e0b1ed1adcb8cb8fc3f655307ffd4e8f': {
-                'Credentials': {
-                    'AccessKeyId': 'foo-cached',
-                    'SecretAccessKey': 'bar-cached',
-                    'SessionToken': 'baz-cached',
-                    'Expiration': expired_creds,
-                }
-            }
-        }
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(), client_creator,
-            cache=cache, profile_name='development')
-
-        creds = provider.load()
-
-        self.assertEqual(creds.access_key, 'foo')
-        self.assertEqual(creds.secret_key, 'bar')
-        self.assertEqual(creds.token, 'baz')
-
-    def test_session_token_duration_provided(self):
-        dev_profile = self.fake_config['profiles']['development']
-        dev_profile['session_token_duration'] = '20000'
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            client_creator, cache={}, profile_name='development')
-
-        # The credentials won't actually be fetched until they're requested.
-        provider.load().get_frozen_credentials()
-
-        client = client_creator.return_value
-        client.get_session_token.assert_called_with(
-            DurationSeconds=20000,)
-
-    def test_serial_number_provided(self):
-        dev_profile = self.fake_config['profiles']['development']
-        dev_profile['session_token_duration'] = '20000'
-        dev_profile['mfa_serial'] = 'mfa'
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            },
-        }
-        token_code = 'token-code'
-        client_creator = self.create_client_creator(with_response=response)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            client_creator, cache={}, profile_name='development',
-            prompter=mock.Mock(return_value=token_code))
-
-        # The credentials won't actually be fetched until they're requested.
-        provider.load().get_frozen_credentials()
-
-        client = client_creator.return_value
-        client.get_session_token.assert_called_with(
-            DurationSeconds=20000,
-            SerialNumber='mfa',
-            TokenCode=token_code,
-        )
-
-    def test_get_session_token_with_mfa(self):
-        self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
-        self.fake_config['profiles']['development']['session_token_duration'] \
-            = '20000'
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': self.some_future_time().isoformat(),
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        prompter = mock.Mock(return_value='token-code')
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(), client_creator,
-            cache={}, profile_name='development', prompter=prompter)
-
-        # The credentials won't actually be fetched until they're requested.
-        provider.load().get_frozen_credentials()
-
-        client = client_creator.return_value
-        # In addition to the normal get session token args, we should also
-        # inject the serial number from the config as well as the
-        # token code that comes from prompting the user (the prompter
-        # object).
-        client.get_session_token.assert_called_with(
-            DurationSeconds=20000, SerialNumber='mfa',
-            TokenCode='token-code')
-
-    def test_get_session_token_populates_session_name_on_refresh(self):
-        expiration_time = self.some_future_time()
-        next_expiration_time = expiration_time + timedelta(hours=4)
-        responses = [{
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                # We're creating an expiry time in the past so as
-                # soon as we try to access the credentials, the
-                # refresh behavior will be triggered.
-                'Expiration': expiration_time.isoformat(),
-            },
-        }, {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                'Expiration': next_expiration_time.isoformat(),
-            }
-        }]
-        client_creator = self.create_client_creator(with_response=responses)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(), client_creator,
-            cache={}, profile_name='development',)
-
-        local_now = mock.Mock(return_value=datetime.now(tzlocal()))
-        with mock.patch('botocore.credentials._local_now', local_now):
-            # This will trigger the first get_session_token() call. It returns
-            # credentials that are expired and will trigger a refresh.
-            creds = provider.load()
-            creds.get_frozen_credentials()
-
-            # This will trigger the second get_session_token() call because
-            # a refresh is needed.
-            local_now.return_value = expiration_time
-            creds.get_frozen_credentials()
-
-        client = client_creator.return_value
-        get_session_token_calls = client.get_session_token.call_args_list
-        self.assertEqual(len(get_session_token_calls), 2,
-                         get_session_token_calls)
-        # The args should be identical. That is, the second
-        # get_session_token call should have the exact same args as the
-        # initial assume_role call.
-        self.assertEqual(get_session_token_calls[0], get_session_token_calls[1])
-
-    def test_get_session_token_mfa_cannot_refresh_credentials(self):
-        # Note: we should look into supporting optional behavior
-        # in the future that allows for reprompting for credentials.
-        # But for now, if we get temp creds with MFA then when those
-        # creds expire, we can't refresh the credentials.
-        self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
-        expiration_time = self.some_future_time()
-        response = {
-            'Credentials': {
-                'AccessKeyId': 'foo',
-                'SecretAccessKey': 'bar',
-                'SessionToken': 'baz',
-                # We're creating an expiry time in the past so as
-                # soon as we try to access the credentials, the
-                # refresh behavior will be triggered.
-                'Expiration': expiration_time.isoformat(),
-            },
-        }
-        client_creator = self.create_client_creator(with_response=response)
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(), client_creator,
-            cache={}, profile_name='development',
-            prompter=mock.Mock(return_value='token-code'))
-
-        local_now = mock.Mock(return_value=datetime.now(tzlocal()))
-        with mock.patch('botocore.credentials._local_now', local_now):
-            # Loads the credentials, resulting in the first get session token
-            # call.
-            creds = provider.load()
-            creds.get_frozen_credentials()
-
-            local_now.return_value = expiration_time
-            with self.assertRaises(credentials.RefreshWithMFAUnsupportedError):
-                # access_key is a property that will refresh credentials
-                # if they're expired.  Because we set the expiry time to
-                # something in the past, this will trigger the refresh
-                # behavior, with with MFA will currently raise an exception.
-                creds.access_key
-
-    def test_no_config_is_noop(self):
-        self.fake_config['profiles']['development'] = {
-            'aws_access_key_id': 'foo',
-            'aws_secret_access_key': 'bar',
-        }
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            mock.Mock(), cache={}, profile_name='development')
-
-        # Because a session_token_duration was not specified, the
-        # GetSessionTokenProvider is a noop and will not return credentials
-        # (which means we move on to the next provider).
-        creds = provider.load()
-        self.assertIsNone(creds)
-
-    def test_incomplete_source_credentials_raises_error(self):
-        del self.fake_config['profiles']['development']['aws_access_key_id']
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            mock.Mock(), cache={}, profile_name='development')
-
-        with self.assertRaises(botocore.exceptions.PartialCredentialsError):
-            provider.load()
-
-    def test_session_token_duration_string(self):
-        profile = self.fake_config['profiles']['development']
-        profile['session_token_duration'] = 'some-string'
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            mock.Mock(), cache={}, profile_name='development')
-
-        with self.assertRaises(botocore.exceptions.InvalidConfigError):
-            provider.load()
-
-    def test_session_token_duration_float(self):
-        profile = self.fake_config['profiles']['development']
-        profile['session_token_duration'] = '1.0'
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            mock.Mock(), cache={}, profile_name='development')
-
-        with self.assertRaises(botocore.exceptions.InvalidConfigError):
-            provider.load()
-
-    def test_session_token_duration_negative(self):
-        profile = self.fake_config['profiles']['development']
-        profile['session_token_duration'] = '-1'
-        provider = credentials.GetSessionTokenProvider(
-            self.create_config_loader(),
-            mock.Mock(), cache={}, profile_name='development')
-
-        with self.assertRaises(botocore.exceptions.InvalidConfigError):
-            provider.load()
-
-
 class TestJSONCache(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
@@ -3567,3 +2778,792 @@ class TestProcessProvider(BaseEnvVar):
         self.assertEqual(creds.secret_key, 'bar')
         self.assertIsNone(creds.token)
         self.assertEqual(creds.method, 'custom-process')
+
+
+class TestGetSessionTokenCredentialFetcher(BaseEnvVar):
+    def setUp(self):
+        super(TestGetSessionTokenCredentialFetcher, self).setUp()
+        self.source_creds = credentials.Credentials('a', 'b', 'c')
+
+    def create_client_creator(self, with_response):
+        # Create a mock sts client that returns a specific response
+        # for get_session_token.
+        client = mock.Mock()
+        if isinstance(with_response, list):
+            client.get_session_token.side_effect = with_response
+        else:
+            client.get_session_token.return_value = with_response
+        return mock.Mock(return_value=client)
+
+    def get_expected_creds_from_response(self, response):
+        expiration = response['Credentials']['Expiration']
+        if isinstance(expiration, datetime):
+            expiration = expiration.isoformat()
+        return {
+            'access_key': response['Credentials']['AccessKeyId'],
+            'secret_key': response['Credentials']['SecretAccessKey'],
+            'token': response['Credentials']['SessionToken'],
+            'expiry_time': expiration
+        }
+
+    def test_no_cache(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat()
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds
+        )
+
+        expected_response = self.get_expected_creds_from_response(response)
+        response = refresher.fetch_credentials()
+
+        self.assertEqual(response, expected_response)
+
+    def test_expiration_in_datetime_format(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                # Note the lack of isoformat(), we're using
+                # a datetime.datetime type.  This will ensure
+                # we test both parsing as well as serializing
+                # from a given datetime because the credentials
+                # are immediately expired.
+                'Expiration': self.some_future_time()
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds,
+        )
+
+        expected_response = self.get_expected_creds_from_response(response)
+        response = refresher.fetch_credentials()
+
+        self.assertEqual(response, expected_response)
+
+    def test_retrieves_from_cache(self):
+        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        utc_timestamp = date_in_future.isoformat() + 'Z'
+        cache_key = (
+            '3828048bbba9e40538a9871551b2fdc0b21841ad'
+        )
+        cache = {
+            cache_key: {
+                'Credentials': {
+                    'AccessKeyId': 'foo-cached',
+                    'SecretAccessKey': 'bar-cached',
+                    'SessionToken': 'baz-cached',
+                    'Expiration': utc_timestamp,
+                }
+            }
+        }
+        client_creator = mock.Mock()
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds, cache=cache
+        )
+
+        expected_response = self.get_expected_creds_from_response(
+            cache[cache_key]
+        )
+        response = refresher.fetch_credentials()
+
+        self.assertEqual(response, expected_response)
+        client_creator.assert_not_called()
+
+    def test_cache_key_is_windows_safe(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat()
+            },
+        }
+        cache = {}
+        client_creator = self.create_client_creator(with_response=response)
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds, cache=cache
+        )
+
+        refresher.fetch_credentials()
+
+        # On windows, you cannot use a a ':' in the filename, so
+        # we need to make sure that it doesn't make it into the cache key.
+        cache_key = (
+            '3828048bbba9e40538a9871551b2fdc0b21841ad'
+        )
+        self.assertIn(cache_key, cache)
+        self.assertEqual(cache[cache_key], response)
+
+    def test_cache_key_with_duration_seconds(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat()
+            },
+        }
+        cache = {}
+        client_creator = self.create_client_creator(with_response=response)
+        duration_seconds = 3600
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds, cache=cache,
+            extra_args={'DurationSeconds': duration_seconds}
+        )
+        refresher.fetch_credentials()
+
+        # This is the sha256 hex digest of the expected get session token args.
+        cache_key = (
+            'f75848d46c00c54667d4f39b7e8d90000a82f141'
+        )
+        self.assertIn(cache_key, cache)
+        self.assertEqual(cache[cache_key], response)
+
+    def test_cache_key_with_serial_number(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat()
+            },
+        }
+        cache = {}
+        client_creator = self.create_client_creator(with_response=response)
+        serial_number = 'mfa'
+        token_code = 'token-code'
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds, cache=cache,
+            extra_args={'SerialNumber': serial_number}, mfa_prompter=mock.Mock(return_value=token_code)
+        )
+        refresher.fetch_credentials()
+
+        # This is the sha256 hex digest of the expected get session token args.
+        cache_key = (
+            'efa35a9b921539cc9036f5cfb13fc7733476af94'
+        )
+        self.assertIn(cache_key, cache)
+        self.assertEqual(cache[cache_key], response)
+
+    def test_get_session_token_in_cache_but_expired(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        cache = {
+            '3828048bbba9e40538a9871551b2fdc0b21841ad': {
+                'Credentials': {
+                    'AccessKeyId': 'foo-cached',
+                    'SecretAccessKey': 'bar-cached',
+                    'SessionToken': 'baz-cached',
+                    'Expiration': datetime.now(tzlocal()),
+                }
+            }
+        }
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds, cache=cache
+        )
+        expected = self.get_expected_creds_from_response(response)
+        response = refresher.fetch_credentials()
+
+        self.assertEqual(response, expected)
+
+    def test_duration_seconds_can_be_provided(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        duration_seconds = 10800
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds,
+            extra_args={'DurationSeconds': duration_seconds}
+        )
+        refresher.fetch_credentials()
+
+        client = client_creator.return_value
+        client.get_session_token.assert_called_with(
+            DurationSeconds=duration_seconds)
+
+    def test_serial_number_can_be_provided(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        serial_number = 'mfa'
+        token_code = 'token-code'
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds, mfa_prompter=mock.Mock(return_value=token_code),
+            extra_args={'SerialNumber': serial_number}
+        )
+        refresher.fetch_credentials()
+
+        client = client_creator.return_value
+        client.get_session_token.assert_called_with(
+            SerialNumber=serial_number,
+            TokenCode=token_code)
+
+    def test_mfa(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        prompter = mock.Mock(return_value='token-code')
+        mfa_serial = 'mfa'
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds,
+            extra_args={'SerialNumber': mfa_serial}, mfa_prompter=prompter
+        )
+        refresher.fetch_credentials()
+
+        client = client_creator.return_value
+        # In addition to the normal get session token args, we should also
+        # inject the serial number from the config as well as the
+        # token code that comes from prompting the user (the prompter
+        # object).
+        client.get_session_token.assert_called_with(
+            SerialNumber='mfa',
+            TokenCode='token-code')
+
+    def test_refreshes(self):
+        responses = [{
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                # We're creating an expiry time in the past so as
+                # soon as we try to access the credentials, the
+                # refresh behavior will be triggered.
+                'Expiration': (
+                        datetime.now(tzlocal()) -
+                        timedelta(seconds=100)).isoformat(),
+            },
+        }, {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            }
+        }]
+        client_creator = self.create_client_creator(with_response=responses)
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds
+        )
+
+        # The first call will simply use whatever credentials it is given.
+        # The second will check the cache, and only make a call if the
+        # cached credentials are expired.
+        refresher.fetch_credentials()
+        refresher.fetch_credentials()
+
+        client = client_creator.return_value
+        get_session_token_calls = client.get_session_token.call_args_list
+        self.assertEqual(len(get_session_token_calls), 2, get_session_token_calls)
+
+    def test_mfa_refresh_enabled(self):
+        responses = [{
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                # We're creating an expiry time in the past so as
+                # soon as we try to access the credentials, the
+                # refresh behavior will be triggered.
+                'Expiration': (
+                        datetime.now(tzlocal()) -
+                        timedelta(seconds=100)).isoformat(),
+            },
+        }, {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            }
+        }]
+        client_creator = self.create_client_creator(with_response=responses)
+
+        token_code = 'token-code-1'
+        prompter = mock.Mock(side_effect=[token_code])
+        mfa_serial = 'mfa'
+
+        refresher = credentials.GetSessionTokenCredentialFetcher(
+            client_creator, self.source_creds,
+            extra_args={'SerialNumber': mfa_serial}, mfa_prompter=prompter
+        )
+
+        # This is will refresh credentials if they're expired. Because
+        # we set the expiry time to something in the past, this will
+        # trigger the refresh behavior.
+        refresher.fetch_credentials()
+
+        get_session_token = client_creator.return_value.get_session_token
+        calls = [c[1] for c in get_session_token.call_args_list]
+        expected_calls = [
+            {
+                'SerialNumber': mfa_serial,
+                'TokenCode': token_code
+            }
+        ]
+        self.assertEqual(calls, expected_calls)
+
+    def some_future_time(self):
+        timeobj = datetime.now(tzlocal())
+        return timeobj + timedelta(hours=24)
+
+
+class TestGetSessionTokenCredentialProvider(unittest.TestCase):
+    def setUp(self):
+        self.fake_config = {
+            'profiles': {
+                'development': {
+                    'aws_access_key_id': 'akid',
+                    'aws_secret_access_key': 'skid',
+                    'session_token_duration': '3600',
+                },
+            }
+        }
+
+    def create_config_loader(self, with_config=None):
+        if with_config is None:
+            with_config = self.fake_config
+        load_config = mock.Mock()
+        load_config.return_value = with_config
+        return load_config
+
+    def create_client_creator(self, with_response):
+        # Create a mock sts client that returns a specific response
+        # for get_session_token.
+        client = mock.Mock()
+        if isinstance(with_response, list):
+            client.get_session_token.side_effect = with_response
+        else:
+            client.get_session_token.return_value = with_response
+        return mock.Mock(return_value=client)
+
+    def some_future_time(self):
+        timeobj = datetime.now(tzlocal())
+        return timeobj + timedelta(hours=24)
+
+    def test_get_session_token_with_no_cache(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat()
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            client_creator, cache={}, profile_name='development')
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+
+    def test_get_session_token_with_datetime(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                # Note the lack of isoformat(), we're using
+                # a datetime.datetime type.  This will ensure
+                # we test both parsing as well as serializing
+                # from a given datetime because the credentials
+                # are immediately expired.
+                'Expiration': datetime.now(tzlocal()) + timedelta(hours=20)
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            client_creator, cache={}, profile_name='development')
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+
+    def test_get_session_token_retrieves_from_cache(self):
+        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        utc_timestamp = date_in_future.isoformat() + 'Z'
+        self.fake_config['profiles']['development']['session_token_duration'] \
+            = '10800'
+
+        cache_key = (
+            '442c2e4543b38cc9453c5a946b152ae6714c83db'
+        )
+        cache = {
+            cache_key: {
+                'Credentials': {
+                    'AccessKeyId': 'foo-cached',
+                    'SecretAccessKey': 'bar-cached',
+                    'SessionToken': 'baz-cached',
+                    'Expiration': utc_timestamp,
+                }
+            }
+        }
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(), mock.Mock(),
+            cache=cache, profile_name='development')
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo-cached')
+        self.assertEqual(creds.secret_key, 'bar-cached')
+        self.assertEqual(creds.token, 'baz-cached')
+
+    def test_cache_key_is_windows_safe(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat()
+            },
+        }
+        cache = {}
+        self.fake_config['profiles']['development']['session_token_duration'] \
+            = '10800'
+
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            client_creator, cache=cache, profile_name='development')
+
+        provider.load().get_frozen_credentials()
+        # On windows, you cannot use a a ':' in the filename, so
+        # we need to make sure it doesn't come up in the cache key.
+        cache_key = (
+            '442c2e4543b38cc9453c5a946b152ae6714c83db'
+        )
+        self.assertIn(cache_key, cache)
+        self.assertEqual(cache[cache_key], response)
+
+    def test_cache_key_with_mfa_serial(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat()
+            },
+        }
+        cache = {}
+        self.fake_config['profiles']['development']['session_token_duration'] \
+            = '10800'
+        self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
+
+        token_code = 'token-code'
+
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            client_creator, cache=cache, profile_name='development',
+            prompter=mock.Mock(return_value=token_code))
+
+        # The credentials won't actually be assumed until they're requested.
+        provider.load().get_frozen_credentials()
+
+        cache_key = (
+            '4a99f5bf3fdf2d26a8dbe0aeb976c357d9a4c9b4'
+        )
+        self.assertIn(cache_key, cache)
+        self.assertEqual(cache[cache_key], response)
+
+    def test_get_session_token_in_cache_but_expired(self):
+        expired_creds = datetime.now(tzlocal())
+        valid_creds = expired_creds + timedelta(hours=1)
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': valid_creds,
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        cache = {
+            '3bde8d90e0b1ed1adcb8cb8fc3f655307ffd4e8f': {
+                'Credentials': {
+                    'AccessKeyId': 'foo-cached',
+                    'SecretAccessKey': 'bar-cached',
+                    'SessionToken': 'baz-cached',
+                    'Expiration': expired_creds,
+                }
+            }
+        }
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(), client_creator,
+            cache=cache, profile_name='development')
+
+        creds = provider.load()
+
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+
+    def test_session_token_duration_provided(self):
+        dev_profile = self.fake_config['profiles']['development']
+        dev_profile['session_token_duration'] = '20000'
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            client_creator, cache={}, profile_name='development')
+
+        # The credentials won't actually be fetched until they're requested.
+        provider.load().get_frozen_credentials()
+
+        client = client_creator.return_value
+        client.get_session_token.assert_called_with(
+            DurationSeconds=20000,)
+
+    def test_serial_number_provided(self):
+        dev_profile = self.fake_config['profiles']['development']
+        dev_profile['session_token_duration'] = '20000'
+        dev_profile['mfa_serial'] = 'mfa'
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        token_code = 'token-code'
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            client_creator, cache={}, profile_name='development',
+            prompter=mock.Mock(return_value=token_code))
+
+        # The credentials won't actually be fetched until they're requested.
+        provider.load().get_frozen_credentials()
+
+        client = client_creator.return_value
+        client.get_session_token.assert_called_with(
+            DurationSeconds=20000,
+            SerialNumber='mfa',
+            TokenCode=token_code,
+        )
+
+    def test_get_session_token_with_mfa(self):
+        self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
+        self.fake_config['profiles']['development']['session_token_duration'] \
+            = '20000'
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        prompter = mock.Mock(return_value='token-code')
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(), client_creator,
+            cache={}, profile_name='development', prompter=prompter)
+
+        # The credentials won't actually be fetched until they're requested.
+        provider.load().get_frozen_credentials()
+
+        client = client_creator.return_value
+        # In addition to the normal get session token args, we should also
+        # inject the serial number from the config as well as the
+        # token code that comes from prompting the user (the prompter
+        # object).
+        client.get_session_token.assert_called_with(
+            DurationSeconds=20000, SerialNumber='mfa',
+            TokenCode='token-code')
+
+    def test_get_session_token_populates_session_name_on_refresh(self):
+        expiration_time = self.some_future_time()
+        next_expiration_time = expiration_time + timedelta(hours=4)
+        responses = [{
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                # We're creating an expiry time in the past so as
+                # soon as we try to access the credentials, the
+                # refresh behavior will be triggered.
+                'Expiration': expiration_time.isoformat(),
+            },
+        }, {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': next_expiration_time.isoformat(),
+            }
+        }]
+        client_creator = self.create_client_creator(with_response=responses)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(), client_creator,
+            cache={}, profile_name='development',)
+
+        local_now = mock.Mock(return_value=datetime.now(tzlocal()))
+        with mock.patch('botocore.credentials._local_now', local_now):
+            # This will trigger the first get_session_token() call. It returns
+            # credentials that are expired and will trigger a refresh.
+            creds = provider.load()
+            creds.get_frozen_credentials()
+
+            # This will trigger the second get_session_token() call because
+            # a refresh is needed.
+            local_now.return_value = expiration_time
+            creds.get_frozen_credentials()
+
+        client = client_creator.return_value
+        get_session_token_calls = client.get_session_token.call_args_list
+        self.assertEqual(len(get_session_token_calls), 2,
+                         get_session_token_calls)
+        # The args should be identical. That is, the second
+        # get_session_token call should have the exact same args as the
+        # initial assume_role call.
+        self.assertEqual(get_session_token_calls[0], get_session_token_calls[1])
+
+    def test_get_session_token_mfa_cannot_refresh_credentials(self):
+        # Note: we should look into supporting optional behavior
+        # in the future that allows for reprompting for credentials.
+        # But for now, if we get temp creds with MFA then when those
+        # creds expire, we can't refresh the credentials.
+        self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
+        expiration_time = self.some_future_time()
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                # We're creating an expiry time in the past so as
+                # soon as we try to access the credentials, the
+                # refresh behavior will be triggered.
+                'Expiration': expiration_time.isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(), client_creator,
+            cache={}, profile_name='development',
+            prompter=mock.Mock(return_value='token-code'))
+
+        local_now = mock.Mock(return_value=datetime.now(tzlocal()))
+        with mock.patch('botocore.credentials._local_now', local_now):
+            # Loads the credentials, resulting in the first get session token
+            # call.
+            creds = provider.load()
+            creds.get_frozen_credentials()
+
+            local_now.return_value = expiration_time
+            with self.assertRaises(credentials.RefreshWithMFAUnsupportedError):
+                # access_key is a property that will refresh credentials
+                # if they're expired.  Because we set the expiry time to
+                # something in the past, this will trigger the refresh
+                # behavior, with with MFA will currently raise an exception.
+                creds.access_key
+
+    def test_no_config_is_noop(self):
+        self.fake_config['profiles']['development'] = {
+            'aws_access_key_id': 'foo',
+            'aws_secret_access_key': 'bar',
+        }
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            mock.Mock(), cache={}, profile_name='development')
+
+        # Because a session_token_duration was not specified, the
+        # GetSessionTokenProvider is a noop and will not return credentials
+        # (which means we move on to the next provider).
+        creds = provider.load()
+        self.assertIsNone(creds)
+
+    def test_incomplete_source_credentials_raises_error(self):
+        del self.fake_config['profiles']['development']['aws_access_key_id']
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            mock.Mock(), cache={}, profile_name='development')
+
+        with self.assertRaises(botocore.exceptions.PartialCredentialsError):
+            provider.load()
+
+    def test_session_token_duration_string(self):
+        profile = self.fake_config['profiles']['development']
+        profile['session_token_duration'] = 'some-string'
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            mock.Mock(), cache={}, profile_name='development')
+
+        with self.assertRaises(botocore.exceptions.InvalidConfigError):
+            provider.load()
+
+    def test_session_token_duration_float(self):
+        profile = self.fake_config['profiles']['development']
+        profile['session_token_duration'] = '1.0'
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            mock.Mock(), cache={}, profile_name='development')
+
+        with self.assertRaises(botocore.exceptions.InvalidConfigError):
+            provider.load()
+
+    def test_session_token_duration_negative(self):
+        profile = self.fake_config['profiles']['development']
+        profile['session_token_duration'] = '-1'
+        provider = credentials.GetSessionTokenProvider(
+            self.create_config_loader(),
+            mock.Mock(), cache={}, profile_name='development')
+
+        with self.assertRaises(botocore.exceptions.InvalidConfigError):
+            provider.load()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -778,8 +778,8 @@ class TestGetSessionTokenCredentialFetcher(BaseEnvVar):
         }
         cache = {}
         client_creator = self.create_client_creator(with_response=response)
-        serial_number = 'arn:aws:iam::111122223333:mfa/username'
-        token_code = '123456'
+        serial_number = 'mfa'
+        token_code = 'token-code'
 
         refresher = credentials.GetSessionTokenCredentialFetcher(
             client_creator, self.source_creds, cache=cache,
@@ -789,7 +789,7 @@ class TestGetSessionTokenCredentialFetcher(BaseEnvVar):
 
         # This is the sha256 hex digest of the expected get session token args.
         cache_key = (
-            '0db79e62534824a7c6c19fb80cc37931003f286d'
+            'efa35a9b921539cc9036f5cfb13fc7733476af94'
         )
         self.assertIn(cache_key, cache)
         self.assertEqual(cache[cache_key], response)
@@ -855,8 +855,8 @@ class TestGetSessionTokenCredentialFetcher(BaseEnvVar):
             },
         }
         client_creator = self.create_client_creator(with_response=response)
-        serial_number = 'arn:aws:iam::111122223333:mfa/username'
-        token_code = '123456'
+        serial_number = 'mfa'
+        token_code = 'token-code'
 
         refresher = credentials.GetSessionTokenCredentialFetcher(
             client_creator, self.source_creds, mfa_prompter=mock.Mock(return_value=token_code),
@@ -2675,10 +2675,9 @@ class TestGetSessionTokenCredentialProvider(unittest.TestCase):
         cache = {}
         self.fake_config['profiles']['development']['session_token_duration'] \
             = '10800'
-        self.fake_config['profiles']['development']['mfa_serial'] = \
-            'arn:aws:iam::111122223333:mfa/username'
+        self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
 
-        token_code = '123456'
+        token_code = 'token-code'
 
         client_creator = self.create_client_creator(with_response=response)
         provider = credentials.GetSessionTokenProvider(
@@ -2690,7 +2689,7 @@ class TestGetSessionTokenCredentialProvider(unittest.TestCase):
         provider.load().get_frozen_credentials()
 
         cache_key = (
-            '20bf2133ccc884a2c21310081319de25ffbd199a'
+            '4a99f5bf3fdf2d26a8dbe0aeb976c357d9a4c9b4'
         )
         self.assertIn(cache_key, cache)
         self.assertEqual(cache[cache_key], response)
@@ -2753,7 +2752,7 @@ class TestGetSessionTokenCredentialProvider(unittest.TestCase):
     def test_serial_number_provided(self):
         dev_profile = self.fake_config['profiles']['development']
         dev_profile['session_token_duration'] = '20000'
-        dev_profile['mfa_serial'] = 'arn:aws:iam::111122223333:mfa/username'
+        dev_profile['mfa_serial'] = 'mfa'
         response = {
             'Credentials': {
                 'AccessKeyId': 'foo',
@@ -2762,7 +2761,7 @@ class TestGetSessionTokenCredentialProvider(unittest.TestCase):
                 'Expiration': self.some_future_time().isoformat(),
             },
         }
-        token_code = '123456'
+        token_code = 'token-code'
         client_creator = self.create_client_creator(with_response=response)
         provider = credentials.GetSessionTokenProvider(
             self.create_config_loader(),
@@ -2775,7 +2774,7 @@ class TestGetSessionTokenCredentialProvider(unittest.TestCase):
         client = client_creator.return_value
         client.get_session_token.assert_called_with(
             DurationSeconds=20000,
-            SerialNumber='arn:aws:iam::111122223333:mfa/username',
+            SerialNumber='mfa',
             TokenCode=token_code,
         )
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -384,7 +384,7 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         }
         client_creator = self.create_client_creator(with_response=response)
         cache = {
-            'development--myrole': {
+            '793d6e2f27667ab2da104824407e486bfec24a47': {
                 'Credentials': {
                     'AccessKeyId': 'foo-cached',
                     'SecretAccessKey': 'bar-cached',
@@ -2078,7 +2078,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         }
         client_creator = self.create_client_creator(with_response=response)
         cache = {
-            'development--myrole': {
+            '793d6e2f27667ab2da104824407e486bfec24a47': {
                 'Credentials': {
                     'AccessKeyId': 'foo-cached',
                     'SecretAccessKey': 'bar-cached',


### PR DESCRIPTION
This PR adds a new credentials provider: `GetSessionTokenProvider`. 

The main use case for this is to reuse cacheable credentials provided by `STS.GetSessionToken` as source credentials for subsequent `STS.AssumeRole` calls. By reusing the cached credentials returned by `STS.GetSessionToken`, botocore clients will be able to continue issuing `STS.AssumeRole` calls for up to 36 hours before being prompted for a new MFA token.

In order for the `GetSessionTokenProvider` to load, users need to add the `session_token_duration` parameter to the config. This parameter is mapped to the `DurationSeconds` parameter for `STS.GetSessionToken`.

Example:
```
# # # credentials
[profile static-credentials]
aws_access_key_id = XXXXX...
aws_secret_access_key = XXXXX...

# # # config
[profile static-credentials]
session_token_duration = 86400  # 24 hrs
mfa_serial = arn:aws:iam::111222333444:mfa/some-user

[profile with-role]
role_arn = arn:aws:iam::111222333444:role/some-role
source_profile = static-credentials
```
When setting the current profile to `with-role`, the `AssumeRoleProvider` will detect that the source profile `static-credentials` has the `session_token_duration` parameter. The `AssumeRoleProvider` will defer to the `GetSessionTokenProvider` to provide the source credentials. The `GetSessionTokenProvider` in turn detects that the `static-credentials` profile has a `mfa_serial` configured, and will prompt for a MFA token. The `AssumeRoleProvider` will use credentials loaded by `GetSessionToken` as the source credentials for the `STS.AssumeRole` call.
