### PR TITLE
allow the use of urllib3 1.25.x (fix)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,5 +11,5 @@ requires-dist =
     simplejson==3.3.0; python_version=="2.6"
     urllib3>=1.20,<1.23; python_version=="3.3"
     urllib3>=1.20,<1.24; python_version=="2.6"
-    urllib3>=1.20,<1.25; python_version=="2.7"
-    urllib3>=1.20,<1.25; python_version>="3.4"
+    urllib3>=1.20,<1.26; python_version=="2.7"
+    urllib3>=1.20,<1.26; python_version>="3.4"


### PR DESCRIPTION
This change was already done in 3a6bd282 and related PR: https://github.com/boto/botocore/pull/1735
In previous PR, version of urlib3 has been modified in :
- `setup.py`
- `requirements.txt`

But not in `setup.cfg`, thus being not effective in some situations (cf details in https://github.com/boto/botocore/pull/1735#issuecomment-495153843).
This PR is trying to fix that.