### PR TITLE
Add sts regional endpoint configuration support

### DIFF
--- a/.changes/next-release/enhancement-sts-29751.json
+++ b/.changes/next-release/enhancement-sts-29751.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``sts``",
+  "description": "Add support for configuring the use of regional STS endpoints."
+}

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -322,7 +322,7 @@ class ClientCreator(object):
         args_creator = ClientArgsCreator(
             self._event_emitter, self._user_agent,
             self._response_parser_factory, self._loader,
-            self._exceptions_factory)
+            self._exceptions_factory, config_store=self._config_store)
         return args_creator.get_client_args(
             service_model, region_name, is_secure, endpoint_url,
             verify, credentials, scoped_config, client_config, endpoint_bridge)

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -79,6 +79,10 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     'endpoint_discovery_enabled': (
         'endpoint_discovery_enabled', 'AWS_ENDPOINT_DISCOVERY_ENABLED',
         False, utils.ensure_boolean),
+    'sts_regional_endpoints': (
+        'sts_regional_endpoints', 'AWS_STS_REGIONAL_ENDPOINTS', 'legacy',
+        None
+    ),
 }
 
 

--- a/botocore/data/endpoints.json
+++ b/botocore/data/endpoints.json
@@ -3382,42 +3382,26 @@
         }
       },
       "sts" : {
-        "defaults" : {
-          "credentialScope" : {
-            "region" : "us-east-1"
-          },
-          "hostname" : "sts.amazonaws.com"
-        },
         "endpoints" : {
-          "ap-east-1" : {
-            "credentialScope" : {
-              "region" : "ap-east-1"
-            },
-            "hostname" : "sts.ap-east-1.amazonaws.com"
-          },
+          "ap-east-1" : { },
           "ap-northeast-1" : { },
-          "ap-northeast-2" : {
-            "credentialScope" : {
-              "region" : "ap-northeast-2"
-            },
-            "hostname" : "sts.ap-northeast-2.amazonaws.com"
-          },
+          "ap-northeast-2" : { },
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
-          "aws-global" : { },
+          "aws-global" : {
+            "credentialScope" : {
+              "region" : "us-east-1"
+            },
+            "hostname" : "sts.amazonaws.com"
+          },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
-          "me-south-1" : {
-            "credentialScope" : {
-              "region" : "me-south-1"
-            },
-            "hostname" : "sts.me-south-1.amazonaws.com"
-          },
+          "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-1-fips" : {

--- a/botocore/data/sts/2011-06-15/service-2.json
+++ b/botocore/data/sts/2011-06-15/service-2.json
@@ -589,7 +589,7 @@
       "members":{
         "message":{"shape":"invalidAuthorizationMessage"}
       },
-      "documentation":"<p>The error returned if the message passed to <code>DecodeAuthorizationMessage</code> was invalid. This can happen if the token contains invalid characters, such as linebreaks. </p>",
+      "documentation":"<p>This error is returned if the message passed to <code>DecodeAuthorizationMessage</code> was invalid. This can happen if the token contains invalid characters, such as linebreaks. </p>",
       "error":{
         "code":"InvalidAuthorizationMessageException",
         "httpStatusCode":400,

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -468,6 +468,15 @@ class InvalidMaxRetryAttemptsError(InvalidRetryConfigurationError):
         'be an integer greater than or equal to zero.'
     )
 
+
+class InvalidSTSRegionalEndpointsConfigError(BotoCoreError):
+    """Error when invalid sts regional endpoints configuration is specified"""
+    fmt = (
+        'STS regional endpoints option {sts_regional_endpoints_config} is '
+        'invaild. Valid options are: legacy and regional'
+    )
+
+
 class StubResponseError(BotoCoreError):
     fmt = 'Error getting response stub for operation {operation_name}: {reason}'
 


### PR DESCRIPTION
To override the use of the global endpoint, set the `sts_regional_endpoints` config file variable or the `AWS_STS_REGIONAL_ENDPOINTS` environment variable to `regional`.