### PR TITLE
Add the send-request event

### DIFF
--- a/.changes/next-release/enhancement-Event-36456.json
+++ b/.changes/next-release/enhancement-Event-36456.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Event",
+  "description": "Add the `before-send` event which allows finalized requests to be inspected before being sent across the wire and allows for custom responses to be returned."
+}

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -443,7 +443,7 @@ class AWSRequestPreparer(object):
 class AWSRequest(object):
     """Represents the elements of an HTTP request.
 
-    This class is originally inspired by requests.models.Request, but has been
+    This class was originally inspired by requests.models.Request, but has been
     boiled down to meet the specific use cases in botocore. That being said this
     class (even in requests) is effectively a named-tuple.
     """
@@ -550,8 +550,8 @@ class AWSPreparedRequest(object):
 class AWSResponse(object):
     """A data class representing an HTTP response.
 
-    This class is originally inspired by requests.models.Response, but has been
-    boiled down to meet the specific use cases in botocore. This has
+    This class was originally inspired by requests.models.Response, but has
+    been boiled down to meet the specific use cases in botocore. This has
     effectively been reduced to a named tuple.
 
     :ivar url: The full url.

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -397,6 +397,14 @@ class AWSRequestPreparer(object):
 
         return headers
 
+    def _to_utf8(self, item):
+        key, value = item
+        if isinstance(key, six.text_type):
+            key = key.encode('utf-8')
+        if isinstance(value, six.text_type):
+            value = value.encode('utf-8')
+        return key, value
+
     def _prepare_body(self, original):
         """Prepares the given HTTP body data."""
         body = original.data
@@ -404,7 +412,7 @@ class AWSRequestPreparer(object):
             body = None
 
         if isinstance(body, dict):
-            params = list(body.items())
+            params = [self._to_utf8(item) for item in body.items()]
             body = urlencode(params, doseq=True)
 
         return body

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -171,7 +171,12 @@ class Endpoint(object):
                 'url': request.url,
                 'body': request.body
             })
-            http_response = self._send(request)
+            service_id = operation_model.service_model.service_id.hyphenize()
+            event_name = 'send-request.%s.%s' % (service_id, operation_model.name)
+            responses = self._event_emitter.emit(event_name, request=request)
+            http_response = first_non_none_response(responses)
+            if http_response is None:
+                http_response = self._send(request)
         except HTTPClientError as e:
             return (None, e)
         except Exception as e:

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -172,7 +172,7 @@ class Endpoint(object):
                 'body': request.body
             })
             service_id = operation_model.service_model.service_id.hyphenize()
-            event_name = 'send-request.%s.%s' % (service_id, operation_model.name)
+            event_name = 'before-send.%s.%s' % (service_id, operation_model.name)
             responses = self._event_emitter.emit(event_name, request=request)
             http_response = first_non_none_response(responses)
             if http_response is None:

--- a/docs/source/reference/awsrequest.rst
+++ b/docs/source/reference/awsrequest.rst
@@ -1,0 +1,15 @@
+.. _ref-awsrequest:
+
+================================
+AWS Request Reference
+================================
+
+botocore.awsrequest
+-------------------
+
+.. autoclass:: botocore.awsrequest.AWSPreparedRequest
+   :members:
+
+
+.. autoclass:: botocore.awsrequest.AWSResponse
+   :members:

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -18,33 +18,90 @@ to events.
 Event Types
 -----------
 
-The table below shows all of the events emitted by botocore.  In some cases,
-the events are listed as ``<service>.<operations>.bar``, in which ``<service>``
-and ``<operation>`` are replaced with a specific service and operation, for
-example ``s3.ListObjects.bar``.
+The list below shows all of the events emitted by botocore.  In some cases, the
+events are listed as ``event-name.<service>.<operations>``, in which
+``<service>`` and ``<operation>`` are replaced with a specific service and
+operation, for example ``event-name.s3.ListObjects``.
 
-.. list-table:: Events
-   :header-rows: 1
+* ``'before-call.<service>.<operation>'``
+* ``'before-send.<service>.<operation>'``
+* ``'after-call.<service>.<operation>'``
 
-   * - Event Name
-     - Occurance
-     - Arguments
-     - Return Value
-   * - **service-created**
-     - Whenever a service is created via the Sessions ``get_service``
-       method.
-     - ``service`` - The newly created :class:`botocore.service.Service`
-       object.
-     - Ignored.
-   * - **before-call.<service>.<operation>**
-     - When an operation is being called (``Operation.call``).
-     - ``operation`` - The newly created :class:`botocore.operation.Operation`
-       object.
-     - Ignored.
-   * - **after-call.<service>.<operation>**
-     - After an operation has been called, but before the response is parsed.
-     - ``http_response`` - The HTTP response, ``parsed`` - The parsed data.
-     - Ignored.
+
+before-call
+~~~~~~~~~~~~~~~~~~~~~
+
+:Full Event Name:
+  ``'before-call.<service>.<operation>'``
+
+:Description:
+  This event is emitted when an operation is called and provides access to the
+  parameters that will be passed when calling the operation.
+
+:Keyword Arguments Emitted:
+
+  :type params: dict
+  :param params: A dictionary representing the keyword arguments that will be
+                 used to invoke the operation call.
+
+  :type context: dict
+  :param context: A dictionary representing the operation context. Additional
+                  information can be stored in this context to share state
+                  between events for the operation call.
+
+:Expected Return Value: A tuple of (http_response, parsed_response) where the
+                        http_response is of type :class:`.AWSResponse` and
+                        parsed_response is of type dict.
+
+
+before-send
+~~~~~~~~~~~~~~~~~~~~~
+
+:Full Event Name:
+  ``'before-send.<service>.<operation>'``
+
+:Description:
+  This event is emitted when the operation has been fully serialized, signed,
+  and is ready to be sent across the wire. This event allows the finalized
+  request to be inspected and allows a response to be returned that fufills
+  the request. If no response is returned botocore will fulfill the request
+  as normal.
+
+:Keyword Arguments Emitted:
+
+  :type request: :class:`.AWSPreparedRequest`
+  :param params: An object representing the properties of an HTTP request.
+
+:Expected Return Value: None or an instance of :class:`.AWSResponse`
+
+
+after-call
+~~~~~~~~~~~~~~~~~~~~~
+
+:Full Event Name:
+  ``'after-call.<service>.<operation>'``
+
+:Description:
+  This event is emitted after an operation is called and provides access to the
+  final HTTP response object as well as the parsed response for the operation.
+
+:Keyword Arguments Emitted:
+
+  :type http_response: :class:`.AWSResponse`
+  :param http_response: An object representing the HTTP response.
+
+  :type parsed: dict
+  :param parsed: A dictionary representing the fully parsed result of calling
+                 the operation.
+
+  :type context: dict
+  :param context: A dictionary representing the operation context. Additional
+                  information can be stored in this context to share state
+                  between events for the operation call.
+
+:Expected Return Value: A tuple of (http_response, parsed_response) where the
+                        http_response is of type :class:`.AWSResponse` and
+                        parsed_response is of type dict.
 
 
 Event Emission

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -19,39 +19,11 @@ Event Types
 -----------
 
 The list below shows all of the events emitted by botocore.  In some cases, the
-events are listed as ``event-name.<service>.<operations>``, in which
-``<service>`` and ``<operation>`` are replaced with a specific service and
-operation, for example ``event-name.s3.ListObjects``.
+events are listed as ``event-name.<service-id>.<operations>``, in which
+``<service-id>`` and ``<operation>`` are replaced with a specific service
+identifier operation, for example ``event-name.s3.ListObjects``.
 
-* ``'before-call.<service>.<operation>'``
-* ``'before-send.<service>.<operation>'``
-* ``'after-call.<service>.<operation>'``
-
-
-before-call
-~~~~~~~~~~~~~~~~~~~~~
-
-:Full Event Name:
-  ``'before-call.<service>.<operation>'``
-
-:Description:
-  This event is emitted when an operation is called and provides access to the
-  parameters that will be passed when calling the operation.
-
-:Keyword Arguments Emitted:
-
-  :type params: dict
-  :param params: A dictionary representing the keyword arguments that will be
-                 used to invoke the operation call.
-
-  :type context: dict
-  :param context: A dictionary representing the operation context. Additional
-                  information can be stored in this context to share state
-                  between events for the operation call.
-
-:Expected Return Value: A tuple of (http_response, parsed_response) where the
-                        http_response is of type :class:`.AWSResponse` and
-                        parsed_response is of type dict.
+* ``'before-send.<service-id>.<operation>'``
 
 
 before-send
@@ -75,37 +47,20 @@ before-send
 :Expected Return Value: None or an instance of :class:`.AWSResponse`
 
 
-after-call
-~~~~~~~~~~~~~~~~~~~~~
-
-:Full Event Name:
-  ``'after-call.<service>.<operation>'``
-
-:Description:
-  This event is emitted after an operation is called and provides access to the
-  final HTTP response object as well as the parsed response for the operation.
-
-:Keyword Arguments Emitted:
-
-  :type http_response: :class:`.AWSResponse`
-  :param http_response: An object representing the HTTP response.
-
-  :type parsed: dict
-  :param parsed: A dictionary representing the fully parsed result of calling
-                 the operation.
-
-  :type context: dict
-  :param context: A dictionary representing the operation context. Additional
-                  information can be stored in this context to share state
-                  between events for the operation call.
-
-:Expected Return Value: A tuple of (http_response, parsed_response) where the
-                        http_response is of type :class:`.AWSResponse` and
-                        parsed_response is of type dict.
-
-
 Event Emission
 --------------
 
 When an event is emitted, the handlers are invoked in the order that they were
 registered.
+
+
+Service ID
+----------
+To get the service id from a service client use the following::
+
+    import botocore
+    import botocore.session
+
+    session = botocore.session.Session()
+    client = session.create_client('elbv2')
+    service_event_name = client.meta.service_model.service_id.hyphenize()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -384,7 +384,7 @@ class ClientHTTPStubber(object):
         self.requests = []
         self.responses = []
 
-    def create_response(self, url=None, status=200, headers=None, body=None):
+    def add_response(self, url=None, status=200, headers=None, body=None):
         if url is None:
             url = 'https://example.com'
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -368,6 +368,8 @@ class HTTPStubberException(Exception):
 
 
 class RawResponse(BytesIO):
+    # TODO: There's a few objects similar to this in various tests, let's
+    # try and consolidate to this one in a future commit.
     def stream(self, **kwargs):
         contents = self.read()
         while contents:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -399,10 +399,10 @@ class BotocoreHTTPStubber(object):
         self.responses.append(response)
 
     def start(self):
-        self._client.meta.events.register('send-request', self)
+        self._client.meta.events.register('before-send', self)
 
     def stop(self):
-        self._client.meta.events.unregister('send-request', self)
+        self._client.meta.events.unregister('before-send', self)
 
     def __enter__(self):
         self.start()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -375,7 +375,7 @@ class RawResponse(BytesIO):
             contents = self.read()
 
 
-class BotocoreHTTPStubber(object):
+class ClientHTTPStubber(object):
     def __init__(self, client):
         self.reset()
         self._client = client

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -384,15 +384,10 @@ class ClientHTTPStubber(object):
         self.requests = []
         self.responses = []
 
-    def add_response(self, url=None, status=200, headers=None, body=None):
-        if url is None:
-            url = 'https://example.com'
-
+    def add_response(self, url='https://example.com', status=200, headers=None,
+                     body=b''):
         if headers is None:
             headers = {}
-
-        if body is None:
-            body = b''
 
         raw = RawResponse(body)
         response = AWSResponse(url, status, headers, raw)
@@ -411,8 +406,7 @@ class ClientHTTPStubber(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.stop()
 
-    def __call__(self, **kwargs):
-        request = kwargs.get('request')
+    def __call__(self, request, **kwargs):
         self.requests.append(request)
         if self.responses:
             response = self.responses.pop(0)

--- a/tests/functional/test_apigateway.py
+++ b/tests/functional/test_apigateway.py
@@ -31,7 +31,7 @@ class TestApiGateway(BaseSessionTest):
             'accepts': 'application/yaml'
         }
 
-        self.http_stubber.create_response(body=b'{}')
+        self.http_stubber.add_response(body=b'{}')
         with self.http_stubber:
             self.client.get_export(**params)
             request = self.http_stubber.requests[0]

--- a/tests/functional/test_apigateway.py
+++ b/tests/functional/test_apigateway.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from botocore.stub import Stubber
 from tests import BaseSessionTest
 
 
@@ -22,7 +21,6 @@ class TestApiGateway(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             'apigateway', self.region)
-        self.stubber = Stubber(self.client)
 
     def test_get_export(self):
         params = {
@@ -32,12 +30,9 @@ class TestApiGateway(BaseSessionTest):
             'accepts': 'application/yaml'
         }
 
-        # TODO: fix with stubber / before send event
-        with mock.patch('botocore.endpoint.Endpoint._send') as _send:
-            _send.return_value = mock.Mock(
-                status_code=200, headers={}, content=b'{}')
+        self.http_stubber.create_response(body=b'{}')
+        with self.http_stubber.wrap_client(self.client):
             self.client.get_export(**params)
-            sent_request = _send.call_args[0][0]
-            self.assertEqual(sent_request.method, 'GET')
-            self.assertEqual(
-                sent_request.headers.get('Accept'), b'application/yaml')
+            request = self.http_stubber.requests[0]
+            self.assertEqual(request.method, 'GET')
+            self.assertEqual(request.headers.get('Accept'), b'application/yaml')

--- a/tests/functional/test_apigateway.py
+++ b/tests/functional/test_apigateway.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 
 
 class TestApiGateway(BaseSessionTest):
@@ -21,6 +21,7 @@ class TestApiGateway(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             'apigateway', self.region)
+        self.http_stubber = BotocoreHTTPStubber(self.client)
 
     def test_get_export(self):
         params = {
@@ -31,7 +32,7 @@ class TestApiGateway(BaseSessionTest):
         }
 
         self.http_stubber.create_response(body=b'{}')
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.get_export(**params)
             request = self.http_stubber.requests[0]
             self.assertEqual(request.method, 'GET')

--- a/tests/functional/test_apigateway.py
+++ b/tests/functional/test_apigateway.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 
 
 class TestApiGateway(BaseSessionTest):
@@ -21,7 +21,7 @@ class TestApiGateway(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             'apigateway', self.region)
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
 
     def test_get_export(self):
         params = {

--- a/tests/functional/test_cloudsearchdomain.py
+++ b/tests/functional/test_cloudsearchdomain.py
@@ -24,7 +24,7 @@ class TestCloudsearchdomain(BaseSessionTest):
         self.http_stubber = ClientHTTPStubber(self.client)
 
     def test_search(self):
-        self.http_stubber.create_response(body=b'{}')
+        self.http_stubber.add_response(body=b'{}')
         with self.http_stubber:
             self.client.search(query='foo')
             request = self.http_stubber.requests[0]

--- a/tests/functional/test_cloudsearchdomain.py
+++ b/tests/functional/test_cloudsearchdomain.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 
 
 class TestCloudsearchdomain(BaseSessionTest):
@@ -21,7 +21,7 @@ class TestCloudsearchdomain(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             'cloudsearchdomain', self.region)
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
 
     def test_search(self):
         self.http_stubber.create_response(body=b'{}')

--- a/tests/functional/test_cloudsearchdomain.py
+++ b/tests/functional/test_cloudsearchdomain.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 
 
 class TestCloudsearchdomain(BaseSessionTest):
@@ -21,10 +21,11 @@ class TestCloudsearchdomain(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             'cloudsearchdomain', self.region)
+        self.http_stubber = BotocoreHTTPStubber(self.client)
 
     def test_search(self):
         self.http_stubber.create_response(body=b'{}')
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.search(query='foo')
             request = self.http_stubber.requests[0]
             self.assertIn('q=foo', request.body)

--- a/tests/functional/test_cloudsearchdomain.py
+++ b/tests/functional/test_cloudsearchdomain.py
@@ -23,14 +23,11 @@ class TestCloudsearchdomain(BaseSessionTest):
             'cloudsearchdomain', self.region)
 
     def test_search(self):
-        # TODO: fix with stubber / before send event
-        with mock.patch('botocore.endpoint.Endpoint._send') as _send:
-            _send.return_value = mock.Mock(
-                status_code=200, headers={}, content=b'{}')
+        self.http_stubber.create_response(body=b'{}')
+        with self.http_stubber.wrap_client(self.client):
             self.client.search(query='foo')
-            sent_request = _send.call_args[0][0]
-            self.assertEqual(sent_request.method, 'POST')
-            self.assertEqual(
-                sent_request.headers.get('Content-Type'),
-                b'application/x-www-form-urlencoded')
-            self.assertIn('q=foo', sent_request.body)
+            request = self.http_stubber.requests[0]
+            self.assertIn('q=foo', request.body)
+            self.assertEqual(request.method, 'POST')
+            content_type = b'application/x-www-form-urlencoded'
+            self.assertEqual(request.headers.get('Content-Type'), content_type)

--- a/tests/functional/test_cognito_idp.py
+++ b/tests/functional/test_cognito_idp.py
@@ -14,7 +14,7 @@ import mock
 
 from nose.tools import assert_false
 
-from tests import create_session
+from tests import create_session, BotocoreHTTPStubber
 
 
 def test_unsigned_operations():
@@ -104,16 +104,15 @@ class UnsignedOperationTestCase(object):
         self._client = client
         self._operation_name = operation_name
         self._parameters = parameters
+        self._http_stubber = BotocoreHTTPStubber()
 
     def run(self):
         operation = getattr(self._client, self._operation_name)
 
-        # TODO: fix with stubber / before send event
-        with mock.patch('botocore.endpoint.Endpoint._send') as _send:
-            _send.return_value = mock.Mock(
-                status_code=200, headers={}, content=b'{}')
+        self._http_stubber.create_response(body=b'{}')
+        with self._http_stubber.wrap_client(self._client):
             operation(**self._parameters)
-            request = _send.call_args[0][0]
+            request = self._http_stubber.requests[0]
 
         assert_false(
             'authorization' in request.headers,

--- a/tests/functional/test_cognito_idp.py
+++ b/tests/functional/test_cognito_idp.py
@@ -109,7 +109,7 @@ class UnsignedOperationTestCase(object):
     def run(self):
         operation = getattr(self._client, self._operation_name)
 
-        self._http_stubber.create_response(body=b'{}')
+        self._http_stubber.add_response(body=b'{}')
         with self._http_stubber:
             operation(**self._parameters)
             request = self._http_stubber.requests[0]

--- a/tests/functional/test_cognito_idp.py
+++ b/tests/functional/test_cognito_idp.py
@@ -104,13 +104,13 @@ class UnsignedOperationTestCase(object):
         self._client = client
         self._operation_name = operation_name
         self._parameters = parameters
-        self._http_stubber = BotocoreHTTPStubber()
+        self._http_stubber = BotocoreHTTPStubber(self._client)
 
     def run(self):
         operation = getattr(self._client, self._operation_name)
 
         self._http_stubber.create_response(body=b'{}')
-        with self._http_stubber.wrap_client(self._client):
+        with self._http_stubber:
             operation(**self._parameters)
             request = self._http_stubber.requests[0]
 

--- a/tests/functional/test_cognito_idp.py
+++ b/tests/functional/test_cognito_idp.py
@@ -14,7 +14,7 @@ import mock
 
 from nose.tools import assert_false
 
-from tests import create_session, BotocoreHTTPStubber
+from tests import create_session, ClientHTTPStubber
 
 
 def test_unsigned_operations():
@@ -104,7 +104,7 @@ class UnsignedOperationTestCase(object):
         self._client = client
         self._operation_name = operation_name
         self._parameters = parameters
-        self._http_stubber = BotocoreHTTPStubber(self._client)
+        self._http_stubber = ClientHTTPStubber(self._client)
 
     def run(self):
         operation = getattr(self._client, self._operation_name)

--- a/tests/functional/test_history.py
+++ b/tests/functional/test_history.py
@@ -48,7 +48,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
         return matching
 
     def test_does_record_api_call(self):
-        self.http_stubber.create_response(body=self.s3_response_body)
+        self.http_stubber.add_response(body=self.s3_response_body)
         with self.http_stubber:
             self.client.list_buckets()
 
@@ -64,7 +64,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
         self.assertEqual(source, 'BOTOCORE')
 
     def test_does_record_http_request(self):
-        self.http_stubber.create_response(body=self.s3_response_body)
+        self.http_stubber.add_response(body=self.s3_response_body)
         with self.http_stubber:
             self.client.list_buckets()
 
@@ -95,7 +95,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
         self.assertEqual(source, 'BOTOCORE')
 
     def test_does_record_http_response(self):
-        self.http_stubber.create_response(body=self.s3_response_body)
+        self.http_stubber.add_response(body=self.s3_response_body)
         with self.http_stubber:
             self.client.list_buckets()
 
@@ -115,7 +115,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
         self.assertEqual(source, 'BOTOCORE')
 
     def test_does_record_parsed_response(self):
-        self.http_stubber.create_response(body=self.s3_response_body)
+        self.http_stubber.add_response(body=self.s3_response_body)
         with self.http_stubber:
             self.client.list_buckets()
 

--- a/tests/functional/test_history.py
+++ b/tests/functional/test_history.py
@@ -46,17 +46,9 @@ class TestRecordStatementsInjections(BaseSessionTest):
                     if call[0] == event_type]
         return matching
 
-    @contextmanager
-    def patch_http_layer(self, response, status_code=200):
-        # TODO: fix with before send event
-        with mock.patch('botocore.endpoint.Endpoint._send') as send:
-            send.return_value = mock.Mock(status_code=status_code,
-                                          headers={},
-                                          content=response)
-            yield send
-
     def test_does_record_api_call(self):
-        with self.patch_http_layer(self.s3_response_body):
+        self.http_stubber.create_response(body=self.s3_response_body)
+        with self.http_stubber.wrap_client(self.client):
             self.client.list_buckets()
 
         api_call_events = self._get_all_events_of_type('API_CALL')
@@ -71,7 +63,8 @@ class TestRecordStatementsInjections(BaseSessionTest):
         self.assertEqual(source, 'BOTOCORE')
 
     def test_does_record_http_request(self):
-        with self.patch_http_layer(self.s3_response_body):
+        self.http_stubber.create_response(body=self.s3_response_body)
+        with self.http_stubber.wrap_client(self.client):
             self.client.list_buckets()
 
         http_request_events = self._get_all_events_of_type('HTTP_REQUEST')
@@ -101,7 +94,8 @@ class TestRecordStatementsInjections(BaseSessionTest):
         self.assertEqual(source, 'BOTOCORE')
 
     def test_does_record_http_response(self):
-        with self.patch_http_layer(self.s3_response_body):
+        self.http_stubber.create_response(body=self.s3_response_body)
+        with self.http_stubber.wrap_client(self.client):
             self.client.list_buckets()
 
         http_response_events = self._get_all_events_of_type('HTTP_RESPONSE')
@@ -120,7 +114,8 @@ class TestRecordStatementsInjections(BaseSessionTest):
         self.assertEqual(source, 'BOTOCORE')
 
     def test_does_record_parsed_response(self):
-        with self.patch_http_layer(self.s3_response_body):
+        self.http_stubber.create_response(body=self.s3_response_body)
+        with self.http_stubber.wrap_client(self.client):
             self.client.list_buckets()
 
         parsed_response_events = self._get_all_events_of_type(

--- a/tests/functional/test_history.py
+++ b/tests/functional/test_history.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 import mock
 
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 from botocore.history import BaseHistoryHandler
 from botocore.history import get_global_history_recorder
 
@@ -20,6 +20,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
     def setUp(self):
         super(TestRecordStatementsInjections, self).setUp()
         self.client = self.session.create_client('s3', 'us-west-2')
+        self.http_stubber = BotocoreHTTPStubber(self.client)
         self.s3_response_body = (
             '<ListAllMyBucketsResult '
             '    xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
@@ -48,7 +49,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
 
     def test_does_record_api_call(self):
         self.http_stubber.create_response(body=self.s3_response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.list_buckets()
 
         api_call_events = self._get_all_events_of_type('API_CALL')
@@ -64,7 +65,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
 
     def test_does_record_http_request(self):
         self.http_stubber.create_response(body=self.s3_response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.list_buckets()
 
         http_request_events = self._get_all_events_of_type('HTTP_REQUEST')
@@ -95,7 +96,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
 
     def test_does_record_http_response(self):
         self.http_stubber.create_response(body=self.s3_response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.list_buckets()
 
         http_response_events = self._get_all_events_of_type('HTTP_RESPONSE')
@@ -115,7 +116,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
 
     def test_does_record_parsed_response(self):
         self.http_stubber.create_response(body=self.s3_response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.list_buckets()
 
         parsed_response_events = self._get_all_events_of_type(

--- a/tests/functional/test_history.py
+++ b/tests/functional/test_history.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 import mock
 
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 from botocore.history import BaseHistoryHandler
 from botocore.history import get_global_history_recorder
 
@@ -20,7 +20,7 @@ class TestRecordStatementsInjections(BaseSessionTest):
     def setUp(self):
         super(TestRecordStatementsInjections, self).setUp()
         self.client = self.session.create_client('s3', 'us-west-2')
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
         self.s3_response_body = (
             '<ListAllMyBucketsResult '
             '    xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'

--- a/tests/functional/test_lex.py
+++ b/tests/functional/test_lex.py
@@ -35,12 +35,10 @@ class TestLex(BaseSessionTest):
 
         with mock.patch('botocore.auth.datetime') as _datetime:
             _datetime.datetime.utcnow.return_value = timestamp
-            # TODO: fix with stubber / before send event
-            with mock.patch('botocore.endpoint.Endpoint._send') as _send:
-                _send.return_value = mock.Mock(
-                    status_code=200, headers={}, content=b'{}')
+            self.http_stubber.create_response(body=b'{}')
+            with self.http_stubber.wrap_client(self.client):
                 self.client.post_content(**params)
-                request = _send.call_args[0][0]
+                request = self.http_stubber.requests[0]
 
         # The payload gets added to the string to sign, and then part of the
         # signature. The signature will be part of the authorization header.

--- a/tests/functional/test_lex.py
+++ b/tests/functional/test_lex.py
@@ -13,7 +13,7 @@
 import mock
 from datetime import datetime
 
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 
 
 class TestLex(BaseSessionTest):
@@ -21,7 +21,7 @@ class TestLex(BaseSessionTest):
         super(TestLex, self).setUp()
         self.region = 'us-west-2'
         self.client = self.session.create_client('lex-runtime', self.region)
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
 
     def test_unsigned_payload(self):
         params = {

--- a/tests/functional/test_lex.py
+++ b/tests/functional/test_lex.py
@@ -36,7 +36,7 @@ class TestLex(BaseSessionTest):
 
         with mock.patch('botocore.auth.datetime') as _datetime:
             _datetime.datetime.utcnow.return_value = timestamp
-            self.http_stubber.create_response(body=b'{}')
+            self.http_stubber.add_response(body=b'{}')
             with self.http_stubber:
                 self.client.post_content(**params)
                 request = self.http_stubber.requests[0]

--- a/tests/functional/test_lex.py
+++ b/tests/functional/test_lex.py
@@ -13,7 +13,7 @@
 import mock
 from datetime import datetime
 
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 
 
 class TestLex(BaseSessionTest):
@@ -21,6 +21,7 @@ class TestLex(BaseSessionTest):
         super(TestLex, self).setUp()
         self.region = 'us-west-2'
         self.client = self.session.create_client('lex-runtime', self.region)
+        self.http_stubber = BotocoreHTTPStubber(self.client)
 
     def test_unsigned_payload(self):
         params = {
@@ -36,7 +37,7 @@ class TestLex(BaseSessionTest):
         with mock.patch('botocore.auth.datetime') as _datetime:
             _datetime.datetime.utcnow.return_value = timestamp
             self.http_stubber.create_response(body=b'{}')
-            with self.http_stubber.wrap_client(self.client):
+            with self.http_stubber:
                 self.client.post_content(**params)
                 request = self.http_stubber.requests[0]
 

--- a/tests/functional/test_machinelearning.py
+++ b/tests/functional/test_machinelearning.py
@@ -23,19 +23,13 @@ class TestMachineLearning(BaseSessionTest):
             'machinelearning', self.region)
 
     def test_predict(self):
-        # TODO: fix with stubber / before send event
-        with mock.patch('botocore.endpoint.Endpoint._send') as \
-                http_session_send_patch:
-            http_response = mock.Mock()
-            http_response.status_code = 200
-            http_response.content = b'{}'
-            http_response.headers = {}
-            http_session_send_patch.return_value = http_response
+        self.http_stubber.create_response(body=b'{}')
+        with self.http_stubber.wrap_client(self.client):
             custom_endpoint = 'https://myendpoint.amazonaws.com/'
             self.client.predict(
                 MLModelId='ml-foo',
                 Record={'Foo': 'Bar'},
                 PredictEndpoint=custom_endpoint
             )
-            sent_request = http_session_send_patch.call_args[0][0]
+            sent_request = self.http_stubber.requests[0]
             self.assertEqual(sent_request.url, custom_endpoint)

--- a/tests/functional/test_machinelearning.py
+++ b/tests/functional/test_machinelearning.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 
 
 class TestMachineLearning(BaseSessionTest):
@@ -21,10 +21,11 @@ class TestMachineLearning(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             'machinelearning', self.region)
+        self.http_stubber = BotocoreHTTPStubber(self.client)
 
     def test_predict(self):
         self.http_stubber.create_response(body=b'{}')
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             custom_endpoint = 'https://myendpoint.amazonaws.com/'
             self.client.predict(
                 MLModelId='ml-foo',

--- a/tests/functional/test_machinelearning.py
+++ b/tests/functional/test_machinelearning.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 
 
 class TestMachineLearning(BaseSessionTest):
@@ -21,7 +21,7 @@ class TestMachineLearning(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             'machinelearning', self.region)
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
 
     def test_predict(self):
         self.http_stubber.create_response(body=b'{}')

--- a/tests/functional/test_machinelearning.py
+++ b/tests/functional/test_machinelearning.py
@@ -24,7 +24,7 @@ class TestMachineLearning(BaseSessionTest):
         self.http_stubber = ClientHTTPStubber(self.client)
 
     def test_predict(self):
-        self.http_stubber.create_response(body=b'{}')
+        self.http_stubber.add_response(body=b'{}')
         with self.http_stubber:
             custom_endpoint = 'https://myendpoint.amazonaws.com/'
             self.client.predict(

--- a/tests/functional/test_neptune.py
+++ b/tests/functional/test_neptune.py
@@ -14,7 +14,7 @@ import mock
 from contextlib import contextmanager
 
 import botocore.session
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 from botocore.stub import Stubber
 from tests import unittest
 
@@ -24,7 +24,7 @@ class TestNeptunePresignUrlInjection(BaseSessionTest):
     def setUp(self):
         super(TestNeptunePresignUrlInjection, self).setUp()
         self.client = self.session.create_client('neptune', 'us-west-2')
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
 
     def assert_presigned_url_injected_in_request(self, body):
         self.assertIn('PreSignedUrl', body)

--- a/tests/functional/test_neptune.py
+++ b/tests/functional/test_neptune.py
@@ -14,7 +14,7 @@ import mock
 from contextlib import contextmanager
 
 import botocore.session
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 from botocore.stub import Stubber
 from tests import unittest
 
@@ -24,6 +24,7 @@ class TestNeptunePresignUrlInjection(BaseSessionTest):
     def setUp(self):
         super(TestNeptunePresignUrlInjection, self).setUp()
         self.client = self.session.create_client('neptune', 'us-west-2')
+        self.http_stubber = BotocoreHTTPStubber(self.client)
 
     def assert_presigned_url_injected_in_request(self, body):
         self.assertIn('PreSignedUrl', body)
@@ -42,7 +43,7 @@ class TestNeptunePresignUrlInjection(BaseSessionTest):
             b'</CreateDBClusterResponse>'
         )
         self.http_stubber.create_response(body=response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.create_db_cluster(**params)
             sent_request = self.http_stubber.requests[0]
             self.assert_presigned_url_injected_in_request(sent_request.body)
@@ -60,7 +61,7 @@ class TestNeptunePresignUrlInjection(BaseSessionTest):
             b'</CopyDBClusterSnapshotResponse>'
         )
         self.http_stubber.create_response(body=response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.copy_db_cluster_snapshot(**params)
             sent_request = self.http_stubber.requests[0]
             self.assert_presigned_url_injected_in_request(sent_request.body)

--- a/tests/functional/test_neptune.py
+++ b/tests/functional/test_neptune.py
@@ -42,7 +42,7 @@ class TestNeptunePresignUrlInjection(BaseSessionTest):
             b'</CreateDBClusterResult>'
             b'</CreateDBClusterResponse>'
         )
-        self.http_stubber.create_response(body=response_body)
+        self.http_stubber.add_response(body=response_body)
         with self.http_stubber:
             self.client.create_db_cluster(**params)
             sent_request = self.http_stubber.requests[0]
@@ -60,7 +60,7 @@ class TestNeptunePresignUrlInjection(BaseSessionTest):
             b'</CopyDBClusterSnapshotResult>'
             b'</CopyDBClusterSnapshotResponse>'
         )
-        self.http_stubber.create_response(body=response_body)
+        self.http_stubber.add_response(body=response_body)
         with self.http_stubber:
             self.client.copy_db_cluster_snapshot(**params)
             sent_request = self.http_stubber.requests[0]

--- a/tests/functional/test_public_apis.py
+++ b/tests/functional/test_public_apis.py
@@ -47,14 +47,13 @@ class EarlyExit(Exception):
 
 
 def _test_public_apis_will_not_be_signed(client, operation, kwargs):
-    http_stubber = BotocoreHTTPStubber()
-    http_stubber.add_response(EarlyExit())
-    with http_stubber.wrap_client(client):
+    with BotocoreHTTPStubber(client) as http_stubber:
+        http_stubber.responses.append(EarlyExit())
         try:
             operation(**kwargs)
         except EarlyExit:
             pass
-    request = http_stubber.requests[0]
+        request = http_stubber.requests[0]
     sig_v2_disabled = 'SignatureVersion=2' not in request.url
     assert sig_v2_disabled, "SigV2 is incorrectly enabled"
     sig_v3_disabled = 'X-Amzn-Authorization' not in request.headers

--- a/tests/functional/test_public_apis.py
+++ b/tests/functional/test_public_apis.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 
 import mock
 
-from tests import BotocoreHTTPStubber
+from tests import ClientHTTPStubber
 from botocore.session import Session
 from botocore.exceptions import NoCredentialsError
 from botocore import xform_name
@@ -47,7 +47,7 @@ class EarlyExit(Exception):
 
 
 def _test_public_apis_will_not_be_signed(client, operation, kwargs):
-    with BotocoreHTTPStubber(client) as http_stubber:
+    with ClientHTTPStubber(client) as http_stubber:
         http_stubber.responses.append(EarlyExit())
         try:
             operation(**kwargs)

--- a/tests/functional/test_rds.py
+++ b/tests/functional/test_rds.py
@@ -14,7 +14,7 @@ import mock
 from contextlib import contextmanager
 
 import botocore.session
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 from botocore.stub import Stubber
 from tests import unittest
 
@@ -24,6 +24,7 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
     def setUp(self):
         super(TestRDSPresignUrlInjection, self).setUp()
         self.client = self.session.create_client('rds', 'us-west-2')
+        self.http_stubber = BotocoreHTTPStubber(self.client)
 
     def assert_presigned_url_injected_in_request(self, body):
         self.assertIn('PreSignedUrl', body)
@@ -41,7 +42,7 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
                     b'</CopyDBSnapshotResponse>'
         )
         self.http_stubber.create_response(body=response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.copy_db_snapshot(**params)
             sent_request = self.http_stubber.requests[0]
             self.assert_presigned_url_injected_in_request(sent_request.body)
@@ -59,7 +60,7 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
             b'</CreateDBInstanceReadReplicaResponse>'
         )
         self.http_stubber.create_response(body=response_body)
-        with self.http_stubber.wrap_client(self.client):
+        with self.http_stubber:
             self.client.create_db_instance_read_replica(**params)
             sent_request = self.http_stubber.requests[0]
             self.assert_presigned_url_injected_in_request(sent_request.body)

--- a/tests/functional/test_rds.py
+++ b/tests/functional/test_rds.py
@@ -14,7 +14,7 @@ import mock
 from contextlib import contextmanager
 
 import botocore.session
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 from botocore.stub import Stubber
 from tests import unittest
 
@@ -24,7 +24,7 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
     def setUp(self):
         super(TestRDSPresignUrlInjection, self).setUp()
         self.client = self.session.create_client('rds', 'us-west-2')
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
 
     def assert_presigned_url_injected_in_request(self, body):
         self.assertIn('PreSignedUrl', body)

--- a/tests/functional/test_rds.py
+++ b/tests/functional/test_rds.py
@@ -41,7 +41,7 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
                     b'<CopyDBSnapshotResult></CopyDBSnapshotResult>'
                     b'</CopyDBSnapshotResponse>'
         )
-        self.http_stubber.create_response(body=response_body)
+        self.http_stubber.add_response(body=response_body)
         with self.http_stubber:
             self.client.copy_db_snapshot(**params)
             sent_request = self.http_stubber.requests[0]
@@ -59,7 +59,7 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
             b'</CreateDBInstanceReadReplicaResult>'
             b'</CreateDBInstanceReadReplicaResponse>'
         )
-        self.http_stubber.create_response(body=response_body)
+        self.http_stubber.add_response(body=response_body)
         with self.http_stubber:
             self.client.create_db_instance_read_replica(**params)
             sent_request = self.http_stubber.requests[0]

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -32,7 +32,7 @@ class TestRetry(BaseSessionTest):
         num_responses = num_retries + 1
         with ClientHTTPStubber(client) as http_stubber:
             for _ in range(num_responses):
-                http_stubber.create_response(status=500, body=b'{}')
+                http_stubber.add_response(status=500, body=b'{}')
             with self.assertRaisesRegexp(
                     ClientError, 'reached max retries: %s' % num_retries):
                 yield

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import contextlib
-from tests import BaseSessionTest, mock, BotocoreHTTPStubber
+from tests import BaseSessionTest, mock, ClientHTTPStubber
 
 from botocore.exceptions import ClientError
 from botocore.config import Config
@@ -30,7 +30,7 @@ class TestRetry(BaseSessionTest):
     @contextlib.contextmanager
     def assert_will_retry_n_times(self, client, num_retries):
         num_responses = num_retries + 1
-        with BotocoreHTTPStubber(client) as http_stubber:
+        with ClientHTTPStubber(client) as http_stubber:
             for _ in range(num_responses):
                 http_stubber.create_response(status=500, body=b'{}')
             with self.assertRaisesRegexp(

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import contextlib
 from tests import BaseSessionTest, mock
 
 from botocore.exceptions import ClientError
@@ -26,37 +27,33 @@ class TestRetry(BaseSessionTest):
     def tearDown(self):
         self.sleep_patch.stop()
 
-    def add_n_retryable_responses(self, mock_send, num_responses):
-        responses = []
+    def add_n_retryable_responses(self, num_responses):
         for _ in range(num_responses):
-            http_response = mock.Mock()
-            http_response.status_code = 500
-            http_response.headers = {}
-            http_response.content = b'{}'
-            responses.append(http_response)
-        mock_send.side_effect = responses
+            self.http_stubber.create_response(status=500, body=b'{}')
 
-    def assert_will_retry_n_times(self, method, num_retries):
+    @contextlib.contextmanager
+    def assert_will_retry_n_times(self, client, num_retries):
         num_responses = num_retries + 1
-        # TODO: fix with stubber / before send event... this one might be hard
-        with mock.patch('botocore.endpoint.Endpoint._send') as mock_send:
-            self.add_n_retryable_responses(mock_send, num_responses)
+        self.add_n_retryable_responses(num_responses)
+        with self.http_stubber.wrap_client(client):
             with self.assertRaisesRegexp(
                     ClientError, 'reached max retries: %s' % num_retries):
-                method()
-            self.assertEqual(mock_send.call_count, num_responses)
+                yield
+            self.assertEqual(self.http_stubber.request_count, num_responses)
 
     def test_can_override_max_attempts(self):
         client = self.session.create_client(
             'dynamodb', self.region, config=Config(
                 retries={'max_attempts': 1}))
-        self.assert_will_retry_n_times(client.list_tables, 1)
+        with self.assert_will_retry_n_times(client, 1):
+            client.list_tables()
 
     def test_do_not_attempt_retries(self):
         client = self.session.create_client(
             'dynamodb', self.region, config=Config(
                 retries={'max_attempts': 0}))
-        self.assert_will_retry_n_times(client.list_tables, 0)
+        with self.assert_will_retry_n_times(client, 0):
+            client.list_tables()
 
     def test_setting_max_attempts_does_not_set_for_other_clients(self):
         # Make one client with max attempts configured.
@@ -68,7 +65,8 @@ class TestRetry(BaseSessionTest):
         client = self.session.create_client('codecommit', self.region)
         # It should use the default max retries, which should be four retries
         # for this service.
-        self.assert_will_retry_n_times(client.list_repositories, 4)
+        with self.assert_will_retry_n_times(client, 4):
+            client.list_repositories()
 
     def test_service_specific_defaults_do_not_mutate_general_defaults(self):
         # This tests for a bug where if you created a client for a service
@@ -80,19 +78,25 @@ class TestRetry(BaseSessionTest):
         # Make a dynamodb client. It's a special case client that is
         # configured to a make a maximum of 10 requests (9 retries).
         client = self.session.create_client('dynamodb', self.region)
-        self.assert_will_retry_n_times(client.list_tables, 9)
+        with self.assert_will_retry_n_times(client, 9):
+            client.list_tables()
+
+        # Reset the stubber to clear previous requests out
+        self.http_stubber.reset()
 
         # A codecommit client is not a special case for retries. It will at
         # most make 5 requests (4 retries) for its default.
         client = self.session.create_client('codecommit', self.region)
-        self.assert_will_retry_n_times(client.list_repositories, 4)
+        with self.assert_will_retry_n_times(client, 4):
+            client.list_repositories()
 
     def test_set_max_attempts_on_session(self):
         self.session.set_default_client_config(
             Config(retries={'max_attempts': 1}))
         # Max attempts should be inherited from the session.
         client = self.session.create_client('codecommit', self.region)
-        self.assert_will_retry_n_times(client.list_repositories, 1)
+        with self.assert_will_retry_n_times(client, 1):
+            client.list_repositories()
 
     def test_can_clobber_max_attempts_on_session(self):
         self.session.set_default_client_config(
@@ -101,4 +105,5 @@ class TestRetry(BaseSessionTest):
         client = self.session.create_client(
             'codecommit', self.region, config=Config(
                 retries={'max_attempts': 0}))
-        self.assert_will_retry_n_times(client.list_repositories, 0)
+        with self.assert_will_retry_n_times(client, 0):
+            client.list_repositories()

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest, mock, BaseSessionTest, create_session
+from tests import unittest, mock, BaseSessionTest, create_session, BotocoreHTTPStubber
 from nose.tools import assert_equal
 
 import botocore.session
@@ -35,31 +35,21 @@ class BaseS3OperationTest(BaseSessionTest):
         self.region = 'us-west-2'
         self.client = self.session.create_client(
             's3', self.region)
-        # TODO: fix with stubber / before send event
-        self.session_send_patch = mock.patch('botocore.endpoint.Endpoint._send')
-        self.http_session_send_mock = self.session_send_patch.start()
-
-    def tearDown(self):
-        super(BaseSessionTest, self).tearDown()
-        self.session_send_patch.stop()
 
 
 class TestOnlyAsciiCharsAllowed(BaseS3OperationTest):
     def test_validates_non_ascii_chars_trigger_validation_error(self):
-        self.http_session_send_mock.return_value = mock.Mock(status_code=200,
-                                                             headers={},
-                                                             content=b'')
-        with self.assertRaises(ParamValidationError):
-            self.client.put_object(
-                Bucket='foo', Key='bar', Metadata={
-                    'goodkey': 'good', 'non-ascii': u'\u2713'})
+        self.http_stubber.create_response()
+        with self.http_stubber.wrap_client(self.client):
+            with self.assertRaises(ParamValidationError):
+                self.client.put_object(
+                    Bucket='foo', Key='bar', Metadata={
+                        'goodkey': 'good', 'non-ascii': u'\u2713'})
 
 
 class TestS3GetBucketLifecycle(BaseS3OperationTest):
     def test_multiple_transitions_returns_one(self):
-        http_response = mock.Mock()
-        http_response.status_code = 200
-        http_response.content = (
+        response_body = (
             '<?xml version="1.0" ?>'
             '<LifecycleConfiguration xmlns="http://s3.amazonaws.'
             'com/doc/2006-03-01/">'
@@ -91,10 +81,10 @@ class TestS3GetBucketLifecycle(BaseS3OperationTest):
             '	</Rule>'
             '</LifecycleConfiguration>'
         ).encode('utf-8')
-        http_response.headers = {}
-        self.http_session_send_mock.return_value = http_response
+        self.http_stubber.create_response(body=response_body)
         s3 = self.session.create_client('s3')
-        response = s3.get_bucket_lifecycle(Bucket='mybucket')
+        with self.http_stubber.wrap_client(s3):
+            response = s3.get_bucket_lifecycle(Bucket='mybucket')
         # Each Transition member should have at least one of the
         # transitions provided.
         self.assertEqual(
@@ -131,24 +121,15 @@ class TestS3PutObject(BaseS3OperationTest):
             'Content-Length: 0\r\n'
             'Server: AmazonS3\r\n'
         ).encode('utf-8')
-        http_500_response = mock.Mock()
-        http_500_response.status_code = 500
-        http_500_response.content = non_xml_content
-        http_500_response.headers = {}
-
-        success_response = mock.Mock()
-        success_response.status_code = 200
-        success_response.content = b''
-        success_response.headers = {}
-
-        self.http_session_send_mock.side_effect = [
-            http_500_response, success_response
-        ]
+        self.http_stubber.create_response(status=500, body=non_xml_content)
+        self.http_stubber.create_response()
         s3 = self.session.create_client('s3')
-        response = s3.put_object(Bucket='mybucket', Key='mykey', Body=b'foo')
+        with self.http_stubber.wrap_client(s3):
+            response = s3.put_object(Bucket='mybucket', Key='mykey', Body=b'foo')
         # The first response should have been retried even though the xml is
         # invalid and eventually return the 200 response.
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        self.assertEqual(self.http_stubber.request_count, 2)
 
 
 class TestS3SigV4(BaseS3OperationTest):
@@ -156,17 +137,14 @@ class TestS3SigV4(BaseS3OperationTest):
         super(TestS3SigV4, self).setUp()
         self.client = self.session.create_client(
             's3', self.region, config=Config(signature_version='s3v4'))
-        self.response_mock = mock.Mock()
-        self.response_mock.content = b''
-        self.response_mock.headers = {}
-        self.response_mock.status_code = 200
-        self.http_session_send_mock.return_value = self.response_mock
+        self.http_stubber.create_response()
 
     def get_sent_headers(self):
-        return self.http_session_send_mock.mock_calls[0][1][0].headers
+        return self.http_stubber.requests[0].headers
 
     def test_content_md5_set(self):
-        self.client.put_object(Bucket='foo', Key='bar', Body='baz')
+        with self.http_stubber.wrap_client(self.client):
+            self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         self.assertIn('content-md5', self.get_sent_headers())
 
     def test_content_sha256_set_if_config_value_is_true(self):
@@ -175,7 +153,8 @@ class TestS3SigV4(BaseS3OperationTest):
         })
         self.client = self.session.create_client(
             's3', self.region, config=config)
-        self.client.put_object(Bucket='foo', Key='bar', Body='baz')
+        with self.http_stubber.wrap_client(self.client):
+            self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         sent_headers = self.get_sent_headers()
         sha_header = sent_headers.get('x-amz-content-sha256')
         self.assertNotEqual(sha_header, b'UNSIGNED-PAYLOAD')
@@ -186,7 +165,8 @@ class TestS3SigV4(BaseS3OperationTest):
         })
         self.client = self.session.create_client(
             's3', self.region, config=config)
-        self.client.put_object(Bucket='foo', Key='bar', Body='baz')
+        with self.http_stubber.wrap_client(self.client):
+            self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         sent_headers = self.get_sent_headers()
         sha_header = sent_headers.get('x-amz-content-sha256')
         self.assertEqual(sha_header, b'UNSIGNED-PAYLOAD')
@@ -194,7 +174,8 @@ class TestS3SigV4(BaseS3OperationTest):
     def test_content_sha256_set_if_md5_is_unavailable(self):
         with mock.patch('botocore.auth.MD5_AVAILABLE', False):
             with mock.patch('botocore.handlers.MD5_AVAILABLE', False):
-                self.client.put_object(Bucket='foo', Key='bar', Body='baz')
+                with self.http_stubber.wrap_client(self.client):
+                    self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         sent_headers = self.get_sent_headers()
         unsigned = 'UNSIGNED-PAYLOAD'
         self.assertNotEqual(sent_headers['x-amz-content-sha256'], unsigned)
@@ -207,14 +188,11 @@ class TestCanSendIntegerHeaders(BaseSessionTest):
     def test_int_values_with_sigv4(self):
         s3 = self.session.create_client(
             's3', config=Config(signature_version='s3v4'))
-        # TODO: fix with stubber / before send event
-        with mock.patch('botocore.endpoint.Endpoint._send') as mock_send:
-            mock_send.return_value = mock.Mock(status_code=200,
-                                               content=b'',
-                                               headers={})
+        self.http_stubber.create_response()
+        with self.http_stubber.wrap_client(s3):
             s3.upload_part(Bucket='foo', Key='bar', Body=b'foo',
                            UploadId='bar', PartNumber=1, ContentLength=3)
-            headers = mock_send.call_args[0][0].headers
+            headers = self.http_stubber.requests[0].headers
             # Verify that the request integer value of 3 has been converted to
             # string '3'.  This also means we've made it pass the signer which
             # expects string values in order to sign properly.
@@ -231,53 +209,52 @@ class TestRegionRedirect(BaseS3OperationTest):
                 s3={'addressing_style': 'path'},
             ))
 
-        self.redirect_response = mock.Mock()
-        self.redirect_response.headers = {
-            'x-amz-bucket-region': 'eu-central-1'
+        self.redirect_response = {
+            'status': 301,
+            'headers': {'x-amz-bucket-region': 'eu-central-1'},
+            'body': (
+                b'<?xml version="1.0" encoding="UTF-8"?>\n'
+                b'<Error>'
+                b'    <Code>PermanentRedirect</Code>'
+                b'    <Message>The bucket you are attempting to access must be'
+                b'        addressed using the specified endpoint. Please send '
+                b'        all future requests to this endpoint.'
+                b'    </Message>'
+                b'    <Bucket>foo</Bucket>'
+                b'    <Endpoint>foo.s3.eu-central-1.amazonaws.com</Endpoint>'
+                b'</Error>'
+            )
         }
-        self.redirect_response.status_code = 301
-        self.redirect_response.content = (
-            b'<?xml version="1.0" encoding="UTF-8"?>\n'
-            b'<Error>'
-            b'    <Code>PermanentRedirect</Code>'
-            b'    <Message>The bucket you are attempting to access must be '
-            b'        addressed using the specified endpoint. Please send all '
-            b'        future requests to this endpoint.'
-            b'    </Message>'
-            b'    <Bucket>foo</Bucket>'
-            b'    <Endpoint>foo.s3.eu-central-1.amazonaws.com</Endpoint>'
-            b'</Error>')
-
-        self.bad_signing_region_response = mock.Mock()
-        self.bad_signing_region_response.headers = {
-            'x-amz-bucket-region': 'eu-central-1'
+        self.bad_signing_region_response = {
+            'status': 400,
+            'headers': {'x-amz-bucket-region': 'eu-central-1'},
+            'body': (
+                b'<?xml version="1.0" encoding="UTF-8"?>'
+                b'<Error>'
+                b'  <Code>AuthorizationHeaderMalformed</Code>'
+                b'  <Message>the region us-west-2 is wrong; '
+                b'expecting eu-central-1</Message>'
+                b'  <Region>eu-central-1</Region>'
+                b'  <RequestId>BD9AA1730D454E39</RequestId>'
+                b'  <HostId></HostId>'
+                b'</Error>'
+            )
         }
-        self.bad_signing_region_response.status_code = 400
-        self.bad_signing_region_response.content = (
-            b'<?xml version="1.0" encoding="UTF-8"?>'
-            b'<Error>'
-            b'  <Code>AuthorizationHeaderMalformed</Code>'
-            b'  <Message>the region us-west-2 is wrong; '
-            b'expecting eu-central-1</Message>'
-            b'  <Region>eu-central-1</Region>'
-            b'  <RequestId>BD9AA1730D454E39</RequestId>'
-            b'  <HostId></HostId>'
-            b'</Error>'
-        )
-
-        self.success_response = mock.Mock()
-        self.success_response.headers = {}
-        self.success_response.status_code = 200
-        self.success_response.content = (
-            b'<?xml version="1.0" encoding="UTF-8"?>\n'
-            b'<ListBucketResult>'
-            b'    <Name>foo</Name>'
-            b'    <Prefix></Prefix>'
-            b'    <Marker></Marker>'
-            b'    <MaxKeys>1000</MaxKeys>'
-            b'    <EncodingType>url</EncodingType>'
-            b'    <IsTruncated>false</IsTruncated>'
-            b'</ListBucketResult>')
+        self.success_response = {
+            'status': 200,
+            'headers': {},
+            'body': (
+                b'<?xml version="1.0" encoding="UTF-8"?>\n'
+                b'<ListBucketResult>'
+                b'    <Name>foo</Name>'
+                b'    <Prefix></Prefix>'
+                b'    <Marker></Marker>'
+                b'    <MaxKeys>1000</MaxKeys>'
+                b'    <EncodingType>url</EncodingType>'
+                b'    <IsTruncated>false</IsTruncated>'
+                b'</ListBucketResult>'
+            )
+        }
 
     def create_response(self, content=b'',
                         status_code=200, headers=None):
@@ -290,126 +267,102 @@ class TestRegionRedirect(BaseS3OperationTest):
         return response
 
     def test_region_redirect(self):
-        self.http_session_send_mock.side_effect = [
-            self.redirect_response, self.success_response]
-        response = self.client.list_objects(Bucket='foo')
+        self.http_stubber.create_response(**self.redirect_response)
+        self.http_stubber.create_response(**self.success_response)
+        with self.http_stubber.wrap_client(self.client):
+            response = self.client.list_objects(Bucket='foo')
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
-        self.assertEqual(self.http_session_send_mock.call_count, 2)
+        self.assertEqual(self.http_stubber.request_count, 2)
 
-        calls = [c[0][0] for c in self.http_session_send_mock.call_args_list]
         initial_url = ('https://s3.us-west-2.amazonaws.com/foo'
                        '?encoding-type=url')
-        self.assertEqual(calls[0].url, initial_url)
+        self.assertEqual(self.http_stubber.requests[0].url, initial_url)
 
         fixed_url = ('https://s3.eu-central-1.amazonaws.com/foo'
                      '?encoding-type=url')
-        self.assertEqual(calls[1].url, fixed_url)
+        self.assertEqual(self.http_stubber.requests[1].url, fixed_url)
 
     def test_region_redirect_cache(self):
-        self.http_session_send_mock.side_effect = [
-            self.redirect_response, self.success_response,
-            self.success_response]
+        self.http_stubber.create_response(**self.redirect_response)
+        self.http_stubber.create_response(**self.success_response)
+        self.http_stubber.create_response(**self.success_response)
 
-        first_response = self.client.list_objects(Bucket='foo')
+        with self.http_stubber.wrap_client(self.client):
+            first_response = self.client.list_objects(Bucket='foo')
+            second_response = self.client.list_objects(Bucket='foo')
+
         self.assertEqual(
             first_response['ResponseMetadata']['HTTPStatusCode'], 200)
-        second_response = self.client.list_objects(Bucket='foo')
         self.assertEqual(
             second_response['ResponseMetadata']['HTTPStatusCode'], 200)
 
-        self.assertEqual(self.http_session_send_mock.call_count, 3)
-        calls = [c[0][0] for c in self.http_session_send_mock.call_args_list]
+        self.assertEqual(self.http_stubber.request_count, 3)
         initial_url = ('https://s3.us-west-2.amazonaws.com/foo'
                        '?encoding-type=url')
-        self.assertEqual(calls[0].url, initial_url)
+        self.assertEqual(self.http_stubber.requests[0].url, initial_url)
 
         fixed_url = ('https://s3.eu-central-1.amazonaws.com/foo'
                      '?encoding-type=url')
-        self.assertEqual(calls[1].url, fixed_url)
-        self.assertEqual(calls[2].url, fixed_url)
+        self.assertEqual(self.http_stubber.requests[1].url, fixed_url)
+        self.assertEqual(self.http_stubber.requests[2].url, fixed_url)
 
     def test_resign_request_with_region_when_needed(self):
-        self.http_session_send_mock.side_effect = [
-            self.bad_signing_region_response, self.success_response,
-        ]
+        self.http_stubber.create_response(**self.bad_signing_region_response)
+        self.http_stubber.create_response(**self.success_response)
 
         # Create a client with no explicit configuration so we can
         # verify the default behavior.
         client = self.session.create_client(
             's3', 'us-west-2')
-        first_response = client.list_objects(Bucket='foo')
+        with self.http_stubber.wrap_client(client):
+            first_response = client.list_objects(Bucket='foo')
         self.assertEqual(
             first_response['ResponseMetadata']['HTTPStatusCode'], 200)
 
-        self.assertEqual(self.http_session_send_mock.call_count, 2)
-        calls = [c[0][0] for c in self.http_session_send_mock.call_args_list]
+        self.assertEqual(self.http_stubber.request_count, 2)
         initial_url = ('https://foo.s3.us-west-2.amazonaws.com/'
                        '?encoding-type=url')
-        self.assertEqual(calls[0].url, initial_url)
+        self.assertEqual(self.http_stubber.requests[0].url, initial_url)
 
         fixed_url = ('https://foo.s3.eu-central-1.amazonaws.com/'
                      '?encoding-type=url')
-        self.assertEqual(calls[1].url, fixed_url)
+        self.assertEqual(self.http_stubber.requests[1].url, fixed_url)
 
     def test_resign_request_in_us_east_1(self):
-        bad_request_response = self.create_response(status_code=400)
-        bad_head_bucket_response = self.create_response(
-            status_code=400,
-            headers={'x-amz-bucket-region': 'eu-central-1'}
-        )
-        head_bucket_response = self.create_response(
-            headers={
-                'x-amz-bucket-region': 'eu-central-1'
-            },
-            status_code=200,
-        )
-        request_response = self.create_response(status_code=200)
-        self.http_session_send_mock.side_effect = [
-            bad_request_response,
-            bad_head_bucket_response,
-            head_bucket_response,
-            request_response,
-        ]
+        region_headers = {'x-amz-bucket-region': 'eu-central-1'}
+        self.http_stubber.create_response(status=400)
+        self.http_stubber.create_response(status=400, headers=region_headers)
+        self.http_stubber.create_response(headers=region_headers)
+        self.http_stubber.create_response()
 
         # Verify that the default behavior in us-east-1 will redirect
         client = self.session.create_client('s3', 'us-east-1')
-        response = client.head_object(Bucket='foo', Key='bar')
+        with self.http_stubber.wrap_client(client):
+            response = client.head_object(Bucket='foo', Key='bar')
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
 
-        self.assertEqual(self.http_session_send_mock.call_count, 4)
-        calls = [c[0][0] for c in self.http_session_send_mock.call_args_list]
+        self.assertEqual(self.http_stubber.request_count, 4)
         initial_url = ('https://foo.s3.amazonaws.com/bar')
-        self.assertEqual(calls[0].url, initial_url)
+        self.assertEqual(self.http_stubber.requests[0].url, initial_url)
 
         fixed_url = ('https://foo.s3.eu-central-1.amazonaws.com/bar')
-        self.assertEqual(calls[-1].url, fixed_url)
+        self.assertEqual(self.http_stubber.requests[-1].url, fixed_url)
 
     def test_resign_request_in_us_east_1_fails(self):
-        bad_request_response = self.create_response(status_code=400)
-        bad_head_bucket_response = self.create_response(
-            status_code=400,
-            headers={'x-amz-bucket-region': 'eu-central-1'}
-        )
-        head_bucket_response = self.create_response(
-            headers={
-                'x-amz-bucket-region': 'eu-central-1'
-            }
-        )
+        region_headers = {'x-amz-bucket-region': 'eu-central-1'}
+        self.http_stubber.create_response(status=400)
+        self.http_stubber.create_response(status=400, headers=region_headers)
+        self.http_stubber.create_response(headers=region_headers)
         # The final request still fails with a 400.
-        request_response = self.create_response(status_code=400)
-
-        self.http_session_send_mock.side_effect = [
-            bad_request_response,
-            bad_head_bucket_response,
-            head_bucket_response,
-            request_response,
-        ]
+        self.http_stubber.create_response(status=400)
 
         # Verify that the final 400 response is propagated
         # back to the user.
         client = self.session.create_client('s3', 'us-east-1')
         with self.assertRaises(ClientError) as e:
-            client.head_object(Bucket='foo', Key='bar')
+            with self.http_stubber.wrap_client(client):
+                client.head_object(Bucket='foo', Key='bar')
+        self.assertEqual(self.http_stubber.request_count, 4)
 
 
 class TestGeneratePresigned(BaseS3OperationTest):
@@ -862,10 +815,6 @@ def _verify_expected_endpoint_url(region, bucket, key, s3_config,
                                   is_secure=True,
                                   customer_provided_endpoint=None,
                                   expected_url=None, signature_version=None):
-    http_response = mock.Mock()
-    http_response.status_code = 200
-    http_response.headers = {}
-    http_response.content = b''
     environ = {}
     with mock.patch('os.environ', environ):
         environ['AWS_ACCESS_KEY_ID'] = 'access_key'
@@ -881,13 +830,11 @@ def _verify_expected_endpoint_url(region, bucket, key, s3_config,
         s3 = session.create_client('s3', region_name=region, use_ssl=is_secure,
                                    config=config,
                                    endpoint_url=customer_provided_endpoint)
-        # TODO: fix with stubber / before send event
-        with mock.patch('botocore.endpoint.Endpoint._send') as mock_send:
-            mock_send.return_value = http_response
-            s3.put_object(Bucket=bucket,
-                          Key=key, Body=b'bar')
-            request_sent = mock_send.call_args[0][0]
-            assert_equal(request_sent.url, expected_url)
+        http_stubber = BotocoreHTTPStubber()
+        http_stubber.create_response()
+        with http_stubber.wrap_client(s3):
+            s3.put_object(Bucket=bucket, Key=key, Body=b'bar')
+            assert_equal(http_stubber.requests[0].url, expected_url)
 
 
 def _create_s3_client(region, is_secure, endpoint_url, s3_config,

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -40,7 +40,7 @@ class BaseS3OperationTest(BaseSessionTest):
 
 class TestOnlyAsciiCharsAllowed(BaseS3OperationTest):
     def test_validates_non_ascii_chars_trigger_validation_error(self):
-        self.http_stubber.create_response()
+        self.http_stubber.add_response()
         with self.http_stubber:
             with self.assertRaises(ParamValidationError):
                 self.client.put_object(
@@ -84,7 +84,7 @@ class TestS3GetBucketLifecycle(BaseS3OperationTest):
         ).encode('utf-8')
         s3 = self.session.create_client('s3')
         with ClientHTTPStubber(s3) as http_stubber:
-            http_stubber.create_response(body=response_body)
+            http_stubber.add_response(body=response_body)
             response = s3.get_bucket_lifecycle(Bucket='mybucket')
         # Each Transition member should have at least one of the
         # transitions provided.
@@ -124,8 +124,8 @@ class TestS3PutObject(BaseS3OperationTest):
         ).encode('utf-8')
         s3 = self.session.create_client('s3')
         with ClientHTTPStubber(s3) as http_stubber:
-            http_stubber.create_response(status=500, body=non_xml_content)
-            http_stubber.create_response()
+            http_stubber.add_response(status=500, body=non_xml_content)
+            http_stubber.add_response()
             response = s3.put_object(Bucket='mybucket', Key='mykey', Body=b'foo')
             # The first response should have been retried even though the xml is
             # invalid and eventually return the 200 response.
@@ -139,7 +139,7 @@ class TestS3SigV4(BaseS3OperationTest):
         self.client = self.session.create_client(
             's3', self.region, config=Config(signature_version='s3v4'))
         self.http_stubber = ClientHTTPStubber(self.client)
-        self.http_stubber.create_response()
+        self.http_stubber.add_response()
 
     def get_sent_headers(self):
         return self.http_stubber.requests[0].headers
@@ -156,7 +156,7 @@ class TestS3SigV4(BaseS3OperationTest):
         self.client = self.session.create_client(
             's3', self.region, config=config)
         self.http_stubber = ClientHTTPStubber(self.client)
-        self.http_stubber.create_response()
+        self.http_stubber.add_response()
         with self.http_stubber:
             self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         sent_headers = self.get_sent_headers()
@@ -170,7 +170,7 @@ class TestS3SigV4(BaseS3OperationTest):
         self.client = self.session.create_client(
             's3', self.region, config=config)
         self.http_stubber = ClientHTTPStubber(self.client)
-        self.http_stubber.create_response()
+        self.http_stubber.add_response()
         with self.http_stubber:
             self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         sent_headers = self.get_sent_headers()
@@ -195,7 +195,7 @@ class TestCanSendIntegerHeaders(BaseSessionTest):
         s3 = self.session.create_client(
             's3', config=Config(signature_version='s3v4'))
         with ClientHTTPStubber(s3) as http_stubber:
-            http_stubber.create_response()
+            http_stubber.add_response()
             s3.upload_part(Bucket='foo', Key='bar', Body=b'foo',
                            UploadId='bar', PartNumber=1, ContentLength=3)
             headers = http_stubber.requests[0].headers
@@ -263,19 +263,9 @@ class TestRegionRedirect(BaseS3OperationTest):
             )
         }
 
-    def create_response(self, content=b'',
-                        status_code=200, headers=None):
-        response = mock.Mock()
-        if headers is None:
-            headers = {}
-        response.headers = headers
-        response.content = content
-        response.status_code = status_code
-        return response
-
     def test_region_redirect(self):
-        self.http_stubber.create_response(**self.redirect_response)
-        self.http_stubber.create_response(**self.success_response)
+        self.http_stubber.add_response(**self.redirect_response)
+        self.http_stubber.add_response(**self.success_response)
         with self.http_stubber:
             response = self.client.list_objects(Bucket='foo')
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
@@ -290,9 +280,9 @@ class TestRegionRedirect(BaseS3OperationTest):
         self.assertEqual(self.http_stubber.requests[1].url, fixed_url)
 
     def test_region_redirect_cache(self):
-        self.http_stubber.create_response(**self.redirect_response)
-        self.http_stubber.create_response(**self.success_response)
-        self.http_stubber.create_response(**self.success_response)
+        self.http_stubber.add_response(**self.redirect_response)
+        self.http_stubber.add_response(**self.success_response)
+        self.http_stubber.add_response(**self.success_response)
 
         with self.http_stubber:
             first_response = self.client.list_objects(Bucket='foo')
@@ -319,8 +309,8 @@ class TestRegionRedirect(BaseS3OperationTest):
         # verify the default behavior.
         client = self.session.create_client('s3', 'us-west-2')
         with ClientHTTPStubber(client) as http_stubber:
-            http_stubber.create_response(**self.bad_signing_region_response)
-            http_stubber.create_response(**self.success_response)
+            http_stubber.add_response(**self.bad_signing_region_response)
+            http_stubber.add_response(**self.success_response)
             first_response = client.list_objects(Bucket='foo')
             self.assertEqual(
                 first_response['ResponseMetadata']['HTTPStatusCode'], 200)
@@ -340,10 +330,10 @@ class TestRegionRedirect(BaseS3OperationTest):
         # Verify that the default behavior in us-east-1 will redirect
         client = self.session.create_client('s3', 'us-east-1')
         with ClientHTTPStubber(client) as http_stubber:
-            http_stubber.create_response(status=400)
-            http_stubber.create_response(status=400, headers=region_headers)
-            http_stubber.create_response(headers=region_headers)
-            http_stubber.create_response()
+            http_stubber.add_response(status=400)
+            http_stubber.add_response(status=400, headers=region_headers)
+            http_stubber.add_response(headers=region_headers)
+            http_stubber.add_response()
             response = client.head_object(Bucket='foo', Key='bar')
             self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
 
@@ -361,11 +351,11 @@ class TestRegionRedirect(BaseS3OperationTest):
         # back to the user.
         client = self.session.create_client('s3', 'us-east-1')
         with ClientHTTPStubber(client) as http_stubber:
-            http_stubber.create_response(status=400)
-            http_stubber.create_response(status=400, headers=region_headers)
-            http_stubber.create_response(headers=region_headers)
+            http_stubber.add_response(status=400)
+            http_stubber.add_response(status=400, headers=region_headers)
+            http_stubber.add_response(headers=region_headers)
             # The final request still fails with a 400.
-            http_stubber.create_response(status=400)
+            http_stubber.add_response(status=400)
             with self.assertRaises(ClientError) as e:
                 client.head_object(Bucket='foo', Key='bar')
             self.assertEqual(len(http_stubber.requests), 4)
@@ -837,7 +827,7 @@ def _verify_expected_endpoint_url(region, bucket, key, s3_config,
                                    config=config,
                                    endpoint_url=customer_provided_endpoint)
         with ClientHTTPStubber(s3) as http_stubber:
-            http_stubber.create_response()
+            http_stubber.add_response()
             s3.put_object(Bucket=bucket, Key=key, Body=b'bar')
             assert_equal(http_stubber.requests[0].url, expected_url)
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -11,7 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest, temporary_file, random_chars, BotocoreHTTPStubber
+from tests import unittest, temporary_file, random_chars, ClientHTTPStubber
 import os
 import time
 from collections import defaultdict
@@ -819,7 +819,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
         super(TestS3SigV4Client, self).setUp()
         self.client = self.session.create_client(
             's3', self.region, config=Config(signature_version='s3v4'))
-        self.http_stubber = BotocoreHTTPStubber(self.client)
+        self.http_stubber = ClientHTTPStubber(self.client)
 
     def test_can_get_bucket_location(self):
         # Even though the bucket is in us-west-2, we should still be able to

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -287,15 +287,12 @@ def test_client_can_retry_request_properly():
 
 def _make_client_call_with_errors(client, operation_name, kwargs):
     operation = getattr(client, xform_name(operation_name))
-    state = mock.Mock()
-    state.error_raised = False
-    exception = ConnectionClosedError(endpoint_url='')
+    exception = ConnectionClosedError(endpoint_url='https://mock.eror')
     with ClientHTTPStubber(client) as http_stubber:
         http_stubber.responses.append(exception)
         http_stubber.responses.append(None)
         try:
             response = operation(**kwargs)
-            assert_true(state.error_raised)
         except ClientError as e:
             assert False, ('Request was not retried properly, '
                            'received error:\n%s' % pformat(e))

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -290,10 +290,9 @@ def _make_client_call_with_errors(client, operation_name, kwargs):
     state = mock.Mock()
     state.error_raised = False
     exception = ConnectionClosedError(endpoint_url='')
-    http_stubber = BotocoreHTTPStubber()
-    http_stubber.add_response(exception)
-    http_stubber.add_response(None)
-    with http_stubber.wrap_client(client):
+    with BotocoreHTTPStubber(client) as http_stubber:
+        http_stubber.responses.append(exception)
+        http_stubber.responses.append(None)
         try:
             response = operation(**kwargs)
             assert_true(state.error_raised)

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -16,7 +16,7 @@ from pprint import pformat
 import warnings
 from nose.tools import assert_equal, assert_true
 
-from tests import BotocoreHTTPStubber
+from tests import ClientHTTPStubber
 from botocore import xform_name
 import botocore.session
 from botocore.client import ClientError
@@ -290,7 +290,7 @@ def _make_client_call_with_errors(client, operation_name, kwargs):
     state = mock.Mock()
     state.error_raised = False
     exception = ConnectionClosedError(endpoint_url='')
-    with BotocoreHTTPStubber(client) as http_stubber:
+    with ClientHTTPStubber(client) as http_stubber:
         http_stubber.responses.append(exception)
         http_stubber.responses.append(None)
         try:

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -180,7 +180,7 @@ class TestRetryInterface(TestEndpointBase):
         self.assertEqual(call_args[5][0][0],
                          'needs-retry.ec2.DescribeInstances')
 
-    def est_retry_attempts_added_to_response_metadata(self):
+    def test_retry_attempts_added_to_response_metadata(self):
         op = Mock(name='DescribeInstances')
         op.metadata = {'protocol': 'query'}
         op.has_event_stream_output = False

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -139,13 +139,13 @@ class TestRetryInterface(TestEndpointBase):
         self.assertEqual(call_args[0][0][0],
                          'request-created.ec2.DescribeInstances')
         self.assertEqual(call_args[1][0][0],
-                         'send-request.ec2.DescribeInstances')
+                         'before-send.ec2.DescribeInstances')
         self.assertEqual(call_args[2][0][0],
                          'needs-retry.ec2.DescribeInstances')
         self.assertEqual(call_args[3][0][0],
                          'request-created.ec2.DescribeInstances')
         self.assertEqual(call_args[4][0][0],
-                         'send-request.ec2.DescribeInstances')
+                         'before-send.ec2.DescribeInstances')
         self.assertEqual(call_args[5][0][0],
                          'needs-retry.ec2.DescribeInstances')
 
@@ -170,13 +170,13 @@ class TestRetryInterface(TestEndpointBase):
         self.assertEqual(call_args[0][0][0],
                          'request-created.ec2.DescribeInstances')
         self.assertEqual(call_args[1][0][0],
-                         'send-request.ec2.DescribeInstances')
+                         'before-send.ec2.DescribeInstances')
         self.assertEqual(call_args[2][0][0],
                          'needs-retry.ec2.DescribeInstances')
         self.assertEqual(call_args[3][0][0],
                          'request-created.ec2.DescribeInstances')
         self.assertEqual(call_args[4][0][0],
-                         'send-request.ec2.DescribeInstances')
+                         'before-send.ec2.DescribeInstances')
         self.assertEqual(call_args[5][0][0],
                          'needs-retry.ec2.DescribeInstances')
 

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -15,7 +15,7 @@
 
 import os
 
-from tests import BaseSessionTest
+from tests import BaseSessionTest, BotocoreHTTPStubber
 from mock import patch, Mock
 
 from botocore.compat import OrderedDict
@@ -35,12 +35,12 @@ class TestS3Addressing(BaseSessionTest):
     def get_prepared_request(self, operation, params, force_hmacv1=False):
         if force_hmacv1:
             self.session.register('choose-signer', self.enable_hmacv1)
-        self.http_stubber.create_response()
         client = self.session.create_client('s3', self.region_name)
-        with self.http_stubber.wrap_client(client):
+        with BotocoreHTTPStubber(client) as http_stubber:
+            http_stubber.create_response()
             getattr(client, operation)(**params)
             # Return the request that was sent over the wire.
-            return self.http_stubber.requests[0]
+            return http_stubber.requests[0]
 
     def enable_hmacv1(self, **kwargs):
         return 's3'

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -15,7 +15,7 @@
 
 import os
 
-from tests import BaseSessionTest, BotocoreHTTPStubber
+from tests import BaseSessionTest, ClientHTTPStubber
 from mock import patch, Mock
 
 from botocore.compat import OrderedDict
@@ -36,7 +36,7 @@ class TestS3Addressing(BaseSessionTest):
         if force_hmacv1:
             self.session.register('choose-signer', self.enable_hmacv1)
         client = self.session.create_client('s3', self.region_name)
-        with BotocoreHTTPStubber(client) as http_stubber:
+        with ClientHTTPStubber(client) as http_stubber:
             http_stubber.create_response()
             getattr(client, operation)(**params)
             # Return the request that was sent over the wire.

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -37,7 +37,7 @@ class TestS3Addressing(BaseSessionTest):
             self.session.register('choose-signer', self.enable_hmacv1)
         client = self.session.create_client('s3', self.region_name)
         with ClientHTTPStubber(client) as http_stubber:
-            http_stubber.create_response()
+            http_stubber.add_response()
             getattr(client, operation)(**params)
             # Return the request that was sent over the wire.
             return http_stubber.requests[0]

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -29,24 +29,18 @@ class TestS3Addressing(BaseSessionTest):
         self.region_name = 'us-east-1'
         self.signature_version = 's3'
 
-        self.mock_response = Mock()
-        self.mock_response.content = ''
-        self.mock_response.headers = {}
-        self.mock_response.status_code = 200
         self.session.unregister('before-parameter-build.s3.ListObjects',
                                 set_list_objects_encoding_type_url)
 
-    def get_prepared_request(self, operation, params,
-                             force_hmacv1=False):
+    def get_prepared_request(self, operation, params, force_hmacv1=False):
         if force_hmacv1:
             self.session.register('choose-signer', self.enable_hmacv1)
-        # TODO: fix with stubber / before send event
-        with patch('botocore.endpoint.Endpoint._send') as mock_send:
-            mock_send.return_value = self.mock_response
-            client = self.session.create_client('s3', self.region_name)
+        self.http_stubber.create_response()
+        client = self.session.create_client('s3', self.region_name)
+        with self.http_stubber.wrap_client(client):
             getattr(client, operation)(**params)
             # Return the request that was sent over the wire.
-            return mock_send.call_args[0][0]
+            return self.http_stubber.requests[0]
 
     def enable_hmacv1(self, **kwargs):
         return 's3'


### PR DESCRIPTION
This adds a `send-request` event which will allow an event handler to return a response and short circuit botocore's default HTTP stack.

This also adds a test utility to stub the HTTP layer and replaces quite a few places where we were patching out internal methods.