### PR TITLE
Improve prepare_body performance

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -268,20 +268,21 @@ class SigV4Auth(BaseSigner):
             # When payload signing is disabled, we use this static string in
             # place of the payload checksum.
             return UNSIGNED_PAYLOAD
-        if request.body and hasattr(request.body, 'seek'):
-            position = request.body.tell()
-            read_chunksize = functools.partial(request.body.read,
+        request_body = request.body
+        if request_body and hasattr(request_body, 'seek'):
+            position = request_body.tell()
+            read_chunksize = functools.partial(request_body.read,
                                                PAYLOAD_BUFFER)
             checksum = sha256()
             for chunk in iter(read_chunksize, b''):
                 checksum.update(chunk)
             hex_checksum = checksum.hexdigest()
-            request.body.seek(position)
+            request_body.seek(position)
             return hex_checksum
-        elif request.body:
+        elif request_body:
             # The request serialization has ensured that
             # request.body is a bytes() type.
-            return sha256(request.body).hexdigest()
+            return sha256(request_body).hexdigest()
         else:
             return EMPTY_SHA256_HASH
 


### PR DESCRIPTION
When performing a SigV4 calculation we access the `AWSRequest.body` property many times which can potentially be expensive depending on the type of body being sent. This removes multiple calls to the body property to avoid calculating it many times, as the value doesn't change within the signer. 

This also removes an additional call to `prepare_body` that is no longer needed after some refactoring to how the body property works. The request is prepared in the `AWSPreparedRequest` constructor now meaning that calculating the `prepare_body` again is no longer needed.

Combined this reduces the number of times we prepare the body from 9 to 2, once when we calculate the signature and once when we actually send it. There's more profiling information in the linked issues.

Closes: #1478 
Fixes: #1561