### PR TITLE
Fix s3 integ test when assume role is used

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -433,7 +433,8 @@ class TestS3Objects(TestS3BaseWithBucket):
 
     def test_thread_safe_auth(self):
         self.auth_paths = []
-        self.session.register('before-sign', self.increment_auth)
+        emitter = self.session.get_component('event_emitter')
+        emitter.register_last('before-sign.s3', self.increment_auth)
         # This test depends on auth_path, which is only added in virtual host
         # style requests.
         config = Config(s3={'addressing_style': 'virtual'})


### PR DESCRIPTION
If assume role is used as the credential source for the integration tests this test will fail as the call to STS was also being picked up on. This updates the register to target `S3` after the `auth_path` has been set more specifically, which are the requests we're actually interested in.

For reference it would fail like this:
```
======================================================================
FAIL: test_thread_safe_auth (tests.integration.test_s3.TestS3Objects)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/.../python-sdks/botocore/tests/integration/test_s3.py", line 459, in test_thread_safe_auth
    (self.auth_paths))
AssertionError: 11 != 10 : Expected 10 unique auth paths, instead received: ['/botocoretest-6a6d3c012d/foo1', None, '/botocoretest-6a6d3c012d/foo0', '/botocoretest-6a6d3c012d/foo1', '/botocoretest-6a6d3c012d/foo2', '/botocoretest-6a6d3c012d/foo3', '/botocoretest-6a6d3c012d/foo4', '/botocoretest-6a6d3c012d/foo5', '/botocoretest-6a6d3c012d/foo6', '/botocoretest-6a6d3c012d/foo7', '/botocoretest-6a6d3c012d/foo8', '/botocoretest-6a6d3c012d/foo9']

```

Note the extra `None` which corresponds to the assume role call where `auth_path` isn't set.