### PR TITLE
Remove use of unnecessary compat shim six.binary_type

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -546,7 +546,7 @@ class SigV4QueryAuth(SigV4Auth):
         # string or bytes. In those cases we attempt to load the data as a
         # dict.
         data = request.data
-        if isinstance(data, six.binary_type):
+        if isinstance(data, bytes):
             data = json.loads(data.decode('utf-8'))
         elif isinstance(data, six.string_types):
             data = json.loads(data)

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -543,7 +543,7 @@ class AWSPreparedRequest(object):
         # the entire body contents again if we need to).
         # Same case if the body is a string/bytes/bytearray type.
 
-        non_seekable_types = (six.binary_type, six.text_type, bytearray)
+        non_seekable_types = (bytes, six.text_type, bytearray)
         if self.body is None or isinstance(self.body, non_seekable_types):
             return
         try:

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -637,7 +637,7 @@ def add_glacier_checksums(params, **kwargs):
     request_dict = params
     headers = request_dict['headers']
     body = request_dict['body']
-    if isinstance(body, six.binary_type):
+    if isinstance(body, bytes):
         # If the user provided a bytes type instead of a file
         # like object, we're temporarily create a BytesIO object
         # so we can use the util functions to calculate the
@@ -772,7 +772,7 @@ def convert_body_to_file_like_object(params, **kwargs):
     if 'Body' in params:
         if isinstance(params['Body'], six.string_types):
             params['Body'] = six.BytesIO(ensure_bytes(params['Body']))
-        elif isinstance(params['Body'], six.binary_type):
+        elif isinstance(params['Body'], bytes):
             params['Body'] = six.BytesIO(params['Body'])
 
 

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -73,7 +73,7 @@ class TokenEncoder(object):
             return self._encode_dict(data, path)
         elif isinstance(data, list):
             return self._encode_list(data, path)
-        elif isinstance(data, six.binary_type):
+        elif isinstance(data, bytes):
             return self._encode_bytes(data, path)
         else:
             return data, []

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -532,10 +532,10 @@ def percent_encode(input_str, safe=SAFE_CHARS):
     first.
     """
     # If its not a binary or text string, make it a text string.
-    if not isinstance(input_str, (six.binary_type, six.text_type)):
+    if not isinstance(input_str, (bytes, six.text_type)):
         input_str = six.text_type(input_str)
     # If it's not bytes, make it bytes by UTF-8 encoding it.
-    if not isinstance(input_str, six.binary_type):
+    if not isinstance(input_str, bytes):
         input_str = input_str.encode('utf-8')
     return quote(input_str, safe=safe)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -340,7 +340,7 @@ class IntegerRefresher(credentials.RefreshableCredentials):
 
 
 def _urlparse(url):
-    if isinstance(url, six.binary_type):
+    if isinstance(url, bytes):
         # Not really necessary, but it helps to reduce noise on Python 2.x
         url = url.decode('utf8')
     return urlparse(url)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -57,25 +57,25 @@ class TestEnsureBytes(unittest.TestCase):
     def test_string(self):
         value = 'foo'
         response = ensure_bytes(value)
-        self.assertIsInstance(response, six.binary_type)
+        self.assertIsInstance(response, bytes)
         self.assertEqual(response, b'foo')
 
     def test_binary(self):
         value = b'bar'
         response = ensure_bytes(value)
-        self.assertIsInstance(response, six.binary_type)
+        self.assertIsInstance(response, bytes)
         self.assertEqual(response, b'bar')
 
     def test_unicode(self):
         value = u'baz'
         response = ensure_bytes(value)
-        self.assertIsInstance(response, six.binary_type)
+        self.assertIsInstance(response, bytes)
         self.assertEqual(response, b'baz')
 
     def test_non_ascii(self):
         value = u'\u2713'
         response = ensure_bytes(value)
-        self.assertIsInstance(response, six.binary_type)
+        self.assertIsInstance(response, bytes)
         self.assertEqual(response, b'\xe2\x9c\x93')
 
     def test_non_string_or_bytes_raises_error(self):

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -26,7 +26,7 @@ from botocore.compat import six
 
 def path(filename):
     directory = os.path.join(os.path.dirname(__file__), 'cfg')
-    if isinstance(filename, six.binary_type):
+    if isinstance(filename, bytes):
         directory = six.b(directory)
     return os.path.join(directory, filename)
 
@@ -50,7 +50,7 @@ class TestConfigLoader(BaseEnvVar):
         )
 
         directory = self.tempdir
-        if isinstance(filename, six.binary_type):
+        if isinstance(filename, bytes):
             directory = six.b(directory)
         full_path = os.path.join(directory, filename)
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1015,7 +1015,7 @@ class TestConvertStringBodyToFileLikeObject(BaseSessionTest):
         handlers.convert_body_to_file_like_object(params)
         self.assertTrue(hasattr(params['Body'], 'read'))
         contents = params['Body'].read()
-        self.assertIsInstance(contents, six.binary_type)
+        self.assertIsInstance(contents, bytes)
         self.assertEqual(contents, body_bytes)
 
     def test_string(self):

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -550,7 +550,7 @@ class TestCSMSerializer(unittest.TestCase):
         event = APICallEvent(
             service=self.service, operation=self.operation, timestamp=1000)
         serialized_event = self.serializer.serialize(event)
-        self.assertIsInstance(serialized_event, six.binary_type)
+        self.assertIsInstance(serialized_event, bytes)
 
     def test_serialize_does_not_add_whitespace(self):
         event = APICallEvent(


### PR DESCRIPTION
On Python 2, starting with Python 2.6, the type bytes exists as an alias
of of str, same as the previously used six.binary_type. By using bytes,
the code has less indirection and is more forward compatible with modern
Python idioms.