### PR TITLE
Allow transcribe streaming endpoint

### DIFF
--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -88,6 +88,7 @@ ENDPOINT_PREFIX_OVERRIDE = {
 }
 NOT_SUPPORTED_IN_SDK = [
     'mobileanalytics',
+    'transcribestreaming',
 ]
 
 


### PR DESCRIPTION
This service has released in other SDKs but requires HTTP/2 support. This whitelists this service as known despite not being supported in our SDK.