### PR TITLE
Refactor session config loading customization

### DIFF
--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -95,10 +95,10 @@ class DefaultConfigChainBuilder(object):
         return ChainProvider(providers=providers)
 
 
-class ConfigProvider(object):
-    """The ConfigProvider object loads configuration values lazily."""
+class ConfigProviderComponent(object):
+    """The ConfigProviderComponent object loads configuration values lazily."""
     def __init__(self, mapping=None):
-        """Initialize a ConfigProvider.
+        """Initialize a ConfigProviderComponent.
 
         :type mapping: dict
         :param mapping: The mapping parameter is a map of string to a subclass
@@ -158,6 +158,16 @@ class ConfigProvider(object):
 
         """
         self._cache[logical_name] = value
+
+    def update_mapping(self, new_mapping):
+        """Update the config mapping.
+
+        :type new_mapping: dict
+        :param new_mapping: The new mapping of logical names to config
+            providers. Each name in this map will be added to or override an
+            existing mapping.
+        """
+        self._mapping.update(new_mapping)
 
 
 class BaseConfigValueProvider(object):

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -17,17 +17,65 @@ import os
 import copy
 
 
+def create_botocore_default_config_mapping(chain_builder):
+    return {
+        'profile': chain_builder.build_config_chain(
+            env_vars=['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'],
+        ),
+        'region': chain_builder.build_config_chain(
+            env_vars='AWS_DEFAULT_REGION',
+            config_property='region',
+            default=None,
+        ),
+        'data_path': chain_builder.build_config_chain(
+            env_vars='AWS_DATA_PATH',
+            config_property='data_path',
+            default=None
+        ),
+        'config_file': chain_builder.build_config_chain(
+            env_vars='AWS_CONFIG_FILE',
+            default='~/.aws/config',
+        ),
+        'ca_bundle': chain_builder.build_config_chain(
+            env_vars='AWS_CA_BUNDLE',
+            config_property='ca_bundle',
+        ),
+        'api_versions': chain_builder.build_config_chain(
+            config_property='api_versions',
+            default={},
+        ),
+        'credentials_file': chain_builder.build_config_chain(
+            env_vars='AWS_SHARED_CREDENTIALS_FILE',
+            default='~/.aws/credentials',
+        ),
+        'metadata_service_timeout': chain_builder.build_config_chain(
+            env_vars='AWS_METADATA_SERVICE_TIMEOUT',
+            config_property='metadata_service_timeout',
+            default=1
+        ),
+        'metadata_service_num_attempts': chain_builder.build_config_chain(
+            env_vars='AWS_METADATA_SERVICE_NUM_ATTEMPTS',
+            config_property='metadata_service_num_attempts',
+            default=1
+        ),
+        'parameter_validation': chain_builder.build_config_chain(
+            config_property='parameter_validation',
+            default=True,
+        ),
+    }
+
+
 class DefaultConfigChainBuilder(object):
     """Common config builder.
 
-    This is a convenience class to construct them with that pattern to help
-    prevent ordering them incorrectly, and to make the config chain
-    construction more readable.
+    This is a convenience class to construct configuration chains that follow
+    our most common pattern. This is to prevent ordering them incorrectly,
+    and to make the config chain construction more readable.
     """
     def __init__(self, session, environ=None):
         """Initialzie a DefaultConfigChainBuilder.
 
-        :type session: A botocore session
+        :type session: :class:`botocore.session.Session`
         :param session: This is the session that should be used to look up
             values from the config file.
 

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -1,0 +1,215 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains the inteface for controlling how configuration
+is loaded.
+"""
+
+class ConfigProvider(object):
+    """The ConfigProvider object loads configuration values lazily."""
+    def __init__(self, mapping=None):
+        """Initialize a ConfigProvider.
+
+        :type mapping: dict
+        :param mapping: The mapping parameter is a map of string to a subclass
+            of ConfigValueProvider. When a config variable is asked for via the
+            get_config_variable method, the corresponding provider will be
+            invoked to load the value.
+        """
+        if mapping is None:
+            mapping = {}
+        self._mapping = mapping
+        self._cache = {}
+
+    def get_config_variable(self, logical_name):
+        """
+        Retrieve the value associeated with the specified logical_name
+        from the corresponding provider. If no value is found None will
+        be returned.
+
+        :type logical_name: str
+        :param logical_name: The logical name of the session variable
+            you want to retrieve.  This name will be mapped to the
+            appropriate environment variable name for this session as
+            well as the appropriate config file entry.
+
+        :returns: value of variable or None if not defined.
+        """
+        if logical_name in self._cache:
+            return self._cache[logical_name]
+        if logical_name not in self._mapping:
+            return None
+        provider = self._mapping[logical_name]
+        return provider.provide()
+
+    def set_config_variable(self, logical_name, value):
+        """Set a configuration variable to a specific value.
+
+        By using this method, you can override the normal lookup
+        process used in ``get_config_variable`` by explicitly setting
+        a value.  Subsequent calls to ``get_config_variable`` will
+        use the ``value``.  This gives you per-session specific
+        configuration values.
+
+        ::
+            >>> # Assume logical name 'foo' maps to env var 'FOO'
+            >>> os.environ['FOO'] = 'myvalue'
+            >>> s.get_config_variable('foo')
+            'myvalue'
+            >>> s.set_config_variable('foo', 'othervalue')
+            >>> s.get_config_variable('foo')
+            'othervalue'
+
+        :type logical_name: str
+        :param logical_name: The logical name of the session variable
+            you want to set.  These are the keys in ``SESSION_VARIABLES``.
+
+        :param value: The value to associate with the config variable.
+
+        """
+        self._cache[logical_name] = value
+
+
+class BaseConfigValueProvider(object):
+    """Base class for configuration value providers.
+
+    A configuration provider has some method of providing a configuration
+    value.
+    """
+    def provide(self):
+        raise NotImplementedError('provide')
+
+
+class ConstantValueProvider(object):
+    """This provider provides a constant value."""
+    def __init__(self, value):
+        self._value = value
+
+    def provide(self):
+        """Provide the constant value given during initialization."""
+        return self._value
+
+
+class DictConfigValueProvider(BaseConfigValueProvider):
+    """This class loads config values from an environment variable."""
+    def __init__(self, names, source):
+        """Initialize with the environment variable names to check.
+
+        :type environment_vars: str or list
+        :param environment_vars: If this is a str, the environment variable
+            with that name will be loaded and returned. If this variable is
+            a list, then it must be a list of str. The same process will be
+            repeated for each string in the list, the first that returns non
+            None will be returned.
+
+        :type source: dict
+        :param source: A source dictionary to fetch vairables from.
+        """
+        self._names = names
+        self._source = source
+
+    def provide(self):
+        """Provide a config value from a source."""
+        names = self._names
+        if not isinstance(names, list):
+            names = [names]
+        for name in names:
+            if name in self._source:
+                return self._source[name]
+        return None
+
+
+class ChainProvider(BaseConfigValueProvider):
+    """This provider wraps one or more other providers.
+
+    Each provider in the chain is called, the first one returning a non-None
+    value is then returned.
+    """
+    def __init__(self, providers=None, cast=None):
+        """Initalize a ChainProvider.
+
+        :type providers: list
+        :param providers: The initial list of providers to check for values
+            when invoked.
+
+        :type cast: None or callable
+        :param cast: If this value is None then it has no affect on the return
+            type. Otherwise, it is treated as a function that will cast our
+            provided type.
+        """
+        if providers is None:
+            providers = []
+        self._providers = providers
+        self._cast = cast
+
+    def append_provider(self, provider):
+        """Append a new provider to the end of the chain.
+
+        :type provider: Subclass of BaseConfigValueProvider
+        :param provider: The new ConfigValueProvider to add to the end of the
+            lookup chain.
+        """
+        self._providers.append(provider)
+
+    def prepend_provider(self, provider):
+        """Prepend a new provider to the beginning of the chain.
+
+        :type provider: Subclass of BaseConfigValueProvider
+        :param provider: The new ConfigValueProvider to prepend to the
+            beginning of the lookup chain.
+        """
+        self._providers.insert(0, provider)
+
+    def provide(self):
+        """Provide the value from the first provider to return non-None.
+
+        Each provider in the chain has its provide method called. The first
+        one in the chain to return a non-None value is the returned from the
+        ChainProvider. When no non-None value is found, None is returned.
+        """
+        for provider in self._providers:
+            value = provider.provide()
+            if value is not None:
+                return self._convert_type(value)
+        return None
+
+    def _convert_type(self, value):
+        if self._cast is not None:
+            return self._cast(value)
+        return value
+
+
+class ScopedConfigValueProvider(BaseConfigValueProvider):
+    def __init__(self, name, scoped_config_method):
+        """Initialize ScopedConfigValueProvider
+
+        :type name: str
+        :param name: The name of the config value to load from the scoped
+            config.
+
+        :type scoped_config_method: callable
+        :param scoped_config_method: A function that when called will return a
+            scoped config.
+        """
+        self._name = name
+        self._scoped_config_method = scoped_config_method
+
+    def provide(self):
+        """Provide a value from a scoped config.
+
+        This method first calls the scoped_config_method given to load the
+        scoped config. Once loaded it looks up the value in the config and
+        reutrns it.
+        """
+        scoped_config = self._scoped_config_method()
+        value = scoped_config.get(self._name)
+        return value

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -213,3 +213,12 @@ class ScopedConfigValueProvider(BaseConfigValueProvider):
         scoped_config = self._scoped_config_method()
         value = scoped_config.get(self._name)
         return value
+
+
+class LazyConstantValueProvider(BaseConfigValueProvider):
+    def __init__(self, source):
+        self._source = source
+
+    def provide(self):
+        value = self._source()
+        return value

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -99,8 +99,7 @@ def create_credential_resolver(session, cache=None):
         instance_metadata_provider
     ]
 
-    explicit_profile = session.get_config_variable('profile',
-                                                   methods=('instance',))
+    explicit_profile = session.get_config_variable('profile')
     if explicit_profile is not None:
         # An explicitly provided profile will negate an EnvProvider.
         # We will defer to providers that understand the "profile"

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -98,9 +98,7 @@ def create_credential_resolver(session, cache=None):
         container_provider,
         instance_metadata_provider
     ]
-
-    explicit_profile = session.get_config_variable('profile')
-    if explicit_profile is not None:
+    if session.instance_variables().get('profile') is not None:
         # An explicitly provided profile will negate an EnvProvider.
         # We will defer to providers that understand the "profile"
         # concept to retrieve credentials.

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -39,7 +39,7 @@ from botocore.exceptions import InfiniteLoopConfigError
 from botocore.exceptions import RefreshWithMFAUnsupportedError
 from botocore.exceptions import MetadataRetrievalError
 from botocore.exceptions import CredentialRetrievalError
-from botocore.utils import InstanceMetadataFetcher, parse_key_val_file
+from botocore.utils import InstanceMetadataCredentialFetcher, parse_key_val_file
 from botocore.utils import ContainerMetadataFetcher
 
 
@@ -67,7 +67,7 @@ def create_credential_resolver(session, cache=None):
     env_provider = EnvProvider()
     container_provider = ContainerProvider()
     instance_metadata_provider = InstanceMetadataProvider(
-        iam_role_fetcher=InstanceMetadataFetcher(
+        iam_role_fetcher=InstanceMetadataCredentialFetcher(
             timeout=metadata_timeout,
             num_attempts=num_attempts,
             user_agent=session.user_agent())

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -192,10 +192,6 @@ class Session(object):
             logical_name)
 
     def set_config_variable(self, logical_name, value):
-        self.self.get_component('config_provider').set_config_variable(
-            logical_name, value)
-
-    def _set_config_variable(self, logical_name, value):
         """Set a configuration variable to a specific value.
 
         By using this method, you can override the normal lookup
@@ -225,6 +221,9 @@ class Session(object):
             value,
         )
         self._session_instance_vars[logical_name] = value
+
+    def instance_variables(self):
+        return copy.copy(self._session_instance_vars)
 
     def get_scoped_config(self):
         """

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -27,11 +27,8 @@ import botocore.configloader
 import botocore.credentials
 import botocore.client
 from botocore.configprovider import ConfigProviderComponent
-from botocore.configprovider import DictConfigValueProvider
-from botocore.configprovider import ScopedConfigValueProvider
-from botocore.configprovider import ConstantValueProvider
-from botocore.configprovider import LazyConstantValueProvider
 from botocore.configprovider import DefaultConfigChainBuilder
+from botocore.configprovider import create_botocore_default_config_mapping
 from botocore.exceptions import ConfigNotFound, ProfileNotFound
 from botocore.exceptions import UnknownServiceError, PartialCredentialsError
 from botocore.errorfactory import ClientExceptionsFactory
@@ -165,51 +162,9 @@ class Session(object):
 
     def _register_config_provider(self):
         chain_builder = DefaultConfigChainBuilder(session=self)
-        config_provider_component = ConfigProviderComponent(mapping={
-            'profile': chain_builder.build_config_chain(
-                env_vars=['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'],
-            ),
-            'region': chain_builder.build_config_chain(
-                env_vars='AWS_DEFAULT_REGION',
-                config_property='region',
-                default=None,
-            ),
-            'data_path': chain_builder.build_config_chain(
-                env_vars='AWS_DATA_PATH',
-                config_property='data_path',
-                default=None
-            ),
-            'config_file': chain_builder.build_config_chain(
-                env_vars='AWS_CONFIG_FILE',
-                default='~/.aws/config',
-            ),
-            'ca_bundle': chain_builder.build_config_chain(
-                env_vars='AWS_CA_BUNDLE',
-                config_property='ca_bundle',
-            ),
-            'api_versions': chain_builder.build_config_chain(
-                config_property='api_versions',
-                default={},
-            ),
-            'credentials_file': chain_builder.build_config_chain(
-                env_vars='AWS_SHARED_CREDENTIALS_FILE',
-                default='~/.aws/credentials',
-            ),
-            'metadata_service_timeout': chain_builder.build_config_chain(
-                env_vars='AWS_METADATA_SERVICE_TIMEOUT',
-                config_property='metadata_service_timeout',
-                default=1
-            ),
-            'metadata_service_num_attempts': chain_builder.build_config_chain(
-                env_vars='AWS_METADATA_SERVICE_NUM_ATTEMPTS',
-                config_property='metadata_service_num_attempts',
-                default=1
-            ),
-            'parameter_validation': chain_builder.build_config_chain(
-                config_property='parameter_validation',
-                default=True,
-            ),
-        })
+        config_provider_component = ConfigProviderComponent(
+            mapping=create_botocore_default_config_mapping(chain_builder)
+        )
         self._components.register_component('config_provider',
                                             config_provider_component)
 

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -26,6 +26,11 @@ from botocore import __version__
 import botocore.configloader
 import botocore.credentials
 import botocore.client
+from botocore.configprovider import ChainProvider
+from botocore.configprovider import ConfigProvider
+from botocore.configprovider import DictConfigValueProvider
+from botocore.configprovider import ScopedConfigValueProvider
+from botocore.configprovider import ConstantValueProvider
 from botocore.exceptions import ConfigNotFound, ProfileNotFound
 from botocore.exceptions import UnknownServiceError, PartialCredentialsError
 from botocore.errorfactory import ClientExceptionsFactory
@@ -80,38 +85,38 @@ class Session(object):
     #: the ``env var`` is the OS environment variable (``os.environ``) to
     #: use, and ``default_value`` is the value to use if no value is otherwise
     #: found.
-    SESSION_VARIABLES = {
-        # logical:  config_file, env_var,        default_value, conversion_func
-        'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None),
-        'region': ('region', 'AWS_DEFAULT_REGION', None, None),
-        'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
-        'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
-        'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
-        'api_versions': ('api_versions', None, {}, None),
+    # SESSION_VARIABLES = {
+    #     # logical:  config_file, env_var,        default_value, conversion_func
+    #     'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None),
+    #     'region': ('region', 'AWS_DEFAULT_REGION', None, None),
+    #     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
+    #     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
+    #     'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
+    #     'api_versions': ('api_versions', None, {}, None),
 
-        # This is the shared credentials file amongst sdks.
-        'credentials_file': (None, 'AWS_SHARED_CREDENTIALS_FILE',
-                             '~/.aws/credentials', None),
+    #     # This is the shared credentials file amongst sdks.
+    #     'credentials_file': (None, 'AWS_SHARED_CREDENTIALS_FILE',
+    #                          '~/.aws/credentials', None),
 
-        # These variables only exist in the config file.
+    #     # These variables only exist in the config file.
 
-        # This is the number of seconds until we time out a request to
-        # the instance metadata service.
-        'metadata_service_timeout': (
-            'metadata_service_timeout',
-            'AWS_METADATA_SERVICE_TIMEOUT', 1, int),
-        # This is the number of request attempts we make until we give
-        # up trying to retrieve data from the instance metadata service.
-        'metadata_service_num_attempts': (
-            'metadata_service_num_attempts',
-            'AWS_METADATA_SERVICE_NUM_ATTEMPTS', 1, int),
-        'parameter_validation': ('parameter_validation', None, True, None),
-    }
+    #     # This is the number of seconds until we time out a request to
+    #     # the instance metadata service.
+    #     'metadata_service_timeout': (
+    #         'metadata_service_timeout',
+    #         'AWS_METADATA_SERVICE_TIMEOUT', 1, int),
+    #     # This is the number of request attempts we make until we give
+    #     # up trying to retrieve data from the instance metadata service.
+    #     'metadata_service_num_attempts': (
+    #         'metadata_service_num_attempts',
+    #         'AWS_METADATA_SERVICE_NUM_ATTEMPTS', 1, int),
+    #     'parameter_validation': ('parameter_validation', None, True, None),
+    # }
 
     #: The default format string to use when configuring the botocore logger.
     LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
-    def __init__(self, session_vars=None, event_hooks=None,
+    def __init__(self, config_provider=None, event_hooks=None,
                  include_builtin_handlers=True, profile=None):
         """
         Create a new Session object.
@@ -137,9 +142,12 @@ class Session(object):
             the session is created.
 
         """
-        self.session_var_map = copy.copy(self.SESSION_VARIABLES)
-        if session_vars:
-            self.session_var_map.update(session_vars)
+        # self.session_var_map = copy.copy(self.SESSION_VARIABLES)
+        # if session_vars:
+        #     self.session_var_map.update(session_vars)
+        if config_provider is None:
+            config_provider = self._create_default_config_provider()
+        self.config_provider = config_provider
         if event_hooks is None:
             self._original_handler = HierarchicalEmitter()
         else:
@@ -166,6 +174,106 @@ class Session(object):
         self._components = ComponentLocator()
         self._internal_components = ComponentLocator()
         self._register_components()
+
+    def _create_default_config_provider(self):
+        provider = ConfigProvider(
+            mapping={
+                'profile': ChainProvider(providers=[
+                    DictConfigValueProvider(
+                        names=['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'],
+                        source=os.environ,
+                    ),
+                ]),
+                'region': ChainProvider(providers=[
+                    DictConfigValueProvider(
+                        names='AWS_DEFAULT_REGION',
+                        source=os.environ,
+                    ),
+                    ScopedConfigValueProvider(
+                        name='region',
+                        scoped_config_method=self.get_scoped_config,
+                    ),
+                ]),
+                'data_path': ChainProvider(providers=[
+                    DictConfigValueProvider(
+                        names='AWS_DATA_PATH',
+                        source=os.environ,
+                    ),
+                    ScopedConfigValueProvider(
+                        name='data_path',
+                        scoped_config_method=self.get_scoped_config,
+                    ),
+
+                ]),
+                'config_file': ChainProvider(providers=[
+                    DictConfigValueProvider(
+                        names='AWS_CONFIG_FILE',
+                        source=os.environ,
+                    ),
+                    ConstantValueProvider(value='~/.aws/config'),
+                ]),
+                'ca_bundle': ChainProvider(providers=[
+                    DictConfigValueProvider(
+                        names='AWS_CA_BUNDLE',
+                        source=os.environ,
+                    ),
+                    ScopedConfigValueProvider(
+                        name='ca_bundle',
+                        scoped_config_method=self.get_scoped_config,
+                    ),
+                ]),
+                'api_versions': ChainProvider(providers=[
+                    ScopedConfigValueProvider(
+                        name='api_versions',
+                        scoped_config_method=self.get_scoped_config,
+                    ),
+                    ConstantValueProvider(value={}),
+                ]),
+                'credentials_file': ChainProvider(providers=[
+                    DictConfigValueProvider(
+                        names='AWS_SHARED_CREDENTIALS_FILE',
+                        source=os.environ,
+                    ),
+                    ConstantValueProvider(value='~/.aws/credentials'),
+                ]),
+                'metadata_service_timeout': ChainProvider(
+                    providers=[
+                        DictConfigValueProvider(
+                            names='AWS_METADATA_SERVICE_TIMEOUT',
+                            source=os.environ,
+                        ),
+                        ScopedConfigValueProvider(
+                            name='metadata_service_timeout',
+                            scoped_config_method=self.get_scoped_config,
+                        ),
+                        ConstantValueProvider(value=1),
+                    ],
+                    cast=int,
+                ),
+                'metadata_service_num_attempts': ChainProvider(
+                    providers=[
+                        DictConfigValueProvider(
+                            names='AWS_METADATA_SERVICE_NUM_ATTEMPTS',
+                            source=os.environ,
+                        ),
+                        ScopedConfigValueProvider(
+                            name='metadata_service_num_attempts',
+                            scoped_config_method=self.get_scoped_config,
+                        ),
+                        ConstantValueProvider(value=1),
+                    ],
+                    cast=int,
+                ),
+                'parameter_validation': ChainProvider(providers=[
+                    ScopedConfigValueProvider(
+                        name='parameter_validation',
+                        scoped_config_method=self.get_scoped_config,
+                    ),
+                    ConstantValueProvider(value=True),
+                ]),
+            },
+        )
+        return provider
 
     def _register_components(self):
         self._register_credential_provider()
@@ -235,7 +343,10 @@ class Session(object):
             self._profile = profile
         return self._profile
 
-    def get_config_variable(self, logical_name,
+    def get_config_variable(self, logical_name):
+        return self.config_provider.get_config_variable(logical_name)
+
+    def _get_config_variable(self, logical_name,
                             methods=('instance', 'env', 'config')):
         """
         Retrieve the value associated with the specified logical_name
@@ -322,6 +433,9 @@ class Session(object):
         return None
 
     def set_config_variable(self, logical_name, value):
+        self.config_provider.set_config_variable(logical_name, value)
+
+    def _set_config_variable(self, logical_name, value):
         """Set a configuration variable to a specific value.
 
         By using this method, you can override the normal lookup

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -30,7 +30,7 @@ class TestSession(unittest.TestCase):
 
     def test_profile_precedence(self):
         self.environ['AWS_PROFILE'] = 'from_env_var'
-        self.session.set_config_variable('profile',  'from_session_instance')
+        self.session.set_config_variable('profile', 'from_session_instance')
         self.assertEqual(self.session.profile, 'from_session_instance')
 
     def test_credentials_with_profile_precedence(self):
@@ -60,7 +60,8 @@ class TestSession(unittest.TestCase):
                 'aws_secret_access_key=shared_creds_sak\n'
             )
             f.flush()
-            self.session.set_config_variable('profile', 'from_session_instance')
+            self.session.set_config_variable('profile',
+                                             'from_session_instance')
             creds = self.session.get_credentials()
             self.assertEqual(creds.access_key, 'shared_creds_akid')
             self.assertEqual(creds.secret_key, 'shared_creds_sak')

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -19,7 +19,7 @@ import botocore.session as session
 from botocore.configprovider import ConfigProviderComponent
 from botocore.configprovider import BaseConfigValueProvider
 from botocore.configprovider import DictConfigValueProvider
-from botocore.configprovider import ScopedConfigValueProvider
+from botocore.configprovider import LazyDictValueProvider
 from botocore.configprovider import ConstantValueProvider
 from botocore.configprovider import ChainProvider
 from botocore.configprovider import DefaultConfigChainBuilder
@@ -265,13 +265,13 @@ class TestDictConfigValueProvider(unittest.TestCase):
         )
 
 
-class TestScopedConfigValueProvider(unittest.TestCase):
+class TestLazyDictValueProvider(unittest.TestCase):
     def assert_provides_value(self, source, name, expected_value):
         dict_loader = mock.Mock(autospec=True)
         dict_loader.return_value = source
-        provider = ScopedConfigValueProvider(
+        provider = LazyDictValueProvider(
             name=name,
-            scoped_config_method=dict_loader
+            source_method=dict_loader,
         )
         value = provider.provide()
         self.assertEqual(value, expected_value)

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -1,0 +1,254 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+import mock
+from nose.tools import assert_equal
+
+from botocore.configprovider import ConfigProvider
+from botocore.configprovider import BaseConfigValueProvider
+from botocore.configprovider import DictConfigValueProvider
+from botocore.configprovider import ScopedConfigValueProvider
+from botocore.configprovider import ConstantValueProvider
+from botocore.configprovider import ChainProvider
+
+
+class TestConfigProvider(unittest.TestCase):
+    def test_does_provide_none_if_no_variable_exists(self):
+        provider = ConfigProvider()
+        value = provider.get_config_variable('fake_variable')
+        self.assertIsNone(value)
+
+    def test_does_provide_value_if_variable_exists(self):
+        mock_value_provider = mock.Mock(spec=BaseConfigValueProvider)
+        mock_value_provider.provide.return_value = 'foo'
+        provider = ConfigProvider(mapping={
+            'fake_variable': mock_value_provider,
+        })
+        value = provider.get_config_variable('fake_variable')
+        self.assertEqual(value, 'foo')
+
+    def test_provided_value_is_cached(self):
+        mock_value_provider = mock.Mock(spec=BaseConfigValueProvider)
+        mock_value_provider.provide.return_value = 'foo'
+        provider = ConfigProvider(mapping={
+            'fake_variable': mock_value_provider,
+        })
+        value = provider.get_config_variable('fake_variable')
+        self.assertEqual(value, 'foo')
+
+        # Change the returned value to bar instead of foo. The value returned
+        # from the ConfigProvider should still be the cached foo from before.
+        mock_value_provider.provide.return_value = 'bar'
+        self.assertEqual(value, 'foo')
+
+    def test_can_set_variable(self):
+        provider = ConfigProvider()
+        provider.set_config_variable('fake_variable', 'foo')
+        value = provider.get_config_variable('fake_variable')
+        self.assertEquals(value, 'foo')
+
+    def test_set_variable_does_override_cache(self):
+        mock_value_provider = mock.Mock(spec=BaseConfigValueProvider)
+        mock_value_provider.provide.return_value = 'foo'
+        provider = ConfigProvider(mapping={
+            'fake_variable': mock_value_provider,
+        })
+        value = provider.get_config_variable('fake_variable')
+        self.assertEqual(value, 'foo')
+
+        provider.set_config_variable('fake_variable', 'bar')
+        value = provider.get_config_variable('fake_variable')
+        self.assertEqual(value, 'bar')
+
+
+class TestDictConfigValueProvider(unittest.TestCase):
+    def assert_does_provide(self, names, source, expected_value):
+        provider = DictConfigValueProvider(
+            names=names,
+            source=source,
+        )
+        value = provider.provide()
+        self.assertEquals(value, expected_value)
+
+    def test_does_provide_none_if_no_variable_exists(self):
+        self.assert_does_provide(
+            names='FOO',
+            source={},
+            expected_value=None,
+        )
+
+    def test_does_provide_value_if_variable_exists(self):
+        self.assert_does_provide(
+            names='FOO',
+            source={
+                'FOO': 'bar',
+            },
+            expected_value='bar',
+        )
+
+    def test_does_provide_none_if_no_variable_exists_in_list(self):
+        self.assert_does_provide(
+            names=['FOO'],
+            source={},
+            expected_value=None,
+        )
+
+    def test_does_provide_value_if_variable_exists_in_list(self):
+        self.assert_does_provide(
+            names=['FOO'],
+            source={
+                'FOO': 'bar',
+            },
+            expected_value='bar',
+        )
+
+    def test_does_provide_first_non_none_value_first(self):
+        self.assert_does_provide(
+            names=['FOO', 'BAR'],
+            source={
+                'FOO': 'baz',
+            },
+            expected_value='baz',
+        )
+
+    def test_does_provide_first_non_none_value_second(self):
+        self.assert_does_provide(
+            names=['FOO', 'BAR'],
+            source={
+                'BAR': 'baz',
+            },
+            expected_value='baz',
+        )
+
+    def test_does_provide_none_if_all_list_variables_are_none(self):
+        self.assert_does_provide(
+            names=['FOO', 'BAR'],
+            source={},
+            expected_value=None,
+        )
+
+    def test_does_provide_first_value_when_both_exist(self):
+        self.assert_does_provide(
+            names=['FOO', 'BAR'],
+            source={
+                'FOO': 'baz',
+                'BAR': 'buz',
+            },
+            expected_value='baz',
+        )
+
+
+class TestScopedConfigValueProvider(unittest.TestCase):
+    def assert_provides_value(self, source, name, expected_value):
+        dict_loader = mock.Mock(autospec=True)
+        dict_loader.return_value = source
+        provider = ScopedConfigValueProvider(
+            name=name,
+            scoped_config_method=dict_loader
+        )
+        value = provider.provide()
+        self.assertEqual(value, expected_value)
+
+    def test_can_provide_value(self):
+        self.assert_provides_value(
+            source={'foo': 'bar'},
+            name='foo',
+            expected_value='bar',
+        )
+
+    def test_does_provide_none_if_value_not_in_dict(self):
+        self.assert_provides_value(
+            source={},
+            name='foo',
+            expected_value=None,
+        )
+
+
+def _make_provider_that_returns(return_value):
+    provider = mock.Mock(spec=BaseConfigValueProvider)
+    provider.provide.return_value = return_value
+    return provider
+
+
+def _make_providers_that_return(return_values):
+    mocks = []
+    for return_value in return_values:
+        provider = _make_provider_that_returns(return_value)
+        mocks.append(provider)
+    return mocks
+
+
+def assert_chain_does_provide(providers, expected_value):
+    provider = ChainProvider(
+        providers=providers,
+    )
+    value = provider.provide()
+    assert_equal(value, expected_value)
+
+
+def test_chain_provider():
+    # Each case is a tuple with the first element being the return values
+    # from the providers in the ChainProvider in order. The second value is the
+    # expected return value from the ChainProvider.
+    cases = [
+        (None, []),
+        (None, [None]),
+        ('foo', ['foo']),
+        ('foo', ['foo', 'bar']),
+        ('bar', [None, 'bar']),
+        ('foo', ['foo', None]),
+        ('baz', [None, None, 'baz']),
+        ('bar', [None, 'bar', None]),
+        ('foo', ['foo', 'bar', None]),
+        ('foo', ['foo', 'bar', 'baz']),
+    ]
+    for case in cases:
+        yield assert_chain_does_provide, \
+            _make_providers_that_return(case[1]), \
+            case[0]
+
+
+class TestChainProvider(unittest.TestCase):
+    def test_can_prepend_to_chain(self):
+        chain_provider = ChainProvider(
+            providers=_make_providers_that_return(['foo'])
+        )
+        bar_provider = _make_provider_that_returns('bar')
+        chain_provider.prepend_provider(bar_provider)
+        value = chain_provider.provide()
+        self.assertEqual(value, 'bar')
+
+    def test_can_append_to_chain(self):
+        chain_provider = ChainProvider(
+            providers=_make_providers_that_return([None])
+        )
+        foo_provider = _make_provider_that_returns('foo')
+        chain_provider.append_provider(foo_provider)
+        value = chain_provider.provide()
+        self.assertEqual(value, 'foo')
+
+    def test_can_cast_provided_value(self):
+        chain_provider = ChainProvider(
+            providers=_make_providers_that_return(['1']),
+            cast=int,
+        )
+        value = chain_provider.provide()
+        self.assertIsInstance(value, int)
+        self.assertEqual(value, 1)
+
+
+class TestConstantValueProvider(unittest.TestCase):
+    def test_can_provide_value(self):
+        provider = ConstantValueProvider(value='foo')
+        value = provider.provide()
+        self.assertEqual(value, 'foo')

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -16,7 +16,7 @@ from nose.tools import assert_equal
 
 import botocore
 import botocore.session as session
-from botocore.configprovider import ConfigProvider
+from botocore.configprovider import ConfigProviderComponent
 from botocore.configprovider import BaseConfigValueProvider
 from botocore.configprovider import DictConfigValueProvider
 from botocore.configprovider import ScopedConfigValueProvider
@@ -103,16 +103,16 @@ class TestDefaultConfigChainBuilder(unittest.TestCase):
         )
 
 
-class TestConfigProvider(unittest.TestCase):
+class TestConfigProviderComponent(unittest.TestCase):
     def test_does_provide_none_if_no_variable_exists(self):
-        provider = ConfigProvider()
+        provider = ConfigProviderComponent()
         value = provider.get_config_variable('fake_variable')
         self.assertIsNone(value)
 
     def test_does_provide_value_if_variable_exists(self):
         mock_value_provider = mock.Mock(spec=BaseConfigValueProvider)
         mock_value_provider.provide.return_value = 'foo'
-        provider = ConfigProvider(mapping={
+        provider = ConfigProviderComponent(mapping={
             'fake_variable': mock_value_provider,
         })
         value = provider.get_config_variable('fake_variable')
@@ -121,19 +121,20 @@ class TestConfigProvider(unittest.TestCase):
     def test_provided_value_is_cached(self):
         mock_value_provider = mock.Mock(spec=BaseConfigValueProvider)
         mock_value_provider.provide.return_value = 'foo'
-        provider = ConfigProvider(mapping={
+        provider = ConfigProviderComponent(mapping={
             'fake_variable': mock_value_provider,
         })
         value = provider.get_config_variable('fake_variable')
         self.assertEqual(value, 'foo')
 
         # Change the returned value to bar instead of foo. The value returned
-        # from the ConfigProvider should still be the cached foo from before.
+        # from the ConfigProviderComponent should still be the cached foo from
+        # before.
         mock_value_provider.provide.return_value = 'bar'
         self.assertEqual(value, 'foo')
 
     def test_can_set_variable(self):
-        provider = ConfigProvider()
+        provider = ConfigProviderComponent()
         provider.set_config_variable('fake_variable', 'foo')
         value = provider.get_config_variable('fake_variable')
         self.assertEquals(value, 'foo')
@@ -141,7 +142,7 @@ class TestConfigProvider(unittest.TestCase):
     def test_set_variable_does_override_cache(self):
         mock_value_provider = mock.Mock(spec=BaseConfigValueProvider)
         mock_value_provider.provide.return_value = 'foo'
-        provider = ConfigProvider(mapping={
+        provider = ConfigProviderComponent(mapping={
             'fake_variable': mock_value_provider,
         })
         value = provider.get_config_variable('fake_variable')

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -29,6 +29,9 @@ from botocore.credentials import EnvProvider, create_assume_role_refresher
 from botocore.credentials import CredentialProvider, AssumeRoleProvider
 from botocore.credentials import ConfigProvider, SharedCredentialProvider
 from botocore.credentials import Credentials
+from botocore.configprovider import create_botocore_default_config_mapping
+from botocore.configprovider import DefaultConfigChainBuilder
+from botocore.configprovider import ConfigProviderComponent
 import botocore.exceptions
 import botocore.session
 from tests import unittest, BaseEnvVar, IntegerRefresher, skip_if_windows
@@ -1277,29 +1280,51 @@ class TestCreateCredentialResolver(BaseEnvVar):
     def setUp(self):
         super(TestCreateCredentialResolver, self).setUp()
 
-        self.session = mock.Mock()
-        self.session_instance_vars = {
+        self.session = mock.Mock(spec=botocore.session.Session)
+        self.session.get_component = self.fake_get_component
+
+        self.fake_instance_variables = {
             'credentials_file': 'a',
             'legacy_config_file': 'b',
             'config_file': 'c',
-            'metadata_service_timeout': 'd',
-            'metadata_service_num_attempts': 'e',
+            'metadata_service_timeout': 1,
+            'metadata_service_num_attempts': 1,
         }
         self.fake_env_vars = {}
-        self.session.get_config_variable = self.fake_get_config_variable
 
-    def fake_get_config_variable(self, name, methods=None):
-        if methods == ('instance',):
-            return self.session_instance_vars.get(name)
-        elif methods is not None and 'env' in methods:
-            return self.fake_env_vars.get(name)
+        chain_builder = DefaultConfigChainBuilder(
+            session=self.session,
+            environ=self.fake_env_vars,
+        )
+        self.config_loader = ConfigProviderComponent(
+            mapping=create_botocore_default_config_mapping(chain_builder)
+        )
+        for name, value in self.fake_instance_variables.items():
+            self.config_loader.set_config_variable(name, value)
+
+        self.session.get_config_variable = \
+            self.config_loader.get_config_variable
+        self.session.set_config_variable = \
+            self.fake_set_config_variable
+        self.session.instance_variables = self.fake_instance_variable_lookup
+
+    def fake_get_component(self, key):
+        if key == 'config_provider':
+            return self.config_loader
+        return None
+
+    def fake_instance_variable_lookup(self):
+        return self.fake_instance_variables
+
+    def fake_set_config_variable(self, logical_name, value):
+        self.fake_instance_variables[logical_name] = value
 
     def test_create_credential_resolver(self):
         resolver = credentials.create_credential_resolver(self.session)
         self.assertIsInstance(resolver, credentials.CredentialResolver)
 
     def test_explicit_profile_ignores_env_provider(self):
-        self.session_instance_vars['profile'] = 'dev'
+        self.session.set_config_variable('profile', 'dev')
         resolver = credentials.create_credential_resolver(self.session)
 
         self.assertTrue(
@@ -1307,7 +1332,7 @@ class TestCreateCredentialResolver(BaseEnvVar):
 
     def test_no_profile_checks_env_provider(self):
         # If no profile is provided,
-        self.session_instance_vars.pop('profile', None)
+        self.config_loader.set_config_variable('profile', None)
         resolver = credentials.create_credential_resolver(self.session)
         # Then an EnvProvider should be part of our credential lookup chain.
         self.assertTrue(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -143,22 +143,6 @@ class SessionTest(BaseSessionTest):
         self.environ['BAR_PROFILE'] = 'second'
         self.assertEqual(self.session.get_config_variable('profile'), 'second')
 
-    # def test_profile(self):
-    #     # TODO: I have no idea what this test is tryint to accomplish
-    #     self.assertEqual(self.session.get_config_variable('profile'), 'foo')
-    #     self.assertEqual(self.session.get_config_variable('region'),
-    #                      'us-west-11')
-    #     self.session.get_config_variable('profile') == 'default'
-    #     saved_region = self.environ['FOO_REGION']
-    #     del self.environ['FOO_REGION']
-    #     saved_profile = self.environ['FOO_PROFILE']
-    #     del self.environ['FOO_PROFILE']
-    #     session = create_session()
-    #     self.assertEqual(session.get_config_variable('profile'), None)
-    #     self.assertEqual(session.get_config_variable('region'), 'us-west-1')
-    #     self.environ['FOO_REGION'] = saved_region
-    #     self.environ['FOO_PROFILE'] = saved_profile
-
     def test_profile_does_not_exist_raises_exception(self):
         # Given we have no profile:
         self.environ['FOO_PROFILE'] = 'profile_that_does_not_exist'

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -28,21 +28,13 @@ from botocore import client
 from botocore.hooks import HierarchicalEmitter
 from botocore.waiter import WaiterModel
 from botocore.paginate import PaginatorModel
+from botocore.configprovider import DefaultConfigChainBuilder
 import botocore.loaders
 
 
 class BaseSessionTest(unittest.TestCase):
 
     def setUp(self):
-        self.env_vars = {
-            'profile': (None, 'FOO_PROFILE', None, None),
-            'region': ('foo_region', 'FOO_REGION', None, None),
-            'data_path': ('data_path', 'FOO_DATA_PATH', None, None),
-            'config_file': (None, 'FOO_CONFIG_FILE', None, None),
-            'credentials_file': (None, None, '/tmp/nowhere', None),
-            'ca_bundle': ('foo_ca_bundle', 'FOO_AWS_CA_BUNDLE', None, None),
-            'api_versions': ('foo_api_versions', None, {}, None)
-        }
         self.environ = {}
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
@@ -53,7 +45,56 @@ class BaseSessionTest(unittest.TestCase):
         config_path = os.path.join(os.path.dirname(__file__), 'cfg',
                                    'foo_config')
         self.environ['FOO_CONFIG_FILE'] = config_path
-        self.session = create_session(session_vars=self.env_vars)
+        self.session = create_session()
+        config_chain_builder = DefaultConfigChainBuilder(
+            session=self.session,
+            environ=self.environ,
+        )
+        self.session.get_component('config_provider').update_mapping(
+            {
+                'profile': config_chain_builder.build_config_chain(
+                    instance_var='profile',
+                    env_vars='FOO_PROFILE',
+                ),
+                'region': config_chain_builder.build_config_chain(
+                    instance_var='region',
+                    env_vars='FOO_REGION',
+                    config_property='foo_region',
+                ),
+                'data_path': config_chain_builder.build_config_chain(
+                    instance_var='data_path',
+                    env_vars='FOO_DATA_PATH',
+                    config_property='data_path',
+                ),
+                'config_file': config_chain_builder.build_config_chain(
+                    instance_var='config_file',
+                    env_vars='FOO_CONFIG_FILE',
+                ),
+                'credentials_file': config_chain_builder.build_config_chain(
+                    instance_var='credentials_file',
+                    default='/tmp/nowhere',
+                ),
+                'ca_bundle': config_chain_builder.build_config_chain(
+                    instance_var='ca_bundle',
+                    env_vars='FOO_AWS_CA_BUNDLE',
+                    config_property='foo_ca_bundle',
+                ),
+                'api_versions': config_chain_builder.build_config_chain(
+                    instance_var='api_versions',
+                    config_property='foo_api_versions',
+                    default={},
+                ),
+            }
+        )
+
+    def update_session_config_mapping(self, logical_name, **kwargs):
+        config_chain_builder = DefaultConfigChainBuilder(
+            session=self.session,
+            environ=self.environ,
+        )
+        self.session.get_component('config_provider').update_mapping({
+            logical_name: config_chain_builder.build_config_chain(**kwargs)
+        })
 
     def tearDown(self):
         self.environ_patch.stop()
@@ -77,17 +118,15 @@ class SessionTest(BaseSessionTest):
         shutil.rmtree(tempdir)
 
     def test_supports_multiple_env_vars_for_single_logical_name(self):
-        env_vars = {
-            'profile': (None, ['BAR_DEFAULT_PROFILE', 'BAR_PROFILE'],
-                        None, None),
-        }
-        session = create_session(session_vars=env_vars)
+        self.update_session_config_mapping(
+            'profile', env_vars=['BAR_DEFAULT_PROFILE', 'BAR_PROFILE']
+        )
         self.environ['BAR_DEFAULT_PROFILE'] = 'first'
         self.environ['BAR_PROFILE'] = 'second'
-        self.assertEqual(session.get_config_variable('profile'), 'first')
+        self.assertEqual(self.session.get_config_variable('profile'), 'first')
 
     def test_profile_when_set_explicitly(self):
-        session = create_session(session_vars=self.env_vars, profile='asdf')
+        session = create_session(profile='asdf')
         self.assertEqual(session.profile, 'asdf')
 
     def test_profile_when_pulled_from_env(self):
@@ -97,49 +136,44 @@ class SessionTest(BaseSessionTest):
         self.assertEqual(self.session.profile, 'bar')
 
     def test_multiple_env_vars_uses_second_var(self):
-        env_vars = {
-            'profile': (None, ['BAR_DEFAULT_PROFILE', 'BAR_PROFILE'],
-                        None, None),
-        }
-        session = create_session(session_vars=env_vars)
+        self.update_session_config_mapping(
+            'profile', env_vars=['BAR_DEFAULT_PROFILE', 'BAR_PROFILE']
+        )
         self.environ.pop('BAR_DEFAULT_PROFILE', None)
         self.environ['BAR_PROFILE'] = 'second'
-        self.assertEqual(session.get_config_variable('profile'), 'second')
+        self.assertEqual(self.session.get_config_variable('profile'), 'second')
 
-    def test_profile(self):
-        self.assertEqual(self.session.get_config_variable('profile'), 'foo')
-        self.assertEqual(self.session.get_config_variable('region'),
-                         'us-west-11')
-        self.session.get_config_variable('profile') == 'default'
-        saved_region = self.environ['FOO_REGION']
-        del self.environ['FOO_REGION']
-        saved_profile = self.environ['FOO_PROFILE']
-        del self.environ['FOO_PROFILE']
-        session = create_session(session_vars=self.env_vars)
-        self.assertEqual(session.get_config_variable('profile'), None)
-        self.assertEqual(session.get_config_variable('region'), 'us-west-1')
-        self.environ['FOO_REGION'] = saved_region
-        self.environ['FOO_PROFILE'] = saved_profile
+    # def test_profile(self):
+    #     # TODO: I have no idea what this test is tryint to accomplish
+    #     self.assertEqual(self.session.get_config_variable('profile'), 'foo')
+    #     self.assertEqual(self.session.get_config_variable('region'),
+    #                      'us-west-11')
+    #     self.session.get_config_variable('profile') == 'default'
+    #     saved_region = self.environ['FOO_REGION']
+    #     del self.environ['FOO_REGION']
+    #     saved_profile = self.environ['FOO_PROFILE']
+    #     del self.environ['FOO_PROFILE']
+    #     session = create_session()
+    #     self.assertEqual(session.get_config_variable('profile'), None)
+    #     self.assertEqual(session.get_config_variable('region'), 'us-west-1')
+    #     self.environ['FOO_REGION'] = saved_region
+    #     self.environ['FOO_PROFILE'] = saved_profile
 
     def test_profile_does_not_exist_raises_exception(self):
         # Given we have no profile:
         self.environ['FOO_PROFILE'] = 'profile_that_does_not_exist'
-        session = create_session(session_vars=self.env_vars)
         with self.assertRaises(botocore.exceptions.ProfileNotFound):
-            session.get_scoped_config()
+            self.session.get_scoped_config()
 
     def test_variable_does_not_exist(self):
-        session = create_session(session_vars=self.env_vars)
-        self.assertIsNone(session.get_config_variable('foo/bar'))
+        self.assertIsNone(self.session.get_config_variable('foo/bar'))
 
     def test_get_aws_services_in_alphabetical_order(self):
-        session = create_session(session_vars=self.env_vars)
-        services = session.get_available_services()
+        services = self.session.get_available_services()
         self.assertEqual(sorted(services), services)
 
     def test_profile_does_not_exist_with_default_profile(self):
-        session = create_session(session_vars=self.env_vars)
-        config = session.get_scoped_config()
+        config = self.session.get_scoped_config()
         # We should have loaded this properly, and we'll check
         # that foo_access_key which is defined in the config
         # file should be present in the loaded config dict.
@@ -149,14 +183,16 @@ class SessionTest(BaseSessionTest):
         # Specify that we can retrieve the var from the
         # FOO_TIMEOUT env var, with a conversion function
         # of int().
-        self.env_vars['metadata_service_timeout'] = (
-            None, 'FOO_TIMEOUT', None, int)
+        self.update_session_config_mapping(
+            'metadata_service_timeout',
+            env_vars='FOO_TIMEOUT',
+            cast=int,
+        )
         # Environment variables are always strings.
         self.environ['FOO_TIMEOUT'] = '10'
-        session = create_session(session_vars=self.env_vars)
         # But we should type convert this to a string.
         self.assertEqual(
-            session.get_config_variable('metadata_service_timeout'), 10)
+            self.session.get_config_variable('metadata_service_timeout'), 10)
 
     def test_default_profile_specified_raises_exception(self):
         # If you explicity set the default profile and you don't
@@ -165,12 +201,11 @@ class SessionTest(BaseSessionTest):
                                    'boto_config_empty')
         self.environ['FOO_CONFIG_FILE'] = config_path
         self.environ['FOO_PROFILE'] = 'default'
-        session = create_session(session_vars=self.env_vars)
         # In this case, even though we specified default, because
         # the boto_config_empty config file does not have a default
         # profile, we should be raising an exception.
         with self.assertRaises(botocore.exceptions.ProfileNotFound):
-            session.get_scoped_config()
+            self.session.get_scoped_config()
 
     def test_file_logger(self):
         tempdir = tempfile.mkdtemp()
@@ -224,8 +259,7 @@ class SessionTest(BaseSessionTest):
 
     def test_emitter_can_be_passed_in(self):
         events = HierarchicalEmitter()
-        session = create_session(session_vars=self.env_vars,
-                                 event_hooks=events)
+        session = create_session(event_hooks=events)
         calls = []
         handler = lambda **kwargs: calls.append(kwargs)
         events.register('foo', handler)
@@ -234,11 +268,10 @@ class SessionTest(BaseSessionTest):
         self.assertEqual(len(calls), 1)
 
     def test_emit_first_non_none(self):
-        session = create_session(session_vars=self.env_vars)
-        session.register('foo', lambda **kwargs: None)
-        session.register('foo', lambda **kwargs: 'first')
-        session.register('foo', lambda **kwargs: 'second')
-        response = session.emit_first_non_none_response('foo')
+        self.session.register('foo', lambda **kwargs: None)
+        self.session.register('foo', lambda **kwargs: 'first')
+        self.session.register('foo', lambda **kwargs: 'second')
+        response = self.session.emit_first_non_none_response('foo')
         self.assertEqual(response, 'first')
 
     @mock.patch('logging.getLogger')
@@ -291,16 +324,19 @@ class TestBuiltinEventHandlers(BaseSessionTest):
         self.handler_patch.stop()
 
     def test_registered_builtin_handlers(self):
-        session = botocore.session.Session(self.env_vars, None,
-                                           include_builtin_handlers=True)
+        session = create_session(include_builtin_handlers=True)
         session.emit('foo')
         self.assertTrue(self.foo_called)
 
 
 class TestSessionConfigurationVars(BaseSessionTest):
     def test_per_session_config_vars(self):
-        self.session.session_var_map['foobar'] = (None, 'FOOBAR',
-                                                  'default', None)
+        self.update_session_config_mapping(
+            'foobar',
+            instance_var='foobar',
+            env_vars='FOOBAR',
+            default='default',
+        )
         # Default value.
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
         # Retrieve from os environment variable.
@@ -312,14 +348,17 @@ class TestSessionConfigurationVars(BaseSessionTest):
         self.assertEqual(self.session.get_config_variable('foobar'),
                          'session-instance')
 
-        # Can disable this check via the ``methods`` arg.
+        # Back to default value.
         del self.environ['FOOBAR']
-        self.assertEqual(self.session.get_config_variable(
-            'foobar', methods=('env', 'config')), 'default')
+        self.session.set_config_variable('foobar', None)
+        self.assertEqual(self.session.get_config_variable('foobar'), 'default')
 
     def test_default_value_can_be_overriden(self):
-        self.session.session_var_map['foobar'] = (None, 'FOOBAR', 'default',
-                                                  None)
+        self.update_session_config_mapping(
+            'foobar',
+            env_vars='FOOBAR',
+            default='default',
+        )
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
 
 
@@ -374,8 +413,7 @@ class TestSessionUserAgent(BaseSessionTest):
 
 class TestConfigLoaderObject(BaseSessionTest):
     def test_config_loader_delegation(self):
-        session = create_session(session_vars=self.env_vars,
-                                 profile='credfile-profile')
+        session = create_session(profile='credfile-profile')
         with temporary_file('w') as f:
             f.write('[credfile-profile]\naws_access_key_id=a\n')
             f.write('aws_secret_access_key=b\n')
@@ -540,7 +578,6 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            self.session = create_session(session_vars=self.env_vars)
             f.write('[default]\n')
             f.write('foo_ca_bundle=config-certs.pem\n')
             f.flush()
@@ -570,7 +607,6 @@ class TestCreateClient(BaseSessionTest):
             # Set the ca cert using the config file
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            self.session = create_session(session_vars=self.env_vars)
             f.write('[default]\n')
             f.write('foo_ca_bundle=config-certs.pem\n')
             f.flush()
@@ -599,7 +635,6 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            self.session = create_session(session_vars=self.env_vars)
             f.write('[default]\n')
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n' % config_api_version)
@@ -617,7 +652,6 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            self.session = create_session(session_vars=self.env_vars)
             f.write('[default]\n')
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n'
@@ -644,7 +678,6 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            self.session = create_session(session_vars=self.env_vars)
             f.write('[default]\n')
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n' % config_api_version)


### PR DESCRIPTION
Adds a new session component to give more fine grained control over config variable loading. This PR maintains backwards compatibility with the existing `session_instance_vars` system while adding a new provider based component to the session. 

All of the classes located in `botocore/configprovider.py` are intended to be a part of the public API of a session and will need to maintain backwards compatibility.

cc @kyleknap @jamesls @JordonPhillips @dstufft @joguSD 