### PR TITLE
Support CSM host configuration

### DIFF
--- a/.changes/next-release/enhancement-CSM-70687.json
+++ b/.changes/next-release/enhancement-CSM-70687.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "CSM",
+  "description": "Support configuration of the host used in client side metrics via AWS_CSM_HOST"
+}

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -72,6 +72,7 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # Do not use them until publicly documented.
     'csm_enabled': (
             'csm_enabled', 'AWS_CSM_ENABLED', False, utils.ensure_boolean),
+    'csm_host': ('csm_host', 'AWS_CSM_HOST', '127.0.0.1', None),
     'csm_port': ('csm_port', 'AWS_CSM_PORT', 31000, int),
     'csm_client_id': ('csm_client_id', 'AWS_CSM_CLIENT_ID', '', None),
     # Endpoint discovery configuration

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -192,12 +192,13 @@ class Session(object):
     def _create_csm_monitor(self):
         if self.get_config_variable('csm_enabled'):
             client_id = self.get_config_variable('csm_client_id')
+            host = self.get_config_variable('csm_host')
             port = self.get_config_variable('csm_port')
             handler = monitoring.Monitor(
                 adapter=monitoring.MonitorEventAdapter(),
                 publisher=monitoring.SocketPublisher(
                     socket=socket.socket(socket.AF_INET, socket.SOCK_DGRAM),
-                    host='127.0.0.1',
+                    host=host,
                     port=port,
                     serializer=monitoring.CSMSerializer(
                         csm_client_id=client_id)


### PR DESCRIPTION
This adds support for a configurable host when using client side metrics.