### PR TITLE
Add support for duration_seconds in the profile for AssumeRole.

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -689,15 +689,19 @@ class AssumeRoleCredentialFetcher(CachedCredentialFetcher):
 
     def _assume_role_kwargs(self):
         """Get the arguments for assume role based on current configuration."""
-        assume_role_kwargs = self._assume_kwargs
+        assume_role_kwargs = deepcopy(self._assume_kwargs)
+
         mfa_serial = assume_role_kwargs.get('SerialNumber')
 
         if mfa_serial is not None:
             prompt = 'Enter MFA code for %s: ' % mfa_serial
             token_code = self._mfa_prompter(prompt)
-
-            assume_role_kwargs = deepcopy(assume_role_kwargs)
             assume_role_kwargs['TokenCode'] = token_code
+
+        duration_seconds = assume_role_kwargs.get('DurationSeconds')
+
+        if duration_seconds is not None:
+            assume_role_kwargs['DurationSeconds'] = duration_seconds
 
         return assume_role_kwargs
 
@@ -1235,6 +1239,10 @@ class AssumeRoleProvider(CredentialProvider):
         if mfa_serial is not None:
             extra_args['SerialNumber'] = mfa_serial
 
+        duration_seconds = role_config.get('duration_seconds')
+        if duration_seconds is not None:
+            extra_args['DurationSeconds'] = duration_seconds
+
         fetcher = AssumeRoleCredentialFetcher(
             client_creator=self._client_creator,
             source_credentials=source_credentials,
@@ -1267,6 +1275,7 @@ class AssumeRoleProvider(CredentialProvider):
         mfa_serial = profile.get('mfa_serial')
         external_id = profile.get('external_id')
         role_session_name = profile.get('role_session_name')
+        duration_seconds = profile.get('duration_seconds')
 
         role_config = {
             'role_arn': role_arn,
@@ -1276,6 +1285,12 @@ class AssumeRoleProvider(CredentialProvider):
             'source_profile': source_profile,
             'credential_source': credential_source
         }
+
+        if duration_seconds is not None:
+          try:
+            role_config['duration_seconds'] = int(duration_seconds)
+          except ValueError:
+            pass
 
         # Either the credential source or the source profile must be
         # specified, but not both.

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1773,6 +1773,51 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         client.assume_role.assert_called_with(
             RoleArn='myrole', ExternalId='myid', RoleSessionName=mock.ANY)
 
+    def test_assume_role_with_duration(self):
+        self.fake_config['profiles']['development']['duration_seconds'] = 7200 
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.AssumeRoleProvider(
+            self.create_config_loader(), client_creator,
+            cache={}, profile_name='development')
+
+        # The credentials won't actually be assumed until they're requested.
+        provider.load().get_frozen_credentials()
+
+        client = client_creator.return_value
+        client.assume_role.assert_called_with(
+            RoleArn='myrole', RoleSessionName=mock.ANY, 
+            DurationSeconds=7200)
+
+    def test_assume_role_with_bad_duration(self):
+        self.fake_config['profiles']['development']['duration_seconds'] = 'garbage value'
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        provider = credentials.AssumeRoleProvider(
+            self.create_config_loader(), client_creator,
+            cache={}, profile_name='development')
+
+        # The credentials won't actually be assumed until they're requested.
+        provider.load().get_frozen_credentials()
+
+        client = client_creator.return_value
+        client.assume_role.assert_called_with(
+            RoleArn='myrole', RoleSessionName=mock.ANY)
+
     def test_assume_role_with_mfa(self):
         self.fake_config['profiles']['development']['mfa_serial'] = 'mfa'
         response = {


### PR DESCRIPTION
Currently assume role support in profiles does not support setting the token duration. This means you cannot use this convenient feature if you need a token with a lifetime of something other than the default 3600 seconds. This PR addresses this by adding a duration_seconds option for the profile.