### PR TITLE
Add Waiter for StacksSetOperationComplete

### DIFF
--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -177,6 +177,37 @@
           "state": "failure"
         }
       ]
+    },
+    "StackSetOperationComplete": {
+      "delay": 30,
+      "operation": "DescribeStackSetOperation",
+      "maxAttempts": 120,
+      "description": "Wait until stack set operation status is SUCCEEDED.",
+      "acceptors": [
+        {
+          "argument": "StackSetOperation.Status",
+          "expected": "SUCCEEDED",
+          "matcher": "path",
+          "state": "success"
+        },
+        {
+          "argument": "StackSetOperation.Status",
+          "expected": "FAILED",
+          "matcher": "path",
+          "state": "failure"
+        },
+        {
+          "argument": "StackSetOperation.Status",
+          "expected": "STOPPED",
+          "matcher": "path",
+          "state": "failure"
+        },
+        {
+          "expected": "ValidationError",
+          "matcher": "error",
+          "state": "failure"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
At our company, we are using StackSets extensively. However, we encountered `OperationInProgressException` whenever we run update/create to close together. Therefore I would like to add a `Waiter` for `StacksSetOperationComplete`.

I was not able to test this `Waiter` within the botocore project, but I used this snippet to test it:
```python
import boto3
from botocore.waiter import SingleWaiterConfig, Waiter

client = boto3.client('cloudformation')

waiter_config = SingleWaiterConfig({
  'delay': 10,
  'operation': 'DescribeStackSetOperation',
  'maxAttempts': 360,
  'acceptors': [
    {
      'argument': 'StackSetOperation.Status',
      'expected': 'SUCCEEDED',
      'matcher': 'path',
      'state': 'success'
    },
    {
      'argument': 'StackSetOperation.Status',
      'expected': 'FAILED',
      'matcher': 'path',
      'state': 'failure'
    },
    {
      'argument': 'StackSetOperation.Status',
      'expected': 'STOPPED',
      'matcher': 'path',
      'state': 'failure'
    },
    {
      'expected': 'ValidationError',
      'matcher': 'error',
      'state': 'failure'
    }
  ]
})

waiter = Waiter('StackSetOperationComplete', waiter_config, client.describe_stack_set_operation)

response = client.create_stack_instances(
    StackSetName='test',
    Accounts=['111111111111'],
    Regions=['eu-west-1'],
)

waiter.wait(
    StackSetName='test',
    OperationId=response['OperationId']
)
```

This snippet works perfectly 👍