### PR TITLE
s3: Decode Prefix query param reflected back in response

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -695,7 +695,7 @@ def decode_list_object(parsed, context, **kwargs):
     # name values in the following response elements:
     # Delimiter, Marker, Prefix, NextMarker, Key.
     _decode_list_object(
-        top_level_keys=['Delimiter', 'Marker', 'NextMarker'],
+        top_level_keys=['Delimiter', 'Marker', 'Prefix', 'NextMarker'],
         nested_keys=[('Contents', 'Key'), ('CommonPrefixes', 'Prefix')],
         parsed=parsed,
         context=context

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -840,6 +840,16 @@ class TestHandlers(BaseSessionTest):
         handlers.decode_list_object(parsed, context=context)
         self.assertEqual(parsed['Delimiter'], u'\xe7\xf6s% asd\x08 c')
 
+    def test_decode_list_objects_with_prefix(self):
+        parsed = {
+            'Prefix': "%C3%A7%C3%B6s%25%20asd%08+c",
+            'EncodingType': 'url',
+        }
+        context = {'encoding_type_auto_set': True}
+        handlers.decode_list_object(parsed, context=context)
+        self.assertEqual(parsed['Prefix'], u'\xe7\xf6s% asd\x08 c')
+
+
     def test_decode_list_objects_v2(self):
         parsed = {
             'Contents': [{'Key': "%C3%A7%C3%B6s%25asd%08"}],


### PR DESCRIPTION
Otherwise you get inconsistent decoding when working with non-ASCII keys:
```
>>> c.list_objects(Bucket='1space-test', Prefix='my\N{SNOWMAN}', Delimiter='\N{SNOWMAN}', Marker='a\N{SNOWMAN}')
{'Contents': ...,
 'Delimiter': '☃',
 'EncodingType': 'url',
 'IsTruncated': False,
 'Marker': 'a☃',
 'MaxKeys': 1000,
 'Name': '1space-test',
 'Prefix': 'my%E2%98%83',
 'ResponseMetadata': ... }
```