### PR TITLE
Added endpoint destructor to close http_session

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -142,6 +142,9 @@ class Endpoint(object):
     def __repr__(self):
         return '%s(%s)' % (self._endpoint_prefix, self.host)
 
+    def __del__(self):
+        self.http_session.close()
+
     def make_request(self, operation_model, request_dict):
         logger.debug("Making request for %s (verify_ssl=%s) with params: %s",
                      operation_model, self.verify, request_dict)

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -146,6 +146,11 @@ class TestEndpointFeatures(TestEndpointBase):
                             self.event_emitter, proxies=proxies)
         self.assertEqual(endpoint.proxies, proxies)
 
+    def test_closes_session_on_destruction(self):
+        with patch.object(self.endpoint.http_session, 'close') as mock_close:
+            del self.endpoint
+            mock_close.assert_called_once_with()
+
 
 class TestRetryInterface(TestEndpointBase):
     def setUp(self):


### PR DESCRIPTION
To resolve ResourceWarnings from requests lib about unclosed SSLSockets - see requests/requests#1882