### PR TITLE
Improve error message with missing service id

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -274,13 +274,13 @@ def _needs_s3_sse_customization(params, sse_member_prefix):
 def register_retries_for_service(service_data, session,
                                  service_name, **kwargs):
     loader = session.get_component('data_loader')
-    service_id = service_data.get('metadata', {}).get('serviceId')
-    service_event_name = hyphenize_service_id(service_id)
     endpoint_prefix = service_data.get('metadata', {}).get('endpointPrefix')
     if endpoint_prefix is None:
         logger.debug("Not registering retry handlers, could not endpoint "
                      "prefix from model for service %s", service_name)
         return
+    service_id = service_data.get('metadata', {}).get('serviceId')
+    service_event_name = hyphenize_service_id(service_id)
     config = _load_retry_config(loader, endpoint_prefix)
     if not config:
         return

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -339,6 +339,10 @@ class ServiceModel(object):
     def signature_version(self, value):
         self._signature_version = value
 
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self.service_name)
+
+
 
 class OperationModel(object):
     def __init__(self, operation_model, service_model, name=None):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -549,8 +549,8 @@ class TestHandlers(BaseSessionTest):
                   'UserData': b64_user_data}
         self.assertEqual(params, result)
 
-    def test_register_retry_for_handlers_with_no_endpoint_prefix(self):
-        no_endpoint_prefix = {'metadata': {'serviceId': 'foo'}}
+    def test_register_retry_for_handlers_with_no_metadata(self):
+        no_endpoint_prefix = {'metadata': {}}
         session = mock.Mock()
         handlers.register_retries_for_service(service_data=no_endpoint_prefix,
                                               session=mock.Mock(),

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -89,6 +89,10 @@ class TestServiceModel(unittest.TestCase):
     def test_shape_names(self):
         self.assertEqual(self.service_model.shape_names, ['StringShape'])
 
+    def test_repr_has_service_name(self):
+        self.assertEqual(repr(self.service_model),
+                         'ServiceModel(endpoint-prefix)')
+
 
 class TestOperationModelFromService(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Originally introduced in ba514720588c520fdf5ed0c77ddc76e4455246d0,
one of the tests was modified to have different behavior than intended.

The test is suppose to verify that without any of the needed
metadata properties we don't register a retry handler.
Right now, if a serviceId is missing you'll get an error message of
"NoneType" has no attribute "lower()".
With this change, you'll get the missing metadata error message
from models.py.

To help clarify this, I've changed the name of the test.  I also
added a repr to the Service class.  You now get:

```
$ aws s3 ls

"serviceId" not defined in the metadata of the model: ServiceModel(s3)
```