### PR TITLE
Check for empty body before splitting lines

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -114,7 +114,8 @@ class StreamingBody(object):
             for line in lines[:-1]:
                 yield line.splitlines()[0]
             pending = lines[-1]
-        yield pending.splitlines()[0]
+        if pending:
+            yield pending.splitlines()[0]
 
     def iter_chunks(self, chunk_size=_DEFAULT_CHUNK_SIZE):
         """Return an iterator to yield chunks of chunk_size bytes from the raw

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -167,6 +167,12 @@ class TestStreamWrapper(unittest.TestCase):
                 [b'1234567890', b'1234567890', b'12345'],
             )
 
+    def test_streaming_line_empty_body(self):
+        stream = response.StreamingBody(
+            six.BytesIO(b''), content_length=0,
+        )
+        self.assert_lines(stream.iter_lines(), [])
+
 
 class FakeRawResponse(six.BytesIO):
     def stream(self, amt=1024, decode_content=None):


### PR DESCRIPTION
If a body is empty, `splitlines` will return an empty list. This
the remaining content before trying to split it.

Fixes #1661