### PR TITLE
added body to error response for clients to consume from exception

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -392,8 +392,7 @@ class ClientError(Exception):
         'operation{retry_info}: {error_message}')
 
     NO_MSG_PRESENT_TEMPLATE = (
-        'Response from {operation_name} operation: {body}, '
-        'you can access the body using the "response" attribute on the exception'
+        'Response from {operation_name} operation: {body}'
     )
 
     def __init__(self, error_response, operation_name):

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -601,6 +601,14 @@ class BaseJSONParser(ResponseParser):
         # so we need to check for both.
         error['Error']['Message'] = body.get('message',
                                              body.get('Message', ''))
+
+        # In the event there is no error message we should return the body back to the consumer
+        # Some servies like Lex do not return a 'message' or 'Message' key, they return
+        # a body which contains information on how to fix the problem under different keys.
+        # We should give the body to the client to give them the option to handle the error using the body
+        if error['Error']['Message'] == '':
+            error['Error']['Body'] = body
+        
         # if the message did not contain an error code
         # include the response status code
         response_code = response.get('status_code')

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -38,6 +38,12 @@ def test_client_error_set_correct_operation_name():
     exception = exceptions.ClientError(response, 'blackhole')
     assert_equal(exception.operation_name, 'blackhole')
 
+def test_response_body_added_when_present():
+    body = { 'foo', 'bar '}
+    response = {'Error': { 'Body': body, 'Code': 'ResourceInUseException' } }
+    error_message_with_body = exceptions.ClientError.NO_MSG_PRESENT_TEMPLATE.format(operation_name='blackhole', body=body)
+    expect = 'An error occurred (ResourceInUseException) when calling the blackhole operation: ' + error_message_with_body
+    assert_equal(str(exceptions.ClientError(response, 'blackhole')), expect)
 
 def test_retry_info_added_when_present():
     response = {


### PR DESCRIPTION
If a service responds with an error and it contains no message key, the body should be added to the exception's response attribute to allow the consumer to use the body to recover, or to gain more information about the error.

Related to this open issue https://github.com/boto/botocore/issues/1937

Here is a code snippet that uses Lex and uses the exception response body to gain information about what resource is blocking the deletion:
```python
import boto3

lex_client = boto3.client("lex-models")

try:
    lex_client.delete_bot(name="aCiqJQSnp")
except Exception as e:
    print(e.response['Error']['Body']['exampleReference']['name'])
  ```

If a user prints the exception they will see the following message:
```
An error occurred (ResourceInUseException) when calling the DeleteBot operation: Response from DeleteBot operation: {'exampleReference': {'name': 'aCiqJQSnp', 'version': None}, 'referenceType': 'BotAlias'}
``` 