### PR TITLE
Fix race condition bug with deferred credentials

### DIFF
--- a/.changes/next-release/bugfix-Credentials-23327.json
+++ b/.changes/next-release/bugfix-Credentials-23327.json
@@ -1,0 +1,5 @@
+{
+  "category": "Credentials", 
+  "type": "bugfix", 
+  "description": "Fix a race condition related to assuming a role for the first time (`#1405 <https://github.com/boto/botocore/pull/1405>`__)"
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -444,6 +444,8 @@ class RefreshableCredentials(Credentials):
             # set of temporary credentials we have.
             return
         self._set_from_data(metadata)
+        self._frozen_credentials = ReadOnlyCredentials(
+            self._access_key, self._secret_key, self._token)
         if self._is_expired():
             # We successfully refreshed credentials but for whatever
             # reason, our refreshing function returned credentials
@@ -454,8 +456,6 @@ class RefreshableCredentials(Credentials):
                    "refreshed credentials are still expired.")
             logger.warning(msg)
             raise RuntimeError(msg)
-        self._frozen_credentials = ReadOnlyCredentials(
-            self._access_key, self._secret_key, self._token)
 
     @staticmethod
     def _expiry_datetime(time_str):
@@ -525,7 +525,7 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         self._frozen_credentials = None
 
     def refresh_needed(self, refresh_in=None):
-        if any(part is None for part in [self._access_key, self._secret_key]):
+        if self._frozen_credentials is None:
             return True
         return super(DeferredRefreshableCredentials, self).refresh_needed(
             refresh_in


### PR DESCRIPTION
Related to: https://github.com/aws/aws-cli/issues/3194

The issue occurred for the following scenario:

1) One thread secures the lock and goes through the initial refresh process
2) The thread with the lock sets the `self._access_key` and `self._secret_key`, but not yet `self._frozen_credentials`
3) The other threads call `refresh_needed()` and notice that since `self._access_key` and `self._secret_key` are set and the credential are not expired. As a result, they just return `self._frozen_credentials`.
4) However since `self._frozen_credentials` starts off as None and since `self._frozen_credentials` have not been set by the thread with the lock, the `DeferredRefreshableCredentials` returns None which causes the threads in this to raise a `NoCredentialsError` for those threads.

To fix this, the `refresh_needed()` was updated to use `self._frozen_credentials` to check if credentials have been set.

I added a test that confirmed this was an issue, and I ran it with the fix in place. I ran it in a loop (about 100 iterations) and I would see the test would fail about 10% of the time. With the fix, the test never failed no matter how many times I would try it.