### PR TITLE
Docs: describe-trusted-advisor-checks

### DIFF
--- a/botocore/data/support/2013-04-15/service-2.json
+++ b/botocore/data/support/2013-04-15/service-2.json
@@ -180,7 +180,7 @@
       "errors":[
         {"shape":"InternalServerError"}
       ],
-      "documentation":"<p>Returns information about all available Trusted Advisor checks, including name, ID, category, description, and metadata. You must specify a language code; English (\"en\") and Japanese (\"ja\") are currently supported. The response contains a <a>TrustedAdvisorCheckDescription</a> for each check.</p>"
+      "documentation":"<p>Returns information about all available Trusted Advisor checks, including name, ID, category, description, and metadata. You must specify a language code; English (\"en\") and Japanese (\"ja\") are currently supported. The response contains a <a>TrustedAdvisorCheckDescription</a> for each check. The region must be set as us-east-1</p>"
     },
     "RefreshTrustedAdvisorCheck":{
       "name":"RefreshTrustedAdvisorCheck",


### PR DESCRIPTION
describe-trusted-advisor-checks currently only works when the region is set to us-east-1. Adding this to the documentation