### PR TITLE
Fix case where sys.getfilessytemencoding returns None

### DIFF
--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -171,7 +171,12 @@ def raw_config_parse(config_filename, parse_subsections=True):
 def _unicode_path(path):
     if isinstance(path, six.text_type):
         return path
-    return path.decode(sys.getfilesystemencoding(), 'replace')
+    # According to the documentation getfilesystemencoding can return None
+    # on unix in which case the default encoding is used instead.
+    filesystem_encoding = sys.getfilesystemencoding()
+    if filesystem_encoding is None:
+        filesystem_encoding = sys.getdefaultencoding()
+    return path.decode(filesystem_encoding, 'replace')
 
 
 def _parse_nested(config_value):

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -67,6 +67,13 @@ class TestConfigLoader(BaseEnvVar):
         with self.assertRaises(botocore.exceptions.ConfigParseError):
             raw_config_parse(filename)
 
+    def test_config_parse_error_filesystem_encoding_none(self):
+        filename = path('aws_config_bad')
+        with mock.patch('sys.getfilesystemencoding') as encoding:
+            encoding.return_value = None
+            with self.assertRaises(botocore.exceptions.ConfigParseError):
+                raw_config_parse(filename)
+
     def test_config(self):
         loaded_config = raw_config_parse(path('aws_config'))
         self.assertIn('default', loaded_config)
@@ -118,6 +125,13 @@ class TestConfigLoader(BaseEnvVar):
         with self.assertRaises(botocore.exceptions.ConfigParseError):
             loaded_config = load_config(filename)
 
+    def test_nested_bad_config_filesystem_encoding_none(self):
+        filename = path('aws_config_nested_bad')
+        with mock.patch('sys.getfilesystemencoding') as encoding:
+            encoding.return_value = None
+            with self.assertRaises(botocore.exceptions.ConfigParseError):
+                loaded_config = load_config(filename)
+
     def test_multi_file_load(self):
         filenames = [path('aws_config_other'),
                      path('aws_config'),
@@ -140,6 +154,12 @@ class TestConfigLoader(BaseEnvVar):
         with self.assertRaises(botocore.exceptions.ConfigNotFound):
             with mock.patch('sys.getfilesystemencoding') as encoding:
                 encoding.return_value = 'utf-8'
+                load_config(path(b'\xe2\x9c\x93'))
+
+    def test_unicode_bytes_path_not_found_filesystem_encoding_none(self):
+        with mock.patch('sys.getfilesystemencoding') as encoding:
+            encoding.return_value = None
+            with self.assertRaises(botocore.exceptions.ConfigNotFound):
                 load_config(path(b'\xe2\x9c\x93'))
 
     def test_unicode_bytes_path(self):


### PR DESCRIPTION
The error handling logic in the configloader assumed that
sys.getfilesystemencoding would return a string, which is not true on
Unix. According to the documentation it can return None, and in that
case the value of getdefaultencoding should be used instead.