### PR TITLE
Do not url decode ContinuationToken

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -743,7 +743,7 @@ def decode_list_object_v2(parsed, context, **kwargs):
     # name values in the following response elements:
     # Delimiter, Prefix, ContinuationToken, Key, and StartAfter.
     _decode_list_object(
-        top_level_keys=['Delimiter', 'Prefix', 'ContinuationToken', 'StartAfter'],
+        top_level_keys=['Delimiter', 'Prefix', 'StartAfter'],
         nested_keys=[('Contents', 'Key'), ('CommonPrefixes', 'Prefix')],
         parsed=parsed,
         context=context

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -908,14 +908,15 @@ class TestHandlers(BaseSessionTest):
         handlers.decode_list_object_v2(parsed, context=context)
         self.assertEqual(parsed['Prefix'], u'\xe7\xf6s% asd\x08 c')
         
-    def test_decode_list_objects_v2_with_continuationtoken(self):
+    def test_decode_list_objects_v2_does_not_decode_continuationtoken(self):
         parsed = {
             'ContinuationToken': "%C3%A7%C3%B6s%25%20asd%08+c",
             'EncodingType': 'url',
         }
         context = {'encoding_type_auto_set': True}
         handlers.decode_list_object_v2(parsed, context=context)
-        self.assertEqual(parsed['ContinuationToken'], u'\xe7\xf6s% asd\x08 c')
+        self.assertEqual(
+            parsed['ContinuationToken'], u"%C3%A7%C3%B6s%25%20asd%08+c")
         
     def test_decode_list_objects_v2_with_startafter(self):
         parsed = {


### PR DESCRIPTION
I was playing around with setting the EncodingType for ListObjectsV2, and I realized the S3 does not url encode the `ContinuationToken` in the response (even though the documentation says it does) and we should not url decode the `ContinuationToken` provided in the response.

Here is an example of what we are doing in the develop branch now with the CLI...

Just doing the initial `ListObjectsV2` call:
```
$ aws s3api list-objects-v2 --bucket mybucketfoo --max-keys 1
{
    "Name": "mybucketfoo", 
    "MaxKeys": 1, 
    "Prefix": "", 
    "KeyCount": 1, 
    "EncodingType": "url", 
    "NextContinuationToken": "1o1fF7/sfdyhcF61mG/KUupibYD3RDvBhH3TM9QHKloJ+oCr87Y19Ag==", 
    "IsTruncated": true, 
    "Contents": [
        {
            "LastModified": "2015-12-08T18:26:43.000Z", 
            "ETag": "\"7f13278c420daa7ec3607db2c0962673\"", 
            "StorageClass": "STANDARD", 
            "Key": "#test test", 
            "Size": 1949
        }
    ]
}
```
Now use the `NextContinuationToken` as the `--continuation-token`:

```
$ aws s3api list-objects-v2 --bucket mybucketfoo --max-keys 1 --continuation-token '1o1fF7/sfdyhcF61mG/KUupibYD3RDvBhH3TM9QHKloJ+oCr87Y19Ag=='
{
    "Name": "mybucketfoo", 
    "IsTruncated": true, 
    "MaxKeys": 1, 
    "Prefix": "", 
    "KeyCount": 1, 
    "EncodingType": "url", 
    "NextContinuationToken": "1oYo4XL4i1tef0RO3Ia1w7M3l7q0GHZtv", 
    "ContinuationToken": "1o1fF7/sfdyhcF61mG/KUupibYD3RDvBhH3TM9QHKloJ oCr87Y19Ag==", 
    "Contents": [
        {
            "LastModified": "2016-08-03T22:44:52.000Z", 
            "ETag": "\"04a7ec057178d36081f3c04c7d675ca7-1280\"", 
            "StorageClass": "STANDARD", 
            "Key": "-", 
            "Size": 10737418240
        }
    ]
}
```
Note the `ContinuationToken` in the response:
```
1o1fF7/sfdyhcF61mG/KUupibYD3RDvBhH3TM9QHKloJ oCr87Y19Ag==
```

does not match the value for `--continuation-token` in the command (note the space instead of the plus sign):
```
1o1fF7/sfdyhcF61mG/KUupibYD3RDvBhH3TM9QHKloJ+oCr87Y19Ag==
```

According to the docs, the `ContinuationToken` in the response is:

>> If ContinuationToken was sent with the request, it is included in the response. 

So they should be exactly the same.

Furthermore looking at the XML, it is not url encoded as well (it matches exactly what we inputted):
```
<ContinuationToken>1o1fF7/sfdyhcF61mG/KUupibYD3RDvBhH3TM9QHKloJ+oCr87Y19Ag==</ContinuationToken>
```
If it was url encoded, the value would have been:
```
1o1fF7/sfdyhcF61mG/KUupibYD3RDvBhH3TM9QHKloJ%2BoCr87Y19Ag%3D%3D
```

In the end while this does not affect pagination logic too much, I think it is something we should fix.