### PR TITLE
Improve reliability of kinesis integ tests

### DIFF
--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -51,7 +51,6 @@ class TestKinesisListStreams(unittest.TestCase):
         self.client.put_record(
             StreamName=self.stream_name, PartitionKey='foo', Data=unique_data)
         # Give it a few seconds for the record to get into the stream.
-        time.sleep(10)
         records = self.wait_for_stream_data()
         self.assert_record_data_contains(records, unique_data.encode('ascii'))
         self.assertTrue(len(records['Records']) > 0)
@@ -67,8 +66,6 @@ class TestKinesisListStreams(unittest.TestCase):
                 'PartitionKey': 'foo'
             }]
         )
-        # Give it a few seconds for the record to get into the stream.
-        time.sleep(10)
         records = self.wait_for_stream_data()
         self.assert_record_data_contains(records, unique_data.encode('ascii'))
 
@@ -84,14 +81,13 @@ class TestKinesisListStreams(unittest.TestCase):
                 'PartitionKey': 'foo'
             }]
         )
-        # Give it a few seconds for the record to get into the stream.
-        time.sleep(10)
         records = self.wait_for_stream_data()
         self.assert_record_data_contains(records, b'foobar', b'barfoo')
 
     def wait_for_stream_data(self, num_attempts=6, poll_time=10):
         # Poll until we get records returned from get_records().
         for i in range(num_attempts):
+            time.sleep(poll_time)
             stream = self.client.describe_stream(StreamName=self.stream_name)
             shard = stream['StreamDescription']['Shards'][0]
             shard_iterator = self.client.get_shard_iterator(
@@ -101,7 +97,6 @@ class TestKinesisListStreams(unittest.TestCase):
                 ShardIterator=shard_iterator['ShardIterator'])
             if records['Records']:
                 return records
-            time.sleep(poll_time)
         raise RuntimeError("Unable to retrieve data from kinesis stream after "
                            "%s attempts with delay of %s seconds."
                            % (num_attempts, poll_time))

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
+from uuid import uuid4
 from tests import unittest, random_chars
 
 from nose.plugins.attrib import attr
@@ -46,44 +47,30 @@ class TestKinesisListStreams(unittest.TestCase):
 
     @attr('slow')
     def test_can_put_stream_blob(self):
+        unique_data = str(uuid4())
         self.client.put_record(
-            StreamName=self.stream_name, PartitionKey='foo', Data='foobar')
+            StreamName=self.stream_name, PartitionKey='foo', Data=unique_data)
         # Give it a few seconds for the record to get into the stream.
         time.sleep(10)
-
-        stream = self.client.describe_stream(StreamName=self.stream_name)
-        shard = stream['StreamDescription']['Shards'][0]
-        shard_iterator = self.client.get_shard_iterator(
-            StreamName=self.stream_name, ShardId=shard['ShardId'],
-            ShardIteratorType='TRIM_HORIZON')
-
-        records = self.client.get_records(
-            ShardIterator=shard_iterator['ShardIterator'])
+        records = self.wait_for_stream_data()
+        self.assert_record_data_contains(records, unique_data.encode('ascii'))
         self.assertTrue(len(records['Records']) > 0)
         self.assertEqual(records['Records'][0]['Data'], b'foobar')
 
     @attr('slow')
     def test_can_put_records_single_blob(self):
+        unique_data = str(uuid4())
         self.client.put_records(
             StreamName=self.stream_name,
             Records=[{
-                'Data': 'foobar',
+                'Data': unique_data,
                 'PartitionKey': 'foo'
             }]
         )
         # Give it a few seconds for the record to get into the stream.
         time.sleep(10)
-
-        stream = self.client.describe_stream(StreamName=self.stream_name)
-        shard = stream['StreamDescription']['Shards'][0]
-        shard_iterator = self.client.get_shard_iterator(
-            StreamName=self.stream_name, ShardId=shard['ShardId'],
-            ShardIteratorType='TRIM_HORIZON')
-
-        records = self.client.get_records(
-            ShardIterator=shard_iterator['ShardIterator'])
-        self.assertTrue(len(records['Records']) > 0)
-        self.assertEqual(records['Records'][0]['Data'], b'foobar')
+        records = self.wait_for_stream_data()
+        self.assert_record_data_contains(records, unique_data.encode('ascii'))
 
     @attr('slow')
     def test_can_put_records_multiple_blob(self):
@@ -99,19 +86,30 @@ class TestKinesisListStreams(unittest.TestCase):
         )
         # Give it a few seconds for the record to get into the stream.
         time.sleep(10)
+        records = self.wait_for_stream_data()
+        self.assert_record_data_contains(records, b'foobar', b'barfoo')
 
-        stream = self.client.describe_stream(StreamName=self.stream_name)
-        shard = stream['StreamDescription']['Shards'][0]
-        shard_iterator = self.client.get_shard_iterator(
-            StreamName=self.stream_name, ShardId=shard['ShardId'],
-            ShardIteratorType='TRIM_HORIZON')
+    def wait_for_stream_data(self, num_attempts=6, poll_time=10):
+        # Poll until we get records returned from get_records().
+        for i in range(num_attempts):
+            stream = self.client.describe_stream(StreamName=self.stream_name)
+            shard = stream['StreamDescription']['Shards'][0]
+            shard_iterator = self.client.get_shard_iterator(
+                StreamName=self.stream_name, ShardId=shard['ShardId'],
+                ShardIteratorType='TRIM_HORIZON')
+            records = self.client.get_records(
+                ShardIterator=shard_iterator['ShardIterator'])
+            if records['Records']:
+                return records
+            time.sleep(poll_time)
+        raise RuntimeError("Unable to retrieve data from kinesis stream after "
+                           "%s attempts with delay of %s seconds."
+                           % (num_attempts, poll_time))
 
-        records = self.client.get_records(
-            ShardIterator=shard_iterator['ShardIterator'])
-        self.assertTrue(len(records['Records']) == 2)
-        # Verify that both made it through.
+    def assert_record_data_contains(self, records, *expected):
         record_data = [r['Data'] for r in records['Records']]
-        self.assertEqual(sorted([b'foobar', b'barfoo']), sorted(record_data))
+        for item in expected:
+            self.assertIn(item, record_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are two things I fixed:

* Poll up to 1 minute before data becomes available.
* Use unique data for payloads data.

The integ tests were technically wrong because they were checking
the first record's data, but given the test all share the same stream
and shard that data will depend on whatever test ran first.  In only
worked for now because the tests were all using the same first data
payload of "foobar".