### PR TITLE
Add missing RDS paginators

### DIFF
--- a/botocore/data/rds/2014-10-31/paginators-1.json
+++ b/botocore/data/rds/2014-10-31/paginators-1.json
@@ -1,16 +1,52 @@
 {
   "pagination": {
+    "DescribeCertificates": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords",
+      "result_key": "Certificates"
+    },
+    "DescribeDBClusterBacktracks": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords",
+      "result_key": "DBClusterBacktracks"
+    },
+    "DescribeDBClusterParameterGroups": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords",
+      "result_key": "DBClusterParameterGroups"
+    },
+    "DescribeDBClusterParameters": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords",
+      "result_key": "Parameters"
+    },
     "DescribeDBClusterSnapshots": {
       "input_token": "Marker",
       "output_token": "Marker",
       "limit_key": "MaxRecords",
       "result_key": "DBClusterSnapshots"
     },
+    "DescribeDBClusters": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "DBClusters"
+    },
     "DescribeDBEngineVersions": {
       "input_token": "Marker",
       "output_token": "Marker",
       "limit_key": "MaxRecords",
       "result_key": "DBEngineVersions"
+    },
+    "DescribeDBInstanceAutomatedBackups": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "DBInstanceAutomatedBackups"
     },
     "DescribeDBInstances": {
       "input_token": "Marker",
@@ -54,6 +90,12 @@
       "limit_key": "MaxRecords",
       "result_key": "DBSubnetGroups"
     },
+    "DescribeEngineDefaultClusterParameters": {
+      "input_token": "Marker",
+      "output_token": "EngineDefaults.Marker",
+      "limit_key": "MaxRecords",
+      "result_key": "EngineDefaults.Parameters"
+    },
     "DescribeEngineDefaultParameters": {
       "input_token": "Marker",
       "output_token": "EngineDefaults.Marker",
@@ -71,6 +113,12 @@
       "output_token": "Marker",
       "limit_key": "MaxRecords",
       "result_key": "Events"
+    },
+    "DescribeGlobalClusters": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "GlobalClusters"
     },
     "DescribeOptionGroupOptions": {
       "input_token": "Marker",
@@ -90,6 +138,12 @@
       "limit_key": "MaxRecords",
       "result_key": "OrderableDBInstanceOptions"
     },
+    "DescribePendingMaintenanceActions": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords",
+      "result_key": "PendingMaintenanceActions"
+    },
     "DescribeReservedDBInstances": {
       "input_token": "Marker",
       "output_token": "Marker",
@@ -102,30 +156,18 @@
       "limit_key": "MaxRecords",
       "result_key": "ReservedDBInstancesOfferings"
     },
+    "DescribeSourceRegions": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords",
+      "result_key": "SourceRegions"
+    },
     "DownloadDBLogFilePortion": {
       "input_token": "Marker",
       "output_token": "Marker",
       "limit_key": "NumberOfLines",
       "more_results": "AdditionalDataPending",
       "result_key": "LogFileData"
-    },
-    "DescribeDBClusters": {
-      "input_token": "Marker",
-      "limit_key": "MaxRecords",
-      "output_token": "Marker",
-      "result_key": "DBClusters"
-    },
-    "DescribeDBInstanceAutomatedBackups": {
-      "input_token": "Marker",
-      "limit_key": "MaxRecords",
-      "output_token": "Marker",
-      "result_key": "DBInstanceAutomatedBackups"
-    },
-    "DescribeGlobalClusters": {
-      "input_token": "Marker",
-      "limit_key": "MaxRecords",
-      "output_token": "Marker",
-      "result_key": "GlobalClusters"
     }
   }
 }


### PR DESCRIPTION
Looks like someone added a paginator for `DescribeDBClusters` but didn't add paginators for any of the other Cluster actions.