### PR TITLE
Treat `AWS_PROFILE` with empty string same as if not defined

### DIFF
--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -270,7 +270,7 @@ class ConfigValueStore(object):
 
     def get_config_variable(self, logical_name):
         """
-        Retrieve the value associeated with the specified logical_name
+        Retrieve the value associated with the specified logical_name
         from the corresponding provider. If no value is found None will
         be returned.
 

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 #: found.
 BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # logical:  config_file, env_var,        default_value, conversion_func
-    'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None),
+    'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, utils.falsey_to_none),
     'region': ('region', 'AWS_DEFAULT_REGION', None, None),
     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -143,6 +143,11 @@ def ensure_boolean(val):
         return val.lower() == 'true'
 
 
+def falsey_to_none(val):
+    """Transforms falsey value to None. If the value parameter is not falsey, it is returned as is."""
+    return val or None
+
+
 def is_json_value_header(shape):
     """Determines if the provided shape is the special header type jsonvalue.
 

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -91,6 +91,16 @@ class TestSession(unittest.TestCase):
             self.assertEqual(creds.access_key, 'env_var_akid')
             self.assertEqual(creds.secret_key, 'env_var_sak')
 
+    def test_empty_profile(self):
+        self.environ['AWS_PROFILE'] = ''
+        self.environ['AWS_ACCESS_KEY_ID'] = 'env_var_akid'
+        self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_var_sak'
+
+        creds = self.session.get_credentials()
+
+        self.assertEqual(creds.access_key, 'env_var_akid')
+        self.assertEqual(creds.secret_key, 'env_var_sak')
+
     def test_provides_available_regions_for_same_endpoint_prefix(self):
         regions = self.session.get_available_regions('s3')
         self.assertTrue(regions)

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -28,6 +28,7 @@ from botocore import client
 from botocore.hooks import HierarchicalEmitter
 from botocore.waiter import WaiterModel
 from botocore.paginate import PaginatorModel
+from botocore import utils
 import botocore.loaders
 
 
@@ -334,7 +335,7 @@ class TestSessionConfigurationVars(BaseSessionTest):
                          ('region', 'AWS_DEFAULT_REGION', None, None))
         self.assertEqual(
             self.session.session_var_map['profile'],
-            (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None))
+            (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, utils.falsey_to_none))
         self.assertEqual(
             self.session.session_var_map['data_path'],
             ('data_path', 'AWS_DATA_PATH', None, None))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -34,6 +34,7 @@ from botocore.model import ServiceModel
 from botocore.model import OperationModel
 from botocore.regions import EndpointResolver
 from botocore.utils import ensure_boolean
+from botocore.utils import falsey_to_none
 from botocore.utils import is_json_value_header
 from botocore.utils import remove_dot_segments
 from botocore.utils import normalize_url_path
@@ -88,6 +89,26 @@ class TestEnsureBoolean(unittest.TestCase):
 
     def test_string_lowercase_true(self):
         self.assertEqual(ensure_boolean('true'), True)
+
+
+class TestFalseToNone(unittest.TestCase):
+    def test_string_empty(self):
+        self.assertEqual(falsey_to_none(""), None)
+
+    def test_string_whitespaces(self):
+        self.assertEqual(falsey_to_none("   "), "   ")
+
+    def test_string_non_empty(self):
+        self.assertEqual(falsey_to_none("Hello, World!"), "Hello, World!")
+
+    def test_none(self):
+        self.assertEqual(falsey_to_none(None), None)
+
+    def test_integer_zero(self):
+        self.assertEqual(falsey_to_none(0), None)
+
+    def test_integer_ten(self):
+        self.assertEqual(falsey_to_none(10), 10)
 
 
 class TestIsJSONValueHeader(unittest.TestCase):


### PR DESCRIPTION
This is another take on https://github.com/boto/botocore/issues/1460

### Issue

I noticed the issues described in https://github.com/boto/botocore/issues/1460 when running tests on a fresh instance (continuous integration), which had no profiles and configuration in `~/.aws` directory and used `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. At the same time, I had the environment variable `AWS_PROFILE` set to empty string, hoping it would have the same meaning as if it was not defined. That caused the build failing with:
```
botocore.exceptions.ProfileNotFound: The config profile () could not be found
```

We use the `AWS_PROFILE` variable in the build scripts so that we can reuse the same build scripts for our local development, where we use profiles. The hope was that we could use the same scripts for continuous integration without any changes to the scripts (and without having to do `aws configure` to create profile on continuous integration or having to do some similar workarounds).

### Changes
Add conversion function to the `profile` entry in `configprovider.BOTOCORE_DEFAUT_SESSION_VARIABLES` that converts falsey values to `None`. This means empty string is converted to `None`. 