### PR TITLE
Don't fetch creds for unsigned clients

### DIFF
--- a/.changes/next-release/bugfix-Credentials-65605.json
+++ b/.changes/next-release/bugfix-Credentials-65605.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Fixes an issue where credentials would be checked when creating an anonymous client. Fixes `#1472 <https://github.com/boto/botocore/issues/1472>`__"
+}

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -25,6 +25,7 @@ import warnings
 import collections
 
 from botocore import __version__
+from botocore import UNSIGNED
 import botocore.configloader
 import botocore.credentials
 import botocore.client
@@ -808,7 +809,9 @@ class Session(object):
         event_emitter = self.get_component('event_emitter')
         response_parser_factory = self.get_component(
             'response_parser_factory')
-        if aws_access_key_id is not None and aws_secret_access_key is not None:
+        if config is not None and config.signature_version is UNSIGNED:
+            credentials = None
+        elif aws_access_key_id is not None and aws_secret_access_key is not None:
             credentials = botocore.credentials.Credentials(
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -23,6 +23,7 @@ import mock
 
 import botocore.session
 import botocore.exceptions
+from botocore import UNSIGNED
 from botocore.model import ServiceModel
 from botocore import client
 from botocore.hooks import HierarchicalEmitter
@@ -498,6 +499,14 @@ class TestCreateClient(BaseSessionTest):
                 aws_access_key_id=None,
                 aws_secret_access_key='foo',
             )
+
+    def test_cred_provider_not_called_on_unsigned_client(self):
+        cred_provider = mock.Mock()
+        self.session.register_component(
+            'credential_provider', cred_provider)
+        config = botocore.config.Config(signature_version=UNSIGNED)
+        self.session.create_client('sts', 'us-west-2', config=config)
+        self.assertFalse(cred_provider.load_credentials.called)
 
     @mock.patch('botocore.client.ClientCreator')
     def test_config_passed_to_client_creator(self, client_creator):


### PR DESCRIPTION
Fixes #1472 
Fixes awslabs/awsprocesscreds#16