### PR TITLE
Raise better error when refresh fails

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -463,6 +463,19 @@ class RefreshableCredentials(Credentials):
         return parse(time_str)
 
     def _set_from_data(self, data):
+        expected_keys = ['access_key', 'secret_key', 'token', 'expiry_time']
+        if not data:
+            missing_keys = expected_keys
+        else:
+            missing_keys = [k for k in expected_keys if k not in data]
+
+        if missing_keys:
+            message = "Credential refresh failed, response did not contain: %s"
+            raise CredentialRetrievalError(
+                provider=self.method,
+                error_msg=message % ', '.join(missing_keys),
+            )
+
         self.access_key = data['access_key']
         self.secret_key = data['secret_key']
         self.token = data['token']

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -140,6 +140,30 @@ class TestRefreshableCredentials(TestCredentials):
         self.assertEqual(credential_set.secret_key, 'ORIGINAL-SECRET')
         self.assertEqual(credential_set.token, 'ORIGINAL-TOKEN')
 
+    def test_refresh_returns_empty_dict(self):
+        self.refresher.return_value = {}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+
+        with self.assertRaises(botocore.exceptions.CredentialRetrievalError):
+            self.creds.access_key
+
+    def test_refresh_returns_none(self):
+        self.refresher.return_value = None
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+
+        with self.assertRaises(botocore.exceptions.CredentialRetrievalError):
+            self.creds.access_key
+
+    def test_refresh_returns_partial_credentials(self):
+        self.refresher.return_value = {'access_key': 'akid'}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+
+        with self.assertRaises(botocore.exceptions.CredentialRetrievalError):
+            self.creds.access_key
+
 
 class TestDeferredRefreshableCredentials(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This will raise a somewhat more helpful error when refreshable credentials receive empty or partial credentials while attempting to refresh.

This doesn't solve boto/boto3#1751 per se, but it does make it a lot more obvious what happened.