### PR TITLE
Prefer AWS_PROFILE over AWS_DEFAULT_PROFILE

### DIFF
--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -43,7 +43,7 @@ from botocore import utils
 #: found.
 BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # logical:  config_file, env_var,        default_value, conversion_func
-    'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None),
+    'profile': (None, ['AWS_PROFILE', 'AWS_DEFAULT_PROFILE'], None, None),
     'region': ('region', 'AWS_DEFAULT_REGION', None, None),
     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -33,6 +33,11 @@ class TestSession(unittest.TestCase):
         self.session.set_config_variable('profile', 'from_session_instance')
         self.assertEqual(self.session.profile, 'from_session_instance')
 
+    def test_default_profile_precedence(self):
+        self.environ['AWS_DEFAULT_PROFILE'] = 'from_default_env_var'
+        self.environ['AWS_PROFILE'] = 'from_env_var'
+        self.assertEqual(self.session.profile, 'from_env_var')
+
     def test_credentials_with_profile_precedence(self):
         self.environ['AWS_PROFILE'] = 'from_env_var'
         self.session.set_config_variable('profile',  'from_session_instance')

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -334,7 +334,7 @@ class TestSessionConfigurationVars(BaseSessionTest):
                          ('region', 'AWS_DEFAULT_REGION', None, None))
         self.assertEqual(
             self.session.session_var_map['profile'],
-            (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None))
+            (None, ['AWS_PROFILE', 'AWS_DEFAULT_PROFILE'], None, None))
         self.assertEqual(
             self.session.session_var_map['data_path'],
             ('data_path', 'AWS_DATA_PATH', None, None))


### PR DESCRIPTION
If one has both `AWS_DEFAULT_PROFILE` and `AWS_PROFILE` environment variables set in their environment, botocore will prefer the default profile. I believe the intended behaviour is to use `AWS_PROFILE` when set (similar to preferring a `profile` set in the config over the environment variables).

This can be confirmed by running the introduced `functional/test_session.py:test_default_profile_precedence` test, or by setting both environment variables to valid aws profiles and calling, e.g., `aws sts get-caller-identity`.

See https://github.com/boto/botocore/issues/1725