### PR TITLE
Add Glue JobRunSucceeded waiter

### DIFF
--- a/botocore/data/glue/2017-03-31/waiters-2.json
+++ b/botocore/data/glue/2017-03-31/waiters-2.json
@@ -1,0 +1,42 @@
+{
+  "version": 2,
+  "waiters": {
+    "JobRunSucceeded": {
+      "delay": 30,
+      "operation": "GetJobRun",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "path",
+          "argument": "JobRun.JobRunState",
+          "expected": "SUCCEEDED"
+        },
+        {
+          "state": "failure",
+          "matcher": "path",
+          "argument": "JobRun.JobRunState",
+          "expected": "FAILED"
+        },
+        {
+          "state": "failure",
+          "matcher": "path",
+          "argument": "JobRun.JobRunState",
+          "expected": "STOPPING"
+        },
+        {
+          "state": "failure",
+          "matcher": "path",
+          "argument": "JobRun.JobRunState",
+          "expected": "STOPPED"
+        },
+        {
+          "state": "failure",
+          "matcher": "path",
+          "argument": "JobRun.JobRunState",
+          "expected": "TIMEOUT"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds a `JobRunSucceeded` waiter to Glue. Polling delay and max attempts are borrowed from the EMR `StepComplete` waiter.