### PR TITLE
Ensure the SigV4 signer signs the host as all lowercase

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -180,7 +180,11 @@ class SigV4Auth(BaseSigner):
             if lname not in SIGNED_HEADERS_BLACKLIST:
                 header_map[lname] = value
         if 'host' not in header_map:
-            header_map['host'] = self._canonical_host(request.url)
+            # Ensure we sign the lowercased version of the host, as that
+            # is what will ultimately be sent on the wire.
+            # TODO: We should set the host ourselves, instead of relying on our
+            # HTTP client to set it for us.
+            header_map['host'] = self._canonical_host(request.url).lower()
         return header_map
 
     def _canonical_host(self, url):

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -219,3 +219,16 @@ class TestClientInjection(unittest.TestCase):
 
         # We should now have access to the extra_client_method above.
         self.assertEqual(client.extra_client_method('foo'), 'foo')
+
+
+class TestMixedEndpointCasing(unittest.TestCase):
+    def setUp(self):
+        self.url = 'https://EC2.US-WEST-2.amazonaws.com/'
+        self.session = botocore.session.get_session()
+        self.client = self.session.create_client('ec2', 'us-west-2',
+                                                 endpoint_url=self.url)
+
+    def test_sigv4_is_correct_when_mixed_endpoint_casing(self):
+        res = self.client.describe_regions()
+        status_code = res['ResponseMetadata']['HTTPStatusCode']
+        self.assertEqual(status_code, 200)

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -91,6 +91,7 @@ SMOKE_TESTS = {
  's3': {'ListBuckets': {}},
  'sdb': {'ListDomains': {}},
  'ses': {'ListIdentities': {}},
+ 'shield': {'GetSubscriptionState': {}},
  'sns': {'ListTopics': {}},
  'sqs': {'ListQueues': {}},
  'ssm': {'ListDocuments': {}},

--- a/tests/unit/test_auth_sigv4.py
+++ b/tests/unit/test_auth_sigv4.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+
+SECRET_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+ACCESS_KEY = 'AKIDEXAMPLE'
+
+
+class TestSigV4Auth(unittest.TestCase):
+    def setUp(self):
+        self.credentials = Credentials(ACCESS_KEY, SECRET_KEY)
+        self.sigv4 = SigV4Auth(self.credentials, 'host', 'us-weast-1')
+
+    def test_signed_host_is_lowercase(self):
+        endpoint = 'https://S5.Us-WeAsT-2.AmAZonAwS.com'
+        expected_host = 's5.us-weast-2.amazonaws.com'
+        request = AWSRequest(method='GET', url=endpoint)
+        headers_to_sign = self.sigv4.headers_to_sign(request)
+        self.assertEqual(expected_host, headers_to_sign.get('host'))


### PR DESCRIPTION
Succeeds: https://github.com/boto/botocore/pull/1538

Basically, if the endpoint has mixed casing we sign using the mixed case but it's actually sent across the wire as all lowercase (this if the `Host` header is not explicitly set).