### PR TITLE
Update endpoint test to use service ids

### DIFF
--- a/botocore/data/appsync/2017-07-25/service-2.json
+++ b/botocore/data/appsync/2017-07-25/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"rest-json",
     "serviceAbbreviation":"AWSAppSync",
     "serviceFullName":"AWS AppSync",
+    "serviceId":"AppSync",
     "signatureVersion":"v4",
     "signingName":"appsync",
     "uid":"appsync-2017-07-25"

--- a/botocore/data/clouddirectory/2017-01-11/service-2.json
+++ b/botocore/data/clouddirectory/2017-01-11/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"clouddirectory",
     "protocol":"rest-json",
     "serviceFullName":"Amazon CloudDirectory",
+    "serviceId":"CloudDirectory",
     "signatureVersion":"v4",
     "signingName":"clouddirectory",
     "uid":"clouddirectory-2017-01-11"

--- a/botocore/data/greengrass/2017-06-07/service-2.json
+++ b/botocore/data/greengrass/2017-06-07/service-2.json
@@ -4,6 +4,7 @@
     "endpointPrefix" : "greengrass",
     "signingName" : "greengrass",
     "serviceFullName" : "AWS Greengrass",
+    "serviceId" : "Greengrass",
     "protocol" : "rest-json",
     "jsonVersion" : "1.1",
     "uid" : "greengrass-2017-06-07",

--- a/botocore/data/iot-jobs-data/2017-09-29/service-2.json
+++ b/botocore/data/iot-jobs-data/2017-09-29/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"data.jobs.iot",
     "protocol":"rest-json",
     "serviceFullName":"AWS IoT Jobs Data Plane",
+    "serviceId":"IoT Jobs Data Plane",
     "signatureVersion":"v4",
     "signingName":"iot-jobs-data",
     "uid":"iot-jobs-data-2017-09-29"

--- a/botocore/data/pinpoint/2016-12-01/service-2.json
+++ b/botocore/data/pinpoint/2016-12-01/service-2.json
@@ -4,6 +4,7 @@
     "endpointPrefix" : "pinpoint",
     "signingName" : "mobiletargeting",
     "serviceFullName" : "Amazon Pinpoint",
+    "serviceId" : "Pinpoint",
     "protocol" : "rest-json",
     "jsonVersion" : "1.1",
     "uid" : "pinpoint-2016-12-01",

--- a/botocore/data/transcribe/2017-10-26/service-2.json
+++ b/botocore/data/transcribe/2017-10-26/service-2.json
@@ -6,7 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon Transcribe Service",
-    "serviceId":"Transcribe Service",
+    "serviceId":"Transcribe",
     "signatureVersion":"v4",
     "signingName":"transcribe",
     "targetPrefix":"Transcribe",

--- a/botocore/data/transcribe/2017-10-26/service-2.json
+++ b/botocore/data/transcribe/2017-10-26/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon Transcribe Service",
+    "serviceId":"Transcribe Service",
     "signatureVersion":"v4",
     "signingName":"transcribe",
     "targetPrefix":"Transcribe",

--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -109,8 +109,7 @@ def test_endpoint_matches_service():
     # ``metadata`` section.
     known_services = loader.list_available_services('service-2')
     known_endpoint_prefixes = [
-        loader.load_service_model(
-            service_name, 'service-2')['metadata']['endpointPrefix']
+        session.get_service_model(service_name).endpoint_prefix
         for service_name in known_services
     ]
 
@@ -147,13 +146,12 @@ def test_service_name_matches_endpoint_prefix():
     services = loader.list_available_services('service-2')
 
     for service in services:
-        yield _assert_service_name_matches_endpoint_prefix, loader, service
+        yield _assert_service_name_matches_endpoint_prefix, session, service
 
 
-def _assert_service_name_matches_endpoint_prefix(loader, service_name):
-    service_model = loader.load_service_model(service_name, 'service-2')
-    computed_name = _get_computed_service_name(
-        service_name, service_model['metadata'])
+def _assert_service_name_matches_endpoint_prefix(session, service_name):
+    service_model = session.get_service_model(service_name)
+    computed_name = service_model.service_id.replace(' ', '-').lower()
 
     # Handle known exceptions where we have renamed the service directory
     # for one reason or another.
@@ -163,10 +161,3 @@ def _assert_service_name_matches_endpoint_prefix(loader, service_name):
         "Actual service name `%s` does not match expected service name "
         "we computed: `%s`" % (
             actual_service_name, computed_name))
-
-
-def _get_computed_service_name(service_name, service_metadata):
-    if 'serviceId' not in service_metadata:
-        raise AssertionError("Service is missing serviceId metadata: %s"
-                             % service_name)
-    return service_metadata['serviceId'].replace(' ', '-').lower()

--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -63,7 +63,6 @@ SERVICE_RENAMES = {
     'servicecatalog': 'service-catalog',
     'stepfunctions': 'sfn',
     'storagegateway': 'storage-gateway',
-    'transcribe': 'transcribe-service',
 }
 
 

--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -10,52 +10,60 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
-import json
 from nose.tools import assert_equal
 from botocore.session import get_session
 
 
 SERVICE_RENAMES = {
     # Actual service name we use -> Allowed computed service name.
-    'alexaforbusiness': 'a4b',
+    'alexaforbusiness': 'alexa-for-business',
     'apigateway': 'api-gateway',
     'application-autoscaling': 'application-auto-scaling',
+    'autoscaling': 'auto-scaling',
     'autoscaling-plans': 'auto-scaling-plans',
     'ce': 'cost-explorer',
     'cloudhsmv2': 'cloudhsm-v2',
-    'cloudwatch': 'monitoring',
+    'cloudsearchdomain': 'cloudsearch-domain',
+    'cognito-idp': 'cognito-identity-provider',
     'config': 'config-service',
+    'cur': 'cost-and-usage-report-service',
+    'datapipeline': 'data-pipeline',
+    'directconnect': 'direct-connect',
     'devicefarm': 'device-farm',
     'discovery': 'application-discovery-service',
     'dms': 'database-migration-service',
     'ds': 'directory-service',
-    'dynamodbstreams': 'streams.dynamodb',
-    'efs': 'elasticfilesystem',
+    'dynamodbstreams': 'dynamodb-streams',
     'elasticbeanstalk': 'elastic-beanstalk',
-    'elb': 'elasticloadbalancing',
+    'elastictranscoder': 'elastic-transcoder',
+    'elb': 'elastic-load-balancing',
     'elbv2': 'elastic-load-balancing-v2',
-    'emr': 'elasticmapreduce',
     'es': 'elasticsearch-service',
     'events': 'cloudwatch-events',
-    'iot-data': 'data.iot',
-    'iot-jobs-data': 'data.jobs.iot',
+    'iot-data': 'iot-data-plane',
+    'iot-jobs-data': 'iot-jobs-data-plane',
     'iot1click-devices': 'iot-1click-devices-service',
     'iot1click-projects': 'iot-1click-projects',
     'kinesisanalytics': 'kinesis-analytics',
     'kinesisvideo': 'kinesis-video',
     'lex-models': 'lex-model-building-service',
     'lex-runtime': 'lex-runtime-service',
-    'marketplace-entitlement': 'entitlement.marketplace',
-    'meteringmarketplace': 'metering.marketplace',
-    'pricing': 'api.pricing',
-    'resourcegroupstaggingapi': 'tagging',
+    'logs': 'cloudwatch-logs',
+    'machinelearning': 'machine-learning',
+    'marketplacecommerceanalytics': 'marketplace-commerce-analytics',
+    'marketplace-entitlement': 'marketplace-entitlement-service',
+    'meteringmarketplace': 'marketplace-metering',
+    'mgh': 'migration-hub',
+    'resourcegroupstaggingapi': 'resource-groups-tagging-api',
     'route53': 'route-53',
+    'route53domains': 'route-53-domains',
+    'sdb': 'simpledb',
     'secretsmanager': 'secrets-manager',
     'serverlessrepo': 'serverlessapplicationrepository',
     'servicecatalog': 'service-catalog',
     'stepfunctions': 'sfn',
     'storagegateway': 'storage-gateway',
+    'transcribe': 'transcribe-service',
 }
 
 
@@ -145,7 +153,8 @@ def test_service_name_matches_endpoint_prefix():
 
 def _assert_service_name_matches_endpoint_prefix(loader, service_name):
     service_model = loader.load_service_model(service_name, 'service-2')
-    computed_name = _get_computed_service_name(service_model['metadata'])
+    computed_name = _get_computed_service_name(
+        service_name, service_model['metadata'])
 
     # Handle known exceptions where we have renamed the service directory
     # for one reason or another.
@@ -157,9 +166,8 @@ def _assert_service_name_matches_endpoint_prefix(loader, service_name):
             actual_service_name, computed_name))
 
 
-def _get_computed_service_name(service_metadata):
+def _get_computed_service_name(service_name, service_metadata):
     if 'serviceId' not in service_metadata:
-        return service_metadata['endpointPrefix']
-    else:
-        service_id = service_metadata['serviceId']
-        return service_id.replace(' ', '-').lower()
+        raise AssertionError("Service is missing serviceId metadata: %s"
+                             % service_name)
+    return service_metadata['serviceId'].replace(' ', '-').lower()


### PR DESCRIPTION
This changes the two tests to more closely map to what
we wanted to test when we originally wrote these tests.

These tests were written before serviceId existed, which
is really want we want to use for testing.  These tests check
two things:

* Ensure that the directory names (i.e the client names) match
  the computed name based on the serviceId.  Existing services
  still need overrides but new services shouldn't as many overrides.
* Update the endpoints tests to be more direct about endpoint prefix
  matching.  We really just care that everything in the endpoints.json
  maps to something we can create a client for.  We now build the
  list of acceptable keys by looking up the endpoint prefix.