### PR TITLE
Add the strict flag to the test http stubber

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -378,8 +378,9 @@ class RawResponse(BytesIO):
 
 
 class ClientHTTPStubber(object):
-    def __init__(self, client):
+    def __init__(self, client, strict=True):
         self.reset()
+        self._strict = strict
         self._client = client
 
     def reset(self):
@@ -416,5 +417,7 @@ class ClientHTTPStubber(object):
                 raise response
             else:
                 return response
-        else:
+        elif self._strict:
             raise HTTPStubberException('Insufficient responses')
+        else:
+            return None

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -288,11 +288,12 @@ def test_client_can_retry_request_properly():
 def _make_client_call_with_errors(client, operation_name, kwargs):
     operation = getattr(client, xform_name(operation_name))
     exception = ConnectionClosedError(endpoint_url='https://mock.eror')
-    with ClientHTTPStubber(client) as http_stubber:
+    with ClientHTTPStubber(client, strict=False) as http_stubber:
         http_stubber.responses.append(exception)
-        http_stubber.responses.append(None)
         try:
             response = operation(**kwargs)
         except ClientError as e:
             assert False, ('Request was not retried properly, '
                            'received error:\n%s' % pformat(e))
+        # Ensure we used the stubber as we're not using it in strict mode
+        assert len(http_stubber.responses) == 0, 'Stubber was not used!'


### PR DESCRIPTION
When porting this test over to the HTTP stubber I made an incorrect assumption.
The test previously would stub out the *first* request with an exception and then all subsequent requests would behave as normal. The way it's currently implemented the HTTP stubber will only allow two requests to be made, meaning if the second request fails for legitimate reasons the third retry attempt fails when it hits the stubber. Rather than throw a bunch of `None`s into the responses I've added a `strict` flag to the stubber which will allow only stubbing a subset of the requests to be made as is required by this test. 

Alternatively, I could implement a special handler for this test case specifically and not use the HTTP stubber.