### PR TITLE
New waiter definition for CloudFormation change set execution.

### DIFF
--- a/botocore/data/cloudformation/2010-05-15/waiters-2.json
+++ b/botocore/data/cloudformation/2010-05-15/waiters-2.json
@@ -177,6 +177,38 @@
           "state": "failure"
         }
       ]
+    },
+    "ChangeSetExecuteComplete": {
+      "delay": 30,
+      "operation": "DescribeChangeSet",
+      "maxAttempts": 120,
+      "description": "Wait until change set status is EXECUTE_COMPLETE.",
+      "acceptors": [
+        {
+          "argument": "ExecutionStatus",
+          "expected": "EXECUTE_COMPLETE",
+          "matcher": "path",
+          "state": "success"
+        },
+        {
+          "argument": "ExecutionStatus",
+          "expected": "EXECUTE_FAILED",
+          "matcher": "path",
+          "state": "failure"
+        },
+        {
+          "argument": "ExecutionStatus",
+          "expected": "OBSOLETE",
+          "matcher": "path",
+          "state": "failure"
+        },
+        {
+          "argument": "ExecutionStatus",
+          "expected": "UNAVAILABLE",
+          "matcher": "path",
+          "state": "failure"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
With the introduction of CloudFormation change sets, the process of stack update can be instrumented to anticipate certain number of operations.

While there is a waiter defined for changeset creation, there is no waiter for changeset execution.  Adding a similar definition for symmetry.