### PR TITLE
Make timestamp-parsing utils platform-independent

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -631,7 +631,14 @@ def parse_posix_timestamp(value):
     # We convert to local time manually, then force-replace the timezone
     # object, due to the platform-dependent nature of datetime.astimezone()
     # and datetime.fromtimestamp()
-    dt = EPOCH + datetime.timedelta(seconds=value + time.localtime().tm_gmtoff)
+
+    if six.PY3:
+        # It's better to get the UTC offset in real-time in case it changes during
+        # runtime. However it seems to only be supported in Python 3.3+
+        utc_offset = time.localtime().tm_gmtoff
+    else:
+        utc_offset = time.timezone
+    dt = EPOCH + datetime.timedelta(seconds=value + utc_offset)
     return dt.replace(tzinfo=tzlocal())
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -313,6 +313,8 @@ class TestParseEC2CredentialsFile(unittest.TestCase):
 
 
 class TestParseTimestamps(unittest.TestCase):
+    # NOTE: These tests assume the system timezone is set to UTC.
+
     def test_parse_iso8601(self):
         self.assertEqual(
             parse_timestamp('1970-01-01T00:10:00.000Z'),
@@ -327,6 +329,11 @@ class TestParseTimestamps(unittest.TestCase):
         self.assertEqual(
             parse_timestamp(0),
             datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=tzutc()))
+
+    def test_parse_epoch_negative_time(self):
+        self.assertEqual(
+            parse_timestamp(-1),
+            datetime.datetime(1969, 12, 31, 23, 59, 59, tzinfo=tzutc()))
 
     def test_parse_epoch_as_string(self):
         self.assertEqual(


### PR DESCRIPTION
Resolves #1939.

In general, this *should* make timestamp-parsing mostly platform-independent, since the use of platform-dependent methods such as `datetime.fromtimestamp()` and `datetime.astimezone()` are no longer being used. Instead, timestamps are manually offset from the Unix epoch, and are also localised manually.

This PR comes with a new utility function, `botocore.utils.parse_posix_timestamp`, which is simply a more specific version of `botocore.utils.parse_timestamp`.

I also made a comment in the relevant tests to note that the tests seem to be written for machines where the timezone is UTC. Tests were failing for me before making any changes, until I ran the tests with the `TZ=UTC` env var.