### PR TITLE
Fix deprecation warning

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -15,7 +15,7 @@ import sys
 import logging
 import functools
 import socket
-import collections
+import collections.abc
 
 import urllib3.util
 from urllib3.connection import VerifiedHTTPSConnection
@@ -621,7 +621,7 @@ class _HeaderKey(object):
         return repr(self._key)
 
 
-class HeadersDict(collections.MutableMapping):
+class HeadersDict(collections.abc.MutableMapping):
     """A case-insenseitive dictionary to represent HTTP headers. """
     def __init__(self, *args, **kwargs):
         self._dict = {}

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -22,7 +22,7 @@ import os
 import platform
 import socket
 import warnings
-import collections
+import collections.abc
 
 from botocore import __version__
 from botocore import UNSIGNED
@@ -944,7 +944,7 @@ class ComponentLocator(object):
             pass
 
 
-class SessionVarDict(collections.MutableMapping):
+class SessionVarDict(collections.abc.MutableMapping):
     def __init__(self, session, session_vars):
         self._session = session
         self._store = copy.copy(session_vars)


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working