### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     package_data={'botocore': ['cacert.pem', 'data/*.json', 'data/*/*.json'],
                   'botocore.vendored.requests': ['*.pem']},
     include_package_data=True,
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=requires,
     extras_require={
         ':python_version=="2.6"': [

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     package_data={'botocore': ['cacert.pem', 'data/*.json', 'data/*/*.json'],
                   'botocore.vendored.requests': ['*.pem']},
     include_package_data=True,
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     install_requires=requires,
     extras_require={
         ':python_version=="2.6"': [


### PR DESCRIPTION
When botocore drops old Python versions, this will help pip install the right version for people still running those old Python versions.
 
For more info on how this works:
* https://hackernoon.com/phasing-out-python-runtimes-gracefully-956f112f33c4
* https://github.com/pypa/python-packaging-user-guide/issues/450