### PR TITLE
ignore missing name in self._deferred to avoid KeyError when session …

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -915,12 +915,15 @@ class ComponentLocator(object):
 
     def get_component(self, name):
         if name in self._deferred:
-            factory = self._deferred[name]
-            self._components[name] = factory()
-            # Only delete the component from the deferred dict after
-            # successfully creating the object from the factory as well as
-            # injecting the instantiated value into the _components dict.
-            del self._deferred[name]
+            try:
+                factory = self._deferred[name]
+                self._components[name] = factory()
+                # Only delete the component from the deferred dict after
+                # successfully creating the object from the factory as well as
+                # injecting the instantiated value into the _components dict.
+                del self._deferred[name]
+            except KeyError:
+                logger.warning("Key %s is missing." % name)
         try:
             return self._components[name]
         except KeyError:


### PR DESCRIPTION
I am observing issues similar to https://github.com/boto/boto3/issues/801
Through previous [communication](https://github.com/boto/botocore/issues/1776) I understand the root cause being that client creation is not thread safe in general. However this simple patch solved my problem, plus that the original method branching logic is retained.