### PR TITLE
Pluggable HMAC signers

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -543,6 +543,11 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         )
 
 
+class SigningCredentials(Credentials):
+    def hmac_sign(self, key, message, hex=False, version=None):
+        raise NotImplementedError('hmac_sign()')
+
+
 class CachedCredentialFetcher(object):
     def __init__(self, cache=None, expiry_window_seconds=60 * 15):
         if cache is None:


### PR DESCRIPTION
To accommodate sequestration of keys into HSMs, signers should not assume that a key is always available verbatim from `self.credentials.secret_key`.

This PR introduces a new class, botocore.credentials.SigningCredentials, and utility methods in botocore.auth to delegate HMAC signing to the credentials class if it's a subclass of SigningCredentials. This allows a custom credentials subclass to be passed in to botocore at init time, that signs the message using a key whose value is only known to a processor inside a hardware security key (such as a YubiKey).

Closes #1689 