### PR TITLE
Remove paginator PageSize config when no limit_key

### DIFF
--- a/botocore/docs/paginator.py
+++ b/botocore/docs/paginator.py
@@ -108,9 +108,10 @@ def document_paginate_method(section, paginator_name, event_emitter,
             'will be provided in the output that you can use to '
             'resume pagination.</p>'))
 
-    pagination_config_members['PageSize'] = DocumentedShape(
-        name='PageSize', type_name='integer',
-        documentation='<p>The size of each page.<p>')
+    if paginator_config.get('limit_key', None):
+        pagination_config_members['PageSize'] = DocumentedShape(
+            name='PageSize', type_name='integer',
+            documentation='<p>The size of each page.<p>')
 
     pagination_config_members['StartingToken'] = DocumentedShape(
         name='StartingToken', type_name='string',

--- a/tests/unit/docs/test_paginator.py
+++ b/tests/unit/docs/test_paginator.py
@@ -74,3 +74,15 @@ class TestPaginatorDocumenter(BaseDocsTest):
             '        - **Biz** *(string) --*',
             '        - **NextToken** *(string) --*'
         ])
+
+    def test_no_page_size_if_no_limit_key(self):
+        paginator = self.paginator_json_model["pagination"]
+        operation = paginator["SampleOperation"]
+        del operation["limit_key"]
+
+        self.paginator_documenter.document_paginators(
+            self.doc_structure)
+        self.assert_not_contains_lines([
+            '              \'PageSize\': 123,',
+            '      - **PageSize** *(integer) --*',
+        ])


### PR DESCRIPTION
Remove the PageSize param from the documentation when there is no limit_key in the api. This results in an exception if used.