### PR TITLE
Add missing paginator definitions for CloudFormation

### DIFF
--- a/botocore/data/cloudformation/2010-05-15/paginators-1.json
+++ b/botocore/data/cloudformation/2010-05-15/paginators-1.json
@@ -8,7 +8,23 @@
     "DescribeChangeSet": {
       "input_token": "NextToken",
       "output_token": "NextToken",
-      "result_key": "Changes"
+      "result_key": "Changes",
+      "non_aggregate_keys": [
+          "ChangeSetName",
+          "ChangeSetId",
+          "StackId",
+          "StackName",
+          "Description",
+          "Parameters",
+          "CreationTime",
+          "ExecutionStatus",
+          "Status",
+          "StatusReason",
+          "NotificationARNs",
+          "RollbackConfiguration",
+          "Capabilities",
+          "Tags"
+      ]
     },
     "DescribeStackEvents": {
       "input_token": "NextToken",

--- a/botocore/data/cloudformation/2010-05-15/paginators-1.json
+++ b/botocore/data/cloudformation/2010-05-15/paginators-1.json
@@ -1,5 +1,15 @@
 {
   "pagination": {
+    "DescribeAccountLimits": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "AccountLimits"
+    },
+    "DescribeChangeSet": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Changes"
+    },
     "DescribeStackEvents": {
       "input_token": "NextToken",
       "output_token": "NextToken",
@@ -10,6 +20,17 @@
       "output_token": "NextToken",
       "result_key": "Stacks"
     },
+    "ListChangeSets": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Summaries"
+    },
+    "ListStackInstances": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Summaries"
+    },
     "ListStackResources": {
       "input_token": "NextToken",
       "output_token": "NextToken",
@@ -19,6 +40,24 @@
       "input_token": "NextToken",
       "output_token": "NextToken",
       "result_key": "StackSummaries"
+    },
+    "ListStackSetOperationResults": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Summaries"
+    },
+    "ListStackSetOperations": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Summaries"
+    },
+    "ListStackSets": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Summaries"
     },
     "ListExports": {
       "input_token": "NextToken",


### PR DESCRIPTION
This adds the missing pagination definitions for the CloudFormation APIs, as described in #1462.

I've tested DescribeChangeSet and ListChangeSets and both work as expected after this change,

```
client = boto3.client('cloudformation', region_name='eu-west-1')

paginator = client.get_paginator('list_change_sets')
page_iterator = paginator.paginate(StackName='MyStack')

for page in page_iterator:
    print(page)
```