### PR TITLE
Test on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
-sudo: false
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+    - python: 2.6
+      dist: trusty
+      sudo: false
+    - python: 2.7
+      dist: trusty
+      sudo: false
+    - python: 3.3
+      dist: trusty
+      sudo: false
+    - python: 3.4
+      dist: trusty
+      sudo: false
+    - python: 3.5
+      dist: trusty
+      sudo: false
+    - python: 3.6
+      dist: trusty
+      sudo: false
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 cache: pip
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/setup.py
+++ b/setup.py
@@ -78,5 +78,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ),
 )

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -1171,7 +1171,7 @@ class TestIncludeNonResultKeys(unittest.TestCase):
             {'Result': {'Key': ['bar', 'baz'], 'Inner': 'v3'},
              'Outer': 'v4', 'NextToken': 't2'},
             {'Result': {'Key': ['qux'], 'Inner': 'v5'},
-             'Outer': 'v6', 'NextToken': 't3'},
+             'Outer': 'v6'},
         ]
         pages = self.paginator.paginate()
         actual = pages.build_full_result()
@@ -1404,7 +1404,7 @@ class TestStringPageSize(unittest.TestCase):
         self.service = model.ServiceModel(self.service_model)
         self.model = self.service.operation_model('ListStuff')
         self.method = mock.Mock()
-        self.method.side_effect = []
+        self.method.side_effect = [{}]
         self.paginator = Paginator(self.method, self.paginate_config, self.model)
 
     def test_int_page_size(self):


### PR DESCRIPTION
This updates the travis configuration to start running tests on python 3.7
as well as updating the tests to fix some issues related to PEP 479.