### PR TITLE
Backport urllib3 upstream fix for reset connections to AWS servers, fixes #1248

### DIFF
--- a/botocore/vendored/requests/packages/urllib3/response.py
+++ b/botocore/vendored/requests/packages/urllib3/response.py
@@ -437,13 +437,13 @@ class HTTPResponse(io.IOBase):
             raise ResponseNotChunked("Response is not chunked. "
                 "Header 'transfer-encoding: chunked' is missing.")
 
-        if self._original_response and self._original_response._method.upper() == 'HEAD':
-            # Don't bother reading the body of a HEAD request.
-            # FIXME: Can we do this somehow without accessing private httplib _method?
-            self._original_response.close()
+        while True:
+            if self._original_response and self._original_response._method.upper() == 'HEAD':
+                # Don't bother reading the body of a HEAD request.
+                # FIXME: Can we do this somehow without accessing private httplib _method?
+                self._original_response.close()
             return
 
-        while True:
             self._update_chunk_length()
             if self.chunk_left == 0:
                 break


### PR DESCRIPTION
This solves #1248 in botocore HEAD. The proper fix is to update urllib3 but I don't know why you are vendoring `requests` in the first place.

Upstream fix I backported was https://github.com/shazow/urllib3/pull/1235