### PR TITLE
Header X-Amz-Content-SHA256

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.json
+++ b/botocore/data/s3/2006-03-01/service-2.json
@@ -1601,6 +1601,7 @@
     "ContentLanguage":{"type":"string"},
     "ContentLength":{"type":"long"},
     "ContentMD5":{"type":"string"},
+    "ContentSHA256":{"type":"string"},
     "ContentRange":{"type":"string"},
     "ContentType":{"type":"string"},
     "ContinuationEvent":{
@@ -6787,6 +6788,12 @@
           "documentation":"<p>The base64-encoded 128-bit MD5 digest of the part data. This parameter is auto-populated when using the command from the CLI</p>",
           "location":"header",
           "locationName":"Content-MD5"
+        },
+        "ContentSHA256":{
+          "shape":"ContentSHA256",
+          "documentation":"<p>SHA-256 digest of the part data.</p>",
+          "location":"header",
+          "locationName":"X-Amz-Content-SHA256"
         },
         "ContentType":{
           "shape":"ContentType",


### PR DESCRIPTION
Enabling signature v4 header *X-Amz-Content-SHA256*
Example:
```
import boto3
from botocore.config import Config

config = Config(signature_version='v4')
client = boto3.client('s3', region_name='eu-central-1', config=config)
filename = '/my/file.test' 

with open(filename,"rb") as f:
    client.put_object(
        Key="file.test", Body=f,
        Bucket="bucket-name",
        ContentSHA256=sha256_hash_hexdigest)
```