### PR TITLE
Check for all known metadata when building models

### DIFF
--- a/botocore/model.py
+++ b/botocore/model.py
@@ -723,8 +723,9 @@ class DenormalizedStructureBuilder(object):
         }
         if 'documentation' in model:
             shape['documentation'] = model['documentation']
-        if 'enum' in model:
-            shape['enum'] = model['enum']
+        for attr in Shape.METADATA_ATTRS:
+            if attr in model:
+                shape[attr] = model[attr]
         return shape
 
     def _build_scalar(self, model):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -870,6 +870,20 @@ class TestBuilders(unittest.TestCase):
         self.assertEqual(shape.members['A'].documentation,
                          'MyDocs')
 
+    def test_min_max_used_in_metadata(self):
+        b = model.DenormalizedStructureBuilder()
+        shape = b.with_members({
+            'A': {
+                'type': 'string',
+                'documentation': 'MyDocs',
+                'min': 2,
+                'max': 3,
+            },
+        }).build_model()
+        metadata = shape.members['A'].metadata
+        self.assertEqual(metadata.get('min'), 2)
+        self.assertEqual(metadata.get('max'), 3)
+
     def test_use_shape_name_when_provided(self):
         b = model.DenormalizedStructureBuilder()
         shape = b.with_members({


### PR DESCRIPTION
This came up when I was writing a test for an AWS CLI PR and needed min/max to be part of the models it was building.