### PR TITLE
Regionalize cached SSO OIDC client IDs

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1394,8 +1394,6 @@ class SSOTokenFetcher(object):
     _EXPIRY_WINDOW = 15 * 60
     _CLIENT_REGISTRATION_TYPE = 'public'
     _GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
-    # This is the default scope as suggested by the SSO team
-    _DEFAULT_SCOPES = ['sso-portal:*']
 
     def __init__(
             self, sso_region, client_creator, cache=None,
@@ -1446,7 +1444,6 @@ class SSOTokenFetcher(object):
             clientName='botocore-client-%s' % int(timestamp),
             clientType=self._CLIENT_REGISTRATION_TYPE,
         )
-        # NOTE: If SSO models this as a timestamp we don't need to do this
         expires_at = response['clientSecretExpiresAt']
         expires_at = datetime.datetime.fromtimestamp(expires_at, tzutc())
         registration = {
@@ -1457,10 +1454,10 @@ class SSOTokenFetcher(object):
         return registration
 
     def _registration(self):
-        # Registration with the OIDC endpoint is global, is good for roughly
-        # one year, and can be shared. This is currently scoped to individual
-        # tools and as such each tool has their own <toolname>-client-id.
-        cache_key = 'botocore-client-id'
+        # Registration with the OIDC endpoint is regional, is good for roughly
+        # 90 days, and can be shared. This is currently scoped to individual
+        # tools and as such each tool has their own cached client id.
+        cache_key = 'botocore-client-id-%s' % self._sso_region
         if cache_key in self._cache:
             registration = self._cache[cache_key]
             if not self._is_expired(registration):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2016,6 +2016,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
         self.sso_region = 'us-west-2'
         # The token cache key is the sha1 of the start url
         self.token_cache_key = '40a89917e3175433e361b710a9d43528d7f1890a'
+        self.client_id_key = 'botocore-client-id-us-west-2'
         # This is just an arbitrary point in time that we can pin to
         self.now = datetime.datetime(2008, 9, 23, 12, 26, 40, tzinfo=tzutc())
         self.now_timestamp = 1222172800
@@ -2122,7 +2123,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
             'clientSecret': 'foo-client-secret',
             'expiresAt': self._expires_at(1000),
         }
-        self.assertEqual(self.cache['botocore-client-id'], expected_client_id)
+        self.assertEqual(self.cache[self.client_id_key], expected_client_id)
 
         expected_token = {
             'region': self.sso_region,
@@ -2138,7 +2139,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
             'clientSecret': 'bar-client-secret',
             'expiresAt': self._expires_at(1000),
         }
-        self.cache['botocore-client-id'] = expected_client_id
+        self.cache[self.client_id_key] = expected_client_id
 
         self.authorization_expected_params.update(
             clientId='bar-client-id',
@@ -2157,7 +2158,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
         self.stubber.assert_no_pending_responses()
 
         # Ensure the cached client-id hasn't changed
-        self.assertEqual(self.cache['botocore-client-id'], expected_client_id)
+        self.assertEqual(self.cache[self.client_id_key], expected_client_id)
 
     def test_fetch_token_respects_cached_token(self):
         expected_token = {
@@ -2182,7 +2183,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
             'clientSecret': 'bar-client-secret',
             'expiresAt': self._expires_at(-1),
         }
-        self.cache['botocore-client-id'] = expired_client_id
+        self.cache[self.client_id_key] = expired_client_id
         expired_token = {
             'accessToken': 'bar.token.string',
             'expiresAt': self._expires_at(-1),
@@ -2201,7 +2202,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
             'clientSecret': 'foo-client-secret',
             'expiresAt': self._expires_at(1000),
         }
-        self.assertEqual(self.cache['botocore-client-id'], expected_client_id)
+        self.assertEqual(self.cache[self.client_id_key], expected_client_id)
         expected_token = {
             'region': self.sso_region,
             'startUrl': self.start_url,


### PR DESCRIPTION
The client IDs are currently cached globally but need to be cached
on a per region basis. This updates the caching scheme to include
the region name.

This also cleans up some leftover constants / comments.