### PR TITLE
Clarify Batch documentation for describe_jobs

### DIFF
--- a/botocore/data/batch/2016-08-10/service-2.json
+++ b/botocore/data/batch/2016-08-10/service-2.json
@@ -992,7 +992,7 @@
       "members":{
         "jobs":{
           "shape":"StringList",
-          "documentation":"<p>A space-separated list of up to 100 job IDs.</p>"
+          "documentation":"<p>A list of up to 100 job IDs.</p>"
         }
       }
     },


### PR DESCRIPTION
This change clarifies that the input to `describe_jobs` should be a list of strings rather than a space-separated string.