### PR TITLE
add socket timeout errors to retry list

### DIFF
--- a/botocore/retryhandler.py
+++ b/botocore/retryhandler.py
@@ -21,6 +21,7 @@ from botocore.vendored.requests import ConnectionError, Timeout
 from botocore.vendored.requests.packages.urllib3.exceptions import ClosedPoolError
 
 from botocore.exceptions import ChecksumError, EndpointConnectionError
+from socket import timeout as SocketTimeout
 
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 EXCEPTION_MAP = {
     'GENERAL_CONNECTION_ERROR': [
         ConnectionError, ClosedPoolError, Timeout,
-        EndpointConnectionError
+        EndpointConnectionError, SocketTimeout
     ],
 }
 


### PR DESCRIPTION
We see occasional read timeouts from AWS but these are not retried under the default retry handler which seems odd:
```
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/paginate.py", line 255, in __iter__
    response = self._make_request(current_kwargs)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/paginate.py", line 332, in _make_request
    return self._method(**current_kwargs)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/client.py", line 314, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/client.py", line 599, in _make_api_call
    operation_model, request_dict)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/endpoint.py", line 148, in make_request
    return self._send_request(request_dict, operation_model)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/endpoint.py", line 177, in _send_request
    success_response, exception):
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/endpoint.py", line 273, in _needs_retry
    caught_exception=caught_exception, request_dict=request_dict)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/retryhandler.py", line 183, in __call__
    if self._checker(attempts, response, caught_exception):
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/retryhandler.py", line 251, in __call__
    caught_exception)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/retryhandler.py", line 269, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/retryhandler.py", line 317, in __call__
    caught_exception)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/retryhandler.py", line 223, in __call__
    attempt_number, caught_exception)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/retryhandler.py", line 359, in _check_caught_exception
    raise caught_exception
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/endpoint.py", line 222, in _get_response
    proxies=self.proxies, timeout=self.timeout)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/vendored/requests/sessions.py", line 605, in send
    r.content
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/vendored/requests/models.py", line 750, in content
    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/vendored/requests/models.py", line 673, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/vendored/requests/packages/urllib3/response.py", line 303, in stream
    for line in self.read_chunked(amt, decode_content=decode_content):
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/vendored/requests/packages/urllib3/response.py", line 450, in read_chunked
    chunk = self._handle_chunk(amt)
  File "/srv/data-job-runner/v1.0.54/lib/python3.5/site-packages/botocore/vendored/requests/packages/urllib3/response.py", line 420, in _handle_chunk
    returned_chunk = self._fp._safe_read(self.chunk_left)
  File "/usr/lib/python3.5/http/client.py", line 607, in _safe_read
    chunk = self.fp.read(min(amt, MAXAMOUNT))
  File "/usr/lib/python3.5/socket.py", line 575, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib/python3.5/ssl.py", line 929, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib/python3.5/ssl.py", line 791, in read
    return self._sslobj.read(len, buffer)
  File "/usr/lib/python3.5/ssl.py", line 575, in read
    v = self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out
```