### PR TITLE
Update IMDS to fix some issues

### DIFF
--- a/.changes/next-release/bugfix-InstanceMetadataFetcher-92647.json
+++ b/.changes/next-release/bugfix-InstanceMetadataFetcher-92647.json
@@ -1,0 +1,5 @@
+{
+  "category": "InstanceMetadataFetcher", 
+  "type": "bugfix", 
+  "description": "Fix failure to retry on empty credentials and invalid JSON returned from IMDS `1049 <https://github.com/boto/botocore/issues/1049>`__ `1403 <https://github.com/boto/botocore/issues/1403>`__"
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -374,11 +374,11 @@ class InstanceMetadataFetcher(object):
 
     def _log_imds_response(self, response, reason_to_log, log_body=False):
         statement = (
-            "Metadata service returned " + reason_to_log + " response "
+            "Metadata service returned %s response "
             "with status code of %s for url: %s"
         )
         logger_args = [
-            response.status_code, response.url
+            reason_to_log, response.status_code, response.url
         ]
         if log_body:
             statement += ", content body: %s"

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -328,6 +328,7 @@ class InstanceMetadataFetcher(object):
                 self._is_empty(response) or
                 self._is_invalid_json(response)):
             return True
+        return False
 
     def _is_empty(self, response):
         return not response.content

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -315,8 +315,9 @@ class InstanceMetadataFetcher(object):
                 else:
                     return response
             except RETRYABLE_HTTP_ERRORS as e:
-                logger.debug("Caught exception while trying to retrieve "
-                             "credentials: %s", e, exc_info=True)
+                logger.debug(
+                    "Caught retryable HTTP exception while making metadata "
+                    "service request to %s: %s", url, e, exc_info=True)
         raise _RetriesExceededError()
 
     def _is_non_ok_response(self, response):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1976,6 +1976,6 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
         self.add_get_role_name_imds_response()
         # Response for creds that has a 200 status code and a JSON body
         # representing an error. We do not necessarily want to retry this.
-        self.add_imds_response(body=b'{"message": "error"')
+        self.add_imds_response(body=b'{"message": "error"}')
         result = InstanceMetadataFetcher().retrieve_iam_role_credentials()
         self.assertEqual(result, {})

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1976,6 +1976,7 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
         self.add_get_role_name_imds_response()
         # Response for creds that has a 200 status code and a JSON body
         # representing an error. We do not necessarily want to retry this.
-        self.add_imds_response(body=b'{"message": "error"}')
+        self.add_imds_response(
+            body=b'{"Code":"AssumeRoleUnauthorizedAccess","Message":"error"}')
         result = InstanceMetadataFetcher().retrieve_iam_role_credentials()
         self.assertEqual(result, {})


### PR DESCRIPTION
Fixes: https://github.com/boto/botocore/issues/1403
Fixes: https://github.com/boto/botocore/issues/1049

Specifically with this we add the ability to retry on empty and invalid json credential responses. I also did quite a bit of refactoring on the `InstanceMetadataFetcher` to simplify it down. The behavior (except for the additional retry cases) should be identical in terms of how it currently got used in botocore. To help with the review, here are the places where I changed a code path:

* Eliminated [branch](https://github.com/boto/botocore/blob/17aa8d5674ab2fa429d9783983f6774118921717/botocore/utils.py#L295-L297) for if the first IMDS response returns something ending in a `\`. This was essentially dead code. If it were hit, it would have been a runtime error because it did not match the signature.
* Eliminated the [checking](https://github.com/boto/botocore/blob/develop/botocore/utils.py#L304-L306) if it starts with a `{`. We now always `json.loads` it. If we hit the code path if it did not get JSON loaded, it would have failed in trying to do the [dictionary access](https://github.com/boto/botocore/blob/develop/botocore/utils.py#L318-L325).
* Removed [looping](https://github.com/boto/botocore/blob/develop/botocore/utils.py#L293-L294) through the fields for the initial IMDS call. There will ever only be one role attached to an instance. Therefore, we would never hit cases where we had to make more than one subsequent call to IMDS. In the case where there is no role attached to the instance, we get a 4xx response which raises a retries exceeded error.
* Flattened the [data](https://github.com/boto/botocore/blob/17aa8d5674ab2fa429d9783983f6774118921717/botocore/utils.py#L318) dictionary. Since we are no longer iterating through fields, there is no reason to have a field key.

I also ran all of the botocore integration tests (using IMDS as the credential provider) and those test pass (there were a couple intermittent failures, but it was not because of IMDS). I also manually tested the following cases:

* No role attached to the instance. Botocore appropriately raises an error that it cannot find credentials.
* A role attached but does not have EC2 as a trusted entity. We get a key error on this (we probably make a better error in the future) because IMDS returns an error response that is formatted as JSON and the HTTP status code is 200. I did not change this to avoid changing too much as this same issue existed prior to refactoring.

Let me know what you all think.