### PR TITLE
Add 404 page to doc source

### DIFF
--- a/docs/source/_static/404.html
+++ b/docs/source/_static/404.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Page Not Found</title>
+    <style>
+    * {
+        box-sizing: border-box;
+    }
+    body {
+        vertical-align: middle;
+        text-align: center;
+        line-height: 1.5;
+        font-family: "Open Sans", Helvetica, Arial, sans-serif;
+        font-size: 16px;
+        margin: 0;
+        padding: 0;
+    }
+    h1 {
+        font-size: 38px;
+        padding: 10px 10px 10px 45px;
+        margin: 20px 0 35px -45px;
+        font-weight: normal;
+    }
+    p {
+        padding: 0;
+        margin: 0 0 10px;
+    }
+    </style>
+</head>
+<body>
+    <h1>Page Not Found</h1>
+    <p>Sorry, the page you requested could not be found.</p>
+</html>


### PR DESCRIPTION
This is put in the static directory so that it is copied over, as
otherwise sphinx does not bring over anything but folders and rst
files.