### PR TITLE
Allow newer versions of dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tox>=2.5.0,<3.0.0
 python-dateutil>=2.1,<2.7.0; python_version=="2.6"
 python-dateutil>=2.1,<3.0.0; python_version>="2.7"
-nose==1.3.0
+nose==1.3.7
 mock==1.3.0
 wheel==0.24.0
 docutils>=0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tox>=2.5.0,<3.0.0
-python-dateutil>=2.1,<2.7.0
+python-dateutil>=2.1,<2.7.0; python_version=="2.6"
+python-dateutil>=2.1,<3.0.0; python_version>="2.7"
 nose==1.3.0
 mock==1.3.0
 wheel==0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,8 @@ universal = 1
 
 [metadata]
 requires-dist =
-	python-dateutil>=2.1,<2.7.0
+	python-dateutil>=2.1,<2.7.0; python_version=="2.6"
+	python-dateutil>=2.1,<3.0.0; python_version>="2.7"
 	jmespath>=0.7.1,<1.0.0
 	docutils>=0.10
 	ordereddict==1.1; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ def find_version(*file_paths):
 
 
 requires = ['jmespath>=0.7.1,<1.0.0',
-            'python-dateutil>=2.1,<2.7.0',
             'docutils>=0.10']
 
 
@@ -39,6 +38,9 @@ if sys.version_info[:2] == (2, 6):
     # JSON objects.  The 2.7 json module has this.  For 2.6
     # we need simplejson.
     requires.append('simplejson==3.3.0')
+    requires.append('python-dateutil>=2.1,<2.7.0')
+else:
+    requires.append('python-dateutil>=2.1,<3.0.0')
 
 
 setup(


### PR DESCRIPTION
This updates dateutil to use version specific requirements and also updates nose to a version that fixes the stack limit bug on Python 3.6 (see [this issue](https://github.com/nose-devs/nose/issues/749)).

This also requires that we make changes to the CLI: https://github.com/aws/aws-cli/pull/3197
These must be merged at the same time.

Closes #1429, #1432, #1430 
