### PR TITLE
Default to virtual style addressing

### DIFF
--- a/.changes/next-release/feature-s3-58965.json
+++ b/.changes/next-release/feature-s3-58965.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``s3``",
+  "description": "Default to virtual hosted addressing regardless of signature version (boto/botocore`#1387 <https://github.com/boto/botocore/issues/1387>`__)"
+}

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -189,16 +189,6 @@ class ClientCreator(object):
         logger.debug("Defaulting to S3 virtual host style addressing with "
                      "path style addressing fallback.")
 
-        # For dual stack mode, we need to clear the default endpoint url in
-        # order to use the existing netloc if the bucket is dns compatible.
-        # Also, the default_endpoint_url of 's3.amazonaws.com' only works
-        # if we're in the 'aws' partition.  Anywhere else we should
-        # just use the existing netloc.
-        if s3_config.get('use_dualstack_endpoint', False) or \
-                partition != 'aws':
-            return functools.partial(
-                fix_s3_host, default_endpoint_url=None)
-
         # By default, try to use virtual style with path fallback.
         return fix_s3_host
 

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -558,7 +558,8 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     expires_in = ExpiresIn
     http_method = HttpMethod
     context = {
-        'is_presign_request': True
+        'is_presign_request': True,
+        'partition': self.meta.partition,
     }
 
     request_signer = self._request_signer
@@ -585,6 +586,8 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     # Prepare the request dict by including the client's endpoint url.
     prepare_request_dict(
         request_dict, endpoint_url=self.meta.endpoint_url, context=context)
+
+    request_dict['context']['partition'] = self.meta.partition
 
     # Generate the presigned url.
     return request_signer.generate_presigned_url(
@@ -686,7 +689,9 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
 
     # Prepare the request dict by including the client's endpoint url.
     prepare_request_dict(
-        request_dict, endpoint_url=self.meta.endpoint_url)
+        request_dict, endpoint_url=self.meta.endpoint_url,
+        context={'is_presign_request': True, 'partition': self.meta.partition},
+    )
 
     # Append that the bucket name to the list of conditions.
     conditions.append({'bucket': bucket})

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -559,7 +559,7 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     http_method = HttpMethod
     context = {
         'is_presign_request': True,
-        'partition': self.meta.partition,
+        'use_global_endpoint': _should_use_global_endpoint(self),
     }
 
     request_signer = self._request_signer
@@ -586,8 +586,6 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     # Prepare the request dict by including the client's endpoint url.
     prepare_request_dict(
         request_dict, endpoint_url=self.meta.endpoint_url, context=context)
-
-    request_dict['context']['partition'] = self.meta.partition
 
     # Generate the presigned url.
     return request_signer.generate_presigned_url(
@@ -690,7 +688,10 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
     # Prepare the request dict by including the client's endpoint url.
     prepare_request_dict(
         request_dict, endpoint_url=self.meta.endpoint_url,
-        context={'is_presign_request': True, 'partition': self.meta.partition},
+        context={
+            'is_presign_request': True,
+            'use_global_endpoint': _should_use_global_endpoint(self),
+        },
     )
 
     # Append that the bucket name to the list of conditions.
@@ -709,3 +710,12 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
     return post_presigner.generate_presigned_post(
         request_dict=request_dict, fields=fields, conditions=conditions,
         expires_in=expires_in)
+
+
+def _should_use_global_endpoint(client):
+    use_dualstack_endpoint = False
+    if client.meta.config.s3 is not None:
+        use_dualstack_endpoint = client.meta.config.s3.get(
+            'use_dualstack_endpoint', False)
+    return (client.meta.partition == 'aws' and
+            not use_dualstack_endpoint)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -672,7 +672,7 @@ def check_dns_name(bucket_name):
 
 
 def fix_s3_host(request, signature_version, region_name,
-                default_endpoint_url='s3.amazonaws.com', **kwargs):
+                default_endpoint_url=None, **kwargs):
     """
     This handler looks at S3 requests just before they are signed.
     If there is a bucket name on the path (true for everything except

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -678,9 +678,8 @@ def fix_s3_host(request, signature_version, region_name,
     addressing.
 
     """
-    if request.context.get('is_presign_request', False):
-        if request.context.get('partition', '') == 'aws':
-            default_endpoint_url = 's3.amazonaws.com'
+    if request.context.get('use_global_endpoint', False):
+        default_endpoint_url = 's3.amazonaws.com'
     try:
         switch_to_virtual_host_style(
             request, signature_version, default_endpoint_url)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -678,6 +678,9 @@ def fix_s3_host(request, signature_version, region_name,
     addressing.
 
     """
+    if request.context.get('is_presign_request', False):
+        if request.context.get('partition', '') == 'aws':
+            default_endpoint_url = 's3.amazonaws.com'
     try:
         switch_to_virtual_host_style(
             request, signature_version, default_endpoint_url)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -41,10 +41,6 @@ METADATA_SECURITY_CREDENTIALS_URL = (
 # Based on rfc2986, section 2.3
 SAFE_CHARS = '-._~'
 LABEL_RE = re.compile(r'[a-z0-9][a-z0-9\-]*[a-z0-9]')
-RESTRICTED_REGIONS = [
-    'us-gov-west-1',
-    'fips-us-gov-west-1',
-]
 RETRYABLE_HTTP_ERRORS = (requests.Timeout, requests.ConnectionError)
 S3_ACCELERATE_WHITELIST = ['dualstack']
 
@@ -679,11 +675,9 @@ def fix_s3_host(request, signature_version, region_name,
     ListAllBuckets) it checks to see if that bucket name conforms to
     the DNS naming conventions.  If it does, it alters the request to
     use ``virtual hosting`` style addressing rather than ``path-style``
-    addressing.  This allows us to avoid 301 redirects for all
-    bucket names that can be CNAME'd.
+    addressing.
+
     """
-    if not _allowed_region(region_name):
-        return
     try:
         switch_to_virtual_host_style(
             request, signature_version, default_endpoint_url)
@@ -758,10 +752,6 @@ def switch_to_virtual_host_style(request, signature_version,
 
 def _is_get_bucket_location_request(request):
     return request.url.endswith('?location')
-
-
-def _allowed_region(region_name):
-    return region_name not in RESTRICTED_REGIONS
 
 
 def instance_cache(func):

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -869,10 +869,21 @@ def test_addressing_for_presigned_urls():
                  expected_url='https://s3.us-east-2.amazonaws.com/bucket/key')
 
     # Dualstack endpoints
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
-                 signature_version=None,
-                 s3_config={'use_dualstack_endpoint': True},
-                 expected_url='https://bucket.s3.amazonaws.com/key')
+    yield t.case(
+        region='us-west-2', bucket='bucket', key='key',
+        signature_version=None,
+        s3_config={'use_dualstack_endpoint': True},
+        expected_url='https://bucket.s3.dualstack.us-west-2.amazonaws.com/key')
+    yield t.case(
+        region='us-west-2', bucket='bucket', key='key',
+        signature_version='s3',
+        s3_config={'use_dualstack_endpoint': True},
+        expected_url='https://bucket.s3.dualstack.us-west-2.amazonaws.com/key')
+    yield t.case(
+        region='us-west-2', bucket='bucket', key='key',
+        signature_version='s3v4',
+        s3_config={'use_dualstack_endpoint': True},
+        expected_url='https://bucket.s3.dualstack.us-west-2.amazonaws.com/key')
 
     # Accelerate
     yield t.case(region='us-west-2', bucket='bucket', key='key',
@@ -884,6 +895,12 @@ def test_addressing_for_presigned_urls():
     yield t.case(region='us-west-50', bucket='bucket', key='key',
                  signature_version=None,
                  expected_url='https://bucket.s3.amazonaws.com/key')
+
+    # Customer provided URL results in us leaving the host untouched.
+    yield t.case(region='us-west-2', bucket='bucket', key='key',
+                 signature_version=None,
+                 customer_provided_endpoint='https://foo.com/',
+                 expected_url='https://foo.com/bucket/key')
 
 
 def _verify_presigned_url_addressing(region, bucket, key, s3_config,

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -330,11 +330,11 @@ class TestRegionRedirect(BaseS3OperationTest):
 
         self.assertEqual(self.http_session_send_mock.call_count, 2)
         calls = [c[0][0] for c in self.http_session_send_mock.call_args_list]
-        initial_url = ('https://foo.s3.amazonaws.com/'
+        initial_url = ('https://foo.s3.us-west-2.amazonaws.com/'
                        '?encoding-type=url')
         self.assertEqual(calls[0].url, initial_url)
 
-        fixed_url = ('https://foo.s3.amazonaws.com/'
+        fixed_url = ('https://foo.s3.eu-central-1.amazonaws.com/'
                      '?encoding-type=url')
         self.assertEqual(calls[1].url, fixed_url)
 
@@ -349,7 +349,7 @@ class TestGeneratePresigned(BaseS3OperationTest):
                 'Bucket': 'foo',
                 'Key': 'bar'
             })
-        self.assertEqual(url, 'https://foo.s3.amazonaws.com/bar')
+        self.assertEqual(url, 'https://foo.s3.us-west-2.amazonaws.com/bar')
 
     def test_generate_unauthed_post(self):
         config = Config(signature_version=botocore.UNSIGNED)
@@ -357,7 +357,7 @@ class TestGeneratePresigned(BaseS3OperationTest):
         parts = client.generate_presigned_post(Bucket='foo', Key='bar')
         expected = {
             'fields': {'key': 'bar'},
-            'url': 'https://foo.s3.amazonaws.com/'
+            'url': 'https://foo.s3.us-west-2.amazonaws.com/'
         }
         self.assertEqual(parts, expected)
 
@@ -446,33 +446,33 @@ def test_correct_url_used_for_s3():
     # The default behavior for sigv2. DNS compatible buckets
     yield t.case(region='us-west-2', bucket='bucket', key='key',
                  signature_version='s3',
-                 expected_url='https://bucket.s3.amazonaws.com/key')
+                 expected_url='https://bucket.s3.us-west-2.amazonaws.com/key')
     yield t.case(region='us-east-1', bucket='bucket', key='key',
                  signature_version='s3',
                  expected_url='https://bucket.s3.amazonaws.com/key')
     yield t.case(region='us-west-1', bucket='bucket', key='key',
                  signature_version='s3',
-                 expected_url='https://bucket.s3.amazonaws.com/key')
+                 expected_url='https://bucket.s3.us-west-1.amazonaws.com/key')
     yield t.case(region='us-west-1', bucket='bucket', key='key',
                  signature_version='s3', is_secure=False,
-                 expected_url='http://bucket.s3.amazonaws.com/key')
+                 expected_url='http://bucket.s3.us-west-1.amazonaws.com/key')
 
     # Virtual host addressing is independent of signature version.
     yield t.case(region='us-west-2', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url=(
-                     'https://bucket.s3.amazonaws.com/key'))
+                     'https://bucket.s3.us-west-2.amazonaws.com/key'))
     yield t.case(region='us-east-1', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url='https://bucket.s3.amazonaws.com/key')
     yield t.case(region='us-west-1', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url=(
-                     'https://bucket.s3.amazonaws.com/key'))
+                     'https://bucket.s3.us-west-1.amazonaws.com/key'))
     yield t.case(region='us-west-1', bucket='bucket', key='key',
                  signature_version='s3v4', is_secure=False,
                  expected_url=(
-                     'http://bucket.s3.amazonaws.com/key'))
+                     'http://bucket.s3.us-west-1.amazonaws.com/key'))
 
     # Regions outside of the 'aws' partition.
     # These should still default to virtual hosted addressing

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -564,15 +564,14 @@ def test_correct_url_used_for_s3():
         s3_config=virtual_hosting,
         expected_url='https://bucket.s3.us-gov-west-1.amazonaws.com/key')
 
-    # Test restricted regions not do virtual host by default
     yield t.case(
         region='us-gov-west-1', bucket='bucket', key='key',
         signature_version='s3',
-        expected_url='https://s3.us-gov-west-1.amazonaws.com/bucket/key')
+        expected_url='https://bucket.s3.us-gov-west-1.amazonaws.com/key')
     yield t.case(
         region='fips-us-gov-west-1', bucket='bucket', key='key',
         signature_version='s3',
-        expected_url='https://s3-fips-us-gov-west-1.amazonaws.com/bucket/key')
+        expected_url='https://bucket.s3-fips-us-gov-west-1.amazonaws.com/key')
 
 
     # Test path style addressing.

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -582,7 +582,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
             'get_object', Params={'Bucket': self.bucket_name, 'Key': self.key})
         self.assertTrue(
             presigned_url.startswith(
-                'https://s3.amazonaws.com/%s/%s' % (
+                'https://%s.s3.amazonaws.com/%s' % (
                     self.bucket_name, self.key)),
             "Host was suppose to be the us-east-1 endpoint, instead "
             "got: %s" % presigned_url)
@@ -647,7 +647,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://s3.amazonaws.com/%s' % self.bucket_name),
+                'https://%s.s3.amazonaws.com/' % self.bucket_name),
             "Host was suppose to use us-east-1 endpoint, instead "
             "got: %s" % post_args['url'])
 
@@ -671,8 +671,8 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
             'get_object', Params={'Bucket': self.bucket_name, 'Key': self.key})
         self.assertTrue(
             presigned_url.startswith(
-                'https://%s.s3.amazonaws.com/%s' % (
-                    self.bucket_name, self.key)),
+                'https://%s.s3.%s.amazonaws.com/%s' % (
+                    self.bucket_name, self.region, self.key)),
             "Host was suppose to use DNS style, instead "
             "got: %s" % presigned_url)
         # Try to retrieve the object using the presigned url.
@@ -687,7 +687,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
 
         self.assertTrue(
             presigned_url.startswith(
-                'https://s3.us-west-2.amazonaws.com/%s/%s' % (
+                'https://%s.s3.us-west-2.amazonaws.com/%s' % (
                     self.bucket_name, self.key)),
             "Host was suppose to be the us-west-2 endpoint, instead "
             "got: %s" % presigned_url)
@@ -715,7 +715,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.amazonaws.com' % self.bucket_name),
+                'https://%s.s3.us-west-2.amazonaws.com' % self.bucket_name),
             "Host was suppose to use DNS style, instead "
             "got: %s" % post_args['url'])
 
@@ -748,7 +748,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://s3.us-west-2.amazonaws.com/%s' % self.bucket_name),
+                'https://%s.s3.us-west-2.amazonaws.com/' % self.bucket_name),
             "Host was suppose to use DNS style, instead "
             "got: %s" % post_args['url'])
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -671,15 +671,22 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
             'get_object', Params={'Bucket': self.bucket_name, 'Key': self.key})
         self.assertTrue(
             presigned_url.startswith(
-                'https://%s.s3.%s.amazonaws.com/%s' % (
-                    self.bucket_name, self.region, self.key)),
+                'https://%s.s3.amazonaws.com/%s' % (
+                    self.bucket_name, self.key)),
             "Host was suppose to use DNS style, instead "
             "got: %s" % presigned_url)
         # Try to retrieve the object using the presigned url.
         self.assertEqual(requests.get(presigned_url).content, b'foo')
 
     def test_presign_sigv4(self):
+        # For a newly created bucket, you can't use virtualhosted
+        # addressing and 's3v4' due to the backwards compat behavior
+        # using '.s3.amazonaws.com' for anything in the AWS partition.
+        # Instead you either have to use the older 's3' signature version
+        # of you have to use path style addressing.  The latter is being
+        # done here.
         self.client_config.signature_version = 's3v4'
+        self.client_config.s3 = {'addressing_style': 'path'}
         self.client = self.session.create_client(
             's3', config=self.client_config)
         presigned_url = self.client.generate_presigned_url(
@@ -687,7 +694,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
 
         self.assertTrue(
             presigned_url.startswith(
-                'https://%s.s3.us-west-2.amazonaws.com/%s' % (
+                'https://s3.us-west-2.amazonaws.com/%s/%s' % (
                     self.bucket_name, self.key)),
             "Host was suppose to be the us-west-2 endpoint, instead "
             "got: %s" % presigned_url)
@@ -715,7 +722,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.us-west-2.amazonaws.com' % self.bucket_name),
+                'https://%s.s3.amazonaws.com' % self.bucket_name),
             "Host was suppose to use DNS style, instead "
             "got: %s" % post_args['url'])
 
@@ -748,7 +755,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.us-west-2.amazonaws.com/' % self.bucket_name),
+                'https://%s.s3.amazonaws.com/' % self.bucket_name),
             "Host was suppose to use DNS style, instead "
             "got: %s" % post_args['url'])
 

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -91,7 +91,7 @@ class TestS3Addressing(BaseSessionTest):
         prepared_request = self.get_prepared_request('list_objects', params)
         # Note how we keep the region specific endpoint here.
         self.assertEqual(prepared_request.url,
-                         'https://s3.us-gov-west-1.amazonaws.com/safename')
+                         'https://safename.s3.us-gov-west-1.amazonaws.com/')
 
     def test_list_objects_in_fips(self):
         self.region_name = 'fips-us-gov-west-1'
@@ -100,7 +100,7 @@ class TestS3Addressing(BaseSessionTest):
         # Note how we keep the region specific endpoint here.
         self.assertEqual(
             prepared_request.url,
-            'https://s3-fips-us-gov-west-1.amazonaws.com/safename')
+            'https://safename.s3-fips-us-gov-west-1.amazonaws.com/')
 
     def test_list_objects_non_dns_name_non_classic(self):
         self.region_name = 'us-west-2'

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -72,7 +72,7 @@ class TestS3Addressing(BaseSessionTest):
         prepared_request = self.get_prepared_request('list_objects', params,
                                                      force_hmacv1=True)
         self.assertEqual(prepared_request.url,
-                         'https://safename.s3.amazonaws.com/')
+                         'https://safename.s3.us-west-2.amazonaws.com/')
 
     def test_list_objects_unicode_query_string_eu_central_1(self):
         self.region_name = 'eu-central-1'
@@ -81,7 +81,7 @@ class TestS3Addressing(BaseSessionTest):
         prepared_request = self.get_prepared_request('list_objects', params)
         self.assertEqual(
             prepared_request.url,
-            ('https://safename.s3.amazonaws.com/'
+            ('https://safename.s3.eu-central-1.amazonaws.com/'
              '?marker=%C3%A4%C3%B6%C3%BC-01.txt')
         )
 

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -81,7 +81,7 @@ class TestS3Addressing(BaseSessionTest):
         prepared_request = self.get_prepared_request('list_objects', params)
         self.assertEqual(
             prepared_request.url,
-            ('https://s3.eu-central-1.amazonaws.com/safename'
+            ('https://safename.s3.amazonaws.com/'
              '?marker=%C3%A4%C3%B6%C3%BC-01.txt')
         )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -677,13 +677,13 @@ class TestFixS3Host(unittest.TestCase):
             request=request, signature_version=signature_version,
             region_name=region_name)
         self.assertEqual(request.url,
-                         'https://bucket.s3.amazonaws.com/key.txt')
+                         'https://bucket.s3-us-west-2.amazonaws.com/key.txt')
         self.assertEqual(request.auth_path, '/bucket/key.txt')
 
     def test_fix_s3_host_only_applied_once(self):
         request = AWSRequest(
             method='PUT', headers={},
-            url='https://s3-us-west-2.amazonaws.com/bucket/key.txt'
+            url='https://s3.us-west-2.amazonaws.com/bucket/key.txt'
         )
         region_name = 'us-west-2'
         signature_version = 's3'
@@ -695,7 +695,7 @@ class TestFixS3Host(unittest.TestCase):
             request=request, signature_version=signature_version,
             region_name=region_name)
         self.assertEqual(request.url,
-                         'https://bucket.s3.amazonaws.com/key.txt')
+                         'https://bucket.s3.us-west-2.amazonaws.com/key.txt')
         # This was a bug previously.  We want to make sure that
         # calling fix_s3_host() again does not alter the auth_path.
         # Otherwise we'll get signature errors.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1393,6 +1393,26 @@ class TestS3RegionRedirector(unittest.TestCase):
             request_dict, response, self.operation)
         self.assertIsNone(redirect_response)
 
+    def test_redirects_400_head_bucket(self):
+        request_dict = {'url': 'https://us-west-2.amazonaws.com/foo',
+                        'context': {'signing': {'bucket': 'foo'}}}
+        response = (None, {
+            'Error': {'Code': '400', 'Message': 'Bad Request'},
+            'ResponseMetadata': {
+                'HTTPHeaders': {'x-amz-bucket-region': 'eu-central-1'}
+            }
+        })
+
+        self.operation.name = 'HeadObject'
+        redirect_response = self.redirector.redirect_from_error(
+            request_dict, response, self.operation)
+        self.assertEqual(redirect_response, 0)
+
+        self.operation.name = 'ListObjects'
+        redirect_response = self.redirector.redirect_from_error(
+            request_dict, response, self.operation)
+        self.assertIsNone(redirect_response)
+
     def test_does_not_redirect_if_None_response(self):
         request_dict = {'url': 'https://us-west-2.amazonaws.com/foo',
                         'context': {'signing': {'bucket': 'foo'}}}


### PR DESCRIPTION
This PR updates botocore to always default to virtual hosted addressing
regardless of signature version and/or region.  A user can always explicitly
configure which addressing mode they'd like to use but the behavior of botocore
is now much simpler and more consistent.  Previously, botocore would use
virtual hosted addressing for the `s3` signature version, but using `s3v4`
would switch to path style addressing.  Additionally, the GovCloud regions
would also use to path style addressing by default as would unsigned
requests.

Now the logic is much simpler and actually consistent:

1. If the user explicitly configures an addressing style, use that value.
2. Otherwise, try to use virtual hosted addressing and fall back to
   path style if needed.  This happens regardless of which signature version
   or region you have configured.

The commit messages have more details about the background and rationale
for these changes.  The one big change worth pointing out is that the
hardcoded `s3.amazonaws.com` suffix used by default for virtual hosted
addressing has been removed.  This caused a number of inconsistencies
depending on whether or not you're in the `aws` partition.  Also, the
original motiviation for adding this no longer applies.  See cfeaae6a
for a detailed explanation.

This will also require a change one of the AWS CLI tests.