### PR TITLE
Add PendingDeprecationWarning to internal requests methods

### DIFF
--- a/botocore/vendored/requests/api.py
+++ b/botocore/vendored/requests/api.py
@@ -10,8 +10,18 @@ This module implements the Requests API.
 :license: Apache2, see LICENSE for more details.
 
 """
+import warnings
 
 from . import sessions
+
+
+_WARNING_MSG = (
+    "You are using the {name}() function from 'botocore.vendored.requests'.  "
+    "This is not a public API in botocore and will be removed in the future. "
+    "Additionally, this version of requests is out of date.  We recommend "
+    "you install the requests package, 'import requests' directly, and use "
+    "the requests.{name}() function instead."
+)
 
 
 def request(method, url, **kwargs):
@@ -45,6 +55,10 @@ def request(method, url, **kwargs):
       >>> req = requests.request('GET', 'http://httpbin.org/get')
       <Response [200]>
     """
+    warnings.warn(
+        _WARNING_MSG.format(name=method),
+        PendingDeprecationWarning
+    )
 
     session = sessions.Session()
     response = session.request(method=method, url=url, **kwargs)


### PR DESCRIPTION
This produces no output yet unless you explicitly turn on
warnings.  In a future release we'll have this emit a warning
by default.

I opted to put this in the high level `botocore.vendored.requests.*`
methods because that's the more common usage of requests and I wanted
better error messages.  Moving it to the `Session.request` method
would mean we couldn't give as helpful of an error message.

## Testing

```
$ cat driver.py
from botocore.vendored import requests


print(requests.get('https://httpbin.org'))
print(requests.head('https://httpbin.org'))

$ python driver.py
<Response [200]>
<Response [200]>

$ python -Wd driver.py
/botocore/botocore/vendored/requests/api.py:60: PendingDeprecationWarning: You are using the get() function from 'botocore.vendored.requests'.  This is not a public API in botocore and will be removed in the future. Additionally, this version of requests is out of date.  We recommend you install the requests package, 'import requests' directly, and use the requests.get() function instead.
  PendingDeprecationWarning
<Response [200]>
/botocore/botocore/vendored/requests/api.py:60: PendingDeprecationWarning: You are using the head() function from 'botocore.vendored.requests'.  This is not a public API in botocore and will be removed in the future. Additionally, this version of requests is out of date.  We recommend you install the requests package, 'import requests' directly, and use the requests.head() function instead.
  PendingDeprecationWarning
<Response [200]>
```