### PR TITLE
Add support for cliArgumentName in the member metadata

### DIFF
--- a/botocore/model.py
+++ b/botocore/model.py
@@ -52,7 +52,8 @@ class Shape(object):
                         'eventstream', 'event', 'eventheader', 'eventpayload',
                         'jsonvalue']
     METADATA_ATTRS = ['required', 'min', 'max', 'sensitive', 'enum',
-                      'idempotencyToken', 'error', 'exception']
+                      'idempotencyToken', 'error', 'exception',
+                      'cliArgumentName']
     MAP_TYPE = OrderedDict
 
     def __init__(self, shape_name, shape_model, shape_resolver=None):
@@ -133,6 +134,7 @@ class Shape(object):
             * sensitive
             * required
             * idempotencyToken
+            * cliArgumentName
 
         :rtype: dict
         :return: Metadata about the shape.

--- a/tests/functional/test_cliargumentname_config.py
+++ b/tests/functional/test_cliargumentname_config.py
@@ -1,0 +1,94 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from jsonschema import Draft4Validator
+
+import botocore.session
+from botocore import xform_name
+
+
+SERVICE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "shapes": {
+            "type": "object",
+            "patternProperties": {
+                ".+": {
+                    "type": "object",
+                    "properties": {
+                        "members": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".+": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cliArgumentName": {"type": "string"},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            },
+        }
+    },
+}
+
+
+def test_lint_cliargmentname_configs():
+    session = botocore.session.get_session()
+    validator = Draft4Validator(SERVICE_SCHEMA)
+    for service_name in session.get_available_services():
+        client = session.create_client(service_name, 'us-east-1')
+        service_model = client.meta.service_model
+        loader = session.get_component('data_loader')
+        service_model = loader.load_service_model(service_name, 'service-2')
+        yield _validate_schema, validator, service_model
+        renames = {}
+        for shape_name, shape in service_model.get("shapes", {}).items():
+            yield _lint_rename_collisions, shape.get("members", {})
+            for member_name, member_shape in shape.get("members", {}).items():
+                if "cliArgumentName" in member_shape:
+                    yield _lint_single_member, member_name, member_shape
+                    renames.setdefault(member_name, []).append(
+                        member_shape["cliArgumentName"]
+                    )
+        yield _lint_consistent_renames, renames
+
+
+def _lint_rename_collisions(members):
+    arguments = [
+        shape.get("cliArgumentName", xform_name(name))
+        for name, shape in members.items()
+    ]
+    if len(set(arguments)) != len(arguments):
+        raise AssertionError(
+            "The cliArgumentName collides with an existing member name.")
+
+
+def _lint_single_member(member_name, member_shape):
+    original_cli_name = xform_name(member_name)
+    assert original_cli_name in member_shape["cliArgumentName"]
+
+
+def _validate_schema(validator, waiter_json):
+    errors = list(e.message for e in validator.iter_errors(waiter_json))
+    if errors:
+        raise AssertionError('\n'.join(errors))
+
+
+def _lint_consistent_renames(renames):
+    for member, clinames in renames.items():
+        if len(set(clinames)) > 1:
+            raise AssertionError(
+                "Inconsistent names for the same member across shapes"
+            )

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -616,6 +616,10 @@ class TestShapeResolver(unittest.TestCase):
                 'members': {
                     'OldPassword': {'shape': 'passwordType'},
                     'NewPassword': {'shape': 'passwordType'},
+                    'Region': {
+                        'shape': 'Region',
+                        'cliArgumentName': 'password-region',
+                    }
                 }
             },
             'passwordType': {
@@ -623,7 +627,8 @@ class TestShapeResolver(unittest.TestCase):
                 "min":1,
                 "max":128,
                 "sensitive":True
-            }
+            },
+            'Region': {"type": "string"}
         }
         resolver = model.ShapeResolver(shapes)
         shape = resolver.get_shape_by_name('ChangePasswordRequest')
@@ -633,6 +638,8 @@ class TestShapeResolver(unittest.TestCase):
         self.assertEqual(member.metadata['min'], 1)
         self.assertEqual(member.metadata['max'], 128)
         self.assertEqual(member.metadata['sensitive'], True)
+        member = shape.members["Region"]
+        self.assertEqual(member.metadata["cliArgumentName"], "password-region")
 
     def test_shape_list(self):
         shapes = {


### PR DESCRIPTION
Adds a member value ``cliArgumentName`` that can be used to override what the automatically generated name on the CLI is.

This includes validation that the property is of the right type (although I decided not to try to validate that the ``cliArgumentName`` doesn't exist anywhere else, because I didn't see a great way of doing that besides validating the entire schema of a service model (and even then, it would block that name from being used as a member name itself, or a model name).

The tests also include validation that the cliArgumentName given does not collide with any other members on the same model, it contains the original argument name, and that within a single service, the same cliArgumentName is used for the same original name consistently (so that you don't have ``Region`` being renamed to ``--foo-region`` in one command, and ``--bar-region`` in another command for the same service).