### PR TITLE
Add role_arn keyword argument to Session()

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -80,6 +80,7 @@ class Session(object):
     SESSION_VARIABLES = {
         # logical:  config_file, env_var,        default_value, conversion_func
         'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None),
+        'role_arn': (None, None, None, None),
         'region': ('region', 'AWS_DEFAULT_REGION', None, None),
         'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
         'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
@@ -109,7 +110,7 @@ class Session(object):
     LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
     def __init__(self, session_vars=None, event_hooks=None,
-                 include_builtin_handlers=True, profile=None):
+                 include_builtin_handlers=True, profile=None, role_arn=None):
         """
         Create a new Session object.
 
@@ -158,6 +159,8 @@ class Session(object):
         self._session_instance_vars = {}
         if profile is not None:
             self._session_instance_vars['profile'] = profile
+        if role_arn is not None:
+            self._session_instance_vars['role_arn'] = role_arn
         self._client_config = None
         self._components = ComponentLocator()
         self._register_components()


### PR DESCRIPTION
Currently Session() can be instantiated with a manual `profile` argument, which forces the use of a profile in your local config, and can be used to get boto to assume a role for you.
This PR takes this one step further and adds a `role_arn` argument which can be used the same way, but does not require config files to exist on the machine.
If `role_arn` is provided, a session will be attempted to be created by assuming `role_arn` from the otherwise default credentials (env vars, config, instance role, etc).

This was done by modifying the AssumeRoleProvider.

Questions:
 - is this an acceptable feature to add? It would eliminate the need to call sts.assume_role and manually instantiate a session in any usage of botocore that I've ever come across.
 - Is this an OK way to go about it? AssumeRoleProvider isn't named like it should be restricted to only assuming roles from profiles, but this does add a few different paths through it. It also has had to be extended a little as it was written with the assumption that it would never have to guess an appropriate credential source.

if the above two questions are fine, then see my github comments in the code itself for more specific questions.

Still to do:
 - [ ] integration tests
 - [ ] functional tests
 - [ ] more unit tests to get coverage up (or to ensure quality code, or something I guess :) )
 - [ ] docs
 - [ ] allow for role_session_name as well

I just want to wait on some indication that this is acceptable before I undertake these.

As is, botocore with this pr can be used by:
```python
   # default session
    botocore.session.Session()

    # assume a role with the credentials inferred as with the default session:
    botocore.session.Session(role_arn='arn:aws:iam::00000000:role/test-role'),

    # assume a role on top of a manually selected profile (I expect this is a corner case)
    botocore.session.Session(profile='some-profile', role_arn='arn:aws:iam::00000000:role/test-role')
```