### PR TITLE
Sync missing serviceIds for service models

### DIFF
--- a/botocore/data/alexaforbusiness/2017-11-09/service-2.json
+++ b/botocore/data/alexaforbusiness/2017-11-09/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Alexa For Business",
+    "serviceId":"Alexa For Business",
     "signatureVersion":"v4",
     "targetPrefix":"AlexaForBusiness",
     "uid":"alexaforbusiness-2017-11-09"

--- a/botocore/data/athena/2017-05-18/service-2.json
+++ b/botocore/data/athena/2017-05-18/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon Athena",
+    "serviceId":"Athena",
     "signatureVersion":"v4",
     "targetPrefix":"AmazonAthena",
     "uid":"athena-2017-05-18"

--- a/botocore/data/autoscaling/2011-01-01/service-2.json
+++ b/botocore/data/autoscaling/2011-01-01/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"autoscaling",
     "protocol":"query",
     "serviceFullName":"Auto Scaling",
+    "serviceId":"Auto Scaling",
     "signatureVersion":"v4",
     "uid":"autoscaling-2011-01-01",
     "xmlNamespace":"http://autoscaling.amazonaws.com/doc/2011-01-01/"

--- a/botocore/data/cloud9/2017-09-23/service-2.json
+++ b/botocore/data/cloud9/2017-09-23/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Cloud9",
+    "serviceId":"Cloud9",
     "signatureVersion":"v4",
     "targetPrefix":"AWSCloud9WorkspaceManagementService",
     "uid":"cloud9-2017-09-23"

--- a/botocore/data/clouddirectory/2016-05-10/service-2.json
+++ b/botocore/data/clouddirectory/2016-05-10/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"clouddirectory",
     "protocol":"rest-json",
     "serviceFullName":"Amazon CloudDirectory",
+    "serviceId":"CloudDirectory",
     "signatureVersion":"v4",
     "signingName":"clouddirectory",
     "uid":"clouddirectory-2016-05-10"

--- a/botocore/data/cloudsearch/2013-01-01/service-2.json
+++ b/botocore/data/cloudsearch/2013-01-01/service-2.json
@@ -4,6 +4,7 @@
     "apiVersion":"2013-01-01",
     "endpointPrefix":"cloudsearch",
     "serviceFullName":"Amazon CloudSearch",
+    "serviceId":"CloudSearch",
     "signatureVersion":"v4",
     "xmlNamespace":"http://cloudsearch.amazonaws.com/doc/2013-01-01/",
     "protocol":"query",

--- a/botocore/data/cloudsearchdomain/2013-01-01/service-2.json
+++ b/botocore/data/cloudsearchdomain/2013-01-01/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"rest-json",
     "serviceFullName":"Amazon CloudSearch Domain",
+    "serviceId":"CloudSearch Domain",
     "signatureVersion":"v4",
     "signingName":"cloudsearch",
     "uid":"cloudsearchdomain-2013-01-01"

--- a/botocore/data/cloudtrail/2013-11-01/service-2.json
+++ b/botocore/data/cloudtrail/2013-11-01/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"CloudTrail",
     "serviceFullName":"AWS CloudTrail",
+    "serviceId":"CloudTrail",
     "signatureVersion":"v4",
     "targetPrefix":"com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101",
     "uid":"cloudtrail-2013-11-01"

--- a/botocore/data/cloudwatch/2010-08-01/service-2.json
+++ b/botocore/data/cloudwatch/2010-08-01/service-2.json
@@ -6,6 +6,7 @@
     "protocol":"query",
     "serviceAbbreviation":"CloudWatch",
     "serviceFullName":"Amazon CloudWatch",
+    "serviceId":"CloudWatch",
     "signatureVersion":"v4",
     "uid":"monitoring-2010-08-01",
     "xmlNamespace":"http://monitoring.amazonaws.com/doc/2010-08-01/"

--- a/botocore/data/codebuild/2016-10-06/service-2.json
+++ b/botocore/data/codebuild/2016-10-06/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS CodeBuild",
+    "serviceId":"CodeBuild",
     "signatureVersion":"v4",
     "targetPrefix":"CodeBuild_20161006",
     "uid":"codebuild-2016-10-06"

--- a/botocore/data/codepipeline/2015-07-09/service-2.json
+++ b/botocore/data/codepipeline/2015-07-09/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"CodePipeline",
     "serviceFullName":"AWS CodePipeline",
+    "serviceId":"CodePipeline",
     "signatureVersion":"v4",
     "targetPrefix":"CodePipeline_20150709",
     "uid":"codepipeline-2015-07-09"

--- a/botocore/data/codestar/2017-04-19/service-2.json
+++ b/botocore/data/codestar/2017-04-19/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"CodeStar",
     "serviceFullName":"AWS CodeStar",
+    "serviceId":"CodeStar",
     "signatureVersion":"v4",
     "targetPrefix":"CodeStar_20170419",
     "uid":"codestar-2017-04-19"

--- a/botocore/data/cognito-identity/2014-06-30/service-2.json
+++ b/botocore/data/cognito-identity/2014-06-30/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon Cognito Identity",
+    "serviceId":"Cognito Identity",
     "signatureVersion":"v4",
     "targetPrefix":"AWSCognitoIdentityService",
     "uid":"cognito-identity-2014-06-30"

--- a/botocore/data/cognito-idp/2016-04-18/service-2.json
+++ b/botocore/data/cognito-idp/2016-04-18/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon Cognito Identity Provider",
+    "serviceId":"Cognito Identity Provider",
     "signatureVersion":"v4",
     "targetPrefix":"AWSCognitoIdentityProviderService",
     "uid":"cognito-idp-2016-04-18"

--- a/botocore/data/cognito-sync/2014-06-30/service-2.json
+++ b/botocore/data/cognito-sync/2014-06-30/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"cognito-sync",
     "jsonVersion":"1.1",
     "serviceFullName":"Amazon Cognito Sync",
+    "serviceId":"Cognito Sync",
     "signatureVersion":"v4",
     "protocol":"rest-json",
     "uid":"cognito-sync-2014-06-30"

--- a/botocore/data/cur/2017-01-06/service-2.json
+++ b/botocore/data/cur/2017-01-06/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Cost and Usage Report Service",
+    "serviceId":"Cost and Usage Report Service",
     "signatureVersion":"v4",
     "signingName":"cur",
     "targetPrefix":"AWSOrigamiServiceGatewayService",

--- a/botocore/data/datapipeline/2012-10-29/service-2.json
+++ b/botocore/data/datapipeline/2012-10-29/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"datapipeline",
     "jsonVersion":"1.1",
     "serviceFullName":"AWS Data Pipeline",
+    "serviceId":"Data Pipeline",
     "signatureVersion":"v4",
     "targetPrefix":"DataPipeline",
     "protocol":"json",

--- a/botocore/data/dax/2017-04-19/service-2.json
+++ b/botocore/data/dax/2017-04-19/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"Amazon DAX",
     "serviceFullName":"Amazon DynamoDB Accelerator (DAX)",
+    "serviceId":"DAX",
     "signatureVersion":"v4",
     "targetPrefix":"AmazonDAXV3",
     "uid":"dax-2017-04-19"

--- a/botocore/data/directconnect/2012-10-25/service-2.json
+++ b/botocore/data/directconnect/2012-10-25/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Direct Connect",
+    "serviceId":"Direct Connect",
     "signatureVersion":"v4",
     "targetPrefix":"OvertureService",
     "uid":"directconnect-2012-10-25"

--- a/botocore/data/dynamodbstreams/2012-08-10/service-2.json
+++ b/botocore/data/dynamodbstreams/2012-08-10/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.0",
     "protocol":"json",
     "serviceFullName":"Amazon DynamoDB Streams",
+    "serviceId":"DynamoDB Streams",
     "signatureVersion":"v4",
     "signingName":"dynamodb",
     "targetPrefix":"DynamoDBStreams_20120810",

--- a/botocore/data/ecr/2015-09-21/service-2.json
+++ b/botocore/data/ecr/2015-09-21/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"Amazon ECR",
     "serviceFullName":"Amazon EC2 Container Registry",
+    "serviceId":"ECR",
     "signatureVersion":"v4",
     "targetPrefix":"AmazonEC2ContainerRegistry_V20150921",
     "uid":"ecr-2015-09-21"

--- a/botocore/data/efs/2015-02-01/service-2.json
+++ b/botocore/data/efs/2015-02-01/service-2.json
@@ -6,6 +6,7 @@
     "protocol":"rest-json",
     "serviceAbbreviation":"EFS",
     "serviceFullName":"Amazon Elastic File System",
+    "serviceId":"EFS",
     "signatureVersion":"v4",
     "uid":"elasticfilesystem-2015-02-01"
   },

--- a/botocore/data/elasticache/2015-02-02/service-2.json
+++ b/botocore/data/elasticache/2015-02-02/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"elasticache",
     "protocol":"query",
     "serviceFullName":"Amazon ElastiCache",
+    "serviceId":"ElastiCache",
     "signatureVersion":"v4",
     "uid":"elasticache-2015-02-02",
     "xmlNamespace":"http://elasticache.amazonaws.com/doc/2015-02-02/"

--- a/botocore/data/elastictranscoder/2012-09-25/service-2.json
+++ b/botocore/data/elastictranscoder/2012-09-25/service-2.json
@@ -6,6 +6,7 @@
     "endpointPrefix":"elastictranscoder",
     "protocol":"rest-json",
     "serviceFullName":"Amazon Elastic Transcoder",
+    "serviceId":"Elastic Transcoder",
     "signatureVersion":"v4"
   },
   "operations":{

--- a/botocore/data/elb/2012-06-01/service-2.json
+++ b/botocore/data/elb/2012-06-01/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"elasticloadbalancing",
     "protocol":"query",
     "serviceFullName":"Elastic Load Balancing",
+    "serviceId":"Elastic Load Balancing",
     "signatureVersion":"v4",
     "uid":"elasticloadbalancing-2012-06-01",
     "xmlNamespace":"http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/"

--- a/botocore/data/emr/2009-03-31/service-2.json
+++ b/botocore/data/emr/2009-03-31/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"Amazon EMR",
     "serviceFullName":"Amazon Elastic MapReduce",
+    "serviceId":"EMR",
     "signatureVersion":"v4",
     "targetPrefix":"ElasticMapReduce",
     "timestampFormat":"unixTimestamp",

--- a/botocore/data/gamelift/2015-10-01/service-2.json
+++ b/botocore/data/gamelift/2015-10-01/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon GameLift",
+    "serviceId":"GameLift",
     "signatureVersion":"v4",
     "targetPrefix":"GameLift",
     "uid":"gamelift-2015-10-01"

--- a/botocore/data/glacier/2012-06-01/service-2.json
+++ b/botocore/data/glacier/2012-06-01/service-2.json
@@ -6,6 +6,7 @@
     "endpointPrefix":"glacier",
     "protocol":"rest-json",
     "serviceFullName":"Amazon Glacier",
+    "serviceId":"Glacier",
     "signatureVersion":"v4",
     "uid":"glacier-2012-06-01"
   },

--- a/botocore/data/glue/2017-03-31/service-2.json
+++ b/botocore/data/glue/2017-03-31/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Glue",
+    "serviceId":"Glue",
     "signatureVersion":"v4",
     "targetPrefix":"AWSGlue",
     "uid":"glue-2017-03-31"

--- a/botocore/data/health/2016-08-04/service-2.json
+++ b/botocore/data/health/2016-08-04/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"AWSHealth",
     "serviceFullName":"AWS Health APIs and Notifications",
+    "serviceId":"Health",
     "signatureVersion":"v4",
     "targetPrefix":"AWSHealth_20160804",
     "uid":"health-2016-08-04"

--- a/botocore/data/importexport/2010-06-01/service-2.json
+++ b/botocore/data/importexport/2010-06-01/service-2.json
@@ -6,6 +6,7 @@
     "endpointPrefix":"importexport",
     "globalEndpoint":"importexport.amazonaws.com",
     "serviceFullName":"AWS Import/Export",
+    "serviceId":"ImportExport",
     "signatureVersion":"v2",
     "xmlNamespace":"http://importexport.amazonaws.com/doc/2010-06-01/",
     "protocol":"query"

--- a/botocore/data/inspector/2016-02-16/service-2.json
+++ b/botocore/data/inspector/2016-02-16/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon Inspector",
+    "serviceId":"Inspector",
     "signatureVersion":"v4",
     "targetPrefix":"InspectorService",
     "uid":"inspector-2016-02-16"

--- a/botocore/data/iot-data/2015-05-28/service-2.json
+++ b/botocore/data/iot-data/2015-05-28/service-2.json
@@ -6,6 +6,7 @@
     "endpointPrefix":"data.iot",
     "protocol":"rest-json",
     "serviceFullName":"AWS IoT Data Plane",
+    "serviceId":"IoT Data Plane",
     "signatureVersion":"v4",
     "signingName":"iotdata"
   },

--- a/botocore/data/logs/2014-03-28/service-2.json
+++ b/botocore/data/logs/2014-03-28/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon CloudWatch Logs",
+    "serviceId":"CloudWatch Logs",
     "signatureVersion":"v4",
     "targetPrefix":"Logs_20140328",
     "uid":"logs-2014-03-28"

--- a/botocore/data/machinelearning/2014-12-12/service-2.json
+++ b/botocore/data/machinelearning/2014-12-12/service-2.json
@@ -6,6 +6,7 @@
     "endpointPrefix":"machinelearning",
     "jsonVersion":"1.1",
     "serviceFullName":"Amazon Machine Learning",
+    "serviceId":"Machine Learning",
     "signatureVersion":"v4",
     "targetPrefix":"AmazonML_20141212",
     "protocol":"json"

--- a/botocore/data/marketplace-entitlement/2017-01-11/service-2.json
+++ b/botocore/data/marketplace-entitlement/2017-01-11/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Marketplace Entitlement Service",
+    "serviceId":"Marketplace Entitlement Service",
     "signatureVersion":"v4",
     "signingName":"aws-marketplace",
     "targetPrefix":"AWSMPEntitlementService",

--- a/botocore/data/marketplacecommerceanalytics/2015-07-01/service-2.json
+++ b/botocore/data/marketplacecommerceanalytics/2015-07-01/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Marketplace Commerce Analytics",
+    "serviceId":"Marketplace Commerce Analytics",
     "signatureVersion":"v4",
     "signingName":"marketplacecommerceanalytics",
     "targetPrefix":"MarketplaceCommerceAnalytics20150701",

--- a/botocore/data/meteringmarketplace/2016-01-14/service-2.json
+++ b/botocore/data/meteringmarketplace/2016-01-14/service-2.json
@@ -7,6 +7,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWSMarketplace Metering",
+    "serviceId":"Marketplace Metering",
     "signatureVersion":"v4",
     "signingName":"aws-marketplace",
     "targetPrefix":"AWSMPMeteringService"

--- a/botocore/data/mgh/2017-05-31/service-2.json
+++ b/botocore/data/mgh/2017-05-31/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Migration Hub",
+    "serviceId":"Migration Hub",
     "signatureVersion":"v4",
     "targetPrefix":"AWSMigrationHub",
     "uid":"AWSMigrationHub-2017-05-31"

--- a/botocore/data/mobile/2017-07-01/service-2.json
+++ b/botocore/data/mobile/2017-07-01/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"rest-json",
     "serviceFullName":"AWS Mobile",
+    "serviceId":"Mobile",
     "signatureVersion":"v4",
     "signingName":"AWSMobileHubService",
     "uid":"mobile-2017-07-01"

--- a/botocore/data/pricing/2017-10-15/service-2.json
+++ b/botocore/data/pricing/2017-10-15/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"AWS Pricing",
     "serviceFullName":"AWS Price List Service",
+    "serviceId":"Pricing",
     "signatureVersion":"v4",
     "signingName":"pricing",
     "targetPrefix":"AWSPriceListService",

--- a/botocore/data/resourcegroupstaggingapi/2017-01-26/service-2.json
+++ b/botocore/data/resourcegroupstaggingapi/2017-01-26/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Resource Groups Tagging API",
+    "serviceId":"Resource Groups Tagging API",
     "signatureVersion":"v4",
     "targetPrefix":"ResourceGroupsTaggingAPI_20170126",
     "uid":"resourcegroupstaggingapi-2017-01-26"

--- a/botocore/data/route53domains/2014-05-15/service-2.json
+++ b/botocore/data/route53domains/2014-05-15/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon Route 53 Domains",
+    "serviceId":"Route 53 Domains",
     "signatureVersion":"v4",
     "targetPrefix":"Route53Domains_v20140515",
     "uid":"route53domains-2014-05-15"

--- a/botocore/data/sagemaker/2017-07-24/service-2.json
+++ b/botocore/data/sagemaker/2017-07-24/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"SageMaker",
     "serviceFullName":"Amazon SageMaker Service",
+    "serviceId":"SageMaker",
     "signatureVersion":"v4",
     "signingName":"sagemaker",
     "targetPrefix":"SageMaker",

--- a/botocore/data/sdb/2009-04-15/service-2.json
+++ b/botocore/data/sdb/2009-04-15/service-2.json
@@ -4,6 +4,7 @@
     "apiVersion":"2009-04-15",
     "endpointPrefix":"sdb",
     "serviceFullName":"Amazon SimpleDB",
+    "serviceId":"SimpleDB",
     "signatureVersion":"v2",
     "xmlNamespace":"http://sdb.amazonaws.com/doc/2009-04-15/",
     "protocol":"query"

--- a/botocore/data/shield/2016-06-02/service-2.json
+++ b/botocore/data/shield/2016-06-02/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"AWS Shield",
     "serviceFullName":"AWS Shield",
+    "serviceId":"Shield",
     "signatureVersion":"v4",
     "targetPrefix":"AWSShield_20160616",
     "uid":"shield-2016-06-02"

--- a/botocore/data/sms/2016-10-24/service-2.json
+++ b/botocore/data/sms/2016-10-24/service-2.json
@@ -8,6 +8,7 @@
     "protocol":"json",
     "serviceAbbreviation":"SMS",
     "serviceFullName":"AWS Server Migration Service",
+    "serviceId":"SMS",
     "signatureVersion":"v4",
     "targetPrefix":"AWSServerMigrationService_V2016_10_24"
   },

--- a/botocore/data/snowball/2016-06-30/service-2.json
+++ b/botocore/data/snowball/2016-06-30/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"Amazon Snowball",
     "serviceFullName":"Amazon Import/Export Snowball",
+    "serviceId":"Snowball",
     "signatureVersion":"v4",
     "targetPrefix":"AWSIESnowballJobManagementService",
     "uid":"snowball-2016-06-30"

--- a/botocore/data/sqs/2012-11-05/service-2.json
+++ b/botocore/data/sqs/2012-11-05/service-2.json
@@ -6,6 +6,7 @@
     "protocol":"query",
     "serviceAbbreviation":"Amazon SQS",
     "serviceFullName":"Amazon Simple Queue Service",
+    "serviceId":"SQS",
     "signatureVersion":"v4",
     "uid":"sqs-2012-11-05",
     "xmlNamespace":"http://queue.amazonaws.com/doc/2012-11-05/"

--- a/botocore/data/support/2013-04-15/service-2.json
+++ b/botocore/data/support/2013-04-15/service-2.json
@@ -7,6 +7,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"AWS Support",
+    "serviceId":"Support",
     "signatureVersion":"v4",
     "targetPrefix":"AWSSupport_20130415"
   },

--- a/botocore/data/swf/2012-01-25/service-2.json
+++ b/botocore/data/swf/2012-01-25/service-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"Amazon SWF",
     "serviceFullName":"Amazon Simple Workflow Service",
+    "serviceId":"SWF",
     "signatureVersion":"v4",
     "targetPrefix":"SimpleWorkflowService",
     "timestampFormat":"unixTimestamp",

--- a/botocore/data/workdocs/2016-05-01/service-2.json
+++ b/botocore/data/workdocs/2016-05-01/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"rest-json",
     "serviceFullName":"Amazon WorkDocs",
+    "serviceId":"WorkDocs",
     "signatureVersion":"v4",
     "uid":"workdocs-2016-05-01"
   },

--- a/botocore/data/workmail/2017-10-01/service-2.json
+++ b/botocore/data/workmail/2017-10-01/service-2.json
@@ -6,6 +6,7 @@
     "jsonVersion":"1.1",
     "protocol":"json",
     "serviceFullName":"Amazon WorkMail",
+    "serviceId":"WorkMail",
     "signatureVersion":"v4",
     "targetPrefix":"WorkMailService",
     "uid":"workmail-2017-10-01"

--- a/botocore/data/xray/2016-04-12/service-2.json
+++ b/botocore/data/xray/2016-04-12/service-2.json
@@ -5,6 +5,7 @@
     "endpointPrefix":"xray",
     "protocol":"rest-json",
     "serviceFullName":"AWS X-Ray",
+    "serviceId":"XRay",
     "signatureVersion":"v4",
     "uid":"xray-2016-04-12"
   },


### PR DESCRIPTION
This adds serviceIds for all missing services.  There's also 5 that are remaining:

Missing: appsync
Missing: iot-jobs-data
Missing: mgh
Missing: pinpoint
Missing: transcribe

Given we're not using these for anything just yet, I think it's ok to add these to start, and then tracking down the missing 5 services.