### PR TITLE
Generally retry provisioned throughput exceptions

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -78,6 +78,14 @@
           "http_status_code": 509
         }
       }
+    },
+    "throughput_exceeded": {
+      "applies_when": {
+        "response": {
+          "service_error_code": "ProvisionedThroughputExceededException",
+          "http_status_code": 400
+        }
+      }
     }
   },
   "retry": {
@@ -99,7 +107,8 @@
           "throttled_exception": {"$ref": "throttled_exception"},
           "request_throttled_exception": {"$ref": "request_throttled_exception"},
           "throttling": {"$ref": "throttling"},
-          "too_many_requests": {"$ref": "too_many_requests"}
+          "too_many_requests": {"$ref": "too_many_requests"},
+          "throughput_exceeded": {"$ref": "throughput_exceeded"}
       }
     },
     "organizations": {
@@ -133,14 +142,6 @@
 	      }
 	    }
 	  },
-          "throughput_exceeded": {
-            "applies_when": {
-              "response": {
-                "service_error_code": "ProvisionedThroughputExceededException",
-                "http_status_code": 400
-              }
-            }
-          },
           "crc32": {
             "applies_when": {
               "response": {


### PR DESCRIPTION
Previously, we only retried the `ProvisionedThroughputExceededException` for DynamoDB. Now we will be retrying it for all services. The new services that this will encompass include TextTract, Rekognition, and Kinesis. In general, these services would throw this exception and the only way to get around it would be to retry or get your limits increased. So it made sense to retry it similar to what we do for DynamoDB. Furthermore, the other SDK's retry ProvisionedThroughputExceededException across all services already so we would be more consistent with the other SDK's as well.
