### PR TITLE
Ensure unicode client errors are handled correctly

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -357,6 +357,11 @@ class ClientError(Exception):
             operation_name=operation_name,
             retry_info=retry_info,
         )
+        if not isinstance(msg, str):
+            # The __str__ implmentation for Exception on Python 2 will attempt
+            # to convert unicode into ascii, which will fail if there is
+            # actually any unicode in the str
+            msg = msg.encode('utf-8')
         super(ClientError, self).__init__(msg)
         self.response = error_response
         self.operation_name = operation_name

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -78,3 +78,17 @@ def test_can_handle_when_response_missing_error_key():
         raise AssertionError(
             "Error code should default to 'Unknown' "
             "when missing error response, instead got: %s" % str(e))
+
+
+def test_client_error_can_convert_to_str_unicode():
+    response = {
+        'Error': {
+            'Code': 'TestError',
+            'Message': u'\u30c6\u30b9\u30c8',
+        }
+    }
+    e = exceptions.ClientError(response, 'TestOperation')
+    try:
+        str(e)
+    except UnicodeEncodeError:
+        raise AssertionError('Failed to convert exception to printable message')


### PR DESCRIPTION
If a service returns unicode in their response (for example, if  unicode was in the request) Python will attempt to represent the exception using ascii which fails for obvious reasons.

Fixes: https://github.com/boto/boto3/issues/1628