### PR TITLE
Increase length of fake directory identifier

### DIFF
--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -193,7 +193,7 @@ ERROR_TESTS = {
         }},
     'swf': {'DescribeDomain': {'name': 'fake'}},
     'waf': {'GetWebACL': {'WebACLId': 'fake'}},
-    'workspaces': {'DescribeWorkspaces': {'DirectoryId': 'fake'}},
+    'workspaces': {'DescribeWorkspaces': {'DirectoryId': 'fake-directory-id'}},
 }
 
 REGION = 'us-east-1'


### PR DESCRIPTION
The minimum length of this id is 10. If that is every enforced on the
client side it would cause this test to start failing.