### PR TITLE
i#1789: Bump docutils to <0.16 due to conflict

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
-docutils>=0.10,<0.15
+docutils>=0.10,<0.16
 Sphinx>=1.1.3,<1.3
 guzzle_sphinx_theme>=0.7.10,<0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ tox>=2.5.0,<3.0.0
 nose==1.3.7
 mock==1.3.0
 wheel==0.24.0
-docutils>=0.10,<0.15
+docutils>=0.10,<0.16
 behave==1.2.5
 jsonschema==2.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ requires-dist =
     python-dateutil>=2.1,<2.7.0; python_version=="2.6"
     python-dateutil>=2.1,<3.0.0; python_version>="2.7"
     jmespath>=0.7.1,<1.0.0
-    docutils>=0.10,<0.15
+    docutils>=0.10,<0.16
     ordereddict==1.1; python_version=="2.6"
     simplejson==3.3.0; python_version=="2.6"
     urllib3>=1.20,<1.23; python_version=="3.3"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 
 
 requires = ['jmespath>=0.7.1,<1.0.0',
-            'docutils>=0.10,<0.15']
+            'docutils>=0.10,<0.16']
 
 
 if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
Docutils have release version 0.15.2 creating conflicts.
This PR bumps docutils from < 0.15 to 0.16.

#1789 