### PR TITLE
Use DescribeStreamSummary instead of DescribeStream for Kinesis waiters

### DIFF
--- a/botocore/data/kinesis/2013-12-02/waiters-2.json
+++ b/botocore/data/kinesis/2013-12-02/waiters-2.json
@@ -3,20 +3,20 @@
   "waiters": {
     "StreamExists": {
       "delay": 10,
-      "operation": "DescribeStream",
+      "operation": "DescribeStreamSummary",
       "maxAttempts": 18,
       "acceptors": [
         {
           "expected": "ACTIVE",
           "matcher": "path",
           "state": "success",
-          "argument": "StreamDescription.StreamStatus"
+          "argument": "StreamDescriptionSummary.StreamStatus"
         }
       ]
     },
     "StreamNotExists": {
       "delay": 10,
-      "operation": "DescribeStream",
+      "operation": "DescribeStreamSummary",
       "maxAttempts": 18,
       "acceptors": [
         {


### PR DESCRIPTION
This PR changes the following waiters for the Kinesis client:
StreamExists
StreamNotExists

This change makes the waiters use the DescribeStreamSummary API endpoint instead of DescribeStreams. Ultimately, both provide the same data that these waiters need to work, but the Summary endpoint allows for 20 requests per second as opposed to the 10 per second for DescribeStream.