### PR TITLE
Prevent infinite loops when handling S3 region redirects

### DIFF
--- a/.changes/next-release/bugfix-s3-85294.json
+++ b/.changes/next-release/bugfix-s3-85294.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``", 
+  "type": "bugfix", 
+  "description": "Fix bug where invalidate head_object requests would cause an infinite loop (alternate fix to `#1400 <https://github.com/boto/botocore/issues/1400>`__)"
+}

--- a/.changes/next-release/bugfix-s3-85294.json
+++ b/.changes/next-release/bugfix-s3-85294.json
@@ -1,5 +1,5 @@
 {
   "category": "``s3``", 
   "type": "bugfix", 
-  "description": "Fix bug where invalidate head_object requests would cause an infinite loop (alternate fix to `#1400 <https://github.com/boto/botocore/issues/1400>`__)"
+  "description": "Fix bug where invalid head_object requests would cause an infinite loop (alternate fix to `#1400 <https://github.com/boto/botocore/issues/1400>`__)"
 }

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -900,6 +900,8 @@ class S3RegionRedirector(object):
             return
 
         if request_dict.get('context', {}).get('s3_redirected'):
+            logger.debug(
+                'S3 request was previously redirected, not redirecting.')
             return
 
         error = response[1].get('Error', {})

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -899,6 +899,9 @@ class S3RegionRedirector(object):
             # transport error.
             return
 
+        if request_dict.get('context', {}).get('s3_redirected'):
+            return
+
         error = response[1].get('Error', {})
         error_code = error.get('Code')
 
@@ -947,6 +950,8 @@ class S3RegionRedirector(object):
 
         self._cache[bucket] = signing_context
         self.set_request_url(request_dict, request_dict['context'])
+
+        request_dict['context']['s3_redirected'] = True
 
         # Return 0 so it doesn't wait to retry
         return 0

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -16,7 +16,7 @@ from nose.tools import assert_equal
 import botocore.session
 from botocore.config import Config
 from botocore.compat import urlsplit
-from botocore.exceptions import ParamValidationError
+from botocore.exceptions import ParamValidationError, ClientError
 from botocore import UNSIGNED
 
 
@@ -277,6 +277,16 @@ class TestRegionRedirect(BaseS3OperationTest):
             b'    <IsTruncated>false</IsTruncated>'
             b'</ListBucketResult>')
 
+    def create_response(self, content=b'',
+                        status_code=200, headers=None):
+        response = mock.Mock()
+        if headers is None:
+            headers = {}
+        response.headers = headers
+        response.content = content
+        response.status_code = status_code
+        return response
+
     def test_region_redirect(self):
         self.http_session_send_mock.side_effect = [
             self.redirect_response, self.success_response]
@@ -340,30 +350,18 @@ class TestRegionRedirect(BaseS3OperationTest):
         self.assertEqual(calls[1].url, fixed_url)
 
     def test_resign_request_in_us_east_1(self):
-        bad_request_response = mock.Mock()
-        bad_request_response.headers = {}
-        bad_request_response.content = b''
-        bad_request_response.status_code = 400
-
-        bad_head_bucket_response = mock.Mock()
-        bad_head_bucket_response.headers = {
-            'x-amz-bucket-region': 'eu-central-1'
-        }
-        bad_head_bucket_response.content = b''
-        bad_head_bucket_response.status_code = 400
-
-        head_bucket_response = mock.Mock()
-        head_bucket_response.headers = {
-            'x-amz-bucket-region': 'eu-central-1'
-        }
-        head_bucket_response.content = b''
-        head_bucket_response.status_code = 200
-
-        request_response = mock.Mock()
-        request_response.headers = {}
-        request_response.content = b''
-        request_response.status_code = 200
-
+        bad_request_response = self.create_response(status_code=400)
+        bad_head_bucket_response = self.create_response(
+            status_code=400,
+            headers={'x-amz-bucket-region': 'eu-central-1'}
+        )
+        head_bucket_response = self.create_response(
+            headers={
+                'x-amz-bucket-region': 'eu-central-1'
+            },
+            status_code=200,
+        )
+        request_response = self.create_response(status_code=200)
         self.http_session_send_mock.side_effect = [
             bad_request_response,
             bad_head_bucket_response,
@@ -383,6 +381,33 @@ class TestRegionRedirect(BaseS3OperationTest):
 
         fixed_url = ('https://foo.s3.eu-central-1.amazonaws.com/bar')
         self.assertEqual(calls[-1].url, fixed_url)
+
+    def test_resign_request_in_us_east_1_fails(self):
+        bad_request_response = self.create_response(status_code=400)
+        bad_head_bucket_response = self.create_response(
+            status_code=400,
+            headers={'x-amz-bucket-region': 'eu-central-1'}
+        )
+        head_bucket_response = self.create_response(
+            headers={
+                'x-amz-bucket-region': 'eu-central-1'
+            }
+        )
+        # The final request still fails with a 400.
+        request_response = self.create_response(status_code=400)
+
+        self.http_session_send_mock.side_effect = [
+            bad_request_response,
+            bad_head_bucket_response,
+            head_bucket_response,
+            request_response,
+        ]
+
+        # Verify that the final 400 response is propagated
+        # back to the user.
+        client = self.session.create_client('s3', 'us-east-1')
+        with self.assertRaises(ClientError) as e:
+            client.head_object(Bucket='foo', Key='bar')
 
 
 class TestGeneratePresigned(BaseS3OperationTest):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1341,6 +1341,28 @@ class TestS3RegionRedirector(unittest.TestCase):
         }
         signing_context = request_dict['context'].get('signing')
         self.assertEqual(signing_context, expected_signing_context)
+        self.assertTrue(request_dict['context'].get('s3_redirected'))
+
+    def test_does_not_redirect_if_previously_redirected(self):
+        request_dict = {
+            'context': {
+                'signing': {'bucket': 'foo', 'region': 'us-west-2'},
+                's3_redirected': True,
+            },
+            'url': 'https://us-west-2.amazonaws.com/foo'
+        }
+        response = (None, {
+            'Error': {
+                'Code': '400',
+                'Message': 'Bad Request',
+            },
+            'ResponseMetadata': {
+                'HTTPHeaders': {'x-amz-bucket-region': 'us-west-2'}
+            }
+        })
+        redirect_response = self.redirector.redirect_from_error(
+            request_dict, response, self.operation)
+        self.assertIsNone(redirect_response)
 
     def test_does_not_redirect_unless_permanentredirect_recieved(self):
         request_dict = {}


### PR DESCRIPTION
This adds an alternate fix for https://github.com/boto/botocore/pull/1409 .  I've pulled in @joguSD's patch and added additional unit/integration tests.

The fix is to set a flag when we redirect the first time and verify we haven't previously redirected on subsequent requests.  I also added an integration test for the specific case mentioned in https://github.com/boto/botocore/issues/1400.

As for the regression caused from #1409, we need buckets with DNS propagated in order to actually test this, but I did write a one off integration test to verify this works as expected.  I don't think it makes sense to include in our main integration test suite, I think the unit/functional tests suffice.  If you're curious though, here's the test: https://gist.github.com/jamesls/9e1f0eb8e6b632f62ea5cb38131de2ae