### PR TITLE
Add region endpoints for missing services

### DIFF
--- a/botocore/data/endpoints.json
+++ b/botocore/data/endpoints.json
@@ -189,6 +189,19 @@
           "us-west-2" : { }
         }
       },
+      "appsync" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-south-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-west-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-2" : { }
+        }
+      },
       "athena" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -382,6 +395,21 @@
           "eu-west-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
+          "us-west-1" : { },
+          "us-west-2" : { }
+        }
+      },
+      "cloudsearchdomain" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-west-1" : { },
+          "sa-east-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
           "us-west-1" : { },
           "us-west-2" : { }
         }
@@ -597,6 +625,14 @@
           "us-west-2" : { }
         }
       },
+      "connect" : {
+        "endpoints" : {
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "us-east-1" : { },
+          "us-west-2" : { }
+        }
+      },
       "cur" : {
         "endpoints" : {
           "us-east-1" : { }
@@ -672,6 +708,25 @@
       },
       "discovery" : {
         "endpoints" : {
+          "us-west-2" : { }
+        }
+      },
+      "dlm" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-south-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "ca-central-1" : { },
+          "eu-central-1" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "eu-west-3" : { },
+          "sa-east-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-1" : { },
           "us-west-2" : { }
         }
       },
@@ -798,6 +853,13 @@
           "us-east-1" : { },
           "us-east-2" : { },
           "us-west-1" : { },
+          "us-west-2" : { }
+        }
+      },
+      "eks" : {
+        "endpoints" : {
+          "eu-west-1" : { },
+          "us-east-1" : { },
           "us-west-2" : { }
         }
       },
@@ -1171,6 +1233,21 @@
           "us-west-2" : { }
         }
       },
+      "iot-jobs-data" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-south-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-2" : { }
+        }
+      },
       "kinesis" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -1287,6 +1364,12 @@
           "us-east-1" : { }
         }
       },
+      "macie" : {
+        "endpoints" : {
+          "us-east-1" : { },
+          "us-west-2" : { }
+        }
+      },
       "marketplacecommerceanalytics" : {
         "endpoints" : {
           "us-east-1" : { }
@@ -1378,6 +1461,23 @@
           "us-west-2" : { }
         }
       },
+      "mobile" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-south-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "sa-east-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-1" : { },
+          "us-west-2" : { }
+        }
+      },
       "mobileanalytics" : {
         "endpoints" : {
           "us-east-1" : { }
@@ -1411,6 +1511,20 @@
           "eu-west-2" : { },
           "eu-west-3" : { },
           "sa-east-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-1" : { },
+          "us-west-2" : { }
+        }
+      },
+      "mq" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-west-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
           "us-west-1" : { },
@@ -1497,6 +1611,25 @@
         },
         "isRegionalized" : false,
         "partitionEndpoint" : "aws-global"
+      },
+      "pi" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-south-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "ca-central-1" : { },
+          "eu-central-1" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "eu-west-3" : { },
+          "sa-east-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-1" : { },
+          "us-west-2" : { }
+        }
       },
       "pinpoint" : {
         "defaults" : {
@@ -2142,6 +2275,16 @@
           "us-east-1" : { },
           "us-east-2" : { },
           "us-west-1" : { },
+          "us-west-2" : { }
+        }
+      },
+      "transcribe" : {
+        "endpoints" : {
+          "ap-southeast-2" : { },
+          "ca-central-1" : { },
+          "eu-west-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
           "us-west-2" : { }
         }
       },


### PR DESCRIPTION
Add region endpoints for missing services, as raised in the boto3 issue https://github.com/boto/boto3/issues/1662. Below is the original list of services with missing region specifications, as well as the source of the newly added regions, taken from either AWS documentation or the AWS console.

1. appsync (A)
1. cloudsearchdomain (B: under CloudSearch)
1. connect (A)
1. dlm (B: under EC2)
1. eks (A)
1. iot-jobs-data (B: under IoT Device Management)
1. iotanalytics (n/a - already exists in file)
1. macie (A)
1. mobile (A)
1. mq (A)
1. pi (B: under RDS)
1. transcribe (A)

A: [AWS region table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/)
B: [AWS console](https://console.aws.amazon.com)
