### PR TITLE
Make redirects for S3 head bucket and object more strict

### DIFF
--- a/.changes/next-release/bugfix-s3-16370.json
+++ b/.changes/next-release/bugfix-s3-16370.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Fixed a bug where head object and bucket calls would attempt redirects incorrectly."
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -891,13 +891,21 @@ class S3RegionRedirector(object):
         error = response[1].get('Error', {})
         error_code = error.get('Code')
 
+        is_special_head_object = (
+            error_code == '301' and
+            operation.name in ['HeadObject', 'HeadBucket']
+        )
         # We have to account for 400 responses because
         # if we sign a Head* request with the wrong region,
+        # and it gets redirected by a temporary redirect
         # we'll get a 400 Bad Request but we won't get a
         # body saying it's an "AuthorizationHeaderMalformed".
-        is_special_head_object = (
-            error_code in ['301', '400'] and
-            operation.name in ['HeadObject', 'HeadBucket']
+        is_special_400_head_object = (
+            error_code == '400' and
+            operation.name in ['HeadObject', 'HeadBucket'] and
+            response[0].history and
+            response[0].history[-1].status_code == 307 and
+            response[0].history[-1].url != response[0].url
         )
         is_wrong_signing_region = (
             error_code == 'AuthorizationHeaderMalformed' and
@@ -905,7 +913,7 @@ class S3RegionRedirector(object):
         )
         is_permanent_redirect = error_code == 'PermanentRedirect'
         if not any([is_special_head_object, is_wrong_signing_region,
-                    is_permanent_redirect]):
+                    is_special_400_head_object, is_permanent_redirect]):
             return
 
         bucket = request_dict['context']['signing']['bucket']
@@ -932,6 +940,13 @@ class S3RegionRedirector(object):
             'bucket': bucket,
             'endpoint': endpoint
         }
+        # if the signing context doesn't change, don't retry
+        if request_dict['context']['signing'] == signing_context:
+            logger.debug(
+                "S3 client attempted a redirect that resulted in the same "
+                "signing context as the previous request. Aborting redirect."
+            )
+            return
         request_dict['context']['signing'] = signing_context
 
         self._cache[bucket] = signing_context

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1396,7 +1396,11 @@ class TestS3RegionRedirector(unittest.TestCase):
     def test_redirects_400_head_bucket(self):
         request_dict = {'url': 'https://us-west-2.amazonaws.com/foo',
                         'context': {'signing': {'bucket': 'foo'}}}
-        response = (None, {
+        raw_response = mock.Mock()
+        previous_response = mock.Mock()
+        previous_response.status_code = 307
+        raw_response.history = [previous_response]
+        response = (raw_response, {
             'Error': {'Code': '400', 'Message': 'Bad Request'},
             'ResponseMetadata': {
                 'HTTPHeaders': {'x-amz-bucket-region': 'eu-central-1'}
@@ -1409,6 +1413,29 @@ class TestS3RegionRedirector(unittest.TestCase):
         self.assertEqual(redirect_response, 0)
 
         self.operation.name = 'ListObjects'
+        redirect_response = self.redirector.redirect_from_error(
+            request_dict, response, self.operation)
+        self.assertIsNone(redirect_response)
+
+    def test_does_not_redirect_on_same_context(self):
+        signing_context = {
+            'bucket': 'foo',
+            'region': 'eu-central-1',
+            'endpoint': 'https://eu-central-1.amazonaws.com',
+        }
+        request_dict = {'url': 'https://eu-central-1.amazonaws.com/foo',
+                        'context': {'signing': signing_context}}
+        response = (None, {
+            'Error': {
+                'Code': '301',
+                'Message': 'Moved Permanently'
+            },
+            'ResponseMetadata': {
+                'HTTPHeaders': {'x-amz-bucket-region': 'eu-central-1'}
+            }
+        })
+
+        self.operation.name = 'HeadObject'
         redirect_response = self.redirector.redirect_from_error(
             request_dict, response, self.operation)
         self.assertIsNone(redirect_response)


### PR DESCRIPTION
Attempting to redirect 400s when performing a head bucket or object is too generic and can cause infinite retries in some circumstances (bad credentials, incorrect SSE-C parameters). This updates the logic to only retry a 400 in the case that the request was previously redirected by `requests` upon receiving a `307` from the global s3 endpoint.

Closes #1400, boto/boto3#1482