### PR TITLE
Add client cert support to client config

### DIFF
--- a/.changes/next-release/enhancement-TLS-71632.json
+++ b/.changes/next-release/enhancement-TLS-71632.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "TLS",
+  "description": "Added support for configuring a client certificate and key when establishing TLS connections."
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -80,7 +80,8 @@ class ClientArgsCreator(object):
             max_pool_connections=new_config.max_pool_connections,
             proxies=new_config.proxies,
             timeout=(new_config.connect_timeout, new_config.read_timeout),
-            socket_options=socket_options)
+            socket_options=socket_options,
+            client_cert=new_config.client_cert)
 
         serializer = botocore.serialize.create_serializer(
             protocol, parameter_validation)
@@ -135,7 +136,8 @@ class ClientArgsCreator(object):
                 read_timeout=client_config.read_timeout,
                 max_pool_connections=client_config.max_pool_connections,
                 proxies=client_config.proxies,
-                retries=client_config.retries
+                retries=client_config.retries,
+                client_cert=client_config.client_cert,
             )
         s3_config = self.compute_s3_config(scoped_config,
                                            client_config)

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -102,6 +102,17 @@ class Config(object):
           this value to 0 will result in no retries ever being attempted on
           the initial request. If not provided, the number of retries will
           default to whatever is modeled, which is typically four retries.
+
+    :type client_cert: str, (str, str)
+    :param client_cert: The path to a certificate for TLS client authentication.
+
+        When a str is provided it is treated as a path to a client certificate
+        to be used when creating a TLS connection.
+
+        If a client key is to be provided alongside the client certificate the
+        client_cert should be set to a tuple of length two where the first
+        element is the path to the client certificate and the second element is
+        the path to the certificate key.
     """
     OPTION_DEFAULTS = OrderedDict([
         ('region_name', None),
@@ -114,7 +125,8 @@ class Config(object):
         ('max_pool_connections', MAX_POOL_CONNECTIONS),
         ('proxies', None),
         ('s3', None),
-        ('retries', None)
+        ('retries', None),
+        ('client_cert', None),
     ])
 
     def __init__(self, *args, **kwargs):

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -233,7 +233,8 @@ class EndpointCreator(object):
                         max_pool_connections=MAX_POOL_CONNECTIONS,
                         http_session_cls=URLLib3Session,
                         proxies=None,
-                        socket_options=None):
+                        socket_options=None,
+                        client_cert=None):
         if not is_valid_endpoint_url(endpoint_url):
 
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
@@ -248,6 +249,7 @@ class EndpointCreator(object):
             verify=self._get_verify_value(verify),
             max_pool_connections=max_pool_connections,
             socket_options=socket_options,
+            client_cert=client_cert,
         )
 
         return Endpoint(

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -150,6 +150,7 @@ class URLLib3Session(object):
                  timeout=None,
                  max_pool_connections=MAX_POOL_CONNECTIONS,
                  socket_options=None,
+                 client_cert=None,
     ):
         self._verify = verify
         self._proxy_config = ProxyConfiguration(proxies=proxies)
@@ -161,6 +162,14 @@ class URLLib3Session(object):
             timeout = DEFAULT_TIMEOUT
         if not isinstance(timeout, (int, float)):
             timeout = Timeout(connect=timeout[0], read=timeout[1])
+
+        self._cert_file = None
+        self._key_file = None
+        if isinstance(client_cert, str):
+            self._cert_file = client_cert
+        elif isinstance(client_cert, tuple):
+            self._cert_file, self._key_file = client_cert
+
         self._timeout = timeout
         self._max_pool_connections = max_pool_connections
         self._socket_options = socket_options
@@ -176,7 +185,9 @@ class URLLib3Session(object):
             'timeout': self._timeout,
             'maxsize': self._max_pool_connections,
             'ssl_context': self._get_ssl_context(),
-            'socket_options': self._socket_options
+            'socket_options': self._socket_options,
+            'cert_file': self._cert_file,
+            'key_file': self._key_file,
         }
         pool_manager_kwargs.update(**extra_kwargs)
         return pool_manager_kwargs
@@ -189,8 +200,7 @@ class URLLib3Session(object):
             proxy_headers = self._proxy_config.proxy_headers_for(proxy_url)
             proxy_manager_kwargs = self._get_pool_manager_kwargs(
                 proxy_headers=proxy_headers)
-            proxy_manager = proxy_from_url(
-                proxy_url, **proxy_manager_kwargs)
+            proxy_manager = proxy_from_url(proxy_url, **proxy_manager_kwargs)
             proxy_manager.pool_classes_by_scheme = self._pool_classes_by_scheme
             self._proxy_managers[proxy_url] = proxy_manager
 

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -71,7 +71,8 @@ class TestCreateClientArgs(unittest.TestCase):
             'verify': True,
             'max_pool_connections': 10,
             'proxies': None,
-            'socket_options': self.default_socket_options
+            'socket_options': self.default_socket_options,
+            'client_cert': None,
         }
         call_kwargs.update(**override_kwargs)
         mock_endpoint.return_value.create_endpoint.assert_called_with(

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -322,6 +322,15 @@ class TestEndpointCreator(unittest.TestCase):
         session_args = self.mock_session.call_args[1]
         self.assertEqual(session_args.get('verify'), '/path/cacerts.pem')
 
+    def test_client_cert_can_specify_path(self):
+        client_cert = '/some/path/cert'
+        endpoint = self.creator.create_endpoint(
+            self.service_model, region_name='us-west-2',
+            endpoint_url='https://example.com', client_cert=client_cert,
+            http_session_cls=self.mock_session)
+        session_args = self.mock_session.call_args[1]
+        self.assertEqual(session_args.get('client_cert'), '/some/path/cert')
+
     def test_honor_cert_bundle_env_var(self):
         self.environ['REQUESTS_CA_BUNDLE'] = '/env/cacerts.pem'
         endpoint = self.creator.create_endpoint(


### PR DESCRIPTION
This allows the `cert_file` and `key_file` parameters to be passed through to the SSL context used when making HTTPS connections. This can be useful in `botocore` if a proxy requires a client certificate to authenticate. This is exposed on the client config as the `client_cert` kwarg.

```python
config = botocore.config.Config(client_cert='/path/to/cert')
config = botocore.config.Config(client_cert=('/path/to/cert', '/path/to/key'))
```