### PR TITLE
Adding ListVPCAssociationAuthorizations pagination (#1416)

### DIFF
--- a/botocore/data/route53/2013-04-01/paginators-1.json
+++ b/botocore/data/route53/2013-04-01/paginators-1.json
@@ -28,6 +28,16 @@
         "NextRecordType",
         "NextRecordIdentifier"
       ]
+    },
+    "ListVPCAssociationAuthorizations": {
+        "input_token": "NextToken",
+        "output_token": "NextToken",
+        "non_aggregate_keys": [
+            "HostedZoneId"
+        ],
+        "result_key": [
+            "VPCs"
+        ]
     }
   }
 }


### PR DESCRIPTION
Adding paginator support for list_vpc_association_authorizations in #1416 

```
>>> import boto3
>>> import botocore
>>>
>>> client = boto3.client('route53')
>>>
>>> client.can_paginate('list_vpc_association_authorizations')
True
>>> client.get_paginator('list_vpc_association_authorizations')
<botocore.client.Route53.Paginator.ListVPCAssociationAuthorizations object at 0x1022d8750>
```