### PR TITLE
Update waiter test to assert for None

### DIFF
--- a/tests/functional/test_waiter_config.py
+++ b/tests/functional/test_waiter_config.py
@@ -156,7 +156,7 @@ def _validate_acceptor(acceptor, op_model, waiter_name):
         # JMESPath expression against the output.  We'll then
         # check a few things about this returned search result.
         search_result = _search_jmespath_expression(expression, op_model)
-        if not search_result:
+        if search_result is None:
             raise AssertionError("JMESPath expression did not match "
                                  "anything for waiter '%s': %s"
                                  % (waiter_name, expression))


### PR DESCRIPTION
Assert something is Falsy is not specific enough. If the waiter is doing a ``length`` check, it is possible for ``False`` to be returned back. Really what we want to be checking here is that ``None`` is not returned back as that indicates the JMESPath expression did not find anything that matched.