### PR TITLE
Add property methods support for get_config_variable in session

### DIFF
--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -348,6 +348,16 @@ class TestSessionConfigurationVars(BaseSessionTest):
         )
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
 
+    def test_can_get_with_methods(self):
+        self.environ['AWS_DEFAULT_REGION'] = 'env-var'
+        self.session.set_config_variable('region', 'instance-var')
+        value = self.session.get_config_variable('region')
+        self.assertEqual(value, 'instance-var')
+
+        value = self.session.get_config_variable(
+            'region', methods=('env',))
+        self.assertEqual(value, 'env-var')
+
 
 class TestSessionPartitionFiles(BaseSessionTest):
     def test_lists_partitions_on_disk(self):


### PR DESCRIPTION
Before any config variables added using the old style with tuples
after a session had been initialized would support the methods
arugment on get_config_variable. However; the default botocore
config variables did not since they were loaded using the new method.

The assumption that if you were using the old method to set them then
you could use the old method to fetch them is not true since the CLI
depends on the methods argument when fetching botocore config
variables.