### PR TITLE
Add GroupIdentifiers to ListGroups result_key list

### DIFF
--- a/botocore/data/resource-groups/2017-11-27/paginators-1.json
+++ b/botocore/data/resource-groups/2017-11-27/paginators-1.json
@@ -1,7 +1,7 @@
 {
   "pagination": {
     "ListGroups": {
-      "result_key": "Groups",
+      "result_key": ["GroupIdentifiers", "Groups"],
       "output_token": "NextToken",
       "input_token": "NextToken",
       "limit_key": "MaxResults"


### PR DESCRIPTION
This API has added a new list to the result that needs to be paginated. This paginator was added in https://github.com/boto/botocore/pull/1345 as part of a mass auto-generated import and only exists within botocore.