### PR TITLE
Properly handle error responses with null or not present body

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -271,8 +271,11 @@ class ResponseParser(object):
         # To prevent this case from happening we first need to check
         # whether or not this response looks like the generic response.
         if response['status_code'] >= 500:
-            body = response['body'].strip()
-            return body.startswith(b'<html>') or not body
+            if 'body' not in response or response['body'] is None:
+                return True
+            else:
+                body = response['body'].strip()
+                return body.startswith(b'<html>') or not body
 
     def _do_generic_error_parse(self, response):
         # There's not really much we can do when we get a generic

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -273,9 +273,9 @@ class ResponseParser(object):
         if response['status_code'] >= 500:
             if 'body' not in response or response['body'] is None:
                 return True
-            else:
-                body = response['body'].strip()
-                return body.startswith(b'<html>') or not body
+
+            body = response['body'].strip()
+            return body.startswith(b'<html>') or not body
 
     def _do_generic_error_parse(self, response):
         # There's not really much we can do when we get a generic

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1144,8 +1144,10 @@ def test_can_handle_generic_error_message():
             '<html><body><b>Http/1.1 Service Unavailable</b></body></html>'
         ).encode('utf-8')
         empty_body = b''
+        none_body = None
         yield _assert_parses_generic_error, parser_cls(), generic_html_body
         yield _assert_parses_generic_error, parser_cls(), empty_body
+        yield _assert_parses_generic_error, parser_cls(), none_body
 
 
 def _assert_parses_generic_error(parser, body):


### PR DESCRIPTION
When a HTTP response contain no body or the body field is None, botocore crashes with this error :

```
'NoneType' object has no attribute 'strip'
Traceback (most recent call last):
[ ...]
  File "/[...]/dist-packages/botocore/parsers.py", line 237, in parse
    if self._is_generic_error_response(response):
  File "/[...]/dist-packages/botocore/parsers.py", line 270, in _is_generic_error_response
    body = response['body'].strip()
```

The typical trigger for this error is a timeout that generate an internal http 599