### PR TITLE
Improve s3 integ test robustness

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -126,6 +126,28 @@ class BaseS3ClientTest(unittest.TestCase):
         self.addCleanup(shutil.rmtree, tempdir)
         return tempdir
 
+    def wait_until_key_exists(self, bucket_name, key_name, extra_params=None,
+                              min_successes=3):
+        self._wait_for_key(bucket_name, key_name, extra_params,
+                           min_successes, exists=True)
+
+    def wait_until_key_not_exists(self, bucket_name, key_name, extra_params=None,
+                                  min_successes=3):
+        self._wait_for_key(bucket_name, key_name, extra_params,
+                           min_successes, exists=False)
+
+    def _wait_for_key(self, bucket_name, key_name, extra_params=None,
+                      min_successes=3, exists=True):
+        if exists:
+            waiter = self.client.get_waiter('object_exists')
+        else:
+            waiter = self.client.get_waiter('object_not_exists')
+        params = {'Bucket': bucket_name, 'Key': key_name}
+        if extra_params is not None:
+            params.update(extra_params)
+        for _ in range(min_successes):
+            waiter.wait(**params)
+
 
 class TestS3BaseWithBucket(BaseS3ClientTest):
     def setUp(self):
@@ -559,6 +581,7 @@ class BaseS3PresignTest(BaseS3ClientTest):
         self.client.put_object(
             Bucket=self.bucket_name, Key=key_name,
             Body=body)
+        self.wait_until_key_exists(self.bucket_name, key_name)
 
 
 class TestS3PresignUsStandard(BaseS3PresignTest):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -121,6 +121,12 @@ class BaseS3ClientTest(unittest.TestCase):
         self.addCleanup(clear_out_bucket, bucket_name, region_name, True)
         return bucket_name
 
+    def create_object(self, key_name, body='foo'):
+        self.client.put_object(
+            Bucket=self.bucket_name, Key=key_name,
+            Body=body)
+        self.wait_until_key_exists(self.bucket_name, key_name)
+
     def make_tempdir(self):
         tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tempdir)
@@ -153,11 +159,6 @@ class TestS3BaseWithBucket(BaseS3ClientTest):
     def setUp(self):
         super(TestS3BaseWithBucket, self).setUp()
         self.caught_exceptions = []
-
-    def create_object(self, key_name, body='foo'):
-        self.client.put_object(
-            Bucket=self.bucket_name, Key=key_name,
-            Body=body)
 
     def create_multipart_upload(self, key_name):
         parsed = self.client.create_multipart_upload(
@@ -576,12 +577,6 @@ class BaseS3PresignTest(BaseS3ClientTest):
     def setup_bucket(self):
         self.key = 'myobject'
         self.create_object(key_name=self.key)
-
-    def create_object(self, key_name, body='foo'):
-        self.client.put_object(
-            Bucket=self.bucket_name, Key=key_name,
-            Body=body)
-        self.wait_until_key_exists(self.bucket_name, key_name)
 
 
 class TestS3PresignUsStandard(BaseS3PresignTest):


### PR DESCRIPTION
This copies over the logic to wait for an object's existence from the CLI and adds it to one of the base S3 integ test classes to make the integration tests a little more resilient to eventual consistency.