### PR TITLE
Ensure the derived endpoint url is lowercased

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -450,7 +450,7 @@ class ClientEndpointBridge(object):
             'region_name': region_name,
             'signing_region': signing_region,
             'signing_name': signing_name,
-            'endpoint_url': endpoint_url,
+            'endpoint_url': endpoint_url.lower(),
             'signature_version': signature_version,
             'metadata': metadata
         }

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1979,3 +1979,13 @@ class TestClientEndpointBridge(unittest.TestCase):
             resolved['endpoint_url'],
             'https://s3.dualstack.cn-north-1.amazonaws.com.cn'
         )
+
+    def test_endpoint_url_is_all_lowerase(self):
+        resolver = mock.Mock()
+        resolver.construct_endpoint.return_value = {
+            'partition': 'aws', 'hostname': 'HoSt.cOm',
+            'signatureVersions': ['v4'],
+            'endpointName': 'us-foo-baz'}
+        bridge = ClientEndpointBridge(resolver)
+        resolved = bridge.resolve('myservice', 'us-foo-baz', is_secure=False)
+        self.assertEqual('http://host.com', resolved['endpoint_url'])


### PR DESCRIPTION
This ensures that the derived endpoints that a client uses are lowercased.
This is important when signing the host header using SigV4 as the casing of the signed header may differ from the actual host header sent when making the HTTP request if it's not normalized to be all lowercase.

This is relevant in particular due to some changes in `urllib3`:
https://github.com/urllib3/urllib3/issues/1032
https://github.com/urllib3/urllib3/issues/1033

In the long-term, we should get a good solution for setting the appropriate host header ourselves rather than relying on our http client to do that for us.