### PR TITLE
Only test and support py37+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,6 @@
 language: python
 matrix:
   include:
-    - python: 2.7
-      dist: trusty
-      sudo: false
-    - python: 3.4
-      dist: trusty
-      sudo: false
-    - python: 3.5
-      dist: trusty
-      sudo: false
-    - python: 3.6
-      dist: trusty
-      sudo: false
     - python: 3.7
       dist: xenial
       sudo: true

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,7 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,py37,py38
+envlist = py37,py38
 
 skipsdist = True
 


### PR DESCRIPTION
Py37 because that's what we use to build cli v2,
Py38 so we can stay on top of keeping compatible with
new versions of python so it's easy for us to upgrade
python.