### PR TITLE
Allow disabling IMDS via env vars

### DIFF
--- a/.changes/next-release/enhancement-Credentials-75846.json
+++ b/.changes/next-release/enhancement-Credentials-75846.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Credentials",
+  "description": "Add the ability to disable fetching credentials from EC2 metadata by setting the environment variable AWS_EC2_METADATA_DISABLED to 'true'."
+}


### PR DESCRIPTION
This allows customers to disable fetching credentials from IMDS by
setting `AWS_EC2_METADATA_DISABLED` to `true`.