### PR TITLE
Add paginators for appstream

### DIFF
--- a/botocore/data/appstream/2016-12-01/paginators-1.json
+++ b/botocore/data/appstream/2016-12-01/paginators-1.json
@@ -26,7 +26,7 @@
     "DescribeSessions": {
       "input_token": "NextToken",
       "output_token": "NextToken",
-      "limit_key": "MaxResults",
+      "limit_key": "Limit",
       "result_key": "Sessions"
     },
     "DescribeStacks": {

--- a/botocore/data/appstream/2016-12-01/paginators-1.json
+++ b/botocore/data/appstream/2016-12-01/paginators-1.json
@@ -1,3 +1,60 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeDirectoryConfigs": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "DirectoryConfigs"
+    },
+    "DescribeFleets": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Fleets"
+    },
+    "DescribeImageBuilders": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "ImageBuilders"
+    },
+    "DescribeImages": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Images"
+    },
+    "DescribeSessions": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Sessions"
+    },
+    "DescribeStacks": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Stacks"
+    },
+    "DescribeUserStackAssociations": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "UserStackAssociations"
+    },
+    "DescribeUsers": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Users"
+    },
+    "ListAssociatedFleets": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Names"
+    },
+    "ListAssociatedStacks": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Names"
+    }
+  }
 }


### PR DESCRIPTION
All but [describe_image_permissions](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/appstream.html#AppStream.Client.describe_image_permissions) were added because it returns both a `Name` and a `SharedImagePermissionsList` in the top-level. Not sure how to handle that.