### PR TITLE
Add iter_chunks()/iter_lines() to StreamingBody

### DIFF
--- a/.changes/next-release/enhancement-StreamingResponses-49160.json
+++ b/.changes/next-release/enhancement-StreamingResponses-49160.json
@@ -1,0 +1,5 @@
+{
+  "category": "StreamingResponses", 
+  "type": "enhancement", 
+  "description": "Add ``iter_lines()`` and ``iter_chunks()`` to streaming responses (`#1195 <https://github.com/boto/botocore/issues/1195>`__)"
+}

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -38,6 +38,8 @@ class StreamingBody(object):
           is raised.
 
     """
+    _DEFAULT_CHUNK_SIZE = 1024
+
     def __init__(self, raw_stream, content_length):
         self._raw_stream = raw_stream
         self._content_length = content_length
@@ -83,20 +85,16 @@ class StreamingBody(object):
     def __iter__(self):
         """Return an iterator to yield lines from the raw stream.
         """
-        # Reading 1024 bytes at a time seems a sane choice [citation needed].
-        # If the user needs to specify something different they can always call
-        # streaming_body._iter_lines(<other-chunk-size>)
-        default_chunk_size = 1024
-        return self._iter_lines(default_chunk_size)
+        return self.iter_chunks(self._DEFAULT_CHUNK_SIZE)
 
-    def _iter_lines(self, chunk_size):
+    def iter_lines(self, chunk_size=1024):
         """Return an iterator to yield lines from the raw stream.
 
         This is achieved by reading chunk of bytes (of size chunk_size) at a
         time from the raw stream, and then yielding lines from there.
         """
         pending = None
-        for chunk in self._iter_chunks(chunk_size):
+        for chunk in self.iter_chunks(chunk_size):
             if pending is not None:
                 chunk = pending + chunk
 
@@ -115,7 +113,7 @@ class StreamingBody(object):
         if pending is not None:
             yield pending
 
-    def _iter_chunks(self, chunk_size):
+    def iter_chunks(self, chunk_size=_DEFAULT_CHUNK_SIZE):
         """Return an iterator to yield chunks of chunk_size bytes from the raw
         stream.
         """

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -122,7 +122,7 @@ class StreamingBody(object):
         while True:
             current_chunk = self.read(chunk_size)
             if current_chunk == b"":
-                raise StopIteration()
+                break
             yield current_chunk
 
     def _verify_content_length(self):

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -85,11 +85,11 @@ class StreamingBody(object):
         """
         # Reading 1024 bytes at a time seems a sane choice [citation needed].
         # If the user needs to specify something different they can always call
-        # streaming_body.iter_lines(<other-chunk-size>)
+        # streaming_body._iter_lines(<other-chunk-size>)
         default_chunk_size = 1024
-        return self.iter_lines(default_chunk_size)
+        return self._iter_lines(default_chunk_size)
 
-    def iter_lines(self, chunk_size):
+    def _iter_lines(self, chunk_size):
         """Return an iterator to yield lines from the raw stream.
 
         This is achieved by reading chunk of bytes (of size chunk_size) at a

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -83,7 +83,7 @@ class StreamingBody(object):
         return chunk
 
     def __iter__(self):
-        """Return an iterator to yield lines from the raw stream.
+        """Return an iterator to yield 1k chunks from the raw stream.
         """
         return self.iter_chunks(self._DEFAULT_CHUNK_SIZE)
 

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -102,9 +102,7 @@ class StreamingBody(object):
 
             lines = chunk.splitlines()
 
-            chunk_ends_with_newline = chunk[-1] == b"\n"
-
-            if lines and lines[-1] and chunk and not chunk_ends_with_newline:
+            if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]:
                 # We might be in the 'middle' of a line. Hence we keep the
                 # last line as pending.
                 pending = lines.pop()

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -89,7 +89,7 @@ class TestStreamWrapper(unittest.TestCase):
             body = six.BytesIO(b'1234567890\n1234567890\n12345')
             stream = response.StreamingBody(body, content_length=27)
             self._assert_lines(
-                stream.iter_lines(chunk_size),
+                stream._iter_lines(chunk_size),
                 [b'1234567890', b'1234567890', b'12345'],
             )
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -68,6 +68,26 @@ class TestStreamWrapper(unittest.TestCase):
         stream.close()
         self.assertTrue(body.closed)
 
+    def test_streaming_line_iterator(self):
+        body = six.BytesIO(b'1234567890\n1234567890\n12345')
+        stream = response.StreamingBody(body, content_length=27)
+        lines = iter(stream)
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'12345')
+        with self.assertRaises(StopIteration):
+            next(lines)
+
+    def test_streaming_line_iterator_ends_newline(self):
+        body = six.BytesIO(b'1234567890\n1234567890\n12345\n')
+        stream = response.StreamingBody(body, content_length=28)
+        lines = iter(stream)
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'1234567890')
+        self.assertEqual(next(lines), b'12345')
+        with self.assertRaises(StopIteration):
+            next(lines)
+
 
 class TestGetResponse(BaseResponseTest):
     maxDiff = None

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -41,6 +41,17 @@ XMLBODY2 = (b'<?xml version="1.0" encoding="UTF-8"?>'
 
 
 class TestStreamWrapper(unittest.TestCase):
+
+    def assert_lines(self, line_iterator, expected_lines):
+        for expected_line in expected_lines:
+            self.assertEqual(
+                next(line_iterator),
+                expected_line,
+            )
+        # We should have exhausted the iterator.
+        with self.assertRaises(StopIteration):
+            next(line_iterator)
+
     def test_streaming_wrapper_validates_content_length(self):
         body = six.BytesIO(b'1234567890')
         stream = response.StreamingBody(body, content_length=10)
@@ -68,19 +79,44 @@ class TestStreamWrapper(unittest.TestCase):
         stream.close()
         self.assertTrue(body.closed)
 
+    def test_default_iter_behavior(self):
+        body = six.BytesIO(b'a' * 2048)
+        stream = response.StreamingBody(body, content_length=2048)
+        chunks = list(stream)
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks, [b'a' * 1024, b'a' * 1024])
+
+    def test_iter_chunks_single_byte(self):
+        body = six.BytesIO(b'abcde')
+        stream = response.StreamingBody(body, content_length=5)
+        chunks = list(stream.iter_chunks(chunk_size=1))
+        self.assertEqual(chunks, [b'a', b'b', b'c', b'd', b'e'])
+
+    def test_iter_chunks_with_leftover(self):
+        body = six.BytesIO(b'abcde')
+        stream = response.StreamingBody(body, content_length=5)
+        chunks = list(stream.iter_chunks(chunk_size=2))
+        self.assertEqual(chunks, [b'ab', b'cd', b'e'])
+
+    def test_iter_chunks_single_chunk(self):
+        body = six.BytesIO(b'abcde')
+        stream = response.StreamingBody(body, content_length=5)
+        chunks = list(stream.iter_chunks(chunk_size=1024))
+        self.assertEqual(chunks, [b'abcde'])
+
     def test_streaming_line_iterator(self):
         body = six.BytesIO(b'1234567890\n1234567890\n12345')
         stream = response.StreamingBody(body, content_length=27)
-        self._assert_lines(
-            iter(stream),
+        self.assert_lines(
+            stream.iter_lines(),
             [b'1234567890', b'1234567890', b'12345'],
         )
 
     def test_streaming_line_iterator_ends_newline(self):
         body = six.BytesIO(b'1234567890\n1234567890\n12345\n')
         stream = response.StreamingBody(body, content_length=28)
-        self._assert_lines(
-            iter(stream),
+        self.assert_lines(
+            stream.iter_lines(),
             [b'1234567890', b'1234567890', b'12345'],
         )
 
@@ -88,20 +124,10 @@ class TestStreamWrapper(unittest.TestCase):
         for chunk_size in range(1, 30):
             body = six.BytesIO(b'1234567890\n1234567890\n12345')
             stream = response.StreamingBody(body, content_length=27)
-            self._assert_lines(
-                stream._iter_lines(chunk_size),
+            self.assert_lines(
+                stream.iter_lines(chunk_size),
                 [b'1234567890', b'1234567890', b'12345'],
             )
-
-    def _assert_lines(self, line_iterator, expected_lines):
-        for expected_line in expected_lines:
-            self.assertEqual(
-                next(line_iterator),
-                expected_line,
-            )
-        # We should have exhausted the iterator.
-        with self.assertRaises(StopIteration):
-            next(line_iterator)
 
 
 class TestGetResponse(BaseResponseTest):


### PR DESCRIPTION
This pulls in https://github.com/boto/botocore/pull/1195 and incorporates review feedback [here](https://github.com/boto/botocore/pull/1195#discussion_r197903058).  The suggested changes make it similar to what requests exposes for its streaming responses.

I also added a few additional test cases.