### PR TITLE
Make tests pass after 2020

### DIFF
--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -2562,7 +2562,7 @@ class TestProcessProvider(BaseEnvVar):
             'AccessKeyId': 'foo',
             'SecretAccessKey': 'bar',
             'SessionToken': 'baz',
-            'Expiration': '2020-01-01T00:00:00Z',
+            'Expiration': '2999-01-01T00:00:00Z',
         })
 
         provider = self.create_process_provider()
@@ -2588,7 +2588,7 @@ class TestProcessProvider(BaseEnvVar):
             'AccessKeyId': 'foo',
             'SecretAccessKey': 'bar',
             'SessionToken': 'baz',
-            'Expiration': '2020-01-01T00:00:00Z',
+            'Expiration': '2999-01-01T00:00:00Z',
         })
 
         provider = self.create_process_provider()
@@ -2655,7 +2655,7 @@ class TestProcessProvider(BaseEnvVar):
             'AccessKeyId': 'foo',
             'SecretAccessKey': 'bar',
             'SessionToken': 'baz',
-            'Expiration': '2020-01-01T00:00:00Z',
+            'Expiration': '2999-01-01T00:00:00Z',
         })
 
         provider = self.create_process_provider()
@@ -2672,7 +2672,7 @@ class TestProcessProvider(BaseEnvVar):
             'AccessKeyId': 'foo',
             'SecretAccessKey': 'bar',
             'SessionToken': 'baz',
-            'Expiration': '2020-01-01T00:00:00Z',
+            'Expiration': '2999-01-01T00:00:00Z',
         })
 
         provider = self.create_process_provider()
@@ -2689,7 +2689,7 @@ class TestProcessProvider(BaseEnvVar):
             # Missing access key.
             'SecretAccessKey': 'bar',
             'SessionToken': 'baz',
-            'Expiration': '2020-01-01T00:00:00Z',
+            'Expiration': '2999-01-01T00:00:00Z',
         })
 
         provider = self.create_process_provider()
@@ -2706,7 +2706,7 @@ class TestProcessProvider(BaseEnvVar):
             'AccessKeyId': 'foo',
             # Missing secret key.
             'SessionToken': 'baz',
-            'Expiration': '2020-01-01T00:00:00Z',
+            'Expiration': '2999-01-01T00:00:00Z',
         })
 
         provider = self.create_process_provider()
@@ -2723,7 +2723,7 @@ class TestProcessProvider(BaseEnvVar):
             'AccessKeyId': 'foo',
             'SecretAccessKey': 'bar',
             # Missing session token.
-            'Expiration': '2020-01-01T00:00:00Z',
+            'Expiration': '2999-01-01T00:00:00Z',
         })
 
         provider = self.create_process_provider()


### PR DESCRIPTION
Without this patch, at least 2 tests failed in 2020 because their
'refreshed' credentials were still expired.

This PR was done while working on reproducible builds for openSUSE.
For that, we test that our packages can still give identical build results in the future, which is impossible if the build fails.

See https://reproducible-builds.org/ for why this matters.