### PR TITLE
Fix list object versions encoding

### DIFF
--- a/.changes/next-release/bugfix-S3-605.json
+++ b/.changes/next-release/bugfix-S3-605.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "Fix an issue that would cause S3 list_object_versions to sometimes fail parsing responses with certain key values."
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -715,6 +715,28 @@ def decode_list_object_v2(parsed, context, **kwargs):
     )
 
 
+def decode_list_object_versions(parsed, context, **kwargs):
+    # From the documentation: If you specify encoding-type request parameter,
+    # Amazon S3 includes this element in the response, and returns encoded key
+    # name values in the following response elements:
+    # KeyMarker, NextKeyMarker, Prefix, Key, and Delimiter.
+    _decode_list_object(
+        top_level_keys=[
+            'KeyMarker',
+            'NextKeyMarker',
+            'Prefix',
+            'Delimiter',
+        ],
+        nested_keys=[
+            ('Versions', 'Key'),
+            ('DeleteMarkers', 'Key'),
+            ('CommonPrefixes', 'Prefix'),
+        ],
+        parsed=parsed,
+        context=context
+    )
+
+
 def _decode_list_object(top_level_keys, nested_keys, parsed, context):
     if parsed.get('EncodingType') == 'url' and \
                     context.get('encoding_type_auto_set'):
@@ -902,6 +924,8 @@ BUILTIN_HANDLERS = [
      set_list_objects_encoding_type_url),
     ('before-parameter-build.s3.ListObjectsV2',
      set_list_objects_encoding_type_url),
+    ('before-parameter-build.s3.ListObjectVersions',
+     set_list_objects_encoding_type_url),
     ('before-call.s3.PutBucketTagging', calculate_md5),
     ('before-call.s3.PutBucketLifecycle', calculate_md5),
     ('before-call.s3.PutBucketLifecycleConfiguration', calculate_md5),
@@ -968,6 +992,7 @@ BUILTIN_HANDLERS = [
     ('before-parameter-build.glacier', inject_account_id),
     ('after-call.s3.ListObjects', decode_list_object),
     ('after-call.s3.ListObjectsV2', decode_list_object_v2),
+    ('after-call.s3.ListObjectVersions', decode_list_object_versions),
 
     # Cloudsearchdomain search operation will be sent by HTTP POST
     ('request-created.cloudsearchdomain.Search',

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -476,6 +476,21 @@ class TestS3Objects(TestS3BaseWithBucket):
         self.assertEqual(len(parsed['Contents']), 1)
         self.assertEqual(parsed['Contents'][0]['Key'], 'foo%08')
 
+    def test_unicode_system_character_with_list_object_versions(self):
+        # Verify we can use a unicode system character which would normally
+        # break the xml parser
+        key_name = 'foo\x03'
+        self.create_object(key_name)
+        self.addCleanup(self.delete_object, key_name, self.bucket_name)
+        parsed = self.client.list_object_versions(Bucket=self.bucket_name)
+        self.assertEqual(len(parsed['Versions']), 1)
+        self.assertEqual(parsed['Versions'][0]['Key'], key_name)
+
+        parsed = self.client.list_object_versions(Bucket=self.bucket_name,
+                                          EncodingType='url')
+        self.assertEqual(len(parsed['Versions']), 1)
+        self.assertEqual(parsed['Versions'][0]['Key'], 'foo%03')
+
     def test_thread_safe_auth(self):
         self.auth_paths = []
         emitter = self.session.get_component('event_emitter')


### PR DESCRIPTION
This applies the same automatic encoding and decoding on ListObjects
to avoid parsing errors when there are problematic characters for our
XML parser.