### PR TITLE
Disable proxy config when fetching container credentials

### DIFF
--- a/.changes/next-release/enhancement-Credentials-28708.json
+++ b/.changes/next-release/enhancement-Credentials-28708.json
@@ -1,0 +1,5 @@
+{
+  "category": "Credentials", 
+  "type": "enhancement", 
+  "description": "Disable proxy configuration when fetching container credentials"
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1020,6 +1020,8 @@ class ContainerMetadataFetcher(object):
     def __init__(self, session=None, sleep=time.sleep):
         if session is None:
             session = requests.Session()
+            session.trust_env = False
+            session.proxies = {}
         self._session = session
         self._sleep = sleep
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1558,6 +1558,12 @@ class TestContainerMetadataFetcher(unittest.TestCase):
             fetcher.retrieve_full_uri(full_uri)
         self.assertFalse(self.http.get.called)
 
+    def test_default_session_disables_proxies(self):
+        with mock.patch('botocore.utils.requests.Session') as session:
+            fetcher = ContainerMetadataFetcher()
+            self.assertFalse(session.return_value.trust_env)
+            self.assertEqual(session.return_value.proxies, {})
+
     def test_can_specify_extra_headers_are_merged(self):
         headers = {
             # The 'Accept' header will override the


### PR DESCRIPTION
This ensures we do not look at proxy config even if
the HTTP(S)_PROXY env var is set.

This happens if we create the requests.Session for the user.
If a user provides a requests.Session (which isn't the default
behavior) then we do not mutate the provided session.

See: http://docs.python-requests.org/en/master/api/?highlight=trust_env#request-sessions