### PR TITLE
Remove duplicate retry handler registration

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -180,7 +180,7 @@
       }
     },
     "kinesis": {
-      "DescribeStream": {
+      "__default__": {
         "policies": {
           "request_limit_exceeded": {
             "applies_when": {


### PR DESCRIPTION

The retry handlers that hook up to service-data-loaded
were added before botocore clients were added.  This results
in the client level retry handlers being a no-op if they were
already loaded (they use the same unique_id).

This means you can have subtly different behavior
depending on if you (or something else) calls
`session.get_service_data()`.

I also changed kinesis per-op to be per-service

The LimitExceededException doesn't apply to just
DescribeStream and the client-based retry handler
doesn't support per-operation retries.
This also ensures we continue to retry this
exception in kinesis for DescribeStream without
requiring per-operation retry functionality.

Fixes https://github.com/boto/botocore/issues/1698