### PR TITLE
Add support for TCP Keep-Alive

### DIFF
--- a/.changes/next-release/enhancement-HTTPSession-32204.json
+++ b/.changes/next-release/enhancement-HTTPSession-32204.json
@@ -1,0 +1,5 @@
+{
+  "category": "HTTP Session", 
+  "type": "enhancement", 
+  "description": "Added the ability to enable TCP Keepalive via the shared config file's ``tcp_keepalive`` option."
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -209,11 +209,13 @@ class ClientArgsCreator(object):
         return None, None
 
     def _compute_socket_options(self, scoped_config):
+        socket_options = [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
         if scoped_config:
             # Enables TCP Keepalive if specified in shared config file.
             if self._ensure_boolean(scoped_config.get('tcp_keepalive', False)):
-                return [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
-        return None
+                socket_options.append(
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1))
+        return socket_options
 
     def _ensure_boolean(self, val):
         if isinstance(val, bool):

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -209,6 +209,8 @@ class ClientArgsCreator(object):
         return None, None
 
     def _compute_socket_options(self, scoped_config):
+        # This disables Nagle's algorithm and is the default socket options
+        # in urllib3.
         socket_options = [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
         if scoped_config:
             # Enables TCP Keepalive if specified in shared config file.

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -232,7 +232,7 @@ class EndpointCreator(object):
                         timeout=DEFAULT_TIMEOUT,
                         max_pool_connections=MAX_POOL_CONNECTIONS,
                         http_session_cls=URLLib3Session,
-                        proxies=None):
+                        proxies=None, tcp_keepalive=False):
         if not is_valid_endpoint_url(endpoint_url):
 
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
@@ -246,6 +246,7 @@ class EndpointCreator(object):
             proxies=proxies,
             verify=self._get_verify_value(verify),
             max_pool_connections=max_pool_connections,
+            tcp_keepalive=tcp_keepalive,
         )
 
         return Endpoint(

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -232,7 +232,8 @@ class EndpointCreator(object):
                         timeout=DEFAULT_TIMEOUT,
                         max_pool_connections=MAX_POOL_CONNECTIONS,
                         http_session_cls=URLLib3Session,
-                        proxies=None, tcp_keepalive=False):
+                        proxies=None,
+                        socket_options=None):
         if not is_valid_endpoint_url(endpoint_url):
 
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
@@ -246,7 +247,7 @@ class EndpointCreator(object):
             proxies=proxies,
             verify=self._get_verify_value(verify),
             max_pool_connections=max_pool_connections,
-            tcp_keepalive=tcp_keepalive,
+            socket_options=socket_options,
         )
 
         return Endpoint(

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -163,7 +163,9 @@ class URLLib3Session(object):
             timeout = Timeout(connect=timeout[0], read=timeout[1])
         self._timeout = timeout
         self._max_pool_connections = max_pool_connections
-        self._extra_socket_options = socket_options
+        self._socket_options = socket_options
+        if socket_options is None:
+            self._socket_options = []
         self._proxy_managers = {}
         self._manager = PoolManager(**self._get_pool_manager_kwargs())
         self._manager.pool_classes_by_scheme = self._pool_classes_by_scheme
@@ -174,19 +176,8 @@ class URLLib3Session(object):
             'timeout': self._timeout,
             'maxsize': self._max_pool_connections,
             'ssl_context': self._get_ssl_context(),
+            'socket_options': self._socket_options
         }
-        if self._extra_socket_options:
-            # HTTP is being used to get the default socket options because
-            # the HTTPS version will inherit the same default socket options,
-            # and urllib3 does not allow you to specify socket options
-            # based on the scheme from the PoolManager interface.
-            # The only way they could differ is if a user explicitly
-            # updated urllib3's connection `default_socket_options` class
-            # variable for HTTPS connections but not HTTP connections.
-            socket_options = self._pool_classes_by_scheme[
-                'http'].ConnectionCls.default_socket_options
-            pool_manager_kwargs[
-                'socket_options'] = socket_options + self._extra_socket_options
         pool_manager_kwargs.update(**extra_kwargs)
         return pool_manager_kwargs
 

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -11,6 +11,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import socket
+
 import botocore.config
 from tests import unittest
 import mock
@@ -66,7 +68,7 @@ class TestCreateClientArgs(unittest.TestCase):
             'verify': True,
             'max_pool_connections': 10,
             'proxies': None,
-            'tcp_keepalive': False
+            'socket_options': None
         }
         call_kwargs.update(**override_kwargs)
         mock_endpoint.return_value.create_endpoint.assert_called_with(
@@ -208,26 +210,34 @@ class TestCreateClientArgs(unittest.TestCase):
         self.assertEqual(
             client_args['client_config'].retries, {'max_attempts': 10})
 
-    def test_tcp_keep_alive_enabled(self):
+    def test_tcp_keepalive_enabled(self):
         scoped_config = {'tcp_keepalive': 'true'}
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
-            self.assert_create_endpoint_call(m, tcp_keepalive=True)
+            self.assert_create_endpoint_call(
+                m, socket_options=[
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+                ]
+            )
 
-    def test_tcp_keep_alive_not_specified(self):
+    def test_tcp_keepalive_not_specified(self):
         scoped_config = {}
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
-            self.assert_create_endpoint_call(m, tcp_keepalive=False)
+            self.assert_create_endpoint_call(m, socket_options=None)
 
-    def test_tcp_keep_alive_explicitly_disabled(self):
+    def test_tcp_keepalive_explicitly_disabled(self):
         scoped_config = {'tcp_keepalive': 'false'}
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
-            self.assert_create_endpoint_call(m, tcp_keepalive=False)
+            self.assert_create_endpoint_call(m, socket_options=None)
 
-    def test_tcp_keep_alive_enabled_case_insensitive(self):
+    def test_tcp_keepalive_enabled_case_insensitive(self):
         scoped_config = {'tcp_keepalive': 'True'}
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
-            self.assert_create_endpoint_call(m, tcp_keepalive=True)
+            self.assert_create_endpoint_call(
+                m, socket_options=[
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+                ]
+            )

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -43,6 +43,9 @@ class TestCreateClientArgs(unittest.TestCase):
             'endpoint_url': self.endpoint_url,
             'signing_name': 'ec2', 'signing_region': self.region,
             'metadata': {}}
+        self.default_socket_options = [
+            (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        ]
 
     def call_get_client_args(self, **override_kwargs):
         call_kwargs = {
@@ -68,7 +71,7 @@ class TestCreateClientArgs(unittest.TestCase):
             'verify': True,
             'max_pool_connections': 10,
             'proxies': None,
-            'socket_options': None
+            'socket_options': self.default_socket_options
         }
         call_kwargs.update(**override_kwargs)
         mock_endpoint.return_value.create_endpoint.assert_called_with(
@@ -215,7 +218,7 @@ class TestCreateClientArgs(unittest.TestCase):
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
             self.assert_create_endpoint_call(
-                m, socket_options=[
+                m, socket_options=self.default_socket_options + [
                     (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 ]
             )
@@ -224,20 +227,22 @@ class TestCreateClientArgs(unittest.TestCase):
         scoped_config = {}
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
-            self.assert_create_endpoint_call(m, socket_options=None)
+            self.assert_create_endpoint_call(
+                m, socket_options=self.default_socket_options)
 
     def test_tcp_keepalive_explicitly_disabled(self):
         scoped_config = {'tcp_keepalive': 'false'}
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
-            self.assert_create_endpoint_call(m, socket_options=None)
+            self.assert_create_endpoint_call(
+                m, socket_options=self.default_socket_options)
 
     def test_tcp_keepalive_enabled_case_insensitive(self):
         scoped_config = {'tcp_keepalive': 'True'}
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(scoped_config=scoped_config)
             self.assert_create_endpoint_call(
-                m, socket_options=[
+                m, socket_options=self.default_socket_options + [
                     (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 ]
             )

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -66,6 +66,7 @@ class TestCreateClientArgs(unittest.TestCase):
             'verify': True,
             'max_pool_connections': 10,
             'proxies': None,
+            'tcp_keepalive': False
         }
         call_kwargs.update(**override_kwargs)
         mock_endpoint.return_value.create_endpoint.assert_called_with(
@@ -206,3 +207,27 @@ class TestCreateClientArgs(unittest.TestCase):
         client_args = self.call_get_client_args(client_config=config)
         self.assertEqual(
             client_args['client_config'].retries, {'max_attempts': 10})
+
+    def test_tcp_keep_alive_enabled(self):
+        scoped_config = {'tcp_keepalive': 'true'}
+        with mock.patch('botocore.args.EndpointCreator') as m:
+            self.call_get_client_args(scoped_config=scoped_config)
+            self.assert_create_endpoint_call(m, tcp_keepalive=True)
+
+    def test_tcp_keep_alive_not_specified(self):
+        scoped_config = {}
+        with mock.patch('botocore.args.EndpointCreator') as m:
+            self.call_get_client_args(scoped_config=scoped_config)
+            self.assert_create_endpoint_call(m, tcp_keepalive=False)
+
+    def test_tcp_keep_alive_explicitly_disabled(self):
+        scoped_config = {'tcp_keepalive': 'false'}
+        with mock.patch('botocore.args.EndpointCreator') as m:
+            self.call_get_client_args(scoped_config=scoped_config)
+            self.assert_create_endpoint_call(m, tcp_keepalive=False)
+
+    def test_tcp_keep_alive_enabled_case_insensitive(self):
+        scoped_config = {'tcp_keepalive': 'True'}
+        with mock.patch('botocore.args.EndpointCreator') as m:
+            self.call_get_client_args(scoped_config=scoped_config)
+            self.assert_create_endpoint_call(m, tcp_keepalive=True)

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
+import socket
 from tests import unittest
 
 from mock import Mock, patch, sentinel
@@ -351,10 +351,11 @@ class TestEndpointCreator(unittest.TestCase):
         session_args = self.mock_session.call_args[1]
         self.assertEqual(session_args.get('max_pool_connections'), 100)
 
-    def test_enable_tcp_keepalive(self):
+    def test_socket_options(self):
+        socket_options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
         self.creator.create_endpoint(
             self.service_model, region_name='us-west-2',
             endpoint_url='https://example.com',
-            http_session_cls=self.mock_session, tcp_keepalive=True)
+            http_session_cls=self.mock_session, socket_options=socket_options)
         session_args = self.mock_session.call_args[1]
-        self.assertEqual(session_args.get('tcp_keepalive'), True)
+        self.assertEqual(session_args.get('socket_options'), socket_options)

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -350,3 +350,11 @@ class TestEndpointCreator(unittest.TestCase):
         )
         session_args = self.mock_session.call_args[1]
         self.assertEqual(session_args.get('max_pool_connections'), 100)
+
+    def test_enable_tcp_keepalive(self):
+        self.creator.create_endpoint(
+            self.service_model, region_name='us-west-2',
+            endpoint_url='https://example.com',
+            http_session_cls=self.mock_session, tcp_keepalive=True)
+        session_args = self.mock_session.call_args[1]
+        self.assertEqual(session_args.get('tcp_keepalive'), True)

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -115,6 +115,7 @@ class TestURLLib3Session(unittest.TestCase):
             timeout=ANY,
             strict=True,
             ssl_context=ANY,
+            socket_options=[],
         )
 
     def test_basic_request(self):
@@ -148,6 +149,7 @@ class TestURLLib3Session(unittest.TestCase):
             timeout=ANY,
             strict=True,
             ssl_context=ANY,
+            socket_options=[],
         )
         self.assert_request_sent()
 
@@ -164,6 +166,7 @@ class TestURLLib3Session(unittest.TestCase):
             timeout=ANY,
             strict=True,
             ssl_context=ANY,
+            socket_options=[],
         )
         session.send(self.request.prepare())
         # assert that we did not create another proxy manager
@@ -180,6 +183,7 @@ class TestURLLib3Session(unittest.TestCase):
             timeout=ANY,
             strict=True,
             ssl_context=ANY,
+            socket_options=[],
         )
         self.assert_request_sent(url=self.request.url)
 
@@ -197,20 +201,20 @@ class TestURLLib3Session(unittest.TestCase):
         self.assertIsNotNone(proxy_kwargs.get('ssl_context'))
 
     def test_session_forwards_socket_options_to_pool_manager(self):
-        socket_option = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-        URLLib3Session(socket_options=[socket_option])
+        socket_options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+        URLLib3Session(socket_options=socket_options)
         manager_kwargs = self.pool_manager_cls.call_args[1]
-        self.assertIn(socket_option, manager_kwargs['socket_options'])
+        self.assertEqual(socket_options, manager_kwargs['socket_options'])
 
     def test_session_forwards_socket_options_to_proxy_manager(self):
-        socket_option = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        socket_options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
         session = URLLib3Session(
             proxies={'http': 'http://proxy.com'},
-            socket_options=[socket_option]
+            socket_options=socket_options
         )
         session.send(self.request.prepare())
         manager_kwargs = self.proxy_manager_fun.call_args[1]
-        self.assertIn(socket_option, manager_kwargs['socket_options'])
+        self.assertEqual(socket_options, manager_kwargs['socket_options'])
 
     def make_request_with_error(self, error):
         self.connection.urlopen.side_effect = error

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -196,23 +196,21 @@ class TestURLLib3Session(unittest.TestCase):
         _, proxy_kwargs = self.proxy_manager_fun.call_args
         self.assertIsNotNone(proxy_kwargs.get('ssl_context'))
 
-    def test_session_forwards_tcp_keepalive_to_pool_manager(self):
-        URLLib3Session(tcp_keepalive=True)
+    def test_session_forwards_socket_options_to_pool_manager(self):
+        socket_option = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        URLLib3Session(socket_options=[socket_option])
         manager_kwargs = self.pool_manager_cls.call_args[1]
-        self.assertIn(
-            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-            manager_kwargs['socket_options']
-        )
+        self.assertIn(socket_option, manager_kwargs['socket_options'])
 
-    def test_session_forwards_tcp_keepalive_to_proxy_manager(self):
+    def test_session_forwards_socket_options_to_proxy_manager(self):
+        socket_option = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         session = URLLib3Session(
-            proxies={'http': 'http://proxy.com'}, tcp_keepalive=True)
+            proxies={'http': 'http://proxy.com'},
+            socket_options=[socket_option]
+        )
         session.send(self.request.prepare())
         manager_kwargs = self.proxy_manager_fun.call_args[1]
-        self.assertIn(
-            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-            manager_kwargs['socket_options']
-        )
+        self.assertIn(socket_option, manager_kwargs['socket_options'])
 
     def make_request_with_error(self, error):
         self.connection.urlopen.side_effect = error


### PR DESCRIPTION
Adds an option to the shared config file to enable TCP Keep-Alive:
```
[default]
tcp_keepalive = true
```