### PR TITLE
#1680 - Treat an empty auth environment variable as if it is unset

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -921,7 +921,10 @@ class EnvProvider(CredentialProvider):
         """
         Search for credentials in explicit environment variables.
         """
-        if self._mapping['access_key'] in self.environ:
+
+        access_key_var = self._mapping['access_key']
+
+        if access_key_var in self.environ and not self.environ.get(access_key_var) == '':
             logger.info('Found credentials in environment variables.')
             fetcher = self._create_credentials_fetcher()
             credentials = fetcher(require_expiry=False)
@@ -951,20 +954,20 @@ class EnvProvider(CredentialProvider):
             credentials = {}
 
             access_key = environ.get(mapping['access_key'])
-            if access_key is None:
+            if access_key is None or access_key == '':
                 raise PartialCredentialsError(
                     provider=method, cred_var=mapping['access_key'])
             credentials['access_key'] = access_key
 
             secret_key = environ.get(mapping['secret_key'])
-            if secret_key is None:
+            if secret_key is None or secret_key == '':
                 raise PartialCredentialsError(
                     provider=method, cred_var=mapping['secret_key'])
             credentials['secret_key'] = secret_key
 
             token = None
             for token_env_var in mapping['token']:
-                if token_env_var in environ:
+                if token_env_var in environ and not environ[token_env_var] == '':
                     token = environ[token_env_var]
                     break
             credentials['token'] = token

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -691,6 +691,16 @@ class TestEnvVar(BaseEnvVar):
         creds = provider.load()
         self.assertIsNone(creds)
 
+    def test_envvars_empty_string(self):
+        environ = {
+            'AWS_ACCESS_KEY_ID': '',
+            'AWS_SECRET_ACCESS_KEY': '',
+            'AWS_SECURITY_TOKEN': '',
+        }
+        provider = credentials.EnvProvider(environ)
+        creds = provider.load()
+        self.assertIsNone(creds)
+
     def test_can_override_env_var_mapping(self):
         # We can change the env var provider to
         # use our specified env var names.
@@ -760,6 +770,18 @@ class TestEnvVar(BaseEnvVar):
         environ = {
             'AWS_ACCESS_KEY_ID': 'foo',
             # Missing the AWS_SECRET_ACCESS_KEY
+        }
+        provider = credentials.EnvProvider(environ)
+        with self.assertRaises(botocore.exceptions.PartialCredentialsError):
+            provider.load()
+
+    def test_partial_creds_is_an_error_empty_string(self):
+        # If the user provides an access key, they must also
+        # provide a secret key.  Not doing so will generate an
+        # error.
+        environ = {
+            'AWS_ACCESS_KEY_ID': 'foo',
+            'AWS_SECRET_ACCESS_KEY': '',
         }
         provider = credentials.EnvProvider(environ)
         with self.assertRaises(botocore.exceptions.PartialCredentialsError):


### PR DESCRIPTION
This PR fixes #1680.

From my comment on that issue:

> We deploy applications to Kubernetes using Terraform. For testing, we deploy on Minikube locally, which requires us to set the auth variables in Terraform. HCL still doesn't have conditionals, so they're always set - even when we use the same module to deploy to a k8s cluster in AWS which is intending to use IAM. As a result auth fails in the real deployment (since the env vars are set but are empty).

This happens even though IAM is configured properly.  I wrote this fix to deploy in our environment to mitigate this issue.

**This PR is dependent on #1680 being accepted to be fixed.**  As @joguSD says in that issue:

> I think this sounds reasonable but it's also arguably a breaking change / not a forwards compatible change. It might be difficult to actually define what a 'valid' credential is in all contexts.

https://github.com/boto/botocore/issues/1680#issuecomment-463357010

Notes:
* This fix is pretty conservative in how it solves the issue.  It special-cases empty string in the places where it matters rather than use Python's idea of falsiness to rule out both empty string and `None`.  If that approach is preferred, I can modify this.
* It comes with a couple new tests for the empty string case.  All tests pass in all the Tox environments.