### PR TITLE
Raise NoCredentialsError when no credentials are found

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -31,6 +31,7 @@ import botocore.configloader
 import botocore.compat
 from botocore.compat import total_seconds
 from botocore.compat import compat_shell_split
+from botocore.exceptions import NoCredentialsError
 from botocore.exceptions import UnknownCredentialError
 from botocore.exceptions import PartialCredentialsError
 from botocore.exceptions import ConfigNotFound
@@ -1748,10 +1749,9 @@ class CredentialResolver(object):
             if creds is not None:
                 return creds
 
-        # If we got here, no credentials could be found.
-        # This feels like it should be an exception, but historically, ``None``
-        # is returned.
-        #
-        # +1
-        # -js
-        return None
+        # This is a change in behavior, but is a safety feature that will
+        # ensure that the session will get credentials. This avoids the
+        # scenario where it's possible to fail to receive credentials from
+        # the instance metadata store and then never refresh, despite that
+        # being the desired credential method.
+        raise NoCredentialsError

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -95,6 +95,24 @@ def create_session(**kwargs):
     return session
 
 
+def write_base_foo_config(f):
+    """Creates a bare minimum foo config.
+
+    Useful for ensuring that valid credentials will be made.
+
+    Assumes that `f` is a file handle to a temporary file.
+    """
+
+    lines = [
+        '[default]',
+        'aws_access_key_id = foo',
+        'aws_secret_access_key = bar',
+        '',  # Needs newline to ensure additional configs can be appended
+    ]
+
+    f.write('\n'.join(lines))
+
+
 @contextlib.contextmanager
 def temporary_file(mode):
     """This is a cross platform temporary file creation.

--- a/tests/functional/test_client_class_names.py
+++ b/tests/functional/test_client_class_names.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from nose.tools import assert_equal
+import mock
 
 import botocore.session
 
@@ -71,6 +72,7 @@ SERVICE_TO_CLASS_NAME = {
 
 def test_client_has_correct_class_name():
     session = botocore.session.get_session()
+    session.get_credentials = mock.Mock(return_value=mock.Mock())
     for service_name in SERVICE_TO_CLASS_NAME:
         client = session.create_client(service_name, REGION)
         yield (_assert_class_name_matches_ref_class_name, client,

--- a/tests/functional/test_client_metadata.py
+++ b/tests/functional/test_client_metadata.py
@@ -11,12 +11,15 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from tests import unittest
+import mock
 
 import botocore.session
+
 
 class TestClientMeta(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
+        self.session.get_credentials = mock.Mock(return_value=mock.Mock())
 
     def test_region_name_on_meta(self):
         client = self.session.create_client('s3', 'us-west-2')

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -370,6 +370,7 @@ class TestAssumeRole(BaseEnvVar):
             '[profile A]\n'
             'role_arn = arn:aws:iam::123456789:role/RoleA\n'
             'source_profile = B\n'
+            'credential_source = CustomInvalidProvider\n'
             '[profile B]\n'
             'region = us-west-2\n'
         )

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1285,8 +1285,7 @@ class CredentialResolverTest(BaseEnvVar):
         self.provider2.load.return_value = None
         resolver = credentials.CredentialResolver(providers=[self.provider1,
                                                              self.provider2])
-        creds = resolver.load_credentials()
-        self.assertIsNone(creds)
+        self.assertRaises(botocore.exceptions.NoCredentialsError, resolver.load_credentials)
 
     def test_inject_additional_providers_after_existing(self):
         self.provider1.load.return_value = None

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -13,6 +13,7 @@
 # language governing permissions and limitations under the License.
 import pickle
 from tests import unittest
+import mock
 
 from nose.tools import assert_equal
 
@@ -121,6 +122,7 @@ class TestPickleExceptions(unittest.TestCase):
 
     def test_dynamic_client_error(self):
         session = botocore.session.Session()
+        session.get_credentials = mock.Mock(return_value=mock.Mock())
         client = session.create_client('s3', 'us-west-2')
         exception = client.exceptions.NoSuchKey(
             error_response={

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -13,7 +13,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import botocore.config
-from tests import unittest, create_session, temporary_file
+from tests import unittest, create_session, temporary_file, write_base_foo_config
 import os
 import logging
 import tempfile
@@ -584,7 +584,7 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_ca_bundle=config-certs.pem\n')
             f.flush()
 
@@ -613,7 +613,7 @@ class TestCreateClient(BaseSessionTest):
             # Set the ca cert using the config file
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_ca_bundle=config-certs.pem\n')
             f.flush()
 
@@ -641,7 +641,7 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n' % config_api_version)
             f.flush()
@@ -658,7 +658,7 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n'
                     '    myservice2 = %s\n' % (
@@ -684,7 +684,7 @@ class TestCreateClient(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n' % config_api_version)
             f.flush()
@@ -747,7 +747,7 @@ class TestClientMonitoring(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('csm_enabled=true\n')
             f.flush()
             self.assert_created_client_is_monitored(self.session)
@@ -776,7 +776,7 @@ class TestClientMonitoring(BaseSessionTest):
         with temporary_file('w') as f:
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('csm_enabled=false\n')
             f.flush()
             self.assert_created_client_is_not_monitored(self.session)

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -13,7 +13,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import botocore.config
-from tests import unittest, create_session, temporary_file
+from tests import unittest, create_session, temporary_file, write_base_foo_config
 import os
 import logging
 import tempfile
@@ -581,7 +581,7 @@ class TestCreateClient(BaseSessionTest):
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
             self.session = create_session(session_vars=self.env_vars)
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_ca_bundle=config-certs.pem\n')
             f.flush()
 
@@ -611,7 +611,7 @@ class TestCreateClient(BaseSessionTest):
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
             self.session = create_session(session_vars=self.env_vars)
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_ca_bundle=config-certs.pem\n')
             f.flush()
 
@@ -640,7 +640,7 @@ class TestCreateClient(BaseSessionTest):
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
             self.session = create_session(session_vars=self.env_vars)
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n' % config_api_version)
             f.flush()
@@ -658,7 +658,7 @@ class TestCreateClient(BaseSessionTest):
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
             self.session = create_session(session_vars=self.env_vars)
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n'
                     '    myservice2 = %s\n' % (
@@ -685,7 +685,7 @@ class TestCreateClient(BaseSessionTest):
             del self.environ['FOO_PROFILE']
             self.environ['FOO_CONFIG_FILE'] = f.name
             self.session = create_session(session_vars=self.env_vars)
-            f.write('[default]\n')
+            write_base_foo_config(f)
             f.write('foo_api_versions =\n'
                     '    myservice = %s\n' % config_api_version)
             f.flush()

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -708,6 +708,7 @@ class TestS3PostPresigner(BaseSignerTest):
 class TestGenerateUrl(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
+        self.session.get_credentials = mock.Mock(return_value=mock.Mock())
         self.client = self.session.create_client('s3', region_name='us-east-1')
         self.bucket = 'mybucket'
         self.key = 'mykey'
@@ -837,6 +838,7 @@ class TestGenerateUrl(unittest.TestCase):
 class TestGeneratePresignedPost(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()
+        self.session.get_credentials = mock.Mock(return_value=mock.Mock())
         self.client = self.session.create_client('s3', region_name='us-east-1')
         self.bucket = 'mybucket'
         self.key = 'mykey'


### PR DESCRIPTION
Certain credential providers, such as the `InstanceMetadataProvider`  have the chance to fail to load credentials on start, even when the credentials exist and valid. Typically, such failures would get handled by the `RefreshableCredentials` class; however, that refresh only occurs if the provider was able to find credentials (thereby being the chosen credential provider).

The above situation results in a scenario where it's possible to create a session that does not have credentials. This will result in the client raising a `NoCredentialsError` upon the first usage of the credentials. That error will not have the ability to auto-resolve.

This PR moves the failure farther up the pipe, such that if credentials cannot be obtained, it will immediately bubble up to the user.

Having systematic credential failures like this are critical to be found upon session creation, rather than client use, as it enables services utilizing the session to know with certainty whether the session is usable or not.