### PR TITLE
More specific service id error

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -506,8 +506,13 @@ class UndefinedModelAttributeError(Exception):
     pass
 
 
-class MissingServiceIdError(UndefinedModelAttributeError, BotoCoreError):
+class MissingServiceIdError(UndefinedModelAttributeError):
     fmt = (
         "The model being used for the service {service_name} is missing the "
         "serviceId metadata property, which is required."
     )
+
+    def __init__(self, **kwargs):
+        msg = self.fmt.format(**kwargs)
+        Exception.__init__(self, msg)
+        self.kwargs = kwargs

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -500,3 +500,14 @@ class MD5UnavailableError(BotoCoreError):
 
 class MetadataRetrievalError(BotoCoreError):
     fmt = "Error retrieving metadata: {error_msg}"
+
+
+class UndefinedModelAttributeError(Exception):
+    pass
+
+
+class MissingServiceIdError(UndefinedModelAttributeError, BotoCoreError):
+    fmt = (
+        "The model being used for the service {service_name} is missing the "
+        "serviceId metadata property, which is required."
+    )

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -35,6 +35,7 @@ from botocore.signers import add_generate_db_auth_token
 from botocore.exceptions import ParamValidationError
 from botocore.exceptions import AliasConflictParameterError
 from botocore.exceptions import UnsupportedTLSVersionWarning
+from botocore.exceptions import MissingServiceIdError
 from botocore.utils import percent_encode, SAFE_CHARS
 from botocore.utils import switch_host_with_param
 from botocore.utils import hyphenize_service_id
@@ -280,6 +281,8 @@ def register_retries_for_service(service_data, session,
                      "prefix from model for service %s", service_name)
         return
     service_id = service_data.get('metadata', {}).get('serviceId')
+    if service_id is None:
+        raise MissingServiceIdError(service_name=service_name)
     service_event_name = hyphenize_service_id(service_id)
     config = _load_retry_config(loader, endpoint_prefix)
     if not config:

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -15,7 +15,8 @@ from collections import defaultdict
 
 from botocore.utils import CachedProperty, instance_cache, hyphenize_service_id
 from botocore.compat import OrderedDict
-
+from botocore.exceptions import MissingServiceIdError
+from botocore.exceptions import UndefinedModelAttributeError
 
 NOT_SET = object()
 
@@ -33,10 +34,6 @@ class OperationNotFoundError(Exception):
 
 
 class InvalidShapeReferenceError(Exception):
-    pass
-
-
-class UndefinedModelAttributeError(Exception):
     pass
 
 
@@ -291,7 +288,12 @@ class ServiceModel(object):
 
     @CachedProperty
     def service_id(self):
-        return ServiceId(self._get_metadata_property('serviceId'))
+        try:
+            return ServiceId(self._get_metadata_property('serviceId'))
+        except UndefinedModelAttributeError:
+            raise MissingServiceIdError(
+                service_name=self._service_name
+            )
 
     @CachedProperty
     def signing_name(self):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2,6 +2,7 @@ from tests import unittest
 
 from botocore import model
 from botocore.compat import OrderedDict
+from botocore.exceptions import MissingServiceIdError
 
 
 def test_missing_model_attribute_raises_exception():
@@ -74,6 +75,24 @@ class TestServiceModel(unittest.TestCase):
     def test_hyphenize_service_id(self):
         self.assertEqual(
             self.service_model.service_id.hyphenize(), 'myservice')
+
+    def test_service_id_does_not_exist(self):
+        service_model = {
+            'metadata': {
+                'protocol': 'query',
+                'endpointPrefix': 'endpoint-prefix',
+            },
+            'documentation': 'Documentation value',
+            'operations': {},
+            'shapes': {
+                'StringShape': {'type': 'string'}
+            }
+        }
+        service_name = 'myservice'
+        service_model = model.ServiceModel(service_model, service_name)
+        with self.assertRaisesRegexp(model.UndefinedModelAttributeError,
+                                     service_name):
+            service_model.service_id
 
     def test_operation_does_not_exist(self):
         with self.assertRaises(model.OperationNotFoundError):


### PR DESCRIPTION
This gives a better error when the service id is missing from a
model. For example, if you called from the CLI you would currently
see an error like this:

```
$ aws secretsmanager help
'NoneType' object has no attribute 'replace'
```

Now you would see something like this:

```
$ aws secretsmanager help
The model being used for the service secretsmanager is missing the
serviceId metadata property, which is required.
```