### PR TITLE
Don't throw error for invalid old starting token

### DIFF
--- a/.changes/next-release/bugfix-Paginator-26689.json
+++ b/.changes/next-release/bugfix-Paginator-26689.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "Fixes a bug where pagination tokens with three consecutive underscores would result in a parsing failure. Resolves boto/boto3`#1984 <https://github.com/boto/boto3/issues/1984>`__."
+}

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -522,8 +522,10 @@ class PageIterator(object):
             try:
                 index = int(parts.pop())
             except ValueError:
-                raise ValueError("Bad starting token: %s" %
-                                 self._starting_token)
+                # This doesn't look like a valid old-style token, so we're
+                # passing it along as an opaque service token.
+                parts = [self._starting_token]
+
         for part in parts:
             if part == 'None':
                 next_token.append(None)


### PR DESCRIPTION
Botocore has support for its own starting token formats, the older
of which simply splits up necessary data with triple underscores.
This format has been deprecated for a while due to various
shortcomings, but there's still input support for it for backwards
compatibility. The last element in that token format should be an
integer, which indicates how far to slice into the response. The
problem is that some services have tokens which include triple
underscores, so we think it's that format but malformed. This fixes
the problem by passing the full starting token along if parsing
fails.

Fixes boto/boto3#1984