### PR TITLE
Check the security-credentials document body code for success

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -205,14 +205,24 @@ class InstanceMetadataFetcher(object):
                         data[field[0:-1]] = self.retrieve_iam_role_credentials(
                             url + field, timeout, num_attempts)
                     else:
-                        val = self._get_request(
-                            url + field,
+                        field_url = url + field
+                        r = self._get_request(
+                            field_url,
                             timeout=timeout,
                             num_attempts=num_attempts,
-                        ).content.decode('utf-8')
+                        )
+                        val = r.content.decode('utf-8')
                         if val[0] == '{':
                             val = json.loads(val)
-                        data[field] = val
+                        code = val['Code']
+                        if code != 'Success':
+                            logger.debug("Metadata service returned non Success"
+                                         " code of %s for url: %s, status code:"
+                                         " %s, content body: %s",
+                                         code, field_url, r.status_code,
+                                         r.content)
+                        else:
+                            data[field] = val
             else:
                 logger.debug("Metadata service returned non 200 status code "
                              "of %s for url: %s, content body: %s",


### PR DESCRIPTION
When the IAM role for an instance contains a condition that cannot
be met, like requiring MFA to assume role, the metdata server
responds with a 200 OK HTTP message but the content contains an
error.

curl -vvvv http://169.254.169.254/latest/meta-data/iam/security-credentials/role-name

Error document:

```
{
  "Code" : "AssumeRoleUnauthorizedAccess",
  "Message" : "EC2 cannot assume the role [redact].  Please see documentation at http://docs.amazonwebservices.com/IAM/latest/UserGuide/RolesTroubleshooting.html.",
  "LastUpdated" : "2018-08-20T05:03:24Z"
}
```

Success document:

```
{
  "Code" : "Success",
  "LastUpdated" : "2018-08-20T05:09:13Z",
  "Type" : "AWS-HMAC",
  "AccessKeyId" : "[redact]",
  "SecretAccessKey" : "[redact]",
  "Token" : "[redact]",
  "Expiration" : "2018-08-20T11:41:42Z"
}
```

By checking the `"Code"` key before using the rest of the document, we can
return an error instead of raising an exception.

Using aws-cli as an example, instead of raising a key exception and printing
the key name like this:

```
$ aws sts get-caller-identity
'AccessKeyId'
```

An error like this is printed:

```
$ aws sts get-caller-identity
Unable to locate credentials. You can configure credentials by running "aws configure".
```

Running aws-cli with `--debug` will then also print the metadata server response to
help you diagnose the situation more quickly.