### PR TITLE
unvendor urllib in exceptions class

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import unicode_literals
 from botocore.vendored import requests
-from botocore.vendored.requests.packages import urllib3
+import urllib3
 
 
 def _exception_from_packed_args(exception_cls, args=None, kwargs=None):


### PR DESCRIPTION
According to 

- https://botocore.amazonaws.com/v1/documentation/api/latest/index.html#upgrading-to-1-11-0
- https://github.com/boto/botocore/issues/1248

urllib has been unvendored and should not be used any more.  In the exceptions class however there's still a reference to it I found with 

    grep -r import .| grep urllib3  | grep botocore.vendored

this patch removes the urllib vendoring in the exceptions class.  Maybe rules like the grep above should also be added to the CI to ensure that all deprecated vendored classes stay removed?  