### PR TITLE
Add better error message for unknown limit key

### DIFF
--- a/tests/functional/test_paginator_config.py
+++ b/tests/functional/test_paginator_config.py
@@ -95,8 +95,9 @@ def _validate_input_keys_match(operation_name, page_config, service_model):
         limit_key = page_config['limit_key']
         if limit_key not in valid_input_names:
             raise AssertionError("limit_key '%s' refers to a non existent "
-                                 "input member for operation: %s"
-                                 % (limit_key, operation_name))
+                                 "input member for operation: %s, valid keys: "
+                                 "%s" % (limit_key, operation_name,
+                                         ', '.join(list(valid_input_names))))
 
 
 def _validate_output_keys_match(operation_name, page_config, service_model):


### PR DESCRIPTION
Error messages now look like:

```
$ nosetests tests/functional/test_paginator_config.py -x
.............................................................................................................................................................F
======================================================================
FAIL: tests.functional.test_paginator_config.test_lint_pagination_configs(u'DescribeVolumes', OrderedDict([(u'input_token', u'NextToken'), (u'output_token', u'NextToken'), (u'limit_key', u'MaxResultsFoo'), (u'result_key', u'Volumes')]), ServiceModel(ec2))
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".virtualenvs/aws-cli/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "botocore/tests/functional/test_paginator_config.py", line 51, in _lint_single_paginator
    _validate_input_keys_match(operation_name, page_config, service_model)
  File "botocore/tests/functional/test_paginator_config.py", line 100, in _validate_input_keys_match
    ', '.join(list(valid_input_names))))
AssertionError: limit_key 'MaxResultsFoo' refers to a non existent input member for operation: DescribeVolumes, valid keys: Filters, VolumeIds, DryRun, MaxResults, NextToken

----------------------------------------------------------------------
Ran 158 tests in 2.397s

FAILED (failures=1)
```