### PR TITLE
[v2] Standardize profile and region env vars

### DIFF
--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -48,8 +48,8 @@ logger = logging.getLogger(__name__)
 #: found.
 BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # logical:  config_file, env_var,        default_value, conversion_func
-    'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None),
-    'region': ('region', 'AWS_DEFAULT_REGION', None, None),
+    'profile': (None, ['AWS_PROFILE', 'AWS_DEFAULT_PROFILE'], None, None),
+    'region': ('region', ['AWS_REGION', 'AWS_DEFAULT_REGION'], None, None),
     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
     'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -33,6 +33,17 @@ class TestSession(unittest.TestCase):
         self.session.set_config_variable('profile', 'from_session_instance')
         self.assertEqual(self.session.profile, 'from_session_instance')
 
+    def test_env_var_precedence_for_profile(self):
+        self.environ['AWS_PROFILE'] = 'from_aws_profile'
+        self.environ['AWS_DEFAULT_PROFILE'] = 'from_aws_default_profile'
+        self.assertEqual(self.session.profile, 'from_aws_profile')
+
+    def test_env_var_precedence_for_region(self):
+        self.environ['AWS_REGION'] = 'from_aws_region'
+        self.environ['AWS_DEFAULT_REGION'] = 'from_aws_default_region'
+        self.assertEqual(self.session.get_config_variable('region'),
+                         'from_aws_region')
+
     def test_credentials_with_profile_precedence(self):
         self.environ['AWS_PROFILE'] = 'from_env_var'
         self.session.set_config_variable('profile',  'from_session_instance')

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -330,10 +330,11 @@ class TestSessionConfigurationVars(BaseSessionTest):
         # information from the session and that it has the expected value.
         self.session = create_session()
         self.assertEqual(self.session.session_var_map['region'],
-                         ('region', 'AWS_DEFAULT_REGION', None, None))
+                         ('region', ['AWS_REGION', 'AWS_DEFAULT_REGION'],
+                          None, None))
         self.assertEqual(
             self.session.session_var_map['profile'],
-            (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None))
+            (None, ['AWS_PROFILE', 'AWS_DEFAULT_PROFILE'], None, None))
         self.assertEqual(
             self.session.session_var_map['data_path'],
             ('data_path', 'AWS_DATA_PATH', None, None))


### PR DESCRIPTION
* Add support for `AWS_REGION`, which is supported in all SDKs
  except python/cli.
* Change precedence to prefer `AWS_<VAR>` before `AWS_DEFAULT_<VAR>`.