### PR TITLE
utils.py: Add the sending of a User-Agent other than the default pyth…

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -69,7 +69,8 @@ def create_credential_resolver(session, cache=None):
     instance_metadata_provider = InstanceMetadataProvider(
         iam_role_fetcher=InstanceMetadataFetcher(
             timeout=metadata_timeout,
-            num_attempts=num_attempts)
+            num_attempts=num_attempts,
+            user_agent=session.user_agent())
     )
     assume_role_provider = AssumeRoleProvider(
         load_config=lambda: session.full_config,

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -177,10 +177,7 @@ class InstanceMetadataFetcher(object):
             raise _RetriesExceededError()
 
         headers = {
-            'User-Agent': 'aws-sdk-botocore/%s ' % botocore_version,
-            'Accept-Encoding': ', '.join(('gzip', 'deflate')),
-            'Accept': '*/*',
-            'Connection': 'keep-alive',
+            'User-Agent': 'aws-sdk-botocore/%s ' % botocore_version
         }
 
         for i in range(num_attempts):

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -25,6 +25,7 @@ import dateutil.parser
 from dateutil.tz import tzlocal, tzutc
 
 import botocore
+from botocore import __version__ as botocore_version
 from botocore.exceptions import InvalidExpressionError, ConfigNotFound
 from botocore.exceptions import InvalidDNSNameError, ClientError
 from botocore.exceptions import MetadataRetrievalError
@@ -175,9 +176,16 @@ class InstanceMetadataFetcher(object):
             logger.debug("Access to EC2 metadata has been disabled.")
             raise _RetriesExceededError()
 
+        headers = {
+            'User-Agent': 'aws-sdk-botocore/{}'.format(botocore_version),
+            'Accept-Encoding': ', '.join(('gzip', 'deflate')),
+            'Accept': '*/*',
+            'Connection': 'keep-alive',
+        }
+
         for i in range(num_attempts):
             try:
-                response = requests.get(url, timeout=timeout)
+                response = requests.get(url, timeout=timeout, headers=headers)
             except RETRYABLE_HTTP_ERRORS as e:
                 logger.debug("Caught exception while trying to retrieve "
                              "credentials: %s", e, exc_info=True)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -177,7 +177,7 @@ class InstanceMetadataFetcher(object):
             raise _RetriesExceededError()
 
         headers = {
-            'User-Agent': 'aws-sdk-botocore/{}'.format(botocore_version),
+            'User-Agent': 'aws-sdk-botocore/%s ' % botocore_version,
             'Accept-Encoding': ', '.join(('gzip', 'deflate')),
             'Accept': '*/*',
             'Connection': 'keep-alive',

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1166,9 +1166,6 @@ class TestInstanceMetadataProvider(BaseEnvVar):
         for arg in mock_get.call_args:
             if isinstance(arg, dict) and arg.get('headers', None):
                 assert(arg.get('headers', {}).get('User-Agent', '').startswith('aws-sdk-botocore/'))
-                self.assertEqual(arg.get('headers', {}).get('Accept-Encoding', ''), 'gzip, deflate')
-                self.assertEqual(arg.get('headers', {}).get('Accept', ''), '*/*')
-                self.assertEqual(arg.get('headers', {}).get('Connection', ''), 'keep-alive')
 
 
 class CredentialResolverTest(BaseEnvVar):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -29,8 +29,6 @@ from botocore.credentials import EnvProvider, create_assume_role_refresher
 from botocore.credentials import CredentialProvider, AssumeRoleProvider
 from botocore.credentials import ConfigProvider, SharedCredentialProvider
 from botocore.credentials import Credentials
-from botocore.vendored import requests
-from botocore.utils import InstanceMetadataFetcher
 import botocore.exceptions
 import botocore.session
 from tests import unittest, BaseEnvVar, IntegerRefresher, skip_if_windows
@@ -1156,16 +1154,6 @@ class TestInstanceMetadataProvider(BaseEnvVar):
         creds = provider.load()
         self.assertIsNone(creds)
         fetcher.retrieve_iam_role_credentials.assert_called_with()
-
-    @mock.patch('botocore.vendored.requests.get')
-    def test_metadata_header(self, mock_get):
-        instance_metadata_provider = credentials.InstanceMetadataProvider(
-            iam_role_fetcher=InstanceMetadataFetcher()
-        )
-        creds = instance_metadata_provider.load()
-        for arg in mock_get.call_args:
-            if isinstance(arg, dict) and arg.get('headers', None):
-                assert(arg.get('headers', {}).get('User-Agent', '').startswith('aws-sdk-botocore/'))
 
 
 class CredentialResolverTest(BaseEnvVar):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1752,3 +1752,9 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
         }
         self.assertEqual(result, expected_result)
 
+    def test_includes_user_agent_header(self):
+        user_agent = 'my-user-agent'
+        InstanceMetadataFetcher(
+            user_agent=user_agent).retrieve_iam_role_credentials()
+        headers = self._requests.get.call_args[1]['headers']
+        self.assertEqual(headers['User-Agent'], user_agent)


### PR DESCRIPTION
Adds the sending of a User-Agent other than the default python requests User-Agent when requesting credentials from the metadata service

Similar to AWS Golang SDK and now AWS Ruby SDK, send a User-Agent when making requests to metadata for credentials.
Golang uses a structure like aws-sdk-go/1.8.19 and now Ruby uses aws-sdk-ruby3/<version> as of PR #1762.

This will enable protection of AWS credentials from Server Side Request Foregery (SSRF) vectors by use of a metadata proxy and rejecting User-Agents that do not meet a regex.