### PR TITLE
Fix spelling of "parameted".

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.json
+++ b/botocore/data/s3/2006-03-01/service-2.json
@@ -6851,7 +6851,7 @@
         },
         "ContentMD5":{
           "shape":"ContentMD5",
-          "documentation":"<p>The base64-encoded 128-bit MD5 digest of the part data. This parameter is auto-populated when using the command from the CLI. This parameted is required if object lock parameters are specified.</p>",
+          "documentation":"<p>The base64-encoded 128-bit MD5 digest of the part data. This parameter is auto-populated when using the command from the CLI. This parameter is required if object lock parameters are specified.</p>",
           "location":"header",
           "locationName":"Content-MD5"
         },
@@ -8330,7 +8330,7 @@
         },
         "ContentMD5":{
           "shape":"ContentMD5",
-          "documentation":"<p>The base64-encoded 128-bit MD5 digest of the part data. This parameter is auto-populated when using the command from the CLI. This parameted is required if object lock parameters are specified.</p>",
+          "documentation":"<p>The base64-encoded 128-bit MD5 digest of the part data. This parameter is auto-populated when using the command from the CLI. This parameter is required if object lock parameters are specified.</p>",
           "location":"header",
           "locationName":"Content-MD5"
         },


### PR DESCRIPTION
Intended to show spelling issue of "parameter". Not intended for merge.