### PR TITLE
Update S3 BucketCannedACL definition to include missing values define…

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.json
+++ b/botocore/data/s3/2006-03-01/service-2.json
@@ -1106,7 +1106,9 @@
         "private",
         "public-read",
         "public-read-write",
-        "authenticated-read"
+        "authenticated-read",
+        "aws-exec-read",
+        "log-delivery-write"
       ]
     },
     "BucketLifecycleConfiguration":{


### PR DESCRIPTION
The S3 API defines Canned ACLs for buckets that can be passed to the boto3 S3 `create_bucket` command, but don't actually show up in the documentation.

The full list is defined here:

https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl

But currently `aws-exec-read` and `log-delivery-write` are missing from the list.  The pydoc text for `s3_client.create_bucket(...)` shows:

```
    **Request Syntax**
    ::

      response = client.create_bucket(
          ACL='private'|'public-read'|'public-read-write'|'authenticated-read',
          Bucket='string',
```

But the two string mentioned above are valid values for the `ACL` parameter.  This has led to some user confusion when trying to set up bucket logging using boto3 and botocore.  e.g.:

https://stackoverflow.com/questions/32513958/boto3-s3-client-put-bucket-logging-broken/32530420#32530420