### PR TITLE
Don't modify arguments to generate_presigned_post

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -671,9 +671,15 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
 
     if fields is None:
         fields = {}
+    else:
+        # We should ensure we don't modify arguments.
+        fields = fields.copy()
 
     if conditions is None:
         conditions = []
+    else:
+        # We should ensure we don't modify arguments.
+        conditions = conditions.copy()
 
     post_presigner = S3PostPresigner(self._request_signer)
     serializer = self._serializer

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -906,6 +906,10 @@ class TestGeneratePresignedPost(unittest.TestCase):
         self.client.generate_presigned_post(
             self.bucket, self.key, Fields=fields, Conditions=conditions)
 
+        # The arguments should not be modified
+        self.assertEqual(conditions, [{'acl': 'public-read'}])
+        self.assertEqual(fields, {'acl': 'public-read'})
+
         _, post_kwargs = self.presign_post_mock.call_args
         request_dict = post_kwargs['request_dict']
         fields = post_kwargs['fields']


### PR DESCRIPTION
This is motivated by a real-world example, where I did

```
my_conditions = <...>

generate_presigned_post(Bucket=.., key='foo', Conditions=my_conditions)
generate_presigned_post(Bucket=.., key='bar', Conditions=my_conditions)
```

and performing the second presigned post failed because `my_conditions` was
altered to include `{'key': 'foo'}` after the first call