### PR TITLE
Remove legacy S3 regional endpoint configuration

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -91,18 +91,6 @@ class Config(object):
           * path -- Addressing style is always by path. Endpoints will be
             addressed as such: s3.amazonaws.com/mybucket
 
-        * 'us_east_1_regional_endpoint' - Refers to what S3 endpoint to use
-          when the region is configured to be us-east-1. Values must be a
-          string that equals:
-
-           * regional -- Use the us-east-1.amazonaws.com endpoint if the
-             client is configured to use the us-east-1 region.
-
-           * legacy -- Use the s3.amazonaws.com endpoint if the client is
-             configured to use the us-east-1 region. This is the default if
-             the configuration option is not specified.
-
-
     :type retries: dict
     :param retries: A dictionary for retry specific configurations.
         Valid keys are:

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -104,11 +104,6 @@ DEFAULT_S3_CONFIG_VARS = {
          ('s3', 'use_arn_region')],
         'AWS_S3_USE_ARN_REGION', None, utils.ensure_boolean
     ),
-    'us_east_1_regional_endpoint': (
-        ['s3_us_east_1_regional_endpoint',
-         ('s3', 'us_east_1_regional_endpoint')],
-        'AWS_S3_US_EAST_1_REGIONAL_ENDPOINT', None, None
-    )
 }
 
 

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -484,15 +484,6 @@ class InvalidMaxRetryAttemptsError(InvalidRetryConfigurationError):
     )
 
 
-class InvalidS3UsEast1RegionalEndpointConfigError(BotoCoreError):
-    """Error for invalid s3 us-east-1 regional endpoints configuration"""
-    fmt = (
-        'S3 us-east-1 regional endpoint option '
-        '{s3_us_east_1_regional_endpoint_config} is '
-        'invaild. Valid options are: legacy and regional'
-    )
-
-
 class StubResponseError(BotoCoreError):
     fmt = 'Error getting response stub for operation {operation_name}: {reason}'
 

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -564,7 +564,7 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
     http_method = HttpMethod
     context = {
         'is_presign_request': True,
-        'use_global_endpoint': _should_use_global_endpoint(self),
+        'use_global_endpoint': False,
     }
 
     request_signer = self._request_signer
@@ -695,7 +695,7 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
         request_dict, endpoint_url=self.meta.endpoint_url,
         context={
             'is_presign_request': True,
-            'use_global_endpoint': _should_use_global_endpoint(self),
+            'use_global_endpoint': False,
         },
     )
 
@@ -715,16 +715,3 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
     return post_presigner.generate_presigned_post(
         request_dict=request_dict, fields=fields, conditions=conditions,
         expires_in=expires_in)
-
-
-def _should_use_global_endpoint(client):
-    if client.meta.partition != 'aws':
-        return False
-    s3_config = client.meta.config.s3
-    if s3_config:
-        if s3_config.get('use_dualstack_endpoint', False):
-            return False
-        if s3_config.get('us_east_1_regional_endpoint') == 'regional' and \
-                client.meta.config.region_name == 'us-east-1':
-            return False
-    return True

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -21,7 +21,6 @@ from botocore.config import Config
 from botocore.compat import urlsplit
 from botocore.compat import parse_qs
 from botocore.exceptions import ParamValidationError, ClientError
-from botocore.exceptions import InvalidS3UsEast1RegionalEndpointConfigError
 from botocore import UNSIGNED
 
 
@@ -280,131 +279,15 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
             }
         )
 
-
-    def test_us_east_1_regional_env_var(self):
-        self.environ['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] = 'regional'
-        client = self.create_s3_client()
-        self.assertEqual(
-            client.meta.config.s3,
-            {
-                'us_east_1_regional_endpoint': 'regional',
-            }
-        )
-
-    def test_us_east_1_regional_config_var(self):
-        with temporary_file('w') as f:
-            self.set_config_file(
-                f,
-                '[default]\n'
-                's3_us_east_1_regional_endpoint = regional'
-            )
-            client = self.create_s3_client()
-            self.assertEqual(
-                client.meta.config.s3,
-                {
-                    'us_east_1_regional_endpoint': 'regional',
-                }
-            )
-
-    def test_us_east_1_regional_nested_config_var(self):
-        with temporary_file('w') as f:
-            self.set_config_file(
-                f,
-                '[default]\n'
-                's3 = \n'
-                '    us_east_1_regional_endpoint = regional'
-            )
-            client = self.create_s3_client()
-            self.assertEqual(
-                client.meta.config.s3,
-                {
-                    'us_east_1_regional_endpoint': 'regional',
-                }
-            )
-
-    def test_us_east_1_regional_env_var_overrides_config_var(self):
-        self.environ['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] = 'regional'
-        with temporary_file('w') as f:
-            self.set_config_file(
-                f,
-                '[default]\n'
-                's3 = \n'
-                '    us_east_1_regional_endpoint = legacy'
-            )
-            client = self.create_s3_client()
-        self.assertEqual(
-            client.meta.config.s3,
-            {
-                'us_east_1_regional_endpoint': 'regional',
-            }
-        )
-
-    def test_client_config_us_east_1_regional_overrides_env_var(self):
-        self.environ['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] = 'regional'
-        client = self.create_s3_client(
-            config=Config(
-                s3={'us_east_1_regional_endpoint': 'legacy'}
-            )
-        )
-        self.assertEqual(
-            client.meta.config.s3,
-            {
-                'us_east_1_regional_endpoint': 'legacy',
-            }
-        )
-
-    def test_client_config_us_east_1_regional_overrides_config_var(self):
-        with temporary_file('w') as f:
-            self.set_config_file(
-                f,
-                '[default]\n'
-                's3 = \n'
-                '    us_east_1_regional_endpoint = legacy'
-            )
-            client = self.create_s3_client(
-                config=Config(
-                    s3={'us_east_1_regional_endpoint': 'regional'}
-                )
-            )
-        self.assertEqual(
-            client.meta.config.s3,
-            {
-                'us_east_1_regional_endpoint': 'regional',
-            }
-        )
-
-    def test_client_validates_us_east_1_regional(self):
-        with self.assertRaises(InvalidS3UsEast1RegionalEndpointConfigError):
-            self.create_s3_client(
-                config=Config(
-                    s3={'us_east_1_regional_endpoint': 'not-valid'}
-                )
-            )
-
-    def test_client_region_defaults_to_us_east_1(self):
+    def test_client_region_defaults_to_aws_global(self):
         client = self.create_s3_client(region_name=None)
-        self.assertEqual(client.meta.region_name, 'us-east-1')
+        self.assertEqual(client.meta.region_name, 'aws-global')
 
     def test_client_region_remains_us_east_1(self):
         client = self.create_s3_client(region_name='us-east-1')
         self.assertEqual(client.meta.region_name, 'us-east-1')
 
     def test_client_region_remains_aws_global(self):
-        client = self.create_s3_client(region_name='aws-global')
-        self.assertEqual(client.meta.region_name, 'aws-global')
-
-    def test_client_region_defaults_to_aws_global_for_regional(self):
-        self.environ['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] = 'regional'
-        client = self.create_s3_client(region_name=None)
-        self.assertEqual(client.meta.region_name, 'aws-global')
-
-    def test_client_region_remains_us_east_1_for_regional(self):
-        self.environ['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] = 'regional'
-        client = self.create_s3_client(region_name='us-east-1')
-        self.assertEqual(client.meta.region_name, 'us-east-1')
-
-    def test_client_region_remains_aws_global_for_regional(self):
-        self.environ['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] = 'regional'
         client = self.create_s3_client(region_name='aws-global')
         self.assertEqual(client.meta.region_name, 'aws-global')
 
@@ -1022,29 +905,8 @@ class TestGeneratePresigned(BaseS3OperationTest):
             'get_object', {'Bucket': 'mybucket', 'Key': 'mykey'})
         self.assert_is_v2_presigned_url(url)
 
-    def test_presign_uses_v2_for_default_region_with_us_east_1_regional(self):
-        config = Config(s3={'us_east_1_regional_endpoint': 'regional'})
-        client = self.session.create_client('s3', config=config)
-        url = client.generate_presigned_url(
-            'get_object', {'Bucket': 'mybucket', 'Key': 'mykey'})
-        self.assert_is_v2_presigned_url(url)
-
-    def test_presign_uses_v2_for_aws_global_with_us_east_1_regional(self):
-        config = Config(s3={'us_east_1_regional_endpoint': 'regional'})
-        client = self.session.create_client('s3', 'aws-global', config=config)
-        url = client.generate_presigned_url(
-            'get_object', {'Bucket': 'mybucket', 'Key': 'mykey'})
-        self.assert_is_v2_presigned_url(url)
-
     def test_presign_uses_v2_for_us_east_1(self):
         client = self.session.create_client('s3', 'us-east-1')
-        url = client.generate_presigned_url(
-            'get_object', {'Bucket': 'mybucket', 'Key': 'mykey'})
-        self.assert_is_v2_presigned_url(url)
-
-    def test_presign_uses_v2_for_us_east_1_with_us_east_1_regional(self):
-        config = Config(s3={'us_east_1_regional_endpoint': 'regional'})
-        client = self.session.create_client('s3', 'us-east-1', config=config)
         url = client.generate_presigned_url(
             'get_object', {'Bucket': 'mybucket', 'Key': 'mykey'})
         self.assert_is_v2_presigned_url(url)
@@ -1631,29 +1493,21 @@ def test_correct_url_used_for_s3():
         )
     )
 
-    # Use us-east-1 regional endpoint cases: regional
-    us_east_1_regional_endpoint = {
-        'us_east_1_regional_endpoint': 'regional'
-    }
     yield t.case(
         region='us-east-1', bucket='bucket', key='key',
-        s3_config=us_east_1_regional_endpoint,
         expected_url=(
             'https://bucket.s3.us-east-1.amazonaws.com/key'))
     yield t.case(
         region='us-west-2', bucket='bucket', key='key',
-        s3_config=us_east_1_regional_endpoint,
         expected_url=(
             'https://bucket.s3.us-west-2.amazonaws.com/key'))
     yield t.case(
         region=None, bucket='bucket', key='key',
-        s3_config=us_east_1_regional_endpoint,
         expected_url=(
             'https://bucket.s3.amazonaws.com/key'))
     yield t.case(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={
-            'us_east_1_regional_endpoint': 'regional',
             'use_dualstack_endpoint': True,
         },
         expected_url=(
@@ -1661,7 +1515,6 @@ def test_correct_url_used_for_s3():
     yield t.case(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={
-            'us_east_1_regional_endpoint': 'regional',
             'use_accelerate_endpoint': True,
         },
         expected_url=(
@@ -1669,28 +1522,11 @@ def test_correct_url_used_for_s3():
     yield t.case(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={
-            'us_east_1_regional_endpoint': 'regional',
             'use_accelerate_endpoint': True,
             'use_dualstack_endpoint': True,
         },
         expected_url=(
             'https://bucket.s3-accelerate.dualstack.amazonaws.com/key'))
-
-    # Use us-east-1 regional endpoint cases: legacy
-    us_east_1_regional_endpoint_legacy = {
-        'us_east_1_regional_endpoint': 'legacy'
-    }
-    yield t.case(
-        region='us-east-1', bucket='bucket', key='key',
-        s3_config=us_east_1_regional_endpoint_legacy,
-        expected_url=(
-            'https://bucket.s3.amazonaws.com/key'))
-
-    yield t.case(
-        region=None, bucket='bucket', key='key',
-        s3_config=us_east_1_regional_endpoint_legacy,
-        expected_url=(
-            'https://bucket.s3.amazonaws.com/key'))
 
 
 class S3AddressingCases(object):

--- a/tests/functional/test_stub.py
+++ b/tests/functional/test_stub.py
@@ -285,7 +285,7 @@ class TestStubber(unittest.TestCase):
                     }
                 )
                 self.assertEqual(
-                    url, 'https://s3.amazonaws.com/mybucket/mykey')
+                    url, 'https://s3.us-east-1.amazonaws.com/mybucket/mykey')
         except StubResponseError:
             self.fail(
                 'Stubbed responses should not be required for generating '
@@ -308,8 +308,10 @@ class TestStubber(unittest.TestCase):
                     'Key': 'myotherkey'
                 }
             )
-            self.assertEqual(
-                    url, 'https://s3.amazonaws.com/myotherbucket/myotherkey')
+            expected_url = (
+                'https://s3.us-east-1.amazonaws.com/myotherbucket/myotherkey'
+            )
+            self.assertEqual(url, expected_url)
             actual_response = self.client.list_objects(**expected_params)
             self.assertEqual(desired_response, actual_response)
         self.stubber.assert_no_pending_responses()

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -665,7 +665,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
             'get_object', Params={'Bucket': self.bucket_name, 'Key': self.key})
         self.assertTrue(
             presigned_url.startswith(
-                'https://%s.s3.amazonaws.com/%s' % (
+                'https://%s.s3.us-east-1.amazonaws.com/%s' % (
                     self.bucket_name, self.key)),
             "Host was suppose to use DNS style, instead "
             "got: %s" % presigned_url)
@@ -691,7 +691,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
             'get_object', Params={'Bucket': self.bucket_name, 'Key': self.key})
         self.assertTrue(
             presigned_url.startswith(
-                'https://%s.s3.amazonaws.com/%s' % (
+                'https://%s.s3.us-east-1.amazonaws.com/%s' % (
                     self.bucket_name, self.key)),
             "Host was suppose to be the us-east-1 endpoint, instead "
             "got: %s" % presigned_url)
@@ -721,7 +721,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.amazonaws.com' % self.bucket_name),
+                'https://%s.s3.us-east-1.amazonaws.com' % self.bucket_name),
             "Host was suppose to use DNS style, instead "
             "got: %s" % post_args['url'])
 
@@ -756,7 +756,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.amazonaws.com/' % self.bucket_name),
+                'https://%s.s3.us-east-1.amazonaws.com/' % self.bucket_name),
             "Host was suppose to use us-east-1 endpoint, instead "
             "got: %s" % post_args['url'])
 
@@ -780,7 +780,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
             'get_object', Params={'Bucket': self.bucket_name, 'Key': self.key})
         self.assertTrue(
             presigned_url.startswith(
-                'https://%s.s3.amazonaws.com/%s' % (
+                'https://%s.s3.us-west-2.amazonaws.com/%s' % (
                     self.bucket_name, self.key)),
             "Host was suppose to use DNS style, instead "
             "got: %s" % presigned_url)
@@ -831,7 +831,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.amazonaws.com' % self.bucket_name),
+                'https://%s.s3.us-west-2.amazonaws.com' % self.bucket_name),
             "Host was suppose to use DNS style, instead "
             "got: %s" % post_args['url'])
 
@@ -864,7 +864,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.amazonaws.com/' % self.bucket_name),
+                'https://%s.s3.us-west-2.amazonaws.com/' % self.bucket_name),
             "Host was suppose to use DNS style, instead "
             "got: %s" % post_args['url'])
 

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -50,14 +50,14 @@ class TestS3Addressing(BaseSessionTest):
         prepared_request = self.get_prepared_request('list_objects', params,
                                                      force_hmacv1=True)
         self.assertEqual(prepared_request.url,
-                         'https://safename.s3.amazonaws.com/')
+                         'https://safename.s3.us-east-1.amazonaws.com/')
 
     def test_list_objects_non_dns_name(self):
         params = {'Bucket': 'un_safe_name'}
         prepared_request = self.get_prepared_request('list_objects', params,
                                                      force_hmacv1=True)
         self.assertEqual(prepared_request.url,
-                         'https://s3.amazonaws.com/un_safe_name')
+                         'https://s3.us-east-1.amazonaws.com/un_safe_name')
 
     def test_list_objects_dns_name_non_classic(self):
         self.region_name = 'us-west-2'
@@ -136,7 +136,7 @@ class TestS3Addressing(BaseSessionTest):
             prepared_request = self.get_prepared_request('put_object', params)
             self.assertEqual(
                 prepared_request.url,
-                'https://s3.amazonaws.com/my.valid.name/mykeyname')
+                'https://s3.us-east-1.amazonaws.com/my.valid.name/mykeyname')
 
     def test_put_object_dns_name_single_letter_non_classic(self):
         self.region_name = 'us-west-2'
@@ -174,8 +174,10 @@ class TestS3Addressing(BaseSessionTest):
             'Key': 'mykeyname'
         }
         prepared_request = self.get_prepared_request('get_object', params)
-        self.assertEqual(prepared_request.url,
-                         'https://s3.amazonaws.com/AnInvalidName/mykeyname')
+        expected_url = (
+            'https://s3.us-east-1.amazonaws.com/AnInvalidName/mykeyname'
+        )
+        self.assertEqual(prepared_request.url, expected_url)
 
     def test_get_object_ip_address_name_non_classic(self):
         self.region_name = 'us-west-2'

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -742,7 +742,7 @@ class TestGenerateUrl(unittest.TestCase):
 
         ref_request_dict = {
             'body': b'',
-            'url': u'https://s3.amazonaws.com/mybucket/mykey',
+            'url': u'https://s3.us-east-1.amazonaws.com/mybucket/mykey',
             'headers': {},
             'query_string': {},
             'url_path': u'/mybucket/mykey',
@@ -765,7 +765,7 @@ class TestGenerateUrl(unittest.TestCase):
                 'ResponseContentDisposition': disposition})
         ref_request_dict = {
             'body': b'',
-            'url': (u'https://s3.amazonaws.com/mybucket/mykey'
+            'url': (u'https://s3.us-east-1.amazonaws.com/mybucket/mykey'
                     '?response-content-disposition='
                     'attachment%3B%20filename%3D%22download.jpg%22'),
             'headers': {},
@@ -791,7 +791,7 @@ class TestGenerateUrl(unittest.TestCase):
             ExpiresIn=20)
         ref_request_dict = {
             'body': b'',
-            'url': u'https://s3.amazonaws.com/mybucket/mykey',
+            'url': u'https://s3.us-east-1.amazonaws.com/mybucket/mykey',
             'headers': {},
             'query_string': {},
             'url_path': u'/mybucket/mykey',
@@ -807,7 +807,7 @@ class TestGenerateUrl(unittest.TestCase):
             HttpMethod='PUT')
         ref_request_dict = {
             'body': b'',
-            'url': u'https://s3.amazonaws.com/mybucket/mykey',
+            'url': u'https://s3.us-east-1.amazonaws.com/mybucket/mykey',
             'headers': {},
             'query_string': {},
             'url_path': u'/mybucket/mykey',
@@ -872,7 +872,7 @@ class TestGeneratePresignedPost(unittest.TestCase):
         fields = post_kwargs['fields']
         conditions = post_kwargs['conditions']
         self.assertEqual(
-            request_dict['url'], 'https://s3.amazonaws.com/mybucket')
+            request_dict['url'], 'https://s3.us-east-1.amazonaws.com/mybucket')
         self.assertEqual(post_kwargs['expires_in'], 3600)
         self.assertEqual(
             conditions,
@@ -890,7 +890,7 @@ class TestGeneratePresignedPost(unittest.TestCase):
         fields = post_kwargs['fields']
         conditions = post_kwargs['conditions']
         self.assertEqual(
-            request_dict['url'], 'https://s3.amazonaws.com/mybucket')
+            request_dict['url'], 'https://s3.us-east-1.amazonaws.com/mybucket')
         self.assertEqual(post_kwargs['expires_in'], 3600)
         self.assertEqual(
             conditions,
@@ -907,7 +907,7 @@ class TestGeneratePresignedPost(unittest.TestCase):
         fields = post_kwargs['fields']
         conditions = post_kwargs['conditions']
         self.assertEqual(
-            request_dict['url'], 'https://s3.amazonaws.com/mybucket')
+            request_dict['url'], 'https://s3.us-east-1.amazonaws.com/mybucket')
         self.assertEqual(post_kwargs['expires_in'], 50)
         self.assertEqual(
             conditions,
@@ -928,7 +928,7 @@ class TestGeneratePresignedPost(unittest.TestCase):
         fields = post_kwargs['fields']
         conditions = post_kwargs['conditions']
         self.assertEqual(
-            request_dict['url'], 'https://s3.amazonaws.com/mybucket')
+            request_dict['url'], 'https://s3.us-east-1.amazonaws.com/mybucket')
         self.assertEqual(
             conditions,
             [{'acl': 'public-read'}, {'bucket': 'mybucket'}, {'key': 'mykey'}])


### PR DESCRIPTION
This removes the legacy S3 endpoint regional configuration and defaults to always use the regional endpoint.