### PR TITLE
Fix Shape of AccessKeyLastUsed. LastUsedDate null

### DIFF
--- a/botocore/data/iam/2010-05-08/service-2.json
+++ b/botocore/data/iam/2010-05-08/service-2.json
@@ -2285,7 +2285,6 @@
     "AccessKeyLastUsed":{
       "type":"structure",
       "required":[
-        "LastUsedDate",
         "ServiceName",
         "Region"
       ],


### PR DESCRIPTION
The AccessKeyLastUsed LastUsedDate field is missing (null) when a user has not used the access key. The shape does not match the boto3 response in this case. Fix is required to allow Stubbing the case where the access key has never been used.