### PR TITLE
Fix annoying DeprecationWarning in parsers.py

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -431,7 +431,7 @@ class BaseXMLResponseParser(ResponseParser):
 
     def _replace_nodes(self, parsed):
         for key, value in parsed.items():
-            if value.getchildren():
+            if list(value):
                 sub_dict = self._build_name_to_xml_node(value)
                 parsed[key] = self._replace_nodes(sub_dict)
             else:


### PR DESCRIPTION
Starting with Python3.7, botocore issues the following warning:
```
/parsers.py:434: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  if value.getchildren():
```
Which is super annoying when working with CloudFormation as it pops up a lot.
Addresses: https://github.com/boto/botocore/issues/1537 