### PR TITLE
Ignore empty text markup tags

### DIFF
--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -88,8 +88,16 @@ class ReSTStyle(BaseStyle):
         # problems in the ReST inline markup so we remove it here
         # by popping the last item written off the stack, striping
         # the whitespace and then pushing it back on the stack.
-        last_write = self.doc.pop_write()
-        self.doc.push_write(last_write.rstrip(' '))
+        last_write = self.doc.pop_write().rstrip(' ')
+
+        # Sometimes, for whatever reason, a tag like <b/> is present. This
+        # is problematic because if we simply translate that directly then
+        # we end up with something like ****, which rst will assume is a
+        # heading instead of an empty bold.
+        if last_write == markup:
+            return
+
+        self.doc.push_write(last_write)
         self.doc.write(markup + ' ')
 
     def start_bold(self, attrs=None):

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -47,10 +47,22 @@ class TestStyle(unittest.TestCase):
         style.bold('foobar')
         self.assertEqual(style.doc.getvalue(), six.b('**foobar** '))
 
+    def test_empty_bold(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_b()
+        style.end_b()
+        self.assertEqual(style.doc.getvalue(), six.b(''))
+
     def test_italics(self):
         style = ReSTStyle(ReSTDocument())
         style.italics('foobar')
         self.assertEqual(style.doc.getvalue(), six.b('*foobar* '))
+
+    def test_empty_italics(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_i()
+        style.end_i()
+        self.assertEqual(style.doc.getvalue(), six.b(''))
 
     def test_p(self):
         style = ReSTStyle(ReSTDocument())
@@ -63,6 +75,12 @@ class TestStyle(unittest.TestCase):
         style = ReSTStyle(ReSTDocument())
         style.code('foobar')
         self.assertEqual(style.doc.getvalue(), six.b('``foobar`` '))
+
+    def test_empty_code(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_code()
+        style.end_code()
+        self.assertEqual(style.doc.getvalue(), six.b(''))
 
     def test_h1(self):
         style = ReSTStyle(ReSTDocument())


### PR DESCRIPTION
This ignores empty markup tags like `<b/>` because writing them out may
lead to issues where rst thinks that markup is something else, such as a
heading.

Fixes aws/aws-cli#3152