### PR TITLE
Retry by default for Kinesis endpoints

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -180,7 +180,7 @@
       }
     },
     "kinesis": {
-      "DescribeStream": {
+      "__default__": {
         "policies": {
           "request_limit_exceeded": {
             "applies_when": {


### PR DESCRIPTION
Several Kinesis endpoints respond with LimitExceededException, this makes the default behavior for all of them retry. At least the following endpoints have small TPS limits that this will benefit: ListStreams, CreateStream, DeleteStream, DescribeStream, GetRecords