### PR TITLE
Fixes error in Python 2.6.6; falls back to json in the standard lib.

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -147,9 +147,12 @@ except ImportError:
     # Python2.6 we use the 3rd party back port.
     from ordereddict import OrderedDict
 
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 if sys.version_info[:2] == (2, 6):
-    import simplejson as json
     # In py26, invalid xml parsed by element tree
     # will raise a plain old SyntaxError instead of
     # a real exception, so we need to abstract this change.


### PR DESCRIPTION
I had this issue on RHEL 6, using Python 2.6.6.  After installing botocore as a dependency of boto3, the import failed due to pointing to simplejson, which is deprecated.  Even installing simplejson did not resolve the error; this wraps the code in a try / except block and gracefully falls back to the json module in the standard library.

```
[root@xhmon-ch2-01 ~]$ python
Python 2.6.6 (r266:84292, May 22 2015, 08:34:51)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-15)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.6/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/usr/lib/python2.6/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/usr/lib/python2.6/site-packages/botocore/session.py", line 26, in <module>
    import botocore.configloader
  File "/usr/lib/python2.6/site-packages/botocore/configloader.py", line 19, in <module>
    from botocore.compat import six
  File "/usr/lib/python2.6/site-packages/botocore/compat.py", line 152, in <module>
    import simplejson as json
ImportError: No module named simplejson
>>> quit()


[root@xhmon-ch2-01 ~]$ rpm -qa python-simplejson
python-simplejson-3.3.3-1.x86_64
```