### PR TITLE
Removed code for checking bucket name length=1 in check_dns_name

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -870,9 +870,6 @@ def check_dns_name(bucket_name):
     if n < 3 or n > 63:
         # Wrong length
         return False
-    if n == 1:
-        if not bucket_name.isalnum():
-            return False
     match = LABEL_RE.match(bucket_name)
     if match is None or match.end() != len(bucket_name):
         return False


### PR DESCRIPTION
Already a condition exists for checking bucket name length<3 so this is not necessary to add another condition for checking length=1.
Fixes: #1785 