### PR TITLE
waiter for ssm that waits until an agent is online

### DIFF
--- a/botocore/data/ssm/2014-11-06/waiters-2.json
+++ b/botocore/data/ssm/2014-11-06/waiters-2.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "waiters": {
+      "AgentIsOnline": {
+          "delay": 15,
+          "operation": "DescribeInstanceInformation",
+          "maxAttempts": 40,
+          "acceptors": [
+              {
+                  "expected": "Online",
+                  "matcher": "pathAny",
+                  "state": "success",
+                  "argument": "InstanceInformationList[].PingStatus"
+              },
+              {
+                  "expected": "ConnectionLost",
+                  "matcher": "pathAny",
+                  "state": "retry",
+                  "argument": "InstanceInformationList[].PingStatus"
+              },
+              {
+                  "expected": "Inactive",
+                  "matcher": "pathAny",
+                  "state": "failure",
+                  "argument": "InstanceInformationList[].PingStatus"
+              }
+          ]
+      }
+  }
+}


### PR DESCRIPTION
A simple waiter config to wait until an ssh agent is in status `Online`.

I use it to make sure I can send commands to the instance.

```python
model = botocore.waiter.WaiterModel({
    "version": 2,
    "waiters": {
        "AgentIsOnline": {
            "delay": 15,
            "operation": "DescribeInstanceInformation",
            "maxAttempts": 40,
            "acceptors": [
                {
                    "expected": "Online",
                    "matcher": "pathAny",
                    "state": "success",
                    "argument": "InstanceInformationList[].PingStatus"
                },
                {
                    "expected": "ConnectionLost",
                    "matcher": "pathAny",
                    "state": "retry",
                    "argument": "InstanceInformationList[].PingStatus"
                },
                {
                    "expected": "Inactive",
                    "matcher": "pathAny",
                    "state": "failure",
                    "argument": "InstanceInformationList[].PingStatus"
                  }
            ]
       }
    }
})

waiter = botocore.waiter.create_waiter_with_client('AgentIsOnline', model, ssm_client)
waiter.wait(Filters=[ { 'Key': 'InstanceIds', 'Values': [ instance_id ] } ])
```
