### PR TITLE
Support transfer-encoding chunked in urllib3

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -239,6 +239,9 @@ class URLLib3Session(object):
             # otherwise just set the request target to the url path
             return self._path_url(url)
 
+    def _chunked(self, headers):
+        return headers.get('Transfer-Encoding', '') == 'chunked'
+
     def send(self, request):
         try:
             proxy_url = self._proxy_config.proxy_url_for(request.url)
@@ -256,6 +259,7 @@ class URLLib3Session(object):
                 assert_same_host=False,
                 preload_content=False,
                 decode_content=False,
+                chunked=self._chunked(request.headers),
             )
 
             http_response = botocore.awsrequest.AWSResponse(

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -93,7 +93,7 @@ class TestURLLib3Session(unittest.TestCase):
         self.pool_patch.stop()
         self.proxy_patch.stop()
 
-    def assert_request_sent(self, headers=None, body=None, url='/'):
+    def assert_request_sent(self, headers=None, body=None, url='/', chunked=False):
         if headers is None:
             headers = {}
 
@@ -106,6 +106,7 @@ class TestURLLib3Session(unittest.TestCase):
             assert_same_host=False,
             preload_content=False,
             decode_content=False,
+            chunked=chunked,
         )
 
     def _assert_manager_call(self, manager, *assert_args, **assert_kwargs):
@@ -266,3 +267,19 @@ class TestURLLib3Session(unittest.TestCase):
         self.assertIs(http_class, AWSHTTPConnectionPool)
         https_class = self.pool_manager.pool_classes_by_scheme.get('https')
         self.assertIs(https_class, AWSHTTPSConnectionPool)
+
+    def test_chunked_encoding_is_set_with_header(self):
+        session = URLLib3Session()
+        self.request.headers['Transfer-Encoding'] = 'chunked'
+
+        session.send(self.request.prepare())
+        self.assert_request_sent(
+            chunked=True,
+            headers={'Transfer-Encoding': 'chunked'},
+        )
+
+    def test_chunked_encoding_is_not_set_without_header(self):
+        session = URLLib3Session()
+
+        session.send(self.request.prepare())
+        self.assert_request_sent(chunked=False)


### PR DESCRIPTION
Before if the Transfer-Encoding header was set, it would have no effect
on the request since chunked was still set to False in the urlopen
call. This change uses the value of the Transfer-Encoding header to set
the chunked parameter to urlopen.