### PR TITLE
Remove duplicate dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,7 @@
 tox>=2.5.0,<3.0.0
-python-dateutil>=2.1,<2.7.0; python_version=="2.6"
-python-dateutil>=2.1,<3.0.0; python_version>="2.7"
 nose==1.3.7
 mock==1.3.0
 wheel==0.24.0
 docutils>=0.10
 behave==1.2.5
--e git://github.com/boto/jmespath.git@develop#egg=jmespath
 jsonschema==2.5.1
-urllib3>=1.20,<1.23; python_version=="3.3"
-urllib3>=1.20,<1.24; python_version=="2.6"
-urllib3>=1.20,<1.26; python_version=="2.7"
-urllib3>=1.20,<1.26; python_version>="3.4"


### PR DESCRIPTION
The requirements files are now only used for dependencies
needed for testing/dev.  All of the runtime dependencies of
botocore are specified via the setup files.

This also reduces the number of files we have to modify when
we bump our dependencies.