### PR TITLE
Corrected example of create_network_a…

### DIFF
--- a/botocore/data/ec2/2016-11-15/examples-1.json
+++ b/botocore/data/ec2/2016-11-15/examples-1.json
@@ -556,7 +556,7 @@
             "From": 53,
             "To": 53
           },
-          "Protocol": "udp",
+          "Protocol": "17",
           "RuleAction": "allow",
           "RuleNumber": 100
         },


### PR DESCRIPTION
Fixes issue [#1716](https://github.com/boto/boto3/issues/1716)

Changed protocol value to a number in the example of create_network_acl_entry as per api documentation this parameter expects a number. 
