### PR TITLE
classifiers needs to be an array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         ]
     },
     license="Apache License 2.0",
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
@@ -80,5 +80,5 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-    ),
+    ]
 )


### PR DESCRIPTION
Solves python3 bdist_wheel upload issue:
```
running upload
Traceback (most recent call last):
  File "setup.py", line 82, in <module>
    'Programming Language :: Python :: 3.7',
  File "/usr/local/lib/python3.6/site-packages/setuptools/__init__.py", line 131, in setup
    return distutils.core.setup(**attrs)
  File "/usr/local/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/local/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.6/distutils/command/upload.py", line 64, in run
    self.upload_file(command, pyversion, filename)
  File "/usr/local/lib/python3.6/distutils/command/upload.py", line 162, in upload_file
    body.write(value)
TypeError: a bytes-like object is required, not 'str'
```