### PR TITLE
Add the SESSION_VARIABLES back to the session object

### DIFF
--- a/.changes/next-release/bugfix-sessionconfig-62324.json
+++ b/.changes/next-release/bugfix-sessionconfig-62324.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "session config",
+  "description": "Added the default session configuration tuples back to session.session_vars_map."
+}

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -30,6 +30,7 @@ import botocore.client
 from botocore.configprovider import ConfigValueStore
 from botocore.configprovider import ConfigChainFactory
 from botocore.configprovider import create_botocore_default_config_mapping
+from botocore.configprovider import BOTOCORE_DEFAUT_SESSION_VARIABLES
 from botocore.exceptions import ConfigNotFound, ProfileNotFound
 from botocore.exceptions import UnknownServiceError, PartialCredentialsError
 from botocore.errorfactory import ClientExceptionsFactory
@@ -59,6 +60,8 @@ class Session(object):
         file associated with this session.
     :ivar profile: The current profile.
     """
+
+    SESSION_VARIABLES = copy.copy(BOTOCORE_DEFAUT_SESSION_VARIABLES)
 
     #: The default format string to use when configuring the botocore logger.
     LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -115,7 +118,9 @@ class Session(object):
         self._components = ComponentLocator()
         self._internal_components = ComponentLocator()
         self._register_components()
-        self.session_var_map = SessionVarDict(self, session_vars)
+        self.session_var_map = SessionVarDict(self, self.SESSION_VARIABLES)
+        if session_vars is not None:
+            self.session_var_map.update(session_vars)
 
     def _register_components(self):
         self._register_credential_provider()
@@ -890,10 +895,7 @@ class ComponentLocator(object):
 class SessionVarDict(collections.MutableMapping):
     def __init__(self, session, session_vars):
         self._session = session
-        self._store = dict()
-        if session_vars is not None:
-            for key, value in session_vars.items():
-                self.__setitem__(key, value)
+        self._store = copy.copy(session_vars)
 
     def __getitem__(self, key):
         return self._store[key]

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -309,11 +309,6 @@ class TestSessionConfigurationVars(BaseSessionTest):
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
         # Retrieve from os environment variable.
         self.environ['FOOBAR'] = 'fromenv'
-        # This line is added from the original tests. Since environment
-        # variables cannot be changed from outside the process it makes little
-        # sense to ensure that they respect changes in the session. Clearing
-        # cache manually here.
-        self.session.set_config_variable('foobar', None)
         self.assertEqual(self.session.get_config_variable('foobar'), 'fromenv')
 
         # Explicit override.
@@ -330,6 +325,42 @@ class TestSessionConfigurationVars(BaseSessionTest):
         self.session.session_var_map['foobar'] = (None, 'FOOBAR', 'default',
                                                   None)
         self.assertEqual(self.session.get_config_variable('foobar'), 'default')
+
+    def test_can_get_session_vars_info_from_default_session(self):
+        # This test is to ensure that you can still reach the session_vars_map
+        # information from the session and that it has the expected value.
+        self.session = create_session()
+        self.assertEqual(self.session.session_var_map['region'],
+                         ('region', 'AWS_DEFAULT_REGION', None, None))
+        self.assertEqual(
+            self.session.session_var_map['profile'],
+            (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None))
+        self.assertEqual(
+            self.session.session_var_map['data_path'],
+            ('data_path', 'AWS_DATA_PATH', None, None))
+        self.assertEqual(
+            self.session.session_var_map['config_file'],
+            (None, 'AWS_CONFIG_FILE', '~/.aws/config', None))
+        self.assertEqual(
+            self.session.session_var_map['ca_bundle'],
+            ('ca_bundle', 'AWS_CA_BUNDLE', None, None))
+        self.assertEqual(
+            self.session.session_var_map['api_versions'],
+            ('api_versions', None, {}, None))
+        self.assertEqual(
+            self.session.session_var_map['credentials_file'],
+            (None, 'AWS_SHARED_CREDENTIALS_FILE', '~/.aws/credentials', None))
+        self.assertEqual(
+            self.session.session_var_map['metadata_service_timeout'],
+            ('metadata_service_timeout',
+             'AWS_METADATA_SERVICE_TIMEOUT', 1, int))
+        self.assertEqual(
+            self.session.session_var_map['metadata_service_num_attempts'],
+            ('metadata_service_num_attempts',
+             'AWS_METADATA_SERVICE_NUM_ATTEMPTS', 1, int))
+        self.assertEqual(
+            self.session.session_var_map['parameter_validation'],
+            ('parameter_validation', None, True, None))
 
 
 class TestSessionPartitionFiles(BaseSessionTest):


### PR DESCRIPTION
The session.session_vars_map was a publicly accessible map that used to
have tuples that configured how variables were loaded, this map was
removed in favor of a new system. The new system is still in place but
the tuples have been put back so that they can be read from the session.