### PR TITLE
Refactor how assume role pulls credential from source_profile

### DIFF
--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -30,7 +30,7 @@ from tests import temporary_file
 from botocore.credentials import EnvProvider, ContainerProvider
 from botocore.credentials import InstanceMetadataProvider
 from botocore.credentials import Credentials, ReadOnlyCredentials
-from botocore.credentials import AssumeRoleProvider, get_profile_providers
+from botocore.credentials import AssumeRoleProvider, ProfileProviderBuilder
 from botocore.credentials import CanonicalNameCredentialSourcer
 from botocore.credentials import DeferredRefreshableCredentials
 from botocore.credentials import create_credential_resolver
@@ -196,7 +196,7 @@ class TestAssumeRole(BaseEnvVar):
                 self.env_provider, self.container_provider,
                 self.metadata_provider
             ]),
-            profile_providers=get_profile_providers(session),
+            profile_provider_builder=ProfileProviderBuilder(session),
         )
 
         component_name = 'credential_provider'

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -28,7 +28,7 @@ from botocore.compat import json
 from botocore.credentials import EnvProvider, create_assume_role_refresher
 from botocore.credentials import CredentialProvider, AssumeRoleProvider
 from botocore.credentials import ConfigProvider, SharedCredentialProvider
-from botocore.credentials import Credentials, get_profile_providers
+from botocore.credentials import Credentials, ProfileProviderBuilder
 from botocore.configprovider import create_botocore_default_config_mapping
 from botocore.configprovider import ConfigChainFactory
 from botocore.configprovider import ConfigValueStore
@@ -2317,12 +2317,14 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
             },
         }
         client_creator = self.create_client_creator(with_response=response)
+        mock_builder = mock.Mock(spec=ProfileProviderBuilder)
+        mock_builder.providers.return_value = [ProfileProvider('foo-profile')]
 
         provider = credentials.AssumeRoleProvider(
             self.create_config_loader(),
             client_creator, cache={},
             profile_name='development',
-            profile_providers=[ProfileProvider],
+            profile_provider_builder=mock_builder,
         )
 
         creds = provider.load().get_frozen_credentials()


### PR DESCRIPTION
This is a continuation of #1770.

This updates the previous to PR to move away from partials to a more proper object to construct credential providers that can vary based on the profile. This new object allows us to share the building logic between how the default credential chain is created and the source profile chain is created within the `AssumeRoleProvider`. 