### PR TITLE
Initial support for SSO credentials in botocore v2

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 from hashlib import sha1
 
 from dateutil.parser import parse
-from dateutil.tz import tzlocal
+from dateutil.tz import tzlocal, tzutc
 
 import botocore.configloader
 import botocore.compat
@@ -40,9 +40,11 @@ from botocore.exceptions import InfiniteLoopConfigError
 from botocore.exceptions import RefreshWithMFAUnsupportedError
 from botocore.exceptions import MetadataRetrievalError
 from botocore.exceptions import CredentialRetrievalError
+from botocore.exceptions import UnauthorizedSSOTokenError
 from botocore.utils import InstanceMetadataFetcher, parse_key_val_file
 from botocore.utils import ContainerMetadataFetcher
 from botocore.utils import FileWebIdentityTokenLoader
+from botocore.utils import SSOTokenLoader
 
 
 logger = logging.getLogger(__name__)
@@ -138,16 +140,19 @@ class ProfileProviderBuilder(object):
     This is needed to enable sharing between the default credential chain and
     the source profile chain created by the assume role provider.
     """
-    def __init__(self, session, cache=None, region_name=None):
+    def __init__(self, session, cache=None, region_name=None,
+                 sso_token_cache=None):
         self._session = session
         self._cache = cache
         self._region_name = region_name
+        self._sso_token_cache = sso_token_cache
 
     def providers(self, profile_name, disable_env_vars=False):
         return [
             self._create_web_identity_provider(
                 profile_name, disable_env_vars,
             ),
+            self._create_sso_provider(profile_name),
             self._create_shared_credential_provider(profile_name),
             self._create_process_provider(profile_name),
             self._create_config_provider(profile_name),
@@ -181,6 +186,15 @@ class ProfileProviderBuilder(object):
             cache=self._cache,
             profile_name=profile_name,
             disable_env_vars=disable_env_vars,
+        )
+
+    def _create_sso_provider(self, profile_name):
+        return SSOProvider(
+            load_config=lambda: self._session.full_config,
+            client_creator=self._session.create_client,
+            profile_name=profile_name,
+            cache=self._cache,
+            token_cache=self._sso_token_cache,
         )
 
 
@@ -1956,3 +1970,148 @@ class CredentialResolver(object):
         # +1
         # -js
         return None
+
+
+class SSOCredentialFetcher(CachedCredentialFetcher):
+    def __init__(self, start_url, sso_region, role_name, account_id,
+                 client_creator, token_loader=None, cache=None,
+                 expiry_window_seconds=None):
+        self._client_creator = client_creator
+        self._sso_region = sso_region
+        self._role_name = role_name
+        self._account_id = account_id
+        self._start_url = start_url
+        self._token_loader = token_loader
+
+        super(SSOCredentialFetcher, self).__init__(
+            cache, expiry_window_seconds
+        )
+
+    def _create_cache_key(self):
+        """Create a predictable cache key for the current configuration.
+
+        The cache key is intended to be compatible with file names.
+        """
+        args = {
+            'startUrl': self._start_url,
+            'roleName': self._role_name,
+            'accountId': self._account_id,
+        }
+        # NOTE: It would be good to hoist this cache key construction logic
+        # into the CachedCredentialFetcher class as we should be consistent.
+        # Unfortunately, the current assume role fetchers that sub class don't
+        # pass separators resulting in non-minified JSON. In the long term,
+        # all fetchers should use the below caching scheme.
+        args = json.dumps(args, sort_keys=True, separators=(',', ':'))
+        argument_hash = sha1(args.encode('utf-8')).hexdigest()
+        return self._make_file_safe(argument_hash)
+
+    def _parse_timestamp(self, timestamp_ms):
+        # fromtimestamp expects seconds so: milliseconds / 1000 = seconds
+        timestamp_seconds = timestamp_ms / 1000.0
+        timestamp = datetime.datetime.fromtimestamp(timestamp_seconds, tzutc())
+        return _serialize_if_needed(timestamp)
+
+    def _get_credentials(self):
+        """Get credentials by calling SSO get role credentials."""
+        config = Config(
+            signature_version=UNSIGNED,
+            region_name=self._sso_region,
+        )
+        client = self._client_creator('sso', config=config)
+
+        kwargs = {
+            'roleName': self._role_name,
+            'accountId': self._account_id,
+            'accessToken': self._token_loader(self._start_url),
+        }
+        try:
+            response = client.get_role_credentials(**kwargs)
+        except client.exceptions.UnauthorizedException:
+            raise UnauthorizedSSOTokenError()
+        credentials = response['roleCredentials']
+
+        credentials = {
+            'ProviderType': 'sso',
+            'Credentials': {
+                'AccessKeyId': credentials['accessKeyId'],
+                'SecretAccessKey': credentials['secretAccessKey'],
+                'SessionToken': credentials['sessionToken'],
+                'Expiration': self._parse_timestamp(credentials['expiration']),
+            }
+        }
+        return credentials
+
+
+class SSOProvider(CredentialProvider):
+    METHOD = 'sso'
+
+    _SSO_TOKEN_CACHE_DIR = os.path.expanduser(
+        os.path.join('~', '.aws', 'sso', 'cache')
+    )
+    _SSO_CONFIG_VARS = [
+        'sso_start_url',
+        'sso_region',
+        'sso_role_name',
+        'sso_account_id',
+    ]
+
+    def __init__(self, load_config, client_creator, profile_name,
+                 cache=None, token_cache=None):
+        if token_cache is None:
+            token_cache = JSONFileCache(self._SSO_TOKEN_CACHE_DIR)
+        self._token_cache = token_cache
+        if cache is None:
+            cache = {}
+        self.cache = cache
+        self._load_config = load_config
+        self._client_creator = client_creator
+        self._profile_name = profile_name
+
+    def _load_sso_config(self):
+        loaded_config = self._load_config()
+        profiles = loaded_config.get('profiles', {})
+        profile_name = self._profile_name
+        profile_config = profiles.get(self._profile_name, {})
+
+        if all(c not in profile_config for c in self._SSO_CONFIG_VARS):
+            return None
+
+        config = {}
+        missing_config_vars = []
+        for config_var in self._SSO_CONFIG_VARS:
+            if config_var in profile_config:
+                config[config_var] = profile_config[config_var]
+            else:
+                missing_config_vars.append(config_var)
+
+        if missing_config_vars:
+            missing = ', '.join(missing_config_vars)
+            raise InvalidConfigError(
+                error_msg=(
+                    'The profile "%s" is configured to use SSO but is missing '
+                    'required configuration: %s' % (profile_name, missing)
+                )
+            )
+
+        return config
+
+    def load(self):
+        sso_config = self._load_sso_config()
+        if not sso_config:
+            return None
+
+        sso_fetcher = SSOCredentialFetcher(
+            sso_config['sso_start_url'],
+            sso_config['sso_region'],
+            sso_config['sso_role_name'],
+            sso_config['sso_account_id'],
+            self._client_creator,
+            token_loader=SSOTokenLoader(cache=self._token_cache),
+            cache=self.cache,
+        )
+
+        return DeferredRefreshableCredentials(
+            method=self.METHOD,
+            refresh_using=sso_fetcher.fetch_credentials,
+        )

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -525,3 +525,26 @@ class MissingServiceIdError(UndefinedModelAttributeError):
         msg = self.fmt.format(**kwargs)
         Exception.__init__(self, msg)
         self.kwargs = kwargs
+
+
+class SSOError(BotoCoreError):
+    fmt = "An unspecified error happened when resolving SSO credentials"
+
+
+class PendingAuthorizationExpiredError(SSOError):
+    fmt = (
+        "The pending authorization to retrieve an SSO token has expired. The "
+        "device authorization flow to retrieve an SSO token must be restarted."
+    )
+
+
+class SSOTokenLoadError(SSOError):
+    fmt = "Error loading SSO Token: {error_msg}"
+
+
+class UnauthorizedSSOTokenError(SSOError):
+    fmt = (
+        "The SSO session associated with this profile has expired or is "
+        "otherwise invalid. To refresh this SSO session run aws sso login "
+        "with the corresponding profile."
+    )

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -30,12 +30,13 @@ import botocore
 import botocore.awsrequest
 import botocore.httpsession
 from botocore.compat import json, quote, zip_longest, urlsplit, urlunsplit
-from botocore.compat import OrderedDict, six, urlparse
+from botocore.compat import OrderedDict, six, urlparse, total_seconds
 from botocore.vendored.six.moves.urllib.request import getproxies, proxy_bypass
 from botocore.exceptions import (
     InvalidExpressionError, ConfigNotFound, InvalidDNSNameError, ClientError,
     MetadataRetrievalError, EndpointConnectionError, ReadTimeoutError,
-    ConnectionClosedError, ConnectTimeoutError,
+    ConnectionClosedError, ConnectTimeoutError, SSOTokenLoadError,
+    PendingAuthorizationExpiredError,
 )
 
 logger = logging.getLogger(__name__)
@@ -1381,3 +1382,188 @@ class FileWebIdentityTokenLoader(object):
     def __call__(self):
         with self._open(self._web_identity_token_path) as token_file:
             return token_file.read()
+
+
+class SSOTokenFetcher(object):
+    # The device flow RFC defines the slow down delay to be an additional
+    # 5 seconds:
+    # https://tools.ietf.org/html/draft-ietf-oauth-device-flow-15#section-3.5
+    _SLOW_DOWN_DELAY = 5
+    # The default interval of 5 is also defined in the RFC (see above link)
+    _DEFAULT_INTERVAL = 5
+    _EXPIRY_WINDOW = 15 * 60
+    _CLIENT_REGISTRATION_TYPE = 'public'
+    _GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
+    # This is the default scope as suggested by the SSO team
+    _DEFAULT_SCOPES = ['sso-portal:*']
+
+    def __init__(
+            self, sso_region, client_creator, cache=None,
+            on_pending_authorization=None, time_fetcher=None, sleep=None,
+    ):
+        self._sso_region = sso_region
+        self._client_creator = client_creator
+        self._on_pending_authorization = on_pending_authorization
+
+        if time_fetcher is None:
+            time_fetcher = self._utc_now
+        self._time_fetcher = time_fetcher
+
+        if sleep is None:
+            sleep = time.sleep
+        self._sleep = sleep
+
+        if cache is None:
+            cache = {}
+        self._cache = cache
+
+    def _utc_now(self):
+        return datetime.datetime.now(tzutc())
+
+    def _parse_if_needed(self, value):
+        if isinstance(value, datetime.datetime):
+            return value
+        return dateutil.parser.parse(value)
+
+    def _is_expired(self, response):
+        end_time = self._parse_if_needed(response['expiresAt'])
+        seconds = total_seconds(end_time - self._time_fetcher())
+        return seconds < self._EXPIRY_WINDOW
+
+    @CachedProperty
+    def _client(self):
+        config = botocore.config.Config(
+            region_name=self._sso_region,
+            signature_version=botocore.UNSIGNED,
+        )
+        return self._client_creator('sso-oidc', config=config)
+
+    def _register_client(self):
+        timestamp = datetime2timestamp(self._time_fetcher())
+        response = self._client.register_client(
+            # NOTE: As far as I know client name will never be returned to the
+            # user. For now we'll just use botocore-client with the timestamp.
+            clientName='botocore-client-%s' % int(timestamp),
+            clientType=self._CLIENT_REGISTRATION_TYPE,
+        )
+        # NOTE: If SSO models this as a timestamp we don't need to do this
+        expires_at = response['clientSecretExpiresAt']
+        expires_at = datetime.datetime.fromtimestamp(expires_at, tzutc())
+        registration = {
+            'clientId': response['clientId'],
+            'clientSecret': response['clientSecret'],
+            'expiresAt': expires_at,
+        }
+        return registration
+
+    def _registration(self):
+        # Registration with the OIDC endpoint is global, is good for roughly
+        # one year, and can be shared. This is currently scoped to individual
+        # tools and as such each tool has their own <toolname>-client-id.
+        cache_key = 'botocore-client-id'
+        if cache_key in self._cache:
+            registration = self._cache[cache_key]
+            if not self._is_expired(registration):
+                return registration
+
+        registration = self._register_client()
+        self._cache[cache_key] = registration
+        return registration
+
+    def _authorize_client(self, start_url, registration):
+        # NOTE: The authorization response is not cached. These responses are
+        # short lived (currently only 10 minutes) and can only be exchanged for
+        # a token once. Having multiple clients share this is problematic.
+        response = self._client.start_device_authorization(
+            clientId=registration['clientId'],
+            clientSecret=registration['clientSecret'],
+            startUrl=start_url,
+        )
+        expires_in = datetime.timedelta(seconds=response['expiresIn'])
+        authorization = {
+            'deviceCode': response['deviceCode'],
+            'userCode': response['userCode'],
+            'verificationUri': response['verificationUri'],
+            'verificationUriComplete': response['verificationUriComplete'],
+            'expiresAt': self._time_fetcher() + expires_in,
+        }
+        if 'interval' in response:
+            authorization['interval'] = response['interval']
+        return authorization
+
+    def _poll_for_token(self, start_url):
+        registration = self._registration()
+        authorization = self._authorize_client(start_url, registration)
+
+        if self._on_pending_authorization:
+            # This callback can display the user code / verification URI
+            # so the user knows the page to go to. Potentially, this call
+            # back could even be used to auto open a browser.
+            self._on_pending_authorization(**authorization)
+
+        interval = authorization.get('interval', self._DEFAULT_INTERVAL)
+        # NOTE: This loop currently relies on the service to either return
+        # a valid token or a ExpiredTokenException to break the loop. If this
+        # proves to be problematic it may be worth adding an additional
+        # mechanism to control timing this loop out.
+        while True:
+            try:
+                response = self._client.create_token(
+                    grantType=self._GRANT_TYPE,
+                    clientId=registration['clientId'],
+                    clientSecret=registration['clientSecret'],
+                    deviceCode=authorization['deviceCode'],
+                )
+                expires_in = datetime.timedelta(seconds=response['expiresIn'])
+                token = {
+                    'startUrl': start_url,
+                    'region': self._sso_region,
+                    'accessToken': response['accessToken'],
+                    'expiresAt': self._time_fetcher() + expires_in
+                }
+                return token
+            except self._client.exceptions.SlowDownException:
+                interval += self._SLOW_DOWN_DELAY
+            except self._client.exceptions.AuthorizationPendingException:
+                pass
+            except self._client.exceptions.ExpiredTokenException:
+                raise PendingAuthorizationExpiredError()
+            self._sleep(interval)
+
+    def _token(self, start_url, force_refresh):
+        cache_key = hashlib.sha1(start_url.encode('utf-8')).hexdigest()
+        # Only obey the token cache if we are not forcing a refresh.
+        if not force_refresh and cache_key in self._cache:
+            token = self._cache[cache_key]
+            if not self._is_expired(token):
+                return token
+
+        token = self._poll_for_token(start_url)
+        self._cache[cache_key] = token
+        return token
+
+    def fetch_token(self, start_url, force_refresh=False):
+        return self._token(start_url, force_refresh)
+
+
+class SSOTokenLoader(object):
+    def __init__(self, cache=None):
+        if cache is None:
+            cache = {}
+        self._cache = cache
+
+    def _generate_cache_key(self, start_url):
+        return hashlib.sha1(start_url.encode('utf-8')).hexdigest()
+
+    def __call__(self, start_url):
+        cache_key = self._generate_cache_key(start_url)
+        try:
+            token = self._cache[cache_key]
+            return token['accessToken']
+        except KeyError:
+            logger.debug('Failed to load SSO token:', exc_info=True)
+            error_msg = (
+                'The SSO access token has either expired or is otherwise '
+                'invalid.'
+            )
+            raise SSOTokenLoadError(error_msg=error_msg)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -520,9 +520,9 @@ class StubbedSession(botocore.session.Session):
         self._client_stubs[service_name] = stubber
         return client
 
-    def stub(self, service_name):
+    def stub(self, service_name, *args, **kwargs):
         if service_name not in self._client_stubs:
-            self.create_client(service_name)
+            self.create_client(service_name, *args, **kwargs)
         return self._client_stubs[service_name]
 
     def activate_stubs(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -26,13 +26,16 @@ from botocore import credentials
 from botocore.utils import ContainerMetadataFetcher
 from botocore.compat import json, six
 from botocore.session import Session
-from botocore.utils import FileWebIdentityTokenLoader
+from botocore.stub import Stubber
+from botocore.utils import datetime2timestamp
+from botocore.utils import FileWebIdentityTokenLoader, SSOTokenLoader
 from botocore.credentials import EnvProvider, create_assume_role_refresher
 from botocore.credentials import CredentialProvider, AssumeRoleProvider
 from botocore.credentials import ConfigProvider, SharedCredentialProvider
 from botocore.credentials import ProcessProvider
 from botocore.credentials import AssumeRoleWithWebIdentityProvider
 from botocore.credentials import Credentials, ProfileProviderBuilder
+from botocore.credentials import SSOCredentialFetcher, SSOProvider
 from botocore.configprovider import create_botocore_default_config_mapping
 from botocore.configprovider import ConfigChainFactory
 from botocore.configprovider import ConfigValueStore
@@ -3222,6 +3225,7 @@ class TestProfileProviderBuilder(unittest.TestCase):
         providers = self.builder.providers('some-profile')
         expected_providers = [
             AssumeRoleWithWebIdentityProvider,
+            SSOProvider,
             SharedCredentialProvider,
             ProcessProvider,
             ConfigProvider,
@@ -3230,3 +3234,196 @@ class TestProfileProviderBuilder(unittest.TestCase):
         zipped_providers = six.moves.zip(providers, expected_providers)
         for provider, expected_type in zipped_providers:
             self.assertTrue(isinstance(provider, expected_type))
+
+
+class TestSSOCredentialFetcher(unittest.TestCase):
+    def setUp(self):
+        self.sso = Session().create_client('sso')
+        self.stubber = Stubber(self.sso)
+        self.mock_session = mock.Mock(spec=Session)
+        self.mock_session.create_client.return_value = self.sso
+
+        self.cache = {}
+        self.sso_region = 'us-east-1'
+        self.start_url = 'https://d-92671207e4.awsapps.com/start'
+        self.role_name = 'test-role'
+        self.account_id = '1234567890'
+        self.access_token = 'some.sso.token'
+        # This is just an arbitrary point in time we can pin to
+        self.now = datetime(2008, 9, 23, 12, 26, 40, tzinfo=tzutc())
+        # The SSO endpoint uses ms whereas the OIDC endpoint uses seconds
+        self.now_timestamp = 1222172800000
+
+        self.loader = mock.Mock(spec=SSOTokenLoader)
+        self.loader.return_value = self.access_token
+        self.fetcher = SSOCredentialFetcher(
+            self.start_url, self.sso_region, self.role_name, self.account_id,
+            self.mock_session.create_client, token_loader=self.loader,
+            cache=self.cache,
+        )
+
+    def test_can_fetch_credentials(self):
+        expected_params = {
+            'roleName': self.role_name,
+            'accountId': self.account_id,
+            'accessToken': self.access_token,
+        }
+        expected_response = {
+            'roleCredentials': {
+                'accessKeyId': 'foo',
+                'secretAccessKey': 'bar',
+                'sessionToken': 'baz',
+                'expiration': self.now_timestamp + 1000000,
+            }
+        }
+        self.stubber.add_response(
+            'get_role_credentials',
+            expected_response,
+            expected_params=expected_params,
+        )
+        with self.stubber:
+            credentials = self.fetcher.fetch_credentials()
+        self.assertEqual(credentials['access_key'], 'foo')
+        self.assertEqual(credentials['secret_key'], 'bar')
+        self.assertEqual(credentials['token'], 'baz')
+        self.assertEqual(credentials['expiry_time'], '2008-09-23T12:43:20UTC')
+        cache_key = '048db75bbe50955c16af7aba6ff9c41a3131bb7e'
+        expected_cached_credentials = {
+            'ProviderType': 'sso',
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': '2008-09-23T12:43:20UTC',
+            }
+        }
+        self.assertEqual(self.cache[cache_key], expected_cached_credentials)
+
+    def test_raises_helpful_message_on_unauthorized_exception(self):
+        expected_params = {
+            'roleName': self.role_name,
+            'accountId': self.account_id,
+            'accessToken': self.access_token,
+        }
+        self.stubber.add_client_error(
+            'get_role_credentials',
+            service_error_code='UnauthorizedException',
+            expected_params=expected_params,
+        )
+        with self.assertRaises(botocore.exceptions.UnauthorizedSSOTokenError):
+            with self.stubber:
+                credentials = self.fetcher.fetch_credentials()
+
+
+class TestSSOProvider(unittest.TestCase):
+    def setUp(self):
+        self.sso = Session().create_client('sso')
+        self.stubber = Stubber(self.sso)
+        self.mock_session = mock.Mock(spec=Session)
+        self.mock_session.create_client.return_value = self.sso
+
+        self.sso_region = 'us-east-1'
+        self.start_url = 'https://d-92671207e4.awsapps.com/start'
+        self.role_name = 'test-role'
+        self.account_id = '1234567890'
+        self.access_token = 'some.sso.token'
+
+        self.profile_name = 'sso-profile'
+        self.config = {
+            'sso_region': self.sso_region,
+            'sso_start_url': self.start_url,
+            'sso_role_name': self.role_name,
+            'sso_account_id': self.account_id,
+        }
+        self.expires_at =  datetime.now(tzlocal()) + timedelta(hours=24)
+        self.cached_creds_key = '048db75bbe50955c16af7aba6ff9c41a3131bb7e'
+        self.cached_token_key = '13f9d35043871d073ab260e020f0ffde092cb14b'
+        self.cache = {
+            self.cached_token_key: {
+                'accessToken': self.access_token,
+                'expiresAt': self.expires_at.strftime('%Y-%m-%dT%H:%M:%S%Z'),
+            }
+        }
+        self.provider = SSOProvider(
+            load_config=self._mock_load_config,
+            client_creator=self.mock_session.create_client,
+            profile_name=self.profile_name,
+            cache=self.cache,
+            token_cache=self.cache,
+        )
+
+        self.expected_get_role_credentials_params = {
+            'roleName': self.role_name,
+            'accountId': self.account_id,
+            'accessToken': self.access_token,
+        }
+        expiration = datetime2timestamp(self.expires_at)
+        self.expected_get_role_credentials_response = {
+            'roleCredentials': {
+                'accessKeyId': 'foo',
+                'secretAccessKey': 'bar',
+                'sessionToken': 'baz',
+                'expiration': int(expiration * 1000),
+            }
+        }
+
+    def _mock_load_config(self):
+        return {
+            'profiles': {
+                self.profile_name: self.config,
+            }
+        }
+
+    def _add_get_role_credentials_response(self):
+        self.stubber.add_response(
+            'get_role_credentials',
+            self.expected_get_role_credentials_response,
+            self.expected_get_role_credentials_params,
+        )
+
+    def test_load_sso_credentials_without_cache(self):
+        self._add_get_role_credentials_response()
+        with self.stubber:
+            credentials = self.provider.load()
+            self.assertEqual(credentials.access_key, 'foo')
+            self.assertEqual(credentials.secret_key, 'bar')
+            self.assertEqual(credentials.token, 'baz')
+
+    def test_load_sso_credentials_with_cache(self):
+        cached_creds = {
+            'Credentials': {
+                'AccessKeyId': 'cached-akid',
+                'SecretAccessKey': 'cached-sak',
+                'SessionToken': 'cached-st',
+                'Expiration': self.expires_at.strftime('%Y-%m-%dT%H:%M:%S%Z'),
+            }
+        }
+        self.cache[self.cached_creds_key] = cached_creds
+        credentials = self.provider.load()
+        self.assertEqual(credentials.access_key, 'cached-akid')
+        self.assertEqual(credentials.secret_key, 'cached-sak')
+        self.assertEqual(credentials.token, 'cached-st')
+
+    def test_load_sso_credentials_with_cache_expired(self):
+        cached_creds = {
+            'Credentials': {
+                'AccessKeyId': 'expired-akid',
+                'SecretAccessKey': 'expired-sak',
+                'SessionToken': 'expired-st',
+                'Expiration': '2002-10-22T20:52:11UTC',
+            }
+        }
+        self.cache[self.cached_creds_key] = cached_creds
+
+        self._add_get_role_credentials_response()
+        with self.stubber:
+            credentials = self.provider.load()
+            self.assertEqual(credentials.access_key, 'foo')
+            self.assertEqual(credentials.secret_key, 'bar')
+            self.assertEqual(credentials.token, 'baz')
+
+    def test_required_config_not_set(self):
+        del self.config['sso_start_url']
+        # If any required configuration is missing we should get an error
+        with self.assertRaises(botocore.exceptions.InvalidConfigError):
+            self.provider.load()


### PR DESCRIPTION
Initial support for SSO credentials
 
This implements an SSO token fetcher class that will retrieve an access token from SSO using the device authorization flow. This token can then be cached and used to fetch AWS credentials.