### PR TITLE
Cap upper version of python-dateutil to 2.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [metadata]
 requires-dist =
     python-dateutil>=2.1,<2.7.0; python_version=="2.6"
-    python-dateutil>=2.1,<3.0.0; python_version>="2.7"
+    python-dateutil>=2.1,<2.8.1; python_version>="2.7"
     jmespath>=0.7.1,<1.0.0
     docutils>=0.10,<0.16
     ordereddict==1.1; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if sys.version_info[:2] == (2, 6):
     requires.append('simplejson==3.3.0')
     requires.append('python-dateutil>=2.1,<2.7.0')
 else:
-    requires.append('python-dateutil>=2.1,<3.0.0')
+    requires.append('python-dateutil>=2.1,<2.8.1')
 
 if sys.version_info[:2] == (2, 6):
     requires.append('urllib3>=1.20,<1.24')


### PR DESCRIPTION
Version 2.8.1 and higher require a new version of setuptools,
due to moving all the setup() metadata into a setup.cfg file.

If you try and use the bundled installer for the AWS CLI, it won't
build the wheel file properly:

```
running bdist_wheel
running build
installing to build/bdist.macosx-10.12-x86_64/wheel
running install
running install_egg_info
running egg_info
writing UNKNOWN.egg-info/PKG-INFO
writing top-level names to UNKNOWN.egg-info/top_level.txt
writing dependency_links to UNKNOWN.egg-info/dependency_links.txt
reading manifest file 'UNKNOWN.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '__pycache__' found anywhere in distribution
warning: no previously-included files matching '*.py[co]' found anywhere in distribution
writing manifest file 'UNKNOWN.egg-info/SOURCES.txt'
Copying UNKNOWN.egg-info to build/bdist.macosx-10.12-x86_64/wheel/UNKNOWN-0.0.0-py2.7.egg-info
running install_scripts
creating build/bdist.macosx-10.12-x86_64/wheel/UNKNOWN-0.0.0.dist-info/WHEEL
creating 'dist/UNKNOWN-0.0.0-py2.py3-none-any.whl' and adding 'build/bdist.macosx-10.12-x86_64/wheel' to it
adding 'UNKNOWN-0.0.0.dist-info/LICENSE'
adding 'UNKNOWN-0.0.0.dist-info/METADATA'
adding 'UNKNOWN-0.0.0.dist-info/WHEEL'
adding 'UNKNOWN-0.0.0.dist-info/top_level.txt'
adding 'UNKNOWN-0.0.0.dist-info/RECORD'
removing build/bdist.macosx-10.12-x86_64/wheel
```

We'll need to upgrade our bundled installer dependencies, but in the
meantime, we'll lock to the last working version for us, 2.8.0.