### PR TITLE
[WIP] Allow sharing credentials between custom profiles

### DIFF
--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1263,7 +1263,7 @@ class TestSharedCredentialsProvider(BaseEnvVar):
             }
         }
         provider = credentials.SharedCredentialProvider(
-            creds_filename='~/.aws/creds', profile_name='default',
+            load_config=lambda: {}, creds_filename='~/.aws/creds', profile_name='default',
             ini_parser=self.ini_parser)
         creds = provider.load()
         self.assertIsNotNone(creds)
@@ -1280,7 +1280,7 @@ class TestSharedCredentialsProvider(BaseEnvVar):
             }
         }
         provider = credentials.SharedCredentialProvider(
-            creds_filename='~/.aws/creds', profile_name='default',
+            load_config=lambda: {}, creds_filename='~/.aws/creds', profile_name='default',
             ini_parser=self.ini_parser)
         with self.assertRaises(botocore.exceptions.PartialCredentialsError):
             provider.load()
@@ -1294,7 +1294,7 @@ class TestSharedCredentialsProvider(BaseEnvVar):
             }
         }
         provider = credentials.SharedCredentialProvider(
-            creds_filename='~/.aws/creds', profile_name='default',
+            load_config=lambda: {}, creds_filename='~/.aws/creds', profile_name='default',
             ini_parser=self.ini_parser)
         creds = provider.load()
         self.assertIsNotNone(creds)
@@ -1319,7 +1319,7 @@ class TestSharedCredentialsProvider(BaseEnvVar):
         }
         # And we specify a profile_name of 'dev'.
         provider = credentials.SharedCredentialProvider(
-            creds_filename='~/.aws/creds', profile_name='dev',
+            load_config=lambda: {}, creds_filename='~/.aws/creds', profile_name='dev',
             ini_parser=self.ini_parser)
         creds = provider.load()
         self.assertIsNotNone(creds)
@@ -1334,7 +1334,7 @@ class TestSharedCredentialsProvider(BaseEnvVar):
         self.ini_parser.side_effect = botocore.exceptions.ConfigNotFound(
             path='foo')
         provider = credentials.SharedCredentialProvider(
-            creds_filename='~/.aws/creds', profile_name='dev',
+            load_config=lambda: {}, creds_filename='~/.aws/creds', profile_name='dev',
             ini_parser=self.ini_parser)
         creds = provider.load()
         self.assertIsNone(creds)

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1675,6 +1675,7 @@ class TestCreateCredentialResolver(BaseEnvVar):
         self.session.set_config_variable = \
             self.fake_set_config_variable
         self.session.instance_variables = self.fake_instance_variable_lookup
+        self.session.full_config = {}
 
     def fake_get_component(self, key):
         if key == 'config_provider':
@@ -3217,6 +3218,7 @@ class TestProfileProviderBuilder(unittest.TestCase):
         super(TestProfileProviderBuilder, self).setUp()
         self.mock_session = mock.Mock(spec=Session)
         self.builder = ProfileProviderBuilder(self.mock_session)
+        self.mock_session.full_config = {}
 
     def test_profile_provider_builder_order(self):
         providers = self.builder.providers('some-profile')


### PR DESCRIPTION
## What?
Implements https://github.com/boto/botocore/issues/1815

This feature allows users to share credentials between profiles without having them defined as different roles:
```cfg
# ~/.aws/config
[profile prod]
region = eu-west-1
source_credentials = default

[profile develop]
region = us-east-1
source_credentials = default
```
would share the same credentials:
```cfg
# ~/.aws/credentials
[default]
aws_access_key_id = 12xxx
aws_secret_access_key = 34xxx
```

## WIP reason?
Want to get a feedback on this feature, i.e. get approval. Once I get the approval, I'll add unit tests as well as update the documentation.

## Thoughts?
Should this be using `source_profile` instead of a new config variable `source_credentials`?