### PR TITLE
Add select_resource_config paginator support

### DIFF
--- a/botocore/data/config/2014-11-12/paginators-1.json
+++ b/botocore/data/config/2014-11-12/paginators-1.json
@@ -31,6 +31,15 @@
       "result_key": "configurationItems",
       "limit_key": "limit"
     },
+    "SelectResourceConfig": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "Results",
+      "limit_key": "Limit",
+      "non_aggregate_keys": [
+        "QueryInfo"
+      ]
+    },
     "ListDiscoveredResources": {
       "input_token": "nextToken",
       "output_token": "nextToken",


### PR DESCRIPTION
Adds paginator data to support the Config service API's `select_resource_config` action.

Addresses #1722 