### PR TITLE
Fix flaky s3 botocore tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -443,10 +443,12 @@ class ConsistencyWaiter(object):
     :param delay: The number of seconds to delay the next API call after a
     failed check call. Default of 5 seconds.
     """
-    def __init__(self, min_successes=1, max_attempts=20, delay=5):
+    def __init__(self, min_successes=1, max_attempts=20, delay=5,
+                 delay_initial_poll=False):
         self.min_successes = min_successes
         self.max_attempts = max_attempts
         self.delay = delay
+        self.delay_initial_poll = delay_initial_poll
 
     def wait(self, check, *args, **kwargs):
         """
@@ -464,6 +466,8 @@ class ConsistencyWaiter(object):
         """
         attempts = 0
         successes = 0
+        if self.delay_initial_poll:
+            time.sleep(self.delay)
         while attempts < self.max_attempts:
             attempts += 1
             if check(*args, **kwargs):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -165,12 +165,15 @@ class BaseS3ClientTest(unittest.TestCase):
             waiter.wait(**params)
 
     def _check_bucket_versioning(self, bucket, enabled=True):
-        response = self.client.get_bucket_versioning(Bucket=bucket)
+        client = self.session.create_client('s3', region_name=self.region)
+        response = client.get_bucket_versioning(Bucket=bucket)
         status = response.get('Status')
         return status == 'Enabled' if enabled else status != 'Enabled'
 
     def wait_until_versioning_enabled(self, bucket, min_successes=3):
-        waiter = ConsistencyWaiter(min_successes=min_successes)
+        waiter = ConsistencyWaiter(
+            min_successes=min_successes,
+            delay=5, delay_initial_poll=True)
         waiter.wait(self._check_bucket_versioning, bucket)
 
 


### PR DESCRIPTION
This adds two fixes:

* Use a new client (and new connection) each time we poll.
* Add an initial delay where we can optionally wait a fixed amount
  of time before we start polling.