### PR TITLE
Fix BytesWarning in parsers.py

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -232,7 +232,7 @@ class ResponseParser(object):
 
         """
         LOG.debug('Response headers: %s', response['headers'])
-        LOG.debug('Response body:\n%s', response['body'])
+        LOG.debug('Response body:\n%r', response['body'])
         if response['status_code'] >= 301:
             if self._is_generic_error_response(response):
                 parsed = self._do_generic_error_parse(response)


### PR DESCRIPTION
In Python3, When Python is started with the `-b` flag, botocore issues a warning:

```
  BytesWarning: str() on a bytes instance
```

As response['body'] is a `bytes` object, can't coerce to `str` without decoding. This warning can indicate mishandling of `bytes`/`str` boundaries. As the value is used for logging purposes, simply log the raw response body by using the `%r` placeholder.

When Python is started with the `-bb` flag, this warning becomes an error. For additional details on the flag, see:

https://docs.python.org/3/using/cmdline.html#miscellaneous-options