### PR TITLE
support setting response metadata when adding client error to stub

### DIFF
--- a/.changes/next-release/enhancement-Stubber-50459.json
+++ b/.changes/next-release/enhancement-Stubber-50459.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Stubber",
+  "description": "Added the ability to add items to response metadata with the stubber."
+}

--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -250,7 +250,8 @@ class Stubber(object):
 
     def add_client_error(self, method, service_error_code='',
                          service_message='', http_status_code=400,
-                         service_error_meta=None, expected_params=None):
+                         service_error_meta=None, expected_params=None,
+                         response_meta=None):
         """
         Adds a ``ClientError`` to the response queue.
 
@@ -278,6 +279,11 @@ class Stubber(object):
             any of the parameters differ a ``StubResponseError`` is thrown.
             You can use stub.ANY to indicate a particular parameter to ignore
             in validation.
+
+        :param response_meta: Additional keys to be added to the
+            response's ResponseMetadata
+        :type response_meta: dict
+
         """
         http_response = Response()
         http_response.status_code = http_status_code
@@ -295,6 +301,9 @@ class Stubber(object):
 
         if service_error_meta is not None:
             parsed_response['Error'].update(service_error_meta)
+
+        if response_meta is not None:
+            parsed_response['ResponseMetadata'].update(response_meta)
 
         operation_name = self.client.meta.method_to_api_mapping.get(method)
         # Note that we do not allow for expected_params while

--- a/tests/unit/test_stub.py
+++ b/tests/unit/test_stub.py
@@ -159,7 +159,7 @@ class TestStubber(unittest.TestCase):
         self.assertEqual(response[1]['Error']['Message'], service_message)
         self.assertEqual(response[1]['Error']['Code'], error_code)
 
-    def test_get_client_error_with_extra_keys(self):
+    def test_get_client_error_with_extra_error_meta(self):
         error_code = "foo"
         error_message = "bar"
         error_meta = {
@@ -174,6 +174,23 @@ class TestStubber(unittest.TestCase):
         error = response[1]['Error']
         self.assertIn('Endpoint', error)
         self.assertEqual(error['Endpoint'], "https://foo.bar.baz")
+
+    def test_get_client_error_with_extra_response_meta(self):
+        error_code = "foo"
+        error_message = "bar"
+        stub_response_meta = {
+            "RequestId": "79104EXAMPLEB723",
+        }
+        self.stubber.add_client_error(
+            'foo', error_code, error_message,
+            http_status_code=301,
+            response_meta=stub_response_meta)
+        with self.stubber:
+            response = self.emit_get_response_event()
+        actual_response_meta = response[1]['ResponseMetadata']
+        self.assertIn('RequestId', actual_response_meta)
+        self.assertEqual(actual_response_meta['RequestId'], "79104EXAMPLEB723")
+
 
     def test_get_response_errors_with_no_stubs(self):
         self.stubber.activate()


### PR DESCRIPTION
Extends stub's add_client_metadata method per https://github.com/boto/botocore/issues/1375