### PR TITLE
Modified lines-from-chunks generator to ensure support for "\r\n"

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -98,25 +98,13 @@ class StreamingBody(object):
         This is achieved by reading chunk of bytes (of size chunk_size) at a
         time from the raw stream, and then yielding lines from there.
         """
-        pending = None
+        pending = b''
         for chunk in self.iter_chunks(chunk_size):
-            if pending is not None:
-                chunk = pending + chunk
-
-            lines = chunk.splitlines()
-
-            if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]:
-                # We might be in the 'middle' of a line. Hence we keep the
-                # last line as pending.
-                pending = lines.pop()
-            else:
-                pending = None
-
-            for line in lines:
-                yield line
-
-        if pending is not None:
-            yield pending
+            lines = (pending + chunk).splitlines(True)
+            for line in lines[:-1]:
+                yield line.splitlines()[0]
+            pending = lines[-1]
+        yield pending.splitlines()[0]
 
     def iter_chunks(self, chunk_size=_DEFAULT_CHUNK_SIZE):
         """Return an iterator to yield chunks of chunk_size bytes from the raw

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -149,15 +149,6 @@ class TestStreamWrapper(unittest.TestCase):
         with self.assertRaises(ReadTimeoutError):
             stream.read()
 
-
-class FakeRawResponse(six.BytesIO):
-    def stream(self, amt=1024, decode_content=None):
-        while True:
-            chunk = self.read(amt)
-            if not chunk:
-                break
-            yield chunk
-
     def test_streaming_line_abstruse_newline_standard(self):
         for chunk_size in range(1, 30):
             body = six.BytesIO(b'1234567890\r\n1234567890\r\n12345\r\n')
@@ -166,6 +157,15 @@ class FakeRawResponse(six.BytesIO):
                 stream.iter_lines(chunk_size),
                 [b'1234567890', b'1234567890', b'12345'],
             )
+
+
+class FakeRawResponse(six.BytesIO):
+    def stream(self, amt=1024, decode_content=None):
+        while True:
+            chunk = self.read(amt)
+            if not chunk:
+                break
+            yield chunk
 
 
 class TestGetResponse(BaseResponseTest):

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -158,6 +158,15 @@ class FakeRawResponse(six.BytesIO):
                 break
             yield chunk
 
+    def test_streaming_line_abstruse_newline_standard(self):
+        for chunk_size in range(1, 30):
+            body = six.BytesIO(b'1234567890\r\n1234567890\r\n12345\r\n')
+            stream = response.StreamingBody(body, content_length=31)
+            self.assert_lines(
+                stream.iter_lines(chunk_size),
+                [b'1234567890', b'1234567890', b'12345'],
+            )
+
 
 class TestGetResponse(BaseResponseTest):
     maxDiff = None


### PR DESCRIPTION
The current code produces empty strings sometimes if the input file follows this unconventional and bizarre "\r\n" newline standard, that nonetheless is still found in some legacy systems. The proposed code tries to make sure whatever `splitlines()` understands as newline is supported.

This PR is the same as #1527, but rebasing after lots of changes upstream.