### PR TITLE
Remove request_url kwarg as it's not support in all urllib3 versions

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -234,7 +234,6 @@ class URLLib3Session(object):
             urllib_response = conn.urlopen(
                 method=request.method,
                 url=request_target,
-                request_url=request.url,
                 body=request.body,
                 headers=request.headers,
                 retries=False,

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -77,8 +77,8 @@ class StreamingBody(object):
         try:
             chunk = self._raw_stream.read(amt)
         except URLLib3ReadTimeoutError as e:
-            url = self._raw_stream.geturl()
-            raise ReadTimeoutError(endpoint_url=url, error=e)
+            # TODO: the url will be None as urllib3 isn't setting it yet
+            raise ReadTimeoutError(endpoint_url=e.url, error=e)
         self._amount_read += len(chunk)
         if amt is None or (not chunk and amt > 0):
             # If the server sends empty contents or

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -103,7 +103,6 @@ class TestURLLib3Session(unittest.TestCase):
             assert_same_host=False,
             preload_content=False,
             decode_content=False,
-            request_url=ANY,
         )
 
     def test_forwards_max_pool_size(self):


### PR DESCRIPTION
The current version range we have doesn't support the `request_url` kwarg in all versions (only the latest 1.23 supports it). urllib3 v1.23 doesn't support Python 3.3 which means we can't rely on this for now. The downside is we get poor exceptions messages but I can fix this upstream in urllib3.