### PR TITLE
Add missing pagination definitions for CloudWatch Events

### DIFF
--- a/botocore/data/events/2015-10-07/paginators-1.json
+++ b/botocore/data/events/2015-10-07/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListRuleNamesByTarget": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "Limit",
+      "result_key": "RuleNames"
+    },
+    "ListRules": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "Limit",
+      "result_key": "Rules"
+    },
+    "ListTargetsByRule": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "Limit",
+      "result_key": "Targets"
+    }
+  }
 }


### PR DESCRIPTION
There are currently no pagination definitions for CloudWatch Events APIs.

I've created them from the API Reference for this PR. The list of definitions now matches the API reference and also the list missing in #1462.

```python
client = boto3.client('events', region_name='eu-west-1')

paginator = client.get_paginator('list_rules')
page_iterator = paginator.paginate(NamePrefix='RDS', PaginationConfig={'PageSize': 2})

for page in page_iterator:
    print(page)
```