### PR TITLE
RFC: Avoid creation of circular references per request

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -34,7 +34,7 @@ from botocore.vendored.requests.packages.urllib3.connectionpool import \
 from botocore.vendored.requests.packages.urllib3.connectionpool import \
     HTTPSConnectionPool
 
-if six.PY3:
+if six.PY34:
     from weakref import WeakMethod
 else:
     import weakref

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -208,7 +208,8 @@ class ResponseParser(object):
             self._event_stream_parser = self.EVENT_STREAM_PARSER_CLS(
                 timestamp_parser, blob_parser)
 
-    def _default_blob_parser(self, value):
+    @staticmethod
+    def _default_blob_parser(value):
         # Blobs are always returned as bytes type (this matters on python3).
         # We don't decode this to a str because it's entirely possible that the
         # blob contains binary data that actually can't be decoded.


### PR DESCRIPTION
This PR aimed to reduce number of circular references remain after a request has being made. 
I am running a tornado app, which for incoming request talks with s3 to get/put an object. At some point, I noticed that default GC thresholds are way to big to successfully collect all the garbage, so app eats tons of memory after a long run. 
I could possibly play with thresholds and configure it to run frequently, but that's all feels more like a hack. 
I noticed there was an old issue https://github.com/boto/botocore/issues/805 saying that client objects are retained in memory to be GC'd later. So I figured that I can reuse client objects across multiple incoming web requests. 
However, digging dipper I found that even making request creates multiple of unreachable objects which are then waiting to be GC'd.

I put a simple test script in place to track down if it is possible to break circular references somewhere manually, so objects would be removed from memory without GC help (which does not seem to be guarranteed in CPYthon anyway)
```python
#!/usr/bin/env python

import gc
import botocore.session

print (gc.get_threshold())
gc.disable()

session = botocore.session.get_session()
client = session.create_client('ec2', region_name='us-west-2')


def test(client):
    for i in range(0, 1):
        client.describe_instances(
            Filters=[{"Name": "instance-state-name", "Values": ["pending"]}])


gc.collect()
gc.set_debug(gc.DEBUG_STATS)
test(client)
gc.collect()
```
Example output would be:
```
(700, 10, 10)
gc: collecting generation 2...
gc: objects in each generation: 511 0 70118
gc: done, 67 unreachable, 0 uncollectable, 0.0324s elapsed.
gc: collecting generation 2...
gc: objects in each generation: 0 0 70196
gc: done, 0.0316s elapsed.
```
Note the 67 unreachable objects after call to `gc.collect()`. Now, when we increase number of iterations (effectively increasing number of requests made), number of unreachable objects will also grow. With 10 requests it outputs `gc: done, 382 unreachable, 0 uncollectable, 0.0309s elapsed.` 

I am proposing 2 changes in this PR. 
First one is to declare `_default_blob_parser` method as static, which gives a little bit of improvement.
1 iteration shows 64 unreachable objects and 10 iterations give 352 (vs 67 and 382). Not a lot, but helps a little.

Second proposed change is to use WeakMethod to attach response hook handler. And I would like to get some advice about it. 
The method, which attached as a hook on response event was added as a way to fix https://github.com/boto/botocore/issues/82 . I did remove this hook attachment and run s3 integration test to capture a failure, but it was passing. What happened is that in original issue virtual host-style URI was [using global service endpoint](https://github.com/boto/botocore/blob/e5610793c162e6df3551bd4f76545506eadf7a18/botocore/handlers.py#L124). In current version this is all changed and[ it uses region-specific endpoint](https://github.com/boto/botocore/blob/develop/botocore/utils.py#L755). So I am not sure if that redirect-hook is all that matters at all now. 
I see that removing the hook might cause other failures down the road, since in general rewinding body on post requests on some redirects are expected. I noticed that such core feature should have being done in `requests` library and it is. [Issue](https://github.com/requests/requests/issues/3079) [was fixed ](https://github.com/requests/requests/pull/3655). So maybe, instead of using `WeakMethod` it would be better to upgrade `requests` lib https://github.com/boto/botocore/issues/1122 ?
tldr: WeakMethod vs removing the hook vs upgrading requests? Which one to go with?


These 2 changes above, running test script would output 
`gc: done, 32 unreachable, 0 uncollectable, 0.0353s elapsed.`
**regardless** of number of iterations.
So now I can safely make aws requests from my long-living app without waiting for GC to kick in to clean circular garbage. Should be performance/memory win after all.