### PR TITLE
Update urllib3 version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ docutils>=0.10
 behave==1.2.5
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 jsonschema==2.5.1
-urllib3>=1.20,<1.24
+urllib3>=1.20,<1.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,7 @@ docutils>=0.10
 behave==1.2.5
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 jsonschema==2.5.1
-urllib3>=1.20,<1.25
+urllib3>=1.20,<1.23; python_version=="3.3"
+urllib3>=1.20,<1.24; python_version=="2.6"
+urllib3>=1.20,<1.25; python_version=="2.7"
+urllib3>=1.20,<1.25; python_version>="3.4"

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ requires-dist =
     docutils>=0.10
     ordereddict==1.1; python_version=="2.6"
     simplejson==3.3.0; python_version=="2.6"
-    urllib3>=1.20,<1.24
+    urllib3>=1.20,<1.25

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,7 @@ requires-dist =
     docutils>=0.10
     ordereddict==1.1; python_version=="2.6"
     simplejson==3.3.0; python_version=="2.6"
-    urllib3>=1.20,<1.25
+    urllib3>=1.20,<1.23; python_version=="3.3"
+    urllib3>=1.20,<1.24; python_version=="2.6"
+    urllib3>=1.20,<1.25; python_version=="2.7"
+    urllib3>=1.20,<1.25; python_version>="3.4"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def find_version(*file_paths):
 
 requires = ['jmespath>=0.7.1,<1.0.0',
             'docutils>=0.10',
-            'urllib3>=1.20,<1.24']
+            'urllib3>=1.20,<1.25']
 
 
 if sys.version_info[:2] == (2, 6):

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ def find_version(*file_paths):
 
 
 requires = ['jmespath>=0.7.1,<1.0.0',
-            'docutils>=0.10',
-            'urllib3>=1.20,<1.25']
+            'docutils>=0.10']
 
 
 if sys.version_info[:2] == (2, 6):
@@ -42,6 +41,13 @@ if sys.version_info[:2] == (2, 6):
     requires.append('python-dateutil>=2.1,<2.7.0')
 else:
     requires.append('python-dateutil>=2.1,<3.0.0')
+
+if sys.version_info[:2] == (2, 6):
+    requires.append('urllib3>=1.20,<1.24')
+elif sys.version_info[:2] == (3, 3):
+    requires.append('urllib3>=1.20,<1.23')
+else:
+    requires.append('urllib3>=1.20,<1.25')
 
 
 setup(


### PR DESCRIPTION
This updates the accepted ranges of urllib3 to match what requests supports.
This also adds version specifiers so the bundled installer can determine which version of urllib3 to install.

I've created a bundled installer locally and tested that 2.6, 2.7, 3.3+ work with it.

Related CLI PR: https://github.com/aws/aws-cli/pull/3664

Closes #1583