### PR TITLE
Add generated paginators

### DIFF
--- a/.changes/next-release/enhancement-Paginator-44918.json
+++ b/.changes/next-release/enhancement-Paginator-44918.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Paginator",
+  "description": "Added over 400 new paginators."
+}

--- a/botocore/data/alexaforbusiness/2017-11-09/paginators-1.json
+++ b/botocore/data/alexaforbusiness/2017-11-09/paginators-1.json
@@ -41,6 +41,42 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "ListBusinessReportSchedules": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "BusinessReportSchedules"
+    },
+    "ListConferenceProviders": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ConferenceProviders"
+    },
+    "ListDeviceEvents": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DeviceEvents"
+    },
+    "ListSkillsStoreCategories": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "CategoryList"
+    },
+    "ListSkillsStoreSkillsByCategory": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SkillsStoreSkills"
+    },
+    "ListSmartHomeAppliances": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SmartHomeAppliances"
     }
   }
 }

--- a/botocore/data/amplify/2017-07-25/paginators-1.json
+++ b/botocore/data/amplify/2017-07-25/paginators-1.json
@@ -1,3 +1,28 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListApps": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "apps"
+    },
+    "ListBranches": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "branches"
+    },
+    "ListDomainAssociations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "domainAssociations"
+    },
+    "ListJobs": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "jobSummaries"
+    }
+  }
 }

--- a/botocore/data/apigateway/2015-07-09/paginators-1.json
+++ b/botocore/data/apigateway/2015-07-09/paginators-1.json
@@ -71,6 +71,42 @@
       "limit_key": "limit",
       "output_token": "position",
       "result_key": "items"
+    },
+    "GetAuthorizers": {
+      "input_token": "position",
+      "limit_key": "limit",
+      "output_token": "position",
+      "result_key": "items"
+    },
+    "GetDocumentationParts": {
+      "input_token": "position",
+      "limit_key": "limit",
+      "output_token": "position",
+      "result_key": "items"
+    },
+    "GetDocumentationVersions": {
+      "input_token": "position",
+      "limit_key": "limit",
+      "output_token": "position",
+      "result_key": "items"
+    },
+    "GetGatewayResponses": {
+      "input_token": "position",
+      "limit_key": "limit",
+      "output_token": "position",
+      "result_key": "items"
+    },
+    "GetRequestValidators": {
+      "input_token": "position",
+      "limit_key": "limit",
+      "output_token": "position",
+      "result_key": "items"
+    },
+    "GetSdkTypes": {
+      "input_token": "position",
+      "limit_key": "limit",
+      "output_token": "position",
+      "result_key": "items"
     }
   }
 }

--- a/botocore/data/apigatewayv2/2018-11-29/paginators-1.json
+++ b/botocore/data/apigatewayv2/2018-11-29/paginators-1.json
@@ -1,3 +1,64 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetApis": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetAuthorizers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetDeployments": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetDomainNames": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetIntegrationResponses": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetIntegrations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetModels": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetRouteResponses": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetRoutes": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    },
+    "GetStages": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    }
+  }
 }

--- a/botocore/data/application-autoscaling/2016-02-06/paginators-1.json
+++ b/botocore/data/application-autoscaling/2016-02-06/paginators-1.json
@@ -17,6 +17,12 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults",
       "result_key": "ScalingPolicies"
+    },
+    "DescribeScheduledActions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ScheduledActions"
     }
   }
 }

--- a/botocore/data/appsync/2017-07-25/paginators-1.json
+++ b/botocore/data/appsync/2017-07-25/paginators-1.json
@@ -1,3 +1,46 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListApiKeys": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "apiKeys"
+    },
+    "ListDataSources": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "dataSources"
+    },
+    "ListFunctions": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "functions"
+    },
+    "ListGraphqlApis": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "graphqlApis"
+    },
+    "ListResolvers": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "resolvers"
+    },
+    "ListResolversByFunction": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "resolvers"
+    },
+    "ListTypes": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "types"
+    }
+  }
 }

--- a/botocore/data/autoscaling-plans/2018-01-06/paginators-1.json
+++ b/botocore/data/autoscaling-plans/2018-01-06/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeScalingPlanResources": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ScalingPlanResources"
+    },
+    "DescribeScalingPlans": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ScalingPlans"
+    }
+  }
 }

--- a/botocore/data/autoscaling/2011-01-01/paginators-1.json
+++ b/botocore/data/autoscaling/2011-01-01/paginators-1.json
@@ -47,6 +47,18 @@
       "output_token": "NextToken",
       "limit_key": "MaxRecords",
       "result_key": "Tags"
+    },
+    "DescribeLoadBalancerTargetGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxRecords",
+      "output_token": "NextToken",
+      "result_key": "LoadBalancerTargetGroups"
+    },
+    "DescribeLoadBalancers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxRecords",
+      "output_token": "NextToken",
+      "result_key": "LoadBalancers"
     }
   }
 }

--- a/botocore/data/batch/2016-08-10/paginators-1.json
+++ b/botocore/data/batch/2016-08-10/paginators-1.json
@@ -1,3 +1,28 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeComputeEnvironments": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "computeEnvironments"
+    },
+    "DescribeJobDefinitions": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "jobDefinitions"
+    },
+    "DescribeJobQueues": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "jobQueues"
+    },
+    "ListJobs": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "jobSummaryList"
+    }
+  }
 }

--- a/botocore/data/budgets/2016-10-20/paginators-1.json
+++ b/botocore/data/budgets/2016-10-20/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeBudgets": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Budgets"
+    },
+    "DescribeNotificationsForBudget": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Notifications"
+    },
+    "DescribeSubscribersForNotification": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Subscribers"
+    }
+  }
 }

--- a/botocore/data/chime/2018-05-01/paginators-1.json
+++ b/botocore/data/chime/2018-05-01/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListAccounts": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Accounts"
+    },
+    "ListUsers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Users"
+    }
+  }
 }

--- a/botocore/data/clouddirectory/2017-01-11/paginators-1.json
+++ b/botocore/data/clouddirectory/2017-01-11/paginators-1.json
@@ -95,6 +95,24 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "ListIncomingTypedLinks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "LinkSpecifiers"
+    },
+    "ListManagedSchemaArns": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SchemaArns"
+    },
+    "ListOutgoingTypedLinks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TypedLinkSpecifiers"
     }
   }
 }

--- a/botocore/data/cloudhsm/2014-05-30/paginators-1.json
+++ b/botocore/data/cloudhsm/2014-05-30/paginators-1.json
@@ -1,3 +1,19 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListHapgs": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "HapgList"
+    },
+    "ListHsms": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "HsmList"
+    },
+    "ListLunaClients": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "ClientList"
+    }
+  }
 }

--- a/botocore/data/cloudtrail/2013-11-01/paginators-1.json
+++ b/botocore/data/cloudtrail/2013-11-01/paginators-1.json
@@ -5,6 +5,16 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults",
       "result_key": "Events"
+    },
+    "ListPublicKeys": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "PublicKeyList"
+    },
+    "ListTags": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "ResourceTagList"
     }
   }
 }

--- a/botocore/data/cloudwatch/2010-08-01/paginators-1.json
+++ b/botocore/data/cloudwatch/2010-08-01/paginators-1.json
@@ -21,6 +21,12 @@
       "input_token": "NextToken",
       "output_token": "NextToken",
       "result_key": "Metrics"
+    },
+    "GetMetricData": {
+      "input_token": "NextToken",
+      "limit_key": "MaxDatapoints",
+      "output_token": "NextToken",
+      "result_key": "MetricDataResults"
     }
   }
 }

--- a/botocore/data/codedeploy/2014-10-06/paginators-1.json
+++ b/botocore/data/codedeploy/2014-10-06/paginators-1.json
@@ -29,6 +29,21 @@
       "input_token": "nextToken",
       "output_token": "nextToken",
       "result_key": "deployments"
+    },
+    "ListDeploymentTargets": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "targetIds"
+    },
+    "ListGitHubAccountTokenNames": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "tokenNameList"
+    },
+    "ListOnPremisesInstances": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "instanceNames"
     }
   }
 }

--- a/botocore/data/codepipeline/2015-07-09/paginators-1.json
+++ b/botocore/data/codepipeline/2015-07-09/paginators-1.json
@@ -1,3 +1,26 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListActionTypes": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "actionTypes"
+    },
+    "ListPipelineExecutions": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "pipelineExecutionSummaries"
+    },
+    "ListPipelines": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "pipelines"
+    },
+    "ListWebhooks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "webhooks"
+    }
+  }
 }

--- a/botocore/data/codestar/2017-04-19/paginators-1.json
+++ b/botocore/data/codestar/2017-04-19/paginators-1.json
@@ -1,3 +1,28 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListProjects": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "projects"
+    },
+    "ListResources": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "resources"
+    },
+    "ListTeamMembers": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "teamMembers"
+    },
+    "ListUserProfiles": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "userProfiles"
+    }
+  }
 }

--- a/botocore/data/cognito-identity/2014-06-30/paginators-1.json
+++ b/botocore/data/cognito-identity/2014-06-30/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListIdentityPools": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "IdentityPools"
+    }
+  }
 }

--- a/botocore/data/cognito-idp/2016-04-18/paginators-1.json
+++ b/botocore/data/cognito-idp/2016-04-18/paginators-1.json
@@ -1,3 +1,52 @@
 {
-  "pagination": {}
+  "pagination": {
+    "AdminListGroupsForUser": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Groups"
+    },
+    "AdminListUserAuthEvents": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "AuthEvents"
+    },
+    "ListGroups": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Groups"
+    },
+    "ListIdentityProviders": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Providers"
+    },
+    "ListResourceServers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ResourceServers"
+    },
+    "ListUserPoolClients": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "UserPoolClients"
+    },
+    "ListUserPools": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "UserPools"
+    },
+    "ListUsersInGroup": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Users"
+    }
+  }
 }

--- a/botocore/data/comprehend/2017-11-27/paginators-1.json
+++ b/botocore/data/comprehend/2017-11-27/paginators-1.json
@@ -5,6 +5,48 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "ListDocumentClassificationJobs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DocumentClassificationJobPropertiesList"
+    },
+    "ListDocumentClassifiers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DocumentClassifierPropertiesList"
+    },
+    "ListDominantLanguageDetectionJobs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DominantLanguageDetectionJobPropertiesList"
+    },
+    "ListEntitiesDetectionJobs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "EntitiesDetectionJobPropertiesList"
+    },
+    "ListEntityRecognizers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "EntityRecognizerPropertiesList"
+    },
+    "ListKeyPhrasesDetectionJobs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "KeyPhrasesDetectionJobPropertiesList"
+    },
+    "ListSentimentDetectionJobs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SentimentDetectionJobPropertiesList"
     }
   }
 }

--- a/botocore/data/config/2014-11-12/paginators-1.json
+++ b/botocore/data/config/2014-11-12/paginators-1.json
@@ -35,6 +35,59 @@
       "input_token": "nextToken",
       "output_token": "nextToken",
       "result_key": "resourceIdentifiers"
+    },
+    "DescribeAggregateComplianceByConfigRules": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "AggregateComplianceByConfigRules"
+    },
+    "DescribeAggregationAuthorizations": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "AggregationAuthorizations"
+    },
+    "DescribeConfigRuleEvaluationStatus": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "ConfigRulesEvaluationStatus"
+    },
+    "DescribeConfigurationAggregatorSourcesStatus": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "AggregatedSourceStatusList"
+    },
+    "DescribeConfigurationAggregators": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "ConfigurationAggregators"
+    },
+    "DescribePendingAggregationRequests": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "PendingAggregationRequests"
+    },
+    "DescribeRetentionConfigurations": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "RetentionConfigurations"
+    },
+    "GetAggregateComplianceDetailsByConfigRule": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "AggregateEvaluationResults"
+    },
+    "ListAggregateDiscoveredResources": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "ResourceIdentifiers"
     }
   }
 }

--- a/botocore/data/connect/2017-08-08/paginators-1.json
+++ b/botocore/data/connect/2017-08-08/paginators-1.json
@@ -1,3 +1,34 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetMetricData": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "MetricResults"
+    },
+    "ListRoutingProfiles": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "RoutingProfileSummaryList"
+    },
+    "ListSecurityProfiles": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SecurityProfileSummaryList"
+    },
+    "ListUserHierarchyGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "UserHierarchyGroupSummaryList"
+    },
+    "ListUsers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "UserSummaryList"
+    }
+  }
 }

--- a/botocore/data/datasync/2018-11-09/paginators-1.json
+++ b/botocore/data/datasync/2018-11-09/paginators-1.json
@@ -1,3 +1,34 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListAgents": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Agents"
+    },
+    "ListLocations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Locations"
+    },
+    "ListTagsForResource": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Tags"
+    },
+    "ListTaskExecutions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TaskExecutions"
+    },
+    "ListTasks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Tasks"
+    }
+  }
 }

--- a/botocore/data/dax/2017-04-19/paginators-1.json
+++ b/botocore/data/dax/2017-04-19/paginators-1.json
@@ -1,3 +1,45 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeClusters": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Clusters"
+    },
+    "DescribeDefaultParameters": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Parameters"
+    },
+    "DescribeEvents": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Events"
+    },
+    "DescribeParameterGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ParameterGroups"
+    },
+    "DescribeParameters": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Parameters"
+    },
+    "DescribeSubnetGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SubnetGroups"
+    },
+    "ListTags": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Tags"
+    }
+  }
 }

--- a/botocore/data/devicefarm/2015-06-23/paginators-1.json
+++ b/botocore/data/devicefarm/2015-06-23/paginators-1.json
@@ -72,6 +72,39 @@
       "input_token": "nextToken",
       "output_token": "nextToken",
       "result_key": "offerings"
+    },
+    "ListDeviceInstances": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "deviceInstances"
+    },
+    "ListInstanceProfiles": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "instanceProfiles"
+    },
+    "ListNetworkProfiles": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "networkProfiles"
+    },
+    "ListOfferingPromotions": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "offeringPromotions"
+    },
+    "ListRemoteAccessSessions": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "remoteAccessSessions"
+    },
+    "ListVPCEConfigurations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "vpceConfigurations"
     }
   }
 }

--- a/botocore/data/directconnect/2012-10-25/paginators-1.json
+++ b/botocore/data/directconnect/2012-10-25/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeDirectConnectGatewayAssociations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "directConnectGatewayAssociations"
+    },
+    "DescribeDirectConnectGatewayAttachments": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "directConnectGatewayAttachments"
+    },
+    "DescribeDirectConnectGateways": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "directConnectGateways"
+    }
+  }
 }

--- a/botocore/data/discovery/2015-11-01/paginators-1.json
+++ b/botocore/data/discovery/2015-11-01/paginators-1.json
@@ -1,3 +1,40 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeAgents": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "agentsInfo"
+    },
+    "DescribeContinuousExports": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "descriptions"
+    },
+    "DescribeExportConfigurations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "exportsInfo"
+    },
+    "DescribeExportTasks": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "exportsInfo"
+    },
+    "DescribeTags": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "tags"
+    },
+    "ListConfigurations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "configurations"
+    }
+  }
 }

--- a/botocore/data/ds/2015-04-16/paginators-1.json
+++ b/botocore/data/ds/2015-04-16/paginators-1.json
@@ -5,6 +5,54 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "Limit"
+    },
+    "DescribeDirectories": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "DirectoryDescriptions"
+    },
+    "DescribeSharedDirectories": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "SharedDirectories"
+    },
+    "DescribeSnapshots": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Snapshots"
+    },
+    "DescribeTrusts": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Trusts"
+    },
+    "ListIpRoutes": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "IpRoutesInfo"
+    },
+    "ListLogSubscriptions": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "LogSubscriptions"
+    },
+    "ListSchemaExtensions": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "SchemaExtensionsInfo"
+    },
+    "ListTagsForResource": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Tags"
     }
   }
 }

--- a/botocore/data/dynamodb/2012-08-10/paginators-1.json
+++ b/botocore/data/dynamodb/2012-08-10/paginators-1.json
@@ -37,6 +37,11 @@
       "non_aggregate_keys": [
         "ConsumedCapacity"
       ]
+    },
+    "ListTagsOfResource": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Tags"
     }
   }
 }

--- a/botocore/data/ec2/2016-11-15/paginators-1.json
+++ b/botocore/data/ec2/2016-11-15/paginators-1.json
@@ -112,6 +112,246 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults",
       "result_key": "VpcEndpointConnections"
+    },
+    "DescribeByoipCidrs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ByoipCidrs"
+    },
+    "DescribeCapacityReservations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "CapacityReservations"
+    },
+    "DescribeClassicLinkInstances": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Instances"
+    },
+    "DescribeClientVpnAuthorizationRules": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "AuthorizationRules"
+    },
+    "DescribeClientVpnConnections": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Connections"
+    },
+    "DescribeClientVpnEndpoints": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ClientVpnEndpoints"
+    },
+    "DescribeClientVpnRoutes": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Routes"
+    },
+    "DescribeClientVpnTargetNetworks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ClientVpnTargetNetworks"
+    },
+    "DescribeEgressOnlyInternetGateways": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "EgressOnlyInternetGateways"
+    },
+    "DescribeFleets": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Fleets"
+    },
+    "DescribeFlowLogs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "FlowLogs"
+    },
+    "DescribeFpgaImages": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "FpgaImages"
+    },
+    "DescribeHostReservationOfferings": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "OfferingSet"
+    },
+    "DescribeHostReservations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "HostReservationSet"
+    },
+    "DescribeHosts": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Hosts"
+    },
+    "DescribeImportImageTasks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ImportImageTasks"
+    },
+    "DescribeImportSnapshotTasks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ImportSnapshotTasks"
+    },
+    "DescribeInstanceCreditSpecifications": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "InstanceCreditSpecifications"
+    },
+    "DescribeLaunchTemplateVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "LaunchTemplateVersions"
+    },
+    "DescribeLaunchTemplates": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "LaunchTemplates"
+    },
+    "DescribeMovingAddresses": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "MovingAddressStatuses"
+    },
+    "DescribeNetworkInterfacePermissions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "NetworkInterfacePermissions"
+    },
+    "DescribePrefixLists": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "PrefixLists"
+    },
+    "DescribePrincipalIdFormat": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Principals"
+    },
+    "DescribePublicIpv4Pools": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "PublicIpv4Pools"
+    },
+    "DescribeScheduledInstanceAvailability": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ScheduledInstanceAvailabilitySet"
+    },
+    "DescribeScheduledInstances": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ScheduledInstanceSet"
+    },
+    "DescribeStaleSecurityGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "StaleSecurityGroupSet"
+    },
+    "DescribeTransitGatewayAttachments": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TransitGatewayAttachments"
+    },
+    "DescribeTransitGatewayRouteTables": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TransitGatewayRouteTables"
+    },
+    "DescribeTransitGatewayVpcAttachments": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TransitGatewayVpcAttachments"
+    },
+    "DescribeTransitGateways": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TransitGateways"
+    },
+    "DescribeVolumesModifications": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "VolumesModifications"
+    },
+    "DescribeVpcClassicLinkDnsSupport": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Vpcs"
+    },
+    "DescribeVpcEndpointConnectionNotifications": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ConnectionNotificationSet"
+    },
+    "DescribeVpcEndpointServiceConfigurations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ServiceConfigurations"
+    },
+    "DescribeVpcEndpointServicePermissions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "AllowedPrincipals"
+    },
+    "GetTransitGatewayAttachmentPropagations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TransitGatewayAttachmentPropagations"
+    },
+    "GetTransitGatewayRouteTableAssociations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Associations"
+    },
+    "GetTransitGatewayRouteTablePropagations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TransitGatewayRouteTablePropagations"
     }
   }
 }

--- a/botocore/data/ecs/2014-11-13/paginators-1.json
+++ b/botocore/data/ecs/2014-11-13/paginators-1.json
@@ -35,6 +35,18 @@
       "output_token": "nextToken",
       "limit_key": "maxResults",
       "result_key": "serviceArns"
+    },
+    "ListAccountSettings": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "settings"
+    },
+    "ListAttributes": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "attributes"
     }
   }
 }

--- a/botocore/data/eks/2017-11-01/paginators-1.json
+++ b/botocore/data/eks/2017-11-01/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListClusters": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "clusters"
+    },
+    "ListUpdates": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "updateIds"
+    }
+  }
 }

--- a/botocore/data/elasticbeanstalk/2010-12-01/paginators-1.json
+++ b/botocore/data/elasticbeanstalk/2010-12-01/paginators-1.json
@@ -5,6 +5,30 @@
       "output_token": "NextToken",
       "limit_key": "MaxRecords",
       "result_key": "Events"
+    },
+    "DescribeApplicationVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxRecords",
+      "output_token": "NextToken",
+      "result_key": "ApplicationVersions"
+    },
+    "DescribeEnvironmentManagedActionHistory": {
+      "input_token": "NextToken",
+      "limit_key": "MaxItems",
+      "output_token": "NextToken",
+      "result_key": "ManagedActionHistoryItems"
+    },
+    "DescribeEnvironments": {
+      "input_token": "NextToken",
+      "limit_key": "MaxRecords",
+      "output_token": "NextToken",
+      "result_key": "Environments"
+    },
+    "ListPlatformVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxRecords",
+      "output_token": "NextToken",
+      "result_key": "PlatformSummaryList"
     }
   }
 }

--- a/botocore/data/elb/2012-06-01/paginators-1.json
+++ b/botocore/data/elb/2012-06-01/paginators-1.json
@@ -5,6 +5,12 @@
       "output_token": "NextMarker",
       "result_key": "LoadBalancerDescriptions",
       "limit_key": "PageSize"
+    },
+    "DescribeAccountLimits": {
+      "input_token": "Marker",
+      "limit_key": "PageSize",
+      "output_token": "NextMarker",
+      "result_key": "Limits"
     }
   }
 }

--- a/botocore/data/elbv2/2015-12-01/paginators-1.json
+++ b/botocore/data/elbv2/2015-12-01/paginators-1.json
@@ -17,6 +17,30 @@
       "output_token": "NextMarker",
       "limit_key": "PageSize",
       "result_key": "Listeners"
+    },
+    "DescribeAccountLimits": {
+      "input_token": "Marker",
+      "limit_key": "PageSize",
+      "output_token": "NextMarker",
+      "result_key": "Limits"
+    },
+    "DescribeListenerCertificates": {
+      "input_token": "Marker",
+      "limit_key": "PageSize",
+      "output_token": "NextMarker",
+      "result_key": "Certificates"
+    },
+    "DescribeRules": {
+      "input_token": "Marker",
+      "limit_key": "PageSize",
+      "output_token": "NextMarker",
+      "result_key": "Rules"
+    },
+    "DescribeSSLPolicies": {
+      "input_token": "Marker",
+      "limit_key": "PageSize",
+      "output_token": "NextMarker",
+      "result_key": "SslPolicies"
     }
   }
 }

--- a/botocore/data/emr/2009-03-31/paginators-1.json
+++ b/botocore/data/emr/2009-03-31/paginators-1.json
@@ -29,6 +29,11 @@
       "input_token": "Marker",
       "output_token": "Marker",
       "result_key": "InstanceFleets"
+    },
+    "ListSecurityConfigurations": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "result_key": "SecurityConfigurations"
     }
   }
 }

--- a/botocore/data/es/2015-01-01/paginators-1.json
+++ b/botocore/data/es/2015-01-01/paginators-1.json
@@ -11,6 +11,24 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "DescribeReservedElasticsearchInstanceOfferings": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ReservedElasticsearchInstanceOfferings"
+    },
+    "DescribeReservedElasticsearchInstances": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ReservedElasticsearchInstances"
+    },
+    "GetUpgradeHistory": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "UpgradeHistories"
     }
   }
 }

--- a/botocore/data/fms/2018-01-01/paginators-1.json
+++ b/botocore/data/fms/2018-01-01/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListComplianceStatus": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "PolicyComplianceStatusList"
+    },
+    "ListMemberAccounts": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "MemberAccounts"
+    },
+    "ListPolicies": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "PolicyList"
+    }
+  }
 }

--- a/botocore/data/fsx/2018-03-01/paginators-1.json
+++ b/botocore/data/fsx/2018-03-01/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeBackups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Backups"
+    },
+    "DescribeFileSystems": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "FileSystems"
+    },
+    "ListTagsForResource": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Tags"
+    }
+  }
 }

--- a/botocore/data/gamelift/2015-10-01/paginators-1.json
+++ b/botocore/data/gamelift/2015-10-01/paginators-1.json
@@ -1,3 +1,100 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeFleetAttributes": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "FleetAttributes"
+    },
+    "DescribeFleetCapacity": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "FleetCapacity"
+    },
+    "DescribeFleetEvents": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Events"
+    },
+    "DescribeFleetUtilization": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "FleetUtilization"
+    },
+    "DescribeGameSessionDetails": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "GameSessionDetails"
+    },
+    "DescribeGameSessionQueues": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "GameSessionQueues"
+    },
+    "DescribeGameSessions": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "GameSessions"
+    },
+    "DescribeInstances": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Instances"
+    },
+    "DescribeMatchmakingConfigurations": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Configurations"
+    },
+    "DescribeMatchmakingRuleSets": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "RuleSets"
+    },
+    "DescribePlayerSessions": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "PlayerSessions"
+    },
+    "DescribeScalingPolicies": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "ScalingPolicies"
+    },
+    "ListAliases": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Aliases"
+    },
+    "ListBuilds": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "Builds"
+    },
+    "ListFleets": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "FleetIds"
+    },
+    "SearchGameSessions": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "GameSessions"
+    }
+  }
 }

--- a/botocore/data/globalaccelerator/2018-08-08/paginators-1.json
+++ b/botocore/data/globalaccelerator/2018-08-08/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListAccelerators": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Accelerators"
+    },
+    "ListEndpointGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "EndpointGroups"
+    },
+    "ListListeners": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Listeners"
+    }
+  }
 }

--- a/botocore/data/glue/2017-03-31/paginators-1.json
+++ b/botocore/data/glue/2017-03-31/paginators-1.json
@@ -77,6 +77,12 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "GetSecurityConfigurations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SecurityConfigurations"
     }
   }
 }

--- a/botocore/data/greengrass/2017-06-07/paginators-1.json
+++ b/botocore/data/greengrass/2017-06-07/paginators-1.json
@@ -1,118 +1,118 @@
 {
   "pagination": {
-    "ListTrainingJobs": {
-      "result_key": "TrainingJobSummaries",
-      "output_token": "NextToken",
-      "input_token": "NextToken",
-      "limit_key": "MaxResults"
-    },
-    "ListEndpoints": {
-      "result_key": "Endpoints",
-      "output_token": "NextToken",
-      "input_token": "NextToken",
-      "limit_key": "MaxResults"
-    },
-    "ListEndpointConfigs": {
-      "result_key": "EndpointConfigs",
-      "output_token": "NextToken",
-      "input_token": "NextToken",
-      "limit_key": "MaxResults"
-    },
-    "ListNotebookInstances": {
-      "result_key": "NotebookInstances",
-      "output_token": "NextToken",
-      "input_token": "NextToken",
-      "limit_key": "MaxResults"
-    },
-    "ListTags": {
-      "result_key": "Tags",
-      "output_token": "NextToken",
-      "input_token": "NextToken",
-      "limit_key": "MaxResults"
-    },
-    "ListModels": {
-      "result_key": "Models",
-      "output_token": "NextToken",
-      "input_token": "NextToken",
-      "limit_key": "MaxResults"
-    },
-    "ListAlgorithms": {
+    "ListBulkDeploymentDetailedReports": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "AlgorithmSummaryList"
+      "result_key": "Deployments"
     },
-    "ListCodeRepositories": {
+    "ListBulkDeployments": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "CodeRepositorySummaryList"
+      "result_key": "BulkDeployments"
     },
-    "ListCompilationJobs": {
+    "ListConnectorDefinitionVersions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "CompilationJobSummaries"
+      "result_key": "Versions"
     },
-    "ListHyperParameterTuningJobs": {
+    "ListConnectorDefinitions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "HyperParameterTuningJobSummaries"
+      "result_key": "Definitions"
     },
-    "ListLabelingJobs": {
+    "ListCoreDefinitionVersions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "LabelingJobSummaryList"
+      "result_key": "Versions"
     },
-    "ListLabelingJobsForWorkteam": {
+    "ListCoreDefinitions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "LabelingJobSummaryList"
+      "result_key": "Definitions"
     },
-    "ListModelPackages": {
+    "ListDeployments": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "ModelPackageSummaryList"
+      "result_key": "Deployments"
     },
-    "ListNotebookInstanceLifecycleConfigs": {
+    "ListDeviceDefinitionVersions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "NotebookInstanceLifecycleConfigs"
+      "result_key": "Versions"
     },
-    "ListSubscribedWorkteams": {
+    "ListDeviceDefinitions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "SubscribedWorkteams"
+      "result_key": "Definitions"
     },
-    "ListTrainingJobsForHyperParameterTuningJob": {
+    "ListFunctionDefinitionVersions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "TrainingJobSummaries"
+      "result_key": "Versions"
     },
-    "ListTransformJobs": {
+    "ListFunctionDefinitions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "TransformJobSummaries"
+      "result_key": "Definitions"
     },
-    "ListWorkteams": {
+    "ListGroupVersions": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "Workteams"
+      "result_key": "Versions"
     },
-    "Search": {
+    "ListGroups": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "Results"
+      "result_key": "Groups"
+    },
+    "ListLoggerDefinitionVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Versions"
+    },
+    "ListLoggerDefinitions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Definitions"
+    },
+    "ListResourceDefinitionVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Versions"
+    },
+    "ListResourceDefinitions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Definitions"
+    },
+    "ListSubscriptionDefinitionVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Versions"
+    },
+    "ListSubscriptionDefinitions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Definitions"
     }
   }
 }

--- a/botocore/data/inspector/2016-02-16/paginators-1.json
+++ b/botocore/data/inspector/2016-02-16/paginators-1.json
@@ -47,6 +47,12 @@
       "output_token": "nextToken",
       "input_token": "nextToken",
       "limit_key": "maxResults"
+    },
+    "ListExclusions": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "exclusionArns"
     }
   }
 }

--- a/botocore/data/iot/2015-05-28/paginators-1.json
+++ b/botocore/data/iot/2015-05-28/paginators-1.json
@@ -65,6 +65,161 @@
       "output_token": "nextToken",
       "limit_key": "maxResults",
       "result_key": "rules"
+    },
+    "ListActiveViolations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "activeViolations"
+    },
+    "ListAttachedPolicies": {
+      "input_token": "marker",
+      "limit_key": "pageSize",
+      "output_token": "nextMarker",
+      "result_key": "policies"
+    },
+    "ListAuditFindings": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "findings"
+    },
+    "ListAuditTasks": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "tasks"
+    },
+    "ListAuthorizers": {
+      "input_token": "marker",
+      "limit_key": "pageSize",
+      "output_token": "nextMarker",
+      "result_key": "authorizers"
+    },
+    "ListBillingGroups": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "billingGroups"
+    },
+    "ListIndices": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "indexNames"
+    },
+    "ListJobExecutionsForJob": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "executionSummaries"
+    },
+    "ListJobExecutionsForThing": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "executionSummaries"
+    },
+    "ListJobs": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "jobs"
+    },
+    "ListOTAUpdates": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "otaUpdates"
+    },
+    "ListRoleAliases": {
+      "input_token": "marker",
+      "limit_key": "pageSize",
+      "output_token": "nextMarker",
+      "result_key": "roleAliases"
+    },
+    "ListScheduledAudits": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "scheduledAudits"
+    },
+    "ListSecurityProfiles": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "securityProfileIdentifiers"
+    },
+    "ListSecurityProfilesForTarget": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "securityProfileTargetMappings"
+    },
+    "ListStreams": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "streams"
+    },
+    "ListTagsForResource": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "tags"
+    },
+    "ListTargetsForPolicy": {
+      "input_token": "marker",
+      "limit_key": "pageSize",
+      "output_token": "nextMarker",
+      "result_key": "targets"
+    },
+    "ListTargetsForSecurityProfile": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "securityProfileTargets"
+    },
+    "ListThingGroups": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "thingGroups"
+    },
+    "ListThingGroupsForThing": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "thingGroups"
+    },
+    "ListThingRegistrationTasks": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "taskIds"
+    },
+    "ListThingsInBillingGroup": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "things"
+    },
+    "ListThingsInThingGroup": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "things"
+    },
+    "ListV2LoggingLevels": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "logTargetConfigurations"
+    },
+    "ListViolationEvents": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "violationEvents"
     }
   }
 }

--- a/botocore/data/iot1click-devices/2018-05-14/paginators-1.json
+++ b/botocore/data/iot1click-devices/2018-05-14/paginators-1.json
@@ -1,16 +1,16 @@
 {
   "pagination": {
-    "ListCertificateAuthorities": {
+    "ListDeviceEvents": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "CertificateAuthorities"
+      "result_key": "Events"
     },
-    "ListTags": {
+    "ListDevices": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",
       "output_token": "NextToken",
-      "result_key": "Tags"
+      "result_key": "Devices"
     }
   }
 }

--- a/botocore/data/iot1click-projects/2018-05-14/paginators-1.json
+++ b/botocore/data/iot1click-projects/2018-05-14/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListPlacements": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "placements"
+    },
+    "ListProjects": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "projects"
+    }
+  }
 }

--- a/botocore/data/iotanalytics/2017-11-27/paginators-1.json
+++ b/botocore/data/iotanalytics/2017-11-27/paginators-1.json
@@ -1,3 +1,34 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListChannels": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "channelSummaries"
+    },
+    "ListDatasetContents": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "datasetContentSummaries"
+    },
+    "ListDatasets": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "datasetSummaries"
+    },
+    "ListDatastores": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "datastoreSummaries"
+    },
+    "ListPipelines": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "pipelineSummaries"
+    }
+  }
 }

--- a/botocore/data/kafka/2018-11-14/paginators-1.json
+++ b/botocore/data/kafka/2018-11-14/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListClusters": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ClusterInfoList"
+    },
+    "ListNodes": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "NodeInfoList"
+    }
+  }
 }

--- a/botocore/data/kinesis-video-archived-media/2017-09-30/paginators-1.json
+++ b/botocore/data/kinesis-video-archived-media/2017-09-30/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListFragments": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Fragments"
+    }
+  }
 }

--- a/botocore/data/kinesis/2013-12-02/paginators-1.json
+++ b/botocore/data/kinesis/2013-12-02/paginators-1.json
@@ -23,6 +23,18 @@
       "more_results": "HasMoreStreams",
       "output_token": "StreamNames[-1]",
       "result_key": "StreamNames"
+    },
+    "ListShards": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Shards"
+    },
+    "ListStreamConsumers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Consumers"
     }
   }
 }

--- a/botocore/data/kinesisanalyticsv2/2018-05-23/paginators-1.json
+++ b/botocore/data/kinesisanalyticsv2/2018-05-23/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListApplicationSnapshots": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "SnapshotSummaries"
+    },
+    "ListApplications": {
+      "input_token": "NextToken",
+      "limit_key": "Limit",
+      "output_token": "NextToken",
+      "result_key": "ApplicationSummaries"
+    }
+  }
 }

--- a/botocore/data/kinesisvideo/2017-09-30/paginators-1.json
+++ b/botocore/data/kinesisvideo/2017-09-30/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListStreams": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "StreamInfoList"
+    }
+  }
 }

--- a/botocore/data/lambda/2015-03-31/paginators-1.json
+++ b/botocore/data/lambda/2015-03-31/paginators-1.json
@@ -17,6 +17,24 @@
       "output_token": "NextMarker",
       "limit_key": "MaxItems",
       "result_key": "Aliases"
+    },
+    "ListLayerVersions": {
+      "input_token": "Marker",
+      "limit_key": "MaxItems",
+      "output_token": "NextMarker",
+      "result_key": "LayerVersions"
+    },
+    "ListLayers": {
+      "input_token": "Marker",
+      "limit_key": "MaxItems",
+      "output_token": "NextMarker",
+      "result_key": "Layers"
+    },
+    "ListVersionsByFunction": {
+      "input_token": "Marker",
+      "limit_key": "MaxItems",
+      "output_token": "NextMarker",
+      "result_key": "Versions"
     }
   }
 }

--- a/botocore/data/license-manager/2018-08-01/paginators-1.json
+++ b/botocore/data/license-manager/2018-08-01/paginators-1.json
@@ -1,3 +1,34 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListAssociationsForLicenseConfiguration": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "LicenseConfigurationAssociations"
+    },
+    "ListLicenseConfigurations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "LicenseConfigurations"
+    },
+    "ListLicenseSpecificationsForResource": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "LicenseSpecifications"
+    },
+    "ListResourceInventory": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ResourceInventoryList"
+    },
+    "ListUsageForLicenseConfiguration": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "LicenseConfigurationUsageList"
+    }
+  }
 }

--- a/botocore/data/lightsail/2016-11-28/paginators-1.json
+++ b/botocore/data/lightsail/2016-11-28/paginators-1.json
@@ -44,6 +44,61 @@
       "input_token": "pageToken",
       "output_token": "nextPageToken",
       "result_key": "staticIps"
+    },
+    "GetCloudFormationStackRecords": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "cloudFormationStackRecords"
+    },
+    "GetDiskSnapshots": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "diskSnapshots"
+    },
+    "GetDisks": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "disks"
+    },
+    "GetExportSnapshotRecords": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "exportSnapshotRecords"
+    },
+    "GetLoadBalancers": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "loadBalancers"
+    },
+    "GetRelationalDatabaseBlueprints": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "blueprints"
+    },
+    "GetRelationalDatabaseBundles": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "bundles"
+    },
+    "GetRelationalDatabaseEvents": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "relationalDatabaseEvents"
+    },
+    "GetRelationalDatabaseParameters": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "parameters"
+    },
+    "GetRelationalDatabaseSnapshots": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "relationalDatabaseSnapshots"
+    },
+    "GetRelationalDatabases": {
+      "input_token": "pageToken",
+      "output_token": "nextPageToken",
+      "result_key": "relationalDatabases"
     }
   }
 }

--- a/botocore/data/logs/2014-03-28/paginators-1.json
+++ b/botocore/data/logs/2014-03-28/paginators-1.json
@@ -38,6 +38,24 @@
         "events",
         "searchedLogStreams"
       ]
+    },
+    "DescribeExportTasks": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "exportTasks"
+    },
+    "DescribeQueries": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "queries"
+    },
+    "DescribeResourcePolicies": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "resourcePolicies"
     }
   }
 }

--- a/botocore/data/macie/2017-12-19/paginators-1.json
+++ b/botocore/data/macie/2017-12-19/paginators-1.json
@@ -1,3 +1,16 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListMemberAccounts": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "memberAccounts"
+    },
+    "ListS3Resources": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "s3Resources"
+    }
+  }
 }

--- a/botocore/data/marketplace-entitlement/2017-01-11/paginators-1.json
+++ b/botocore/data/marketplace-entitlement/2017-01-11/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetEntitlements": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Entitlements"
+    }
+  }
 }

--- a/botocore/data/mediaconnect/2018-11-14/paginators-1.json
+++ b/botocore/data/mediaconnect/2018-11-14/paginators-1.json
@@ -5,6 +5,12 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults",
       "result_key": "Flows"
+    },
+    "ListEntitlements": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Entitlements"
     }
   }
 }

--- a/botocore/data/mediastore-data/2017-09-01/paginators-1.json
+++ b/botocore/data/mediastore-data/2017-09-01/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListItems": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    }
+  }
 }

--- a/botocore/data/mediastore/2017-09-01/paginators-1.json
+++ b/botocore/data/mediastore/2017-09-01/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListContainers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Containers"
+    }
+  }
 }

--- a/botocore/data/mediatailor/2018-04-23/paginators-1.json
+++ b/botocore/data/mediatailor/2018-04-23/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListPlaybackConfigurations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Items"
+    }
+  }
 }

--- a/botocore/data/mgh/2017-05-31/paginators-1.json
+++ b/botocore/data/mgh/2017-05-31/paginators-1.json
@@ -1,3 +1,28 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListCreatedArtifacts": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "CreatedArtifactList"
+    },
+    "ListDiscoveredResources": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DiscoveredResourceList"
+    },
+    "ListMigrationTasks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "MigrationTaskSummaryList"
+    },
+    "ListProgressUpdateStreams": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ProgressUpdateStreamSummaryList"
+    }
+  }
 }

--- a/botocore/data/mq/2017-11-27/paginators-1.json
+++ b/botocore/data/mq/2017-11-27/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListBrokers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "BrokerSummaries"
+    }
+  }
 }

--- a/botocore/data/neptune/2014-10-31/paginators-1.json
+++ b/botocore/data/neptune/2014-10-31/paginators-1.json
@@ -53,6 +53,36 @@
       "limit_key": "MaxRecords",
       "output_token": "Marker",
       "result_key": "OrderableDBInstanceOptions"
+    },
+    "DescribeDBClusterParameterGroups": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "DBClusterParameterGroups"
+    },
+    "DescribeDBClusterParameters": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "Parameters"
+    },
+    "DescribeDBClusterSnapshots": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "DBClusterSnapshots"
+    },
+    "DescribeDBClusters": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "DBClusters"
+    },
+    "DescribePendingMaintenanceActions": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "PendingMaintenanceActions"
     }
   }
 }

--- a/botocore/data/opsworkscm/2016-11-01/paginators-1.json
+++ b/botocore/data/opsworkscm/2016-11-01/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeBackups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Backups"
+    },
+    "DescribeEvents": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ServerEvents"
+    },
+    "DescribeServers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Servers"
+    }
+  }
 }

--- a/botocore/data/pinpoint-email/2018-07-26/paginators-1.json
+++ b/botocore/data/pinpoint-email/2018-07-26/paginators-1.json
@@ -1,3 +1,34 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetDedicatedIps": {
+      "input_token": "NextToken",
+      "limit_key": "PageSize",
+      "output_token": "NextToken",
+      "result_key": "DedicatedIps"
+    },
+    "ListConfigurationSets": {
+      "input_token": "NextToken",
+      "limit_key": "PageSize",
+      "output_token": "NextToken",
+      "result_key": "ConfigurationSets"
+    },
+    "ListDedicatedIpPools": {
+      "input_token": "NextToken",
+      "limit_key": "PageSize",
+      "output_token": "NextToken",
+      "result_key": "DedicatedIpPools"
+    },
+    "ListDeliverabilityTestReports": {
+      "input_token": "NextToken",
+      "limit_key": "PageSize",
+      "output_token": "NextToken",
+      "result_key": "DeliverabilityTestReports"
+    },
+    "ListEmailIdentities": {
+      "input_token": "NextToken",
+      "limit_key": "PageSize",
+      "output_token": "NextToken",
+      "result_key": "EmailIdentities"
+    }
+  }
 }

--- a/botocore/data/polly/2016-06-10/paginators-1.json
+++ b/botocore/data/polly/2016-06-10/paginators-1.json
@@ -4,6 +4,17 @@
       "input_token": "NextToken",
       "output_token": "NextToken",
       "result_key": "Voices"
+    },
+    "ListLexicons": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Lexicons"
+    },
+    "ListSpeechSynthesisTasks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SynthesisTasks"
     }
   }
 }

--- a/botocore/data/ram/2018-01-04/paginators-1.json
+++ b/botocore/data/ram/2018-01-04/paginators-1.json
@@ -1,3 +1,40 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetResourcePolicies": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "policies"
+    },
+    "GetResourceShareAssociations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "resourceShareAssociations"
+    },
+    "GetResourceShareInvitations": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "resourceShareInvitations"
+    },
+    "GetResourceShares": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "resourceShares"
+    },
+    "ListPrincipals": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "principals"
+    },
+    "ListResources": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "resources"
+    }
+  }
 }

--- a/botocore/data/rds/2014-10-31/paginators-1.json
+++ b/botocore/data/rds/2014-10-31/paginators-1.json
@@ -168,6 +168,12 @@
       "limit_key": "NumberOfLines",
       "more_results": "AdditionalDataPending",
       "result_key": "LogFileData"
+    },
+    "DescribeDBClusterEndpoints": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "DBClusterEndpoints"
     }
   }
 }

--- a/botocore/data/redshift/2012-12-01/paginators-1.json
+++ b/botocore/data/redshift/2012-12-01/paginators-1.json
@@ -89,6 +89,48 @@
       "output_token": "Marker",
       "limit_key": "MaxRecords",
       "result_key": "ReservedNodes"
+    },
+    "DescribeClusterDbRevisions": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "ClusterDbRevisions"
+    },
+    "DescribeClusterTracks": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "MaintenanceTracks"
+    },
+    "DescribeSnapshotCopyGrants": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "SnapshotCopyGrants"
+    },
+    "DescribeSnapshotSchedules": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "SnapshotSchedules"
+    },
+    "DescribeTableRestoreStatus": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "TableRestoreStatusDetails"
+    },
+    "DescribeTags": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "TaggedResources"
+    },
+    "GetReservedNodeExchangeOfferings": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "ReservedNodeOfferings"
     }
   }
 }

--- a/botocore/data/robomaker/2018-06-29/paginators-1.json
+++ b/botocore/data/robomaker/2018-06-29/paginators-1.json
@@ -1,3 +1,40 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListDeploymentJobs": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "deploymentJobs"
+    },
+    "ListFleets": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "fleetDetails"
+    },
+    "ListRobotApplications": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "robotApplicationSummaries"
+    },
+    "ListRobots": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "robots"
+    },
+    "ListSimulationApplications": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "simulationApplicationSummaries"
+    },
+    "ListSimulationJobs": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "simulationJobSummaries"
+    }
+  }
 }

--- a/botocore/data/route53/2013-04-01/paginators-1.json
+++ b/botocore/data/route53/2013-04-01/paginators-1.json
@@ -38,6 +38,12 @@
       "result_key": [
         "VPCs"
       ]
+    },
+    "ListQueryLoggingConfigs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "QueryLoggingConfigs"
     }
   }
 }

--- a/botocore/data/route53domains/2014-05-15/paginators-1.json
+++ b/botocore/data/route53domains/2014-05-15/paginators-1.json
@@ -12,6 +12,12 @@
       "input_token": "Marker",
       "output_token": "NextPageMarker",
       "result_key": "Operations"
+    },
+    "ViewBilling": {
+      "input_token": "Marker",
+      "limit_key": "MaxItems",
+      "output_token": "NextPageMarker",
+      "result_key": "BillingRecords"
     }
   }
 }

--- a/botocore/data/route53resolver/2018-04-01/paginators-1.json
+++ b/botocore/data/route53resolver/2018-04-01/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListTagsForResource": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Tags"
+    }
+  }
 }

--- a/botocore/data/secretsmanager/2017-10-17/paginators-1.json
+++ b/botocore/data/secretsmanager/2017-10-17/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListSecrets": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "SecretList"
+    }
+  }
 }

--- a/botocore/data/securityhub/2018-10-26/paginators-1.json
+++ b/botocore/data/securityhub/2018-10-26/paginators-1.json
@@ -1,3 +1,40 @@
 {
-  "pagination": {}
+  "pagination": {
+    "GetEnabledStandards": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "StandardsSubscriptions"
+    },
+    "GetFindings": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Findings"
+    },
+    "GetInsights": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Insights"
+    },
+    "ListEnabledProductsForImport": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ProductSubscriptions"
+    },
+    "ListInvitations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Invitations"
+    },
+    "ListMembers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Members"
+    }
+  }
 }

--- a/botocore/data/serverlessrepo/2017-09-08/paginators-1.json
+++ b/botocore/data/serverlessrepo/2017-09-08/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListApplicationDependencies": {
+      "input_token": "NextToken",
+      "limit_key": "MaxItems",
+      "output_token": "NextToken",
+      "result_key": "Dependencies"
+    },
+    "ListApplicationVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxItems",
+      "output_token": "NextToken",
+      "result_key": "Versions"
+    },
+    "ListApplications": {
+      "input_token": "NextToken",
+      "limit_key": "MaxItems",
+      "output_token": "NextToken",
+      "result_key": "Applications"
+    }
+  }
 }

--- a/botocore/data/servicecatalog/2015-12-10/paginators-1.json
+++ b/botocore/data/servicecatalog/2015-12-10/paginators-1.json
@@ -53,6 +53,48 @@
       "output_token": "PageToken",
       "input_token": "PageToken",
       "limit_key": "PageSize"
+    },
+    "ListOrganizationPortfolioAccess": {
+      "input_token": "PageToken",
+      "limit_key": "PageSize",
+      "output_token": "NextPageToken",
+      "result_key": "OrganizationNodes"
+    },
+    "ListProvisionedProductPlans": {
+      "input_token": "PageToken",
+      "limit_key": "PageSize",
+      "output_token": "NextPageToken",
+      "result_key": "ProvisionedProductPlans"
+    },
+    "ListProvisioningArtifactsForServiceAction": {
+      "input_token": "PageToken",
+      "limit_key": "PageSize",
+      "output_token": "NextPageToken",
+      "result_key": "ProvisioningArtifactViews"
+    },
+    "ListRecordHistory": {
+      "input_token": "PageToken",
+      "limit_key": "PageSize",
+      "output_token": "NextPageToken",
+      "result_key": "RecordDetails"
+    },
+    "ListServiceActions": {
+      "input_token": "PageToken",
+      "limit_key": "PageSize",
+      "output_token": "NextPageToken",
+      "result_key": "ServiceActionSummaries"
+    },
+    "ListServiceActionsForProvisioningArtifact": {
+      "input_token": "PageToken",
+      "limit_key": "PageSize",
+      "output_token": "NextPageToken",
+      "result_key": "ServiceActionSummaries"
+    },
+    "ScanProvisionedProducts": {
+      "input_token": "PageToken",
+      "limit_key": "PageSize",
+      "output_token": "NextPageToken",
+      "result_key": "ProvisionedProducts"
     }
   }
 }

--- a/botocore/data/ses/2010-12-01/paginators-1.json
+++ b/botocore/data/ses/2010-12-01/paginators-1.json
@@ -11,6 +11,23 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "ListConfigurationSets": {
+      "input_token": "NextToken",
+      "limit_key": "MaxItems",
+      "output_token": "NextToken",
+      "result_key": "ConfigurationSets"
+    },
+    "ListReceiptRuleSets": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "RuleSets"
+    },
+    "ListTemplates": {
+      "input_token": "NextToken",
+      "limit_key": "MaxItems",
+      "output_token": "NextToken",
+      "result_key": "TemplatesMetadata"
     }
   }
 }

--- a/botocore/data/shield/2016-06-02/paginators-1.json
+++ b/botocore/data/shield/2016-06-02/paginators-1.json
@@ -5,6 +5,12 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults",
       "result_key": "Protections"
+    },
+    "ListAttacks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "AttackSummaries"
     }
   }
 }

--- a/botocore/data/signer/2017-08-25/paginators-1.json
+++ b/botocore/data/signer/2017-08-25/paginators-1.json
@@ -1,3 +1,22 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListSigningJobs": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "jobs"
+    },
+    "ListSigningPlatforms": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "platforms"
+    },
+    "ListSigningProfiles": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "profiles"
+    }
+  }
 }

--- a/botocore/data/sms/2016-10-24/paginators-1.json
+++ b/botocore/data/sms/2016-10-24/paginators-1.json
@@ -23,6 +23,12 @@
       "output_token": "nextToken",
       "limit_key": "maxResults",
       "result_key": "serverList"
+    },
+    "ListApps": {
+      "input_token": "nextToken",
+      "limit_key": "maxResults",
+      "output_token": "nextToken",
+      "result_key": "apps"
     }
   }
 }

--- a/botocore/data/snowball/2016-06-30/paginators-1.json
+++ b/botocore/data/snowball/2016-06-30/paginators-1.json
@@ -11,6 +11,24 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "result_key": "Addresses"
+    },
+    "ListClusterJobs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "JobListEntries"
+    },
+    "ListClusters": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ClusterListEntries"
+    },
+    "ListCompatibleImages": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "CompatibleImages"
     }
   }
 }

--- a/botocore/data/sns/2010-03-31/paginators-1.json
+++ b/botocore/data/sns/2010-03-31/paginators-1.json
@@ -24,6 +24,11 @@
       "input_token": "NextToken",
       "output_token": "NextToken",
       "result_key": "Topics"
+    },
+    "ListPhoneNumbersOptedOut": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "result_key": "phoneNumbers"
     }
   }
 }

--- a/botocore/data/ssm/2014-11-06/paginators-1.json
+++ b/botocore/data/ssm/2014-11-06/paginators-1.json
@@ -71,6 +71,174 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "DescribeAutomationExecutions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "AutomationExecutionMetadataList"
+    },
+    "DescribeAutomationStepExecutions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "StepExecutions"
+    },
+    "DescribeAvailablePatches": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Patches"
+    },
+    "DescribeEffectiveInstanceAssociations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Associations"
+    },
+    "DescribeEffectivePatchesForPatchBaseline": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "EffectivePatches"
+    },
+    "DescribeInstanceAssociationsStatus": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "InstanceAssociationStatusInfos"
+    },
+    "DescribeInstancePatchStates": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "InstancePatchStates"
+    },
+    "DescribeInstancePatchStatesForPatchGroup": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "InstancePatchStates"
+    },
+    "DescribeInstancePatches": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Patches"
+    },
+    "DescribeInventoryDeletions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "InventoryDeletions"
+    },
+    "DescribeMaintenanceWindowExecutionTaskInvocations": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "WindowExecutionTaskInvocationIdentities"
+    },
+    "DescribeMaintenanceWindowExecutionTasks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "WindowExecutionTaskIdentities"
+    },
+    "DescribeMaintenanceWindowExecutions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "WindowExecutions"
+    },
+    "DescribeMaintenanceWindowSchedule": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ScheduledWindowExecutions"
+    },
+    "DescribeMaintenanceWindowTargets": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Targets"
+    },
+    "DescribeMaintenanceWindowTasks": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Tasks"
+    },
+    "DescribeMaintenanceWindows": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "WindowIdentities"
+    },
+    "DescribeMaintenanceWindowsForTarget": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "WindowIdentities"
+    },
+    "DescribePatchBaselines": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "BaselineIdentities"
+    },
+    "DescribePatchGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Mappings"
+    },
+    "DescribeSessions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Sessions"
+    },
+    "GetInventorySchema": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Schemas"
+    },
+    "ListAssociationVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "AssociationVersions"
+    },
+    "ListComplianceItems": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ComplianceItems"
+    },
+    "ListComplianceSummaries": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ComplianceSummaryItems"
+    },
+    "ListDocumentVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DocumentVersions"
+    },
+    "ListResourceComplianceSummaries": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ResourceComplianceSummaryItems"
+    },
+    "ListResourceDataSync": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ResourceDataSyncItems"
     }
   }
 }

--- a/botocore/data/storagegateway/2013-06-30/paginators-1.json
+++ b/botocore/data/storagegateway/2013-06-30/paginators-1.json
@@ -35,6 +35,12 @@
       "limit_key": "Limit",
       "output_token": "Marker",
       "result_key": "VolumeInfos"
+    },
+    "ListTapes": {
+      "input_token": "Marker",
+      "limit_key": "Limit",
+      "output_token": "Marker",
+      "result_key": "TapeInfos"
     }
   }
 }

--- a/botocore/data/transfer/2018-11-05/paginators-1.json
+++ b/botocore/data/transfer/2018-11-05/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListServers": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Servers"
+    }
+  }
 }

--- a/botocore/data/translate/2017-07-01/paginators-1.json
+++ b/botocore/data/translate/2017-07-01/paginators-1.json
@@ -1,3 +1,10 @@
 {
-  "pagination": {}
+  "pagination": {
+    "ListTerminologies": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "TerminologyPropertiesList"
+    }
+  }
 }

--- a/botocore/data/waf/2015-08-24/paginators-1.json
+++ b/botocore/data/waf/2015-08-24/paginators-1.json
@@ -41,6 +41,59 @@
       "output_token": "NextMarker",
       "limit_key": "Limit",
       "result_key": "XssMatchSets"
+    },
+    "GetRateBasedRuleManagedKeys": {
+      "input_token": "NextMarker",
+      "output_token": "NextMarker",
+      "result_key": "ManagedKeys"
+    },
+    "ListActivatedRulesInRuleGroup": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "ActivatedRules"
+    },
+    "ListGeoMatchSets": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "GeoMatchSets"
+    },
+    "ListLoggingConfigurations": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "LoggingConfigurations"
+    },
+    "ListRateBasedRules": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "Rules"
+    },
+    "ListRegexMatchSets": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "RegexMatchSets"
+    },
+    "ListRegexPatternSets": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "RegexPatternSets"
+    },
+    "ListRuleGroups": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "RuleGroups"
+    },
+    "ListSubscribedRuleGroups": {
+      "input_token": "NextMarker",
+      "limit_key": "Limit",
+      "output_token": "NextMarker",
+      "result_key": "RuleGroups"
     }
   }
 }

--- a/botocore/data/workdocs/2016-05-01/paginators-1.json
+++ b/botocore/data/workdocs/2016-05-01/paginators-1.json
@@ -20,6 +20,42 @@
       "limit_key": "Limit",
       "output_token": "Marker",
       "result_key": "Users"
+    },
+    "DescribeActivities": {
+      "input_token": "Marker",
+      "limit_key": "Limit",
+      "output_token": "Marker",
+      "result_key": "UserActivities"
+    },
+    "DescribeComments": {
+      "input_token": "Marker",
+      "limit_key": "Limit",
+      "output_token": "Marker",
+      "result_key": "Comments"
+    },
+    "DescribeGroups": {
+      "input_token": "Marker",
+      "limit_key": "Limit",
+      "output_token": "Marker",
+      "result_key": "Groups"
+    },
+    "DescribeNotificationSubscriptions": {
+      "input_token": "Marker",
+      "limit_key": "Limit",
+      "output_token": "Marker",
+      "result_key": "Subscriptions"
+    },
+    "DescribeResourcePermissions": {
+      "input_token": "Marker",
+      "limit_key": "Limit",
+      "output_token": "Marker",
+      "result_key": "Principals"
+    },
+    "DescribeRootFolders": {
+      "input_token": "Marker",
+      "limit_key": "Limit",
+      "output_token": "Marker",
+      "result_key": "Folders"
     }
   }
 }

--- a/botocore/data/workmail/2017-10-01/paginators-1.json
+++ b/botocore/data/workmail/2017-10-01/paginators-1.json
@@ -35,6 +35,18 @@
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"
+    },
+    "ListMailboxPermissions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Permissions"
+    },
+    "ListResourceDelegates": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Delegates"
     }
   }
 }

--- a/botocore/data/workspaces/2015-04-08/paginators-1.json
+++ b/botocore/data/workspaces/2015-04-08/paginators-1.json
@@ -15,6 +15,34 @@
       "input_token": "NextToken",
       "output_token": "NextToken",
       "result_key": "Workspaces"
+    },
+    "DescribeAccountModifications": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "AccountModifications"
+    },
+    "DescribeIpGroups": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Result"
+    },
+    "DescribeWorkspaceImages": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Images"
+    },
+    "DescribeWorkspacesConnectionStatus": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "WorkspacesConnectionStatus"
+    },
+    "ListAvailableManagementCidrRanges": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ManagementCidrRanges"
     }
   }
 }

--- a/botocore/data/xray/2016-04-12/paginators-1.json
+++ b/botocore/data/xray/2016-04-12/paginators-1.json
@@ -19,6 +19,21 @@
       "input_token": "NextToken",
       "output_token": "NextToken",
       "result_key": "TraceSummaries"
+    },
+    "GetGroups": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Groups"
+    },
+    "GetSamplingRules": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "SamplingRuleRecords"
+    },
+    "GetSamplingStatisticSummaries": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "SamplingStatisticSummaries"
     }
   }
 }


### PR DESCRIPTION
This adds generated paginators for a number of services. This only adds
the simple cases where the response contains only two elements: a list
which is the result key and the next token.

The script that generated these will look for the standard values
('NextToken', 'MaxResults') but also look for any values that are common
within a given service.