### PR TITLE
adding aws-exec-read and log-delivery-read to bucketCannedACL list

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.json
+++ b/botocore/data/s3/2006-03-01/service-2.json
@@ -1203,7 +1203,9 @@
         "private",
         "public-read",
         "public-read-write",
-        "authenticated-read"
+        "authenticated-read",
+        "aws-exec-read",
+        "log-delivery-write"
       ]
     },
     "BucketLifecycleConfiguration":{


### PR DESCRIPTION
fixes #1690 