### PR TITLE
Skip resetting stream when it is a bytearray

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -419,7 +419,8 @@ class AWSPreparedRequest(models.PreparedRequest):
         # the entire body contents again if we need to).
         # Same case if the body is a string/bytes type.
         if self.body is None or isinstance(self.body, six.text_type) or \
-                isinstance(self.body, six.binary_type):
+                isinstance(self.body, six.binary_type) or \
+                (six.PY3 and isinstance(self.body, bytearray)):
             return
         try:
             logger.debug("Rewinding stream: %s", self.body)


### PR DESCRIPTION
Allows `bytearray` to be used in requests instead of `bytes`.

I couldn't figure out if the existing behavior is being tested, but I'm happy to add tests with some guidance as to where they belong.

Fixes #1359