### PR TITLE
Add proper description for GovCloud

### DIFF
--- a/botocore/data/endpoints.json
+++ b/botocore/data/endpoints.json
@@ -4487,7 +4487,7 @@
         "description" : "AWS GovCloud (US-East)"
       },
       "us-gov-west-1" : {
-        "description" : "AWS GovCloud (US)"
+        "description" : "AWS GovCloud (US-West)"
       }
     },
     "services" : {


### PR DESCRIPTION
Added the description to distinguish between east and west regions,
https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html