### PR TITLE
Sync opsworks waiter from upstream

### DIFF
--- a/botocore/data/opsworks/2013-02-18/waiters-2.json
+++ b/botocore/data/opsworks/2013-02-18/waiters-2.json
@@ -22,7 +22,7 @@
       "delay": 15,
       "operation": "DescribeDeployments",
       "maxAttempts": 40,
-      "description": "Wait until a deployment has completed successfully",
+      "description": "Wait until a deployment has completed successfully.",
       "acceptors": [
         {
           "expected": "successful",
@@ -170,12 +170,6 @@
         },
         {
           "expected": "booting",
-          "matcher": "pathAny",
-          "state": "failure",
-          "argument": "Instances[].Status"
-        },
-        {
-          "expected": "online",
           "matcher": "pathAny",
           "state": "failure",
           "argument": "Instances[].Status"


### PR DESCRIPTION
Removes an incorrect acceptor and syncs with what other SDKs use.  For example, see the waiters used in the javascript SDK: https://github.com/aws/aws-sdk-js/blob/master/apis/opsworks-2013-02-18.waiters2.json#L178