### PR TITLE
Tighten upper bound on python-dateutil version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tox>=2.5.0,<3.0.0
-python-dateutil>=2.1,<3.0.0
+python-dateutil>=2.1,<2.7.0
 nose==1.3.0
 mock==1.3.0
 wheel==0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 requires-dist =
-	python-dateutil>=2.1,<3.0.0
+	python-dateutil>=2.1,<2.7.0
 	jmespath>=0.7.1,<1.0.0
 	docutils>=0.10
 	ordereddict==1.1; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 
 
 requires = ['jmespath>=0.7.1,<1.0.0',
-            'python-dateutil>=2.1,<3.0.0',
+            'python-dateutil>=2.1,<2.7.0',
             'docutils>=0.10']
 
 


### PR DESCRIPTION
Version 2.7.0 of `python-dateutil` [dropped support for Python 2.6](https://github.com/dateutil/dateutil/pull/362).
