### PR TITLE
Show requests deprecation warning by default

### DIFF
--- a/botocore/vendored/requests/api.py
+++ b/botocore/vendored/requests/api.py
@@ -24,6 +24,13 @@ _WARNING_MSG = (
 )
 
 
+warnings.filterwarnings(
+    action="always",
+    category=DeprecationWarning,
+    module=__name__,
+)
+
+
 def request(method, url, **kwargs):
     """Constructs and sends a :class:`Request <Request>`.
 


### PR DESCRIPTION
This adds a warning filter that ensures that the requests
deprecation warning is printed unless a user manually disables it.