### PR TITLE
Add a history recorder scope

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -568,11 +568,12 @@ class BaseClient(object):
     def _make_api_call(self, operation_name, api_params):
         operation_model = self._service_model.operation_model(operation_name)
         service_name = self._service_model.service_name
+        client_id = id(self)
         history_recorder.record('API_CALL', {
             'service': service_name,
             'operation': operation_name,
             'params': api_params,
-        })
+        }, scope_id=client_id)
         if operation_model.deprecated:
             logger.debug('Warning: %s.%s() is deprecated',
                          service_name, operation_name)
@@ -581,6 +582,7 @@ class BaseClient(object):
             'client_config': self.meta.config,
             'has_streaming_input': operation_model.has_streaming_input,
             'auth_type': operation_model.auth_type,
+            'client_id': client_id,
         }
         request_dict = self._convert_to_request_dict(
             api_params, operation_model, context=request_context)

--- a/botocore/history.py
+++ b/botocore/history.py
@@ -18,37 +18,159 @@ logger = logging.getLogger(__name__)
 
 
 class BaseHistoryHandler(object):
+    """Handler to respond to events that are recorded from a HistoryRecorder
+
+    All handlers that get added to a HistoryRecorder must subclass
+    and implement the ``emit()`` method.
+    """
     def emit(self, event_type, payload, source):
+        """Emit a recorded event to the handler
+
+        :type event_type: string
+        :param event_type: The name of event to be emitted
+
+        :type payload: any
+        :param payload: The data associated to the event. This typically
+            should be a dictionary with information relevant to the event
+
+        :type source: string
+        :param source: The source of the event. This is typically the name
+            of the library (i.e. BOTOCORE, CLI, etc.)
+        """
         raise NotImplementedError('emit()')
 
 
 class HistoryRecorder(object):
+    """Records events pertinent to a workflow"""
     def __init__(self):
         self._enabled = False
         self._handlers = []
+        self._scopes = []
 
     def enable(self):
+        """Enables the recorder to emit events to registered handlers
+
+        By default, the record is **not** enabled.
+        """
         self._enabled = True
 
     def disable(self):
+        """Disables the recorder from emitting events to registered handlers
+
+        By default, the record is **not** enabled.
+        """
         self._enabled = False
 
     def add_handler(self, handler):
+        """Adds a handler to listen to events from the recorder
+
+        :type handler: BaseHistoryHandler
+        :param handler: The handler to add to the history recorder. Even if the
+            handler is added to the recorder, the recorder must be enabled
+            for the handler's ``emit()`` to actually be called.
+        """
         self._handlers.append(handler)
 
-    def record(self, event_type, payload, source='BOTOCORE'):
-        if self._enabled and self._handlers:
+    def add_scope(self, scope):
+        """Adds a scope to a history recorder
+
+        :type scope: HistoryRecorderScope
+        :param scope: The scope to add to the history recorder. Handlers that
+            are added to the registered scope will only be called if the event
+            came from a client registered to that scope
+        """
+        self._scopes.append(scope)
+
+    def record(self, event_type, payload, source='BOTOCORE', scope_id=None):
+        """Record an event and emit the event to attached handlers
+
+        :type event_type: string
+        :param event_type: The name of event to be emitted
+
+        :type payload: any
+        :param payload: The data associated to the event. This typically
+            should be a dictionary with information relevant to the event
+
+        :type source: string
+        :param source: The source of the event. This is typically the name
+            of the library (i.e. BOTOCORE, CLI, etc.)
+
+        :type scope_id: string
+        :param scope_id: An identifier used to determine if an event should
+            be passed to a registered scope. If the identifier matches one
+            of the registered idenitfiers of a registered scope. The event
+            will be emitted to the handlers attached to that registered scope.
+            If the value is None, no handlers of any of the registered scopes
+            will have the event emitted to them.
+        """
+        if self._enabled:
             for handler in self._handlers:
-                try:
-                    handler.emit(event_type, payload, source)
-                except Exception:
-                    # Never let the process die because we had a failure in
-                    # a record collection handler.
-                    logger.debug("Exception raised in %s.", handler,
-                                 exc_info=True)
+                self._emit_event(handler, event_type, payload, source)
+            if scope_id is not None:
+                scopes = self._get_scopes_for_scope_id(scope_id)
+                for scope in scopes:
+                    for handler in scope.handlers:
+                        self._emit_event(handler, event_type, payload, source)
+
+    def _emit_event(self, handler, event_type, payload, source):
+        try:
+            handler.emit(event_type, payload, source)
+        except Exception:
+            # Never let the process die because we had a failure in
+            # a record collection handler.
+            logger.debug("Exception raised in %s.", handler,
+                         exc_info=True)
+
+    def _get_scopes_for_scope_id(self, scope_id):
+        return [
+            scope for scope in self._scopes
+            if scope_id in scope.registered_scope_ids
+        ]
+
+
+class HistoryRecorderScope(object):
+    """Scopes events from the history recorder
+
+    This allows handlers to only be fired if the recorded event is associated
+    to a particular scope instead of having the handler fired for all events
+    generated from a history recorder
+    """
+    def __init__(self):
+        self._registered_scope_ids = []
+        self._handlers = []
+
+    @property
+    def handlers(self):
+        """The handlers registered to the scope"""
+        return self._handlers
+
+    @property
+    def registered_scope_ids(self):
+        """The idenitifiers for which the scope's handlers will be fired for"""
+        return self._registered_scope_ids
+
+    def register_client(self, client):
+        """Registers a client to the scope
+
+        It will use the client's id as the scope identifier. So if the client
+        id is passed in as the `scope_id` to a `HistoryRecoreder.record()`
+        call, all handlers registered to this scope will be fired.
+        """
+        self._registered_scope_ids.append(id(client))
+
+    def add_handler(self, handler):
+        """Adds a handler to listen for events associated to this scope
+
+        :type handler: BaseHistoryHandler
+        :param handler: The handler to add to the scope. Handlers that
+            are registered will only be called if the event recorded included
+            an identifier registered to the scope
+        """
+        self._handlers.append(handler)
 
 
 def get_global_history_recorder():
+    """Retrieves a global history recorder to record events"""
     global HISTORY_RECORDER
     if HISTORY_RECORDER is None:
         HISTORY_RECORDER = HistoryRecorder()

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -4,6 +4,7 @@ import mock
 
 from botocore.history import HistoryRecorder
 from botocore.history import BaseHistoryHandler
+from botocore.history import HistoryRecorderScope
 from botocore.history import get_global_history_recorder
 
 
@@ -17,6 +18,11 @@ class ExceptionThrowingHandler(BaseHistoryHandler):
 
 
 class TestHistoryRecorder(unittest.TestCase):
+    def get_enabled_history_recorder(self):
+        history_recorder = HistoryRecorder()
+        history_recorder.enable()
+        return history_recorder
+
     def test_can_attach_and_call_handler_emit(self):
         mock_handler = mock.Mock(spec=BaseHistoryHandler)
         recorder = HistoryRecorder()
@@ -77,6 +83,159 @@ class TestHistoryRecorder(unittest.TestCase):
         except TerribleError:
             self.fail('Should not have raised a TerribleError')
         mock_handler.emit.assert_called_with('foo', 'bar', 'BOTOCORE')
+
+    def test_add_scope_and_emit_handlers_for_scope(self):
+        history_scope = HistoryRecorderScope()
+        mock_handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(mock_handler)
+        mock_client = object()
+        history_scope.register_client(mock_client)
+
+        recorder = self.get_enabled_history_recorder()
+        recorder.add_scope(history_scope)
+
+        recorder.record('myevent', {}, scope_id=id(mock_client))
+        mock_handler.emit.assert_called_with('myevent', {}, 'BOTOCORE')
+
+    def test_add_scope_and_emit_all_handlers_for_scope(self):
+        history_scope = HistoryRecorderScope()
+        mock_handler = mock.Mock(spec=BaseHistoryHandler)
+        other_mock_hanlder = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(mock_handler)
+        history_scope.add_handler(other_mock_hanlder)
+        mock_client = object()
+        history_scope.register_client(mock_client)
+
+        recorder = self.get_enabled_history_recorder()
+        recorder.add_scope(history_scope)
+
+        recorder.record('myevent', {}, scope_id=id(mock_client))
+        mock_handler.emit.assert_called_with('myevent', {}, 'BOTOCORE')
+        other_mock_hanlder.emit.assert_called_with('myevent', {}, 'BOTOCORE')
+
+    def test_emits_scoped_and_not_scoped_handlders(self):
+        history_scope = HistoryRecorderScope()
+        scoped_handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(scoped_handler)
+        mock_client = object()
+        history_scope.register_client(mock_client)
+
+        recorder = self.get_enabled_history_recorder()
+        recorder.add_scope(history_scope)
+
+        global_handler = mock.Mock(spec=BaseHistoryHandler)
+        recorder.add_handler(global_handler)
+
+        recorder.record('myevent', {}, scope_id=id(mock_client))
+        scoped_handler.emit.assert_called_with('myevent', {}, 'BOTOCORE')
+        global_handler.emit.assert_called_with('myevent', {}, 'BOTOCORE')
+
+    def test_does_not_call_scoped_handler_with_wrong_scope_id(self):
+        history_scope = HistoryRecorderScope()
+        mock_handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(mock_handler)
+        mock_client = object()
+        other_mock_client = object()
+        history_scope.register_client(mock_client)
+
+        recorder = self.get_enabled_history_recorder()
+        recorder.add_scope(history_scope)
+
+        recorder.record('myevent', {}, scope_id=id(other_mock_client))
+        mock_handler.emit.assert_not_called()
+
+    def test_does_not_called_scoped_handler_with_no_scope_id(self):
+        history_scope = HistoryRecorderScope()
+        mock_handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(mock_handler)
+        mock_client = object()
+        history_scope.register_client(mock_client)
+
+        recorder = self.get_enabled_history_recorder()
+        recorder.add_scope(history_scope)
+
+        recorder.record('myevent', {})
+        mock_handler.emit.assert_not_called()
+
+    def test_calls_handlers_for_all_scopes_registered_to_same_id(self):
+        history_scope = HistoryRecorderScope()
+        mock_handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(mock_handler)
+
+        other_history_scope = HistoryRecorderScope()
+        other_mock_handler = mock.Mock(spec=BaseHistoryHandler)
+        other_history_scope.add_handler(other_mock_handler)
+
+        mock_client = object()
+        history_scope.register_client(mock_client)
+        other_history_scope.register_client(mock_client)
+
+        recorder = self.get_enabled_history_recorder()
+        recorder.add_scope(history_scope)
+        recorder.add_scope(other_history_scope)
+
+        recorder.record('myevent', {}, scope_id=id(mock_client))
+        mock_handler.emit.assert_called_with('myevent', {}, 'BOTOCORE')
+        other_mock_handler.emit.assert_called_with('myevent', {}, 'BOTOCORE')
+
+    def test_does_not_call_scoped_handlers_when_not_enabled(self):
+        history_scope = HistoryRecorderScope()
+        mock_handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(mock_handler)
+        mock_client = object()
+        history_scope.register_client(mock_client)
+
+        recorder = HistoryRecorder()
+        recorder.add_scope(history_scope)
+
+        recorder.record('myevent', {}, scope_id=id(mock_client))
+        mock_handler.emit.assert_not_called()
+
+    def test_can_ignore_scoped_handler_exceptions(self):
+        history_scope = HistoryRecorderScope()
+        bad_handler = ExceptionThrowingHandler()
+        history_scope.add_handler(bad_handler)
+        mock_client = object()
+        history_scope.register_client(mock_client)
+
+        recorder = self.get_enabled_history_recorder()
+        recorder.add_scope(history_scope)
+
+        try:
+            recorder.record('myevent', {}, scope_id=id(mock_client))
+        except TerribleError:
+            self.fail('Should not have raised a TerribleError')
+
+
+class TestHistoryRecorderScope(unittest.TestCase):
+    def test_add_handlers(self):
+        history_scope = HistoryRecorderScope()
+        handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(handler)
+        self.assertEqual(history_scope.handlers, [handler])
+
+    def test_add_multiple_handlers(self):
+        history_scope = HistoryRecorderScope()
+        handler = mock.Mock(spec=BaseHistoryHandler)
+        other_handler = mock.Mock(spec=BaseHistoryHandler)
+        history_scope.add_handler(handler)
+        history_scope.add_handler(other_handler)
+        self.assertEqual(history_scope.handlers, [handler, other_handler])
+
+    def test_register_clients(self):
+        history_scope = HistoryRecorderScope()
+        client = object()
+        history_scope.register_client(client)
+        self.assertEqual(history_scope.registered_scope_ids, [id(client)])
+
+    def test_register_multiple_clients(self):
+        history_scope = HistoryRecorderScope()
+        client = object()
+        other_client = object()
+        history_scope.register_client(client)
+        history_scope.register_client(other_client)
+        self.assertEqual(
+            history_scope.registered_scope_ids, [id(client), id(other_client)])
 
 
 class TestGetHistoryRecorder(unittest.TestCase):


### PR DESCRIPTION
The abstraction allows for the registering of handlers to a scope so that if a client is also registered to the same scope, the handler added to that scope will only receive events from all clients registered to that scope. In this commit, doc strings were added to the history module as well to clarify functionality. The functional tests  would be good to start with to help understand the in's and out's of the interface, but for a general overview of how you go about using this here is an example:
```python
import botocore.session
from botocore.history import get_global_history_recorder
from botocore.history import BaseHistoryHandler
from botocore.history import HistoryRecorderScope


class PrintHistoryHandler(BaseHistoryHandler):
    def emit(self, event_type, payload, source):
        if event_type == 'HTTP_REQUEST':
            payload = payload['url']
        elif event_type == 'HTTP_RESPONSE':
            payload = payload['headers']
        print('%s: %s' % (event_type, payload))


session = botocore.session.Session()
s3_client = session.create_client('s3')
ec2_client = session.create_client('ec2')


history_scope = HistoryRecorderScope()
scoped_handler = PrintHistoryHandler()
history_scope.add_handler(scoped_handler)
history_scope.register_client(ec2_client)

history_recorder = get_global_history_recorder()
history_recorder.add_scope(history_scope)
history_recorder.enable()

s3_client.list_buckets()
ec2_client.describe_regions()
```
That will print out (Note that there are no S3 events in the output):
```
API_CALL: {'operation': u'DescribeRegions', 'params': {}, 'service': 'ec2'}
HTTP_REQUEST: https://ec2.us-west-2.amazonaws.com/
HTTP_RESPONSE: {'date': 'Tue, 24 Apr 2018 22:44:42 GMT', 'vary': 'Accept-Encoding', 'content-length': '2720', 'content-type': 'text/xml;charset=UTF-8', 'server': 'AmazonEC2'}
PARSED_RESPONSE: {u'Regions': [{u'Endpoint': 'ec2.ap-south-1.amazonaws.com', u'RegionName': 'ap-south-1'}, {u'Endpoint': 'ec2.eu-west-3.amazonaws.com', u'RegionName': 'eu-west-3'}, {u'Endpoint': 'ec2.eu-west-2.amazonaws.com', u'RegionName': 'eu-west-2'}, {u'Endpoint': 'ec2.eu-west-1.amazonaws.com', u'RegionName': 'eu-west-1'}, {u'Endpoint': 'ec2.ap-northeast-3.amazonaws.com', u'RegionName': 'ap-northeast-3'}, {u'Endpoint': 'ec2.ap-northeast-2.amazonaws.com', u'RegionName': 'ap-northeast-2'}, {u'Endpoint': 'ec2.ap-northeast-1.amazonaws.com', u'RegionName': 'ap-northeast-1'}, {u'Endpoint': 'ec2.sa-east-1.amazonaws.com', u'RegionName': 'sa-east-1'}, {u'Endpoint': 'ec2.ca-central-1.amazonaws.com', u'RegionName': 'ca-central-1'}, {u'Endpoint': 'ec2.ap-southeast-1.amazonaws.com', u'RegionName': 'ap-southeast-1'}, {u'Endpoint': 'ec2.ap-southeast-2.amazonaws.com', u'RegionName': 'ap-southeast-2'}, {u'Endpoint': 'ec2.eu-central-1.amazonaws.com', u'RegionName': 'eu-central-1'}, {u'Endpoint': 'ec2.us-east-1.amazonaws.com', u'RegionName': 'us-east-1'}, {u'Endpoint': 'ec2.us-east-2.amazonaws.com', u'RegionName': 'us-east-2'}, {u'Endpoint': 'ec2.us-west-1.amazonaws.com', u'RegionName': 'us-west-1'}, {u'Endpoint': 'ec2.us-west-2.amazonaws.com', u'RegionName': 'us-west-2'}], 'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': 'c2759f73-f7b9-414a-9c48-c2f12e8dd535', 'HTTPHeaders': {'date': 'Tue, 24 Apr 2018 22:44:42 GMT', 'vary': 'Accept-Encoding', 'content-length': '2720', 'content-type': 'text/xml;charset=UTF-8', 'server': 'AmazonEC2'}}}
```

The one thing that I feel like there may be a better interface for (but have not figured out and are open for ideas on) is the `scope_id` interface. Essentially the `scope_id` interface gives us the ability for `HistoryRecorder.record()` to emit identifiers to help the scope and its handlers determine if the recorded event is for them. Currently, I am using the `id(client)` to generate the `scope_id` that gets passed into the `HistoryRecorder.record()` call. This allows `botocore` to pass an identifier of the client to these globally emitted events without having to keep reference of the actual client objects, but it does open a couple of potential issues:

1) For each event that we want to be scopeable to a client, it must have access to the id of the client. To do this, the id is stored in the request context (which most abstractions by now have access to).

2) If the client gets deleted, there is the potential that another client gets created under the same id. This would cause the newly created client to start emitting events to that scope without actually have registering to it. A few ideas to fix this include:
    * Include the class name passed to the `scope_id` to better avoid collisions
    * Expose a `deregister_client` so that you can at least remove the client from the scope before it getting deleted.
    * Expose a `client_id` on `client.meta` that returns a uid. Thinking about this now this may be the best option to avoid collisions, but would like to get your opinions on it first.

Let me know what you all think.