### PR TITLE
Add retry case for cognito-idp

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -287,6 +287,20 @@
           }
         }
       }
+    },
+    "cognito-idp": {
+      "__default__": {
+        "policies": {
+          "too_many_requests": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "TooManyRequestsException",
+                "http_status_code": 400
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
* Add case for TooManyReqeustsException with HTTP 400 for cognito-idp
requests

Related Issue: https://github.com/boto/botocore/issues/1732