### PR TITLE
Fix non deterministic sig selection

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -514,8 +514,8 @@ class ClientEndpointBridge(object):
                 return 'v4'
             # Now just iterate over the signature versions in order until we
             # find the first one that is known to Botocore.
-            for known in AUTH_TYPE_MAPS:
-                if known in potential_versions:
+            for known in potential_versions:
+                if known in AUTH_TYPE_MAPS:
                     return known
         raise UnknownSignatureVersionError(
             signature_version=resolved.get('signatureVersions'))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1892,6 +1892,16 @@ class TestClientEndpointBridge(unittest.TestCase):
         with self.assertRaises(UnknownSignatureVersionError):
             bridge.resolve('test', 'us-west-2')
 
+    def test_uses_first_known_signature_version(self):
+        resolver = mock.Mock()
+        resolver.construct_endpoint.return_value = {
+            'partition': 'aws', 'hostname': 'test',
+            'endpointName': 'us-west-2',
+            'signatureVersions': ['foo', 'bar', 'baz', 's3v4', 'v2']}
+        bridge = ClientEndpointBridge(resolver)
+        resolved = bridge.resolve('test', 'us-west-2')
+        self.assertEqual('s3v4', resolved['signature_version'])
+
     def test_raises_when_signature_version_is_not_found(self):
         resolver = mock.Mock()
         resolver.construct_endpoint.return_value = {


### PR DESCRIPTION
Signature version selection was selecting the first known value
it found in the AUTH_TYPE_MAP instead of the potential_versions list it
gets from the endpoints file. In python 3.6+ this is an ordered dict
implicitly so it would always choose earlier entries in the
AUTH_TYPE_MAP which are not ordered in any significant way. In earlier
versions of python the map is not deterministically ordered, so the
signature selection would not be deterministic.

This change fixes the selection logic to pick the first known version
from the endpoints file instead.