### PR TITLE
Fix a crash when METADATA_SECURITY_CREDENTIALS_URL doesn't return JSON

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -303,7 +303,7 @@ class InstanceMetadataFetcher(object):
                         ).content.decode('utf-8')
                         if val[0] == '{':
                             val = json.loads(val)
-                        data[field] = val
+                            data[field] = val
             else:
                 logger.debug("Metadata service returned non 200 status code "
                              "of %s for url: %s, content body: %s",


### PR DESCRIPTION
  File "/var/www/venv/lib/python3.5/site-packages/boto3/session.py", line 183, in get_credentials
    return self._session.get_credentials()
  File "/var/www/venv/lib/python3.5/site-packages/botocore/session.py", line 474, in get_credentials
    'credential_provider').load_credentials()
  File "/var/www/venv/lib/python3.5/site-packages/botocore/credentials.py", line 1663, in load_credentials
    creds = provider.load()
  File "/var/www/venv/lib/python3.5/site-packages/botocore/credentials.py", line 842, in load
    metadata = fetcher.retrieve_iam_role_credentials()
  File "/var/www/venv/lib/python3.5/site-packages/botocore/utils.py", line 235, in retrieve_iam_role_credentials
    'access_key': data[role_name]['AccessKeyId'],
TypeError: string indices must be integers
