### PR TITLE
[v2] Add support for adaptive mode retries

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -40,6 +40,7 @@ from botocore.discovery import (
     block_endpoint_discovery_required_operations
 )
 from botocore.retries import standard
+from botocore.retries import adaptive
 
 
 logger = logging.getLogger(__name__)
@@ -115,6 +116,9 @@ class ClientCreator(object):
         retry_mode = client.meta.config.retries['mode']
         if retry_mode == 'standard':
             self._register_v2_standard_retries(client)
+        elif retry_mode == 'adaptive':
+            self._register_v2_standard_retries(client)
+            self._register_v2_adaptive_retries(client)
 
     def _register_v2_standard_retries(self, client):
         max_attempts = client.meta.config.retries.get('max_attempts')
@@ -122,6 +126,9 @@ class ClientCreator(object):
         if max_attempts is not None:
             kwargs['max_attempts'] = max_attempts
         standard.register_retry_handler(**kwargs)
+
+    def _register_v2_adaptive_retries(self, client):
+        adaptive.register_retry_handler(client)
 
     def _register_endpoint_discovery(self, client, endpoint_url, config):
         if endpoint_url is not None:

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -563,3 +563,9 @@ class UnauthorizedSSOTokenError(SSOError):
         "otherwise invalid. To refresh this SSO session run aws2 sso login "
         "with the corresponding profile."
     )
+
+
+class CapacityNotAvailableError(BotoCoreError):
+    fmt = (
+        'Insufficient request capacity available.'
+    )

--- a/botocore/retries/adaptive.py
+++ b/botocore/retries/adaptive.py
@@ -1,0 +1,117 @@
+import math
+import logging
+import threading
+
+from botocore.retries import bucket
+from botocore.retries import throttling
+from botocore.retries import standard
+
+
+logger = logging.getLogger(__name__)
+
+
+def register_retry_handler(client):
+    clock = bucket.Clock()
+    rate_adjustor = throttling.CubicCalculator(starting_max_rate=0,
+                                               start_time=clock.current_time())
+    token_bucket = bucket.TokenBucket(max_rate=1, clock=clock)
+    rate_clocker = RateClocker(clock)
+    throttling_detector = standard.ThrottlingErrorDetector(
+        retry_event_adapter=standard.RetryEventAdapter(),
+    )
+    limiter = ClientRateLimiter(
+        rate_adjustor=rate_adjustor,
+        rate_clocker=rate_clocker,
+        token_bucket=token_bucket,
+        throttling_detector=throttling_detector,
+        clock=clock,
+    )
+    client.meta.events.register(
+        'before-send', limiter.on_sending_request,
+    )
+    client.meta.events.register(
+        'needs-retry', limiter.on_receiving_response,
+    )
+    return limiter
+
+
+class ClientRateLimiter(object):
+
+    _MAX_RATE_ADJUST_SCALE = 2.0
+
+    def __init__(self, rate_adjustor, rate_clocker, token_bucket,
+                 throttling_detector, clock):
+        self._rate_adjustor = rate_adjustor
+        self._rate_clocker = rate_clocker
+        self._token_bucket = token_bucket
+        self._throttling_detector = throttling_detector
+        self._clock = clock
+        self._enabled = False
+        self._lock = threading.Lock()
+
+    def on_sending_request(self, request, **kwargs):
+        if self._enabled:
+            self._token_bucket.acquire()
+
+    # Hooked up to needs-retry.
+    def on_receiving_response(self, **kwargs):
+        measured_rate = self._rate_clocker.record()
+        timestamp = self._clock.current_time()
+        with self._lock:
+            if not self._throttling_detector.is_throttling_error(**kwargs):
+                throttling = False
+                new_rate = self._rate_adjustor.success_received(timestamp)
+            else:
+                throttling = True
+                if not self._enabled:
+                    rate_to_use = measured_rate
+                else:
+                    rate_to_use = min(measured_rate, self._token_bucket.max_rate)
+                new_rate = self._rate_adjustor.error_received(
+                    rate_to_use, timestamp)
+                logger.debug("Throttling response received, new send rate: %s "
+                             "measured rate: %s, token bucket capacity "
+                             "available: %s", new_rate, measured_rate,
+                             self._token_bucket.available_capacity)
+                self._enabled = True
+            self._token_bucket.max_rate = min(
+                new_rate, self._MAX_RATE_ADJUST_SCALE * measured_rate)
+
+
+class RateClocker(object):
+    """Tracks the rate at which a client is sending a request."""
+
+    _DEFAULT_SMOOTHING = 0.8
+    # Update the rate every _TIME_BUCKET_RANGE seconds.
+    _TIME_BUCKET_RANGE = 0.5
+
+    def __init__(self, clock, smoothing=_DEFAULT_SMOOTHING,
+                 time_bucket_range=_TIME_BUCKET_RANGE):
+        self._clock = clock
+        self._measured_rate = 0
+        self._smoothing = smoothing
+        self._last_bucket = math.floor(self._clock.current_time())
+        self._time_bucket_scale = 1 / self._TIME_BUCKET_RANGE
+        self._count = 0
+        self._lock = threading.Lock()
+
+    def record(self, amount=1):
+        with self._lock:
+            t = self._clock.current_time()
+            bucket = math.floor(
+                t * self._time_bucket_scale) / self._time_bucket_scale
+            self._count += amount
+            if bucket > self._last_bucket:
+                current_rate = self._count / float(
+                    bucket - self._last_bucket)
+                self._measured_rate = (
+                    (current_rate * self._smoothing) +
+                    (self._measured_rate * (1 - self._smoothing))
+                )
+                self._count = 0
+                self._last_bucket = bucket
+            return self._measured_rate
+
+    @property
+    def measured_rate(self):
+        return self._measured_rate

--- a/botocore/retries/bucket.py
+++ b/botocore/retries/bucket.py
@@ -1,0 +1,114 @@
+"""This module implements token buckets used for client side throttling."""
+import time
+import threading
+
+from botocore.exceptions import CapacityNotAvailableError
+
+
+class Clock(object):
+    def __init__(self):
+        pass
+
+    def sleep(self, amount):
+        time.sleep(amount)
+
+    def current_time(self):
+        return time.time()
+
+
+class TokenBucket(object):
+
+    _MIN_RATE = 0.5
+
+    def __init__(self, max_rate, clock, min_rate=_MIN_RATE):
+        self._fill_rate = None
+        self._max_capacity = None
+        self._current_capacity = 0
+        self._clock = clock
+        self._last_timestamp = None
+        self._min_rate = min_rate
+        self._lock = threading.Lock()
+        self._new_fill_rate_condition = threading.Condition(self._lock)
+        self.max_rate = max_rate
+
+    @property
+    def max_rate(self):
+        return self._fill_rate
+
+    @max_rate.setter
+    def max_rate(self, value):
+        with self._new_fill_rate_condition:
+            # Before we can change the rate we need to fill any pending
+            # tokens we might have based on the current rate.  If we don't
+            # do this it means everything since the last recorded timestamp
+            # will accumulate at the rate we're about to set which isn't
+            # correct.
+            self._refill()
+            self._fill_rate = max(value, self._min_rate)
+            if value >= 1:
+                self._max_capacity = value
+            else:
+                self._max_capacity = 1
+            # If we're scaling down, we also can't have a capacity that's
+            # more than our max_capacity.
+            self._current_capacity = min(self._current_capacity,
+                                        self._max_capacity)
+            self._new_fill_rate_condition.notify()
+
+    @property
+    def max_capacity(self):
+        return self._max_capacity
+
+    @property
+    def available_capacity(self):
+        return self._current_capacity
+
+    def acquire(self, amount=1, block=True):
+        """Acquire token or return amount of time until next token available.
+
+        If block is True, then this method will block until there's sufficient
+        capacity to acquire the desired amount.
+
+        If block is False, then this method will return True is capacity
+        was successfully acquired, False otherwise.
+
+        """
+        with self._new_fill_rate_condition:
+            return self._acquire(amount=amount, block=block)
+
+    def _acquire(self, amount, block):
+        self._refill()
+        if amount <= self._current_capacity:
+            self._current_capacity -= amount
+            return True
+        else:
+            if not block:
+                raise CapacityNotAvailableError()
+            # Not enough capacity.
+            sleep_amount = self._sleep_amount(amount)
+            while sleep_amount > 0:
+                # Until python3.2, wait() always returned None so we can't
+                # tell if a timeout occurred waiting on the cond var.
+                # Because of this we'll unconditionally call _refill().
+                # The downside to this is that we were waken up via
+                # a notify(), we're calling unnecessarily calling _refill() an
+                # extra time.
+                self._new_fill_rate_condition.wait(sleep_amount)
+                self._refill()
+                sleep_amount = self._sleep_amount(amount)
+            self._current_capacity -= amount
+            return True
+
+    def _sleep_amount(self, amount):
+        return (amount - self._current_capacity) / self._fill_rate
+
+    def _refill(self):
+        timestamp = self._clock.current_time()
+        if self._last_timestamp is None:
+            self._last_timestamp = timestamp
+            return
+        current_capacity = self._current_capacity
+        fill_amount = (timestamp - self._last_timestamp) * self._fill_rate
+        new_capacity = min(self._max_capacity, current_capacity + fill_amount)
+        self._current_capacity = new_capacity
+        self._last_timestamp = timestamp

--- a/botocore/retries/throttling.py
+++ b/botocore/retries/throttling.py
@@ -1,0 +1,54 @@
+from collections import namedtuple
+
+CubicParams = namedtuple('CubicParams', ['w_max', 'k', 'last_fail'])
+
+
+class CubicCalculator(object):
+    _SCALE_CONSTANT = 0.4
+    _BETA = 0.7
+
+    def __init__(self, starting_max_rate,
+                 start_time,
+                 scale_constant=_SCALE_CONSTANT, beta=_BETA):
+        self._w_max = starting_max_rate
+        self._scale_constant = scale_constant
+        self._beta = beta
+        self._k = self._calculate_zero_point()
+        self._last_fail = start_time
+
+    def _calculate_zero_point(self):
+        k = ((self._w_max * (1 - self._beta)) / self._scale_constant) ** (1 / 3.0)
+        return k
+
+    def success_received(self, timestamp):
+        dt = timestamp - self._last_fail
+        new_rate = (
+            self._scale_constant * (dt - self._k) ** 3 + self._w_max
+        )
+        return new_rate
+
+    def error_received(self, current_rate, timestamp):
+        # Consider not having this be the current measured rate.
+
+        # We have a new max rate, which is the current rate we were sending
+        # at when we received an error response.
+        self._w_max = current_rate
+        self._k = self._calculate_zero_point()
+        self._last_fail = timestamp
+        return current_rate * self._beta
+
+    def get_params_snapshot(self):
+        """Return a read-only object of the current cubic parameters.
+
+        These parameters are intended to be used for debug/troubleshooting
+        purposes.  These object is a read-only snapshot and cannot be used
+        to modify the behavior of the CUBIC calculations.
+
+        New parameters may be added to this object in the future.
+
+        """
+        return CubicParams(
+            w_max=self._w_max,
+            k=self._k,
+            last_fail=self._last_fail
+        )

--- a/tests/functional/retries/test_bucket.py
+++ b/tests/functional/retries/test_bucket.py
@@ -1,0 +1,109 @@
+import random
+import time
+import threading
+from tests import unittest
+
+from botocore.retries import bucket
+
+
+class InstrumentedTokenBucket(bucket.TokenBucket):
+    def _acquire(self, amount, block):
+        rval = super(InstrumentedTokenBucket, self)._acquire(amount, block)
+        assert self._current_capacity >= 0
+        return rval
+
+
+class TestTokenBucketThreading(unittest.TestCase):
+    def setUp(self):
+        self.shutdown_threads = False
+        self.caught_exceptions = []
+        self.acquisitions_by_thread = {}
+
+    def run_in_thread(self):
+        while not self.shutdown_threads:
+            capacity = random.randint(1, self.max_capacity)
+            self.retry_quota.acquire(capacity)
+            self.seen_capacities.append(self.retry_quota.available_capacity)
+            self.retry_quota.release(capacity)
+            self.seen_capacities.append(self.retry_quota.available_capacity)
+
+    def create_clock(self):
+        return bucket.Clock()
+
+    def test_can_change_max_rate_while_blocking(self):
+        # This isn't a stress test, we just want to verify we can change
+        # the rate at which we acquire a token.
+        min_rate = 0.1
+        max_rate = 1
+        token_bucket = bucket.TokenBucket(
+            min_rate=min_rate, max_rate=max_rate,
+            clock=self.create_clock(),
+        )
+        # First we'll set the max_rate to 0.1 (min_rate).  This means that
+        # it will take 10 seconds to accumulate a single token.  We'll start
+        # a thread and have it acquire() a token.
+        # Then in the main thread we'll change the max_rate to something
+        # really quick (e.g 100).  We should immediately get a token back.
+        # This is going to be timing sensitive, but we can verify that
+        # as long as it doesn't take 10 seconds to get a token, we were
+        # able to update the rate as needed.
+        thread = threading.Thread(target=token_bucket.acquire)
+        token_bucket.max_rate = min_rate
+        start_time = time.time()
+        thread.start()
+        # This shouldn't block the main thread.
+        token_bucket.max_rate = 100
+        thread.join()
+        end_time = time.time()
+        self.assertLessEqual(end_time - start_time, 1.0 / min_rate)
+
+    def acquire_in_loop(self, token_bucket):
+        while not self.shutdown_threads:
+            try:
+                self.assertTrue(token_bucket.acquire())
+                thread_name = threading.current_thread().name
+                self.acquisitions_by_thread[thread_name] += 1
+            except Exception as e:
+                self.caught_exceptions.append(e)
+
+    def randomly_set_max_rate(self, token_bucket, min_val, max_val):
+        while not self.shutdown_threads:
+            new_rate = random.randint(min_val, max_val)
+            token_bucket.max_rate = new_rate
+            time.sleep(0.01)
+
+    def test_stress_test_token_bucket(self):
+        token_bucket = InstrumentedTokenBucket(
+            max_rate=10,
+            clock=self.create_clock(),
+        )
+        all_threads = []
+        for _ in range(2):
+            all_threads.append(
+                threading.Thread(target=self.randomly_set_max_rate,
+                                 args=(token_bucket, 30, 200))
+            )
+        for _ in range(10):
+            t = threading.Thread(target=self.acquire_in_loop,
+                                 args=(token_bucket,))
+            self.acquisitions_by_thread[t.name] = 0
+            all_threads.append(t)
+        for thread in all_threads:
+            thread.start()
+        try:
+            # If you're working on this code you can bump this number way
+            # up to stress test it more locally.
+            time.sleep(3)
+        finally:
+            self.shutdown_threads = True
+            for thread in all_threads:
+                thread.join()
+        self.assertEqual(self.caught_exceptions, [])
+        distribution = self.acquisitions_by_thread.values()
+        mean = sum(distribution) / float(len(distribution))
+        # We can't really rely on any guarantees about evenly distributing
+        # thread acquisition(), e.g. must be with a 2 stddev range, but we
+        # can sanity check that our implementation isn't drastically
+        # starving a thread.  So we'll arbitrarily say that a thread
+        # can't have less than 30% of the mean allocations per thread.
+        self.assertTrue(not any(x < (0.3 * mean) for x in distribution))

--- a/tests/functional/retries/test_quota.py
+++ b/tests/functional/retries/test_quota.py
@@ -1,0 +1,42 @@
+import random
+import time
+import threading
+from tests import unittest
+
+from botocore.retries import quota
+
+
+class TestRetryQuota(unittest.TestCase):
+    def setUp(self):
+        self.max_capacity = 50
+        self.retry_quota = quota.RetryQuota(self.max_capacity)
+        self.shutdown_threads = False
+        self.seen_capacities = []
+
+    def run_in_thread(self):
+        while not self.shutdown_threads:
+            capacity = random.randint(1, self.max_capacity)
+            self.retry_quota.acquire(capacity)
+            self.seen_capacities.append(self.retry_quota.available_capacity)
+            self.retry_quota.release(capacity)
+            self.seen_capacities.append(self.retry_quota.available_capacity)
+
+    def test_capacity_stays_within_range(self):
+        # The main thing we're after is that the available_capacity
+        # should always be 0 <= capacity <= max_capacity.
+        # So what we do is spawn a number of threads and them acquire
+        # random capacity.  They'll check that they never see an invalid
+        # capacity.
+        threads = []
+        for i in range(10):
+            threads.append(threading.Thread(target=self.run_in_thread))
+        for thread in threads:
+            thread.start()
+        # We'll let things run for a second.
+        time.sleep(1)
+        self.shutdown_threads = True
+        for thread in threads:
+            thread.join()
+        for seen_capacity in self.seen_capacities:
+            self.assertGreaterEqual(seen_capacity, 0)
+            self.assertLessEqual(seen_capacity, self.max_capacity)

--- a/tests/unit/retries/test_adaptive.py
+++ b/tests/unit/retries/test_adaptive.py
@@ -1,0 +1,172 @@
+from tests import unittest
+
+import mock
+
+from botocore.retries import adaptive
+from botocore.retries import standard
+from botocore.retries import bucket
+from botocore.retries import throttling
+
+
+class FakeClock(bucket.Clock):
+    def __init__(self, timestamp_sequences):
+        self.timestamp_sequences = timestamp_sequences
+        self.sleep_call_amounts = []
+
+    def sleep(self, amount):
+        self.sleep_call_amounts.append(amount)
+
+    def current_time(self):
+        return self.timestamp_sequences.pop(0)
+
+
+class TestCanCreateRetryHandler(unittest.TestCase):
+    def test_can_register_retry_handler(self):
+        client = mock.Mock()
+        limiter = adaptive.register_retry_handler(client)
+        self.assertEqual(
+            client.meta.events.register.call_args_list,
+            [mock.call('before-send', limiter.on_sending_request),
+             mock.call('needs-retry', limiter.on_receiving_response)]
+        )
+
+
+class TestClientRateLimiter(unittest.TestCase):
+    def setUp(self):
+        self.timestamp_sequences = [0]
+        self.clock = FakeClock(self.timestamp_sequences)
+        self.token_bucket = mock.Mock(spec=bucket.TokenBucket)
+        self.rate_adjustor = mock.Mock(spec=throttling.CubicCalculator)
+        self.rate_clocker = mock.Mock(spec=adaptive.RateClocker)
+        self.throttling_detector = mock.Mock(
+            spec=standard.ThrottlingErrorDetector)
+
+    def create_client_limiter(self):
+        rate_limiter = adaptive.ClientRateLimiter(
+            rate_adjustor=self.rate_adjustor,
+            rate_clocker=self.rate_clocker,
+            token_bucket=self.token_bucket,
+            throttling_detector=self.throttling_detector,
+            clock=self.clock,
+        )
+        return rate_limiter
+
+    def test_bucket_bucket_acquisition_only_if_enabled(self):
+        rate_limiter = self.create_client_limiter()
+        rate_limiter.on_sending_request(request=mock.sentinel.request)
+        self.assertFalse(self.token_bucket.acquire.called)
+
+    def test_token_bucket_enabled_on_throttling_error(self):
+        rate_limiter = self.create_client_limiter()
+        self.throttling_detector.is_throttling_error.return_value = True
+        self.rate_clocker.record.return_value = 21
+        self.rate_adjustor.error_received.return_value = 17
+        rate_limiter.on_receiving_response()
+        # Now if we call on_receiving_response we should try to acquire
+        # token.
+        self.timestamp_sequences.append(1)
+        rate_limiter.on_sending_request(request=mock.sentinel.request)
+        self.assertTrue(self.token_bucket.acquire.called)
+
+    def test_max_rate_updated_on_success_response(self):
+        rate_limiter = self.create_client_limiter()
+        self.throttling_detector.is_throttling_error.return_value = False
+        self.rate_adjustor.success_received.return_value = 20
+        self.rate_clocker.record.return_value = 21
+        rate_limiter.on_receiving_response()
+        self.assertEqual(self.token_bucket.max_rate, 20)
+
+    def test_max_rate_cant_exceed_20_percent_max(self):
+        rate_limiter = self.create_client_limiter()
+        self.throttling_detector.is_throttling_error.return_value = False
+        # So if our actual measured sending rate is 20 TPS
+        self.rate_clocker.record.return_value = 20
+        # But the rate adjustor is telling us to go up to 100 TPS
+        self.rate_adjustor.success_received.return_value = 100
+
+        # The most we should go up is 2.0 * 20
+        rate_limiter.on_receiving_response()
+        self.assertEqual(self.token_bucket.max_rate, 2.0 * 20)
+
+class TestRateClocker(unittest.TestCase):
+
+    def setUp(self):
+        self.timestamp_sequences = [0]
+        self.clock = FakeClock(self.timestamp_sequences)
+        self.rate_measure = adaptive.RateClocker(self.clock)
+        self.smoothing = 0.8
+
+    def test_initial_rate_is_0(self):
+        self.assertEqual(self.rate_measure.measured_rate, 0)
+
+    def test_time_updates_if_after_bucket_range(self):
+        self.timestamp_sequences.append(1)
+        # This should be 1 * 0.8 + 0 * 0.2, or just 0.8
+        self.assertEqual(self.rate_measure.record(), 0.8)
+
+    def test_can_measure_constant_rate(self):
+        # Timestamps of 1 every second indicate a rate of 1 TPS.
+        self.timestamp_sequences.extend(range(1, 21))
+        for _ in range(20):
+            self.rate_measure.record()
+        self.assertAlmostEqual(self.rate_measure.measured_rate, 1)
+
+    def test_uses_smoothing_to_favor_recent_weights(self):
+        self.timestamp_sequences.extend([
+            1,
+            1.5,
+            2,
+            2.5,
+            3,
+            3.5,
+            4,
+            # If we now wait 10 seconds (.1 TPS),
+            # our rate is somewhere between 2 TPS and .1 TPS.
+            14,
+        ])
+        for _ in range(7):
+            self.rate_measure.record()
+        # We should almost be at 2.0 but not quite.
+        self.assertGreaterEqual(self.rate_measure.measured_rate, 1.99)
+        self.assertLessEqual(self.rate_measure.measured_rate, 2.0)
+        # With our last recording we now drop down between 0.1 and 2
+        # depending on our smoothing factor.
+        self.rate_measure.record()
+        self.assertGreaterEqual(self.rate_measure.measured_rate, 0.1)
+        self.assertLessEqual(self.rate_measure.measured_rate, 2.0)
+
+    def test_noop_when_delta_t_is_0(self):
+        self.timestamp_sequences.extend([
+            1,
+            1,
+            1,
+            2,
+            3
+        ])
+        for _ in range(5):
+            self.rate_measure.record()
+        self.assertGreaterEqual(self.rate_measure.measured_rate, 1.0)
+
+    def test_times_are_grouped_per_time_bucket(self):
+        # Using our default of 0.5 time buckets, we have:
+        self.timestamp_sequences.extend([
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.49,
+        ])
+        for _ in range(len(self.timestamp_sequences)):
+            self.rate_measure.record()
+        # This is showing the tradeoff we're making with measuring rates.
+        # we're currently in the window from 0 <= x < 0.5, which means
+        # we use the rate from the previous bucket, which is 0:
+        self.assertEqual(self.rate_measure.measured_rate, 0)
+        # However if we now add a new measurement that's in the next
+        # time bucket  0.5 <= x < 1.0
+        # we'll use the range from the previous bucket:
+        self.timestamp_sequences.append(0.5)
+        self.rate_measure.record()
+        # And our previous bucket will be:
+        # 12 * 0.8 + 0.2 * 0
+        self.assertEqual(self.rate_measure.measured_rate, 12 * 0.8)

--- a/tests/unit/retries/test_bucket.py
+++ b/tests/unit/retries/test_bucket.py
@@ -1,0 +1,112 @@
+from tests import unittest
+
+from botocore.retries import bucket
+from botocore.exceptions import CapacityNotAvailableError
+
+
+class FakeClock(bucket.Clock):
+    def __init__(self, timestamp_sequences):
+        self.timestamp_sequences = timestamp_sequences
+        self.sleep_call_amounts = []
+
+    def sleep(self, amount):
+        self.sleep_call_amounts.append(amount)
+
+    def current_time(self):
+        return self.timestamp_sequences.pop(0)
+
+
+class TestTokenBucket(unittest.TestCase):
+    def setUp(self):
+        self.timestamp_sequences = [0]
+        self.clock = FakeClock(self.timestamp_sequences)
+
+    def create_token_bucket(self, max_rate=10, min_rate=0.1):
+        return bucket.TokenBucket(max_rate=max_rate, clock=self.clock,
+                                  min_rate=min_rate)
+
+    def test_can_acquire_amount(self):
+        self.timestamp_sequences.extend([
+            # Requests tokens every second, which is well below our
+            # 10 TPS fill rate.
+            1,
+            2,
+            3,
+            4,
+            5,
+        ])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        for _ in range(5):
+            self.assertTrue(token_bucket.acquire(1, block=False))
+
+    def test_can_change_max_capacity_lower(self):
+        # Requests at 1 TPS.
+        self.timestamp_sequences.extend([1, 2, 3, 4, 5])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        # Request the first 5 tokens with max_rate=10
+        for _ in range(5):
+            self.assertTrue(token_bucket.acquire(1, block=False))
+        # Now scale the max_rate down to 1 on the 5th second.
+        self.timestamp_sequences.append(5)
+        token_bucket.max_rate = 1
+        # And then from seconds 6-10 we request at one per second.
+        self.timestamp_sequences.extend([6, 7, 8, 9, 10])
+        for _ in range(5):
+            self.assertTrue(token_bucket.acquire(1, block=False))
+
+    def test_max_capacity_is_at_least_one(self):
+        token_bucket = self.create_token_bucket()
+        self.timestamp_sequences.append(1)
+        token_bucket.max_rate = 0.5
+        self.assertEqual(token_bucket.max_rate, 0.5)
+        self.assertEqual(token_bucket.max_capacity, 1)
+
+    def test_acquire_fails_on_non_block_mode_returns_false(self):
+        self.timestamp_sequences.extend([
+            # Initial creation time.
+            0,
+            # Requests a token 1 second later.
+            1
+        ])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        with self.assertRaises(CapacityNotAvailableError):
+            token_bucket.acquire(100, block=False)
+
+    def test_can_retrieve_at_max_send_rate(self):
+        self.timestamp_sequences.extend([
+            # Request a new token every 100ms (10 TPS) for 2 seconds.
+            1 + 0.1 * i for i in range(20)
+        ])
+        token_bucket = self.create_token_bucket(max_rate=10)
+        for _ in range(20):
+            self.assertTrue(token_bucket.acquire(1, block=False))
+
+    def test_acquiring_blocks_when_capacity_reached(self):
+        # This is 1 token every 0.1 seconds.
+        token_bucket = self.create_token_bucket(max_rate=10)
+        self.timestamp_sequences.extend([
+            # The first acquire() happens after .1 seconds.
+            0.1,
+            # The second acquire() will fail because we get tokens at
+            # 1 per 0.1 seconds.  We will then sleep for 0.05 seconds until we
+            # get a new token.
+            0.15,
+            # And at 0.2 seconds we get our token.
+            0.2,
+            # And at 0.3 seconds we have no issues getting a token.
+            # Because we're using such small units (to avoid bloating the
+            # test run time), we have to go slightly over 0.3 seconds here.
+            0.300001,
+        ])
+        self.assertTrue(token_bucket.acquire(1, block=False))
+        self.assertEqual(token_bucket.available_capacity, 0)
+        self.assertTrue(token_bucket.acquire(1, block=True))
+        self.assertEqual(token_bucket.available_capacity, 0)
+        self.assertTrue(token_bucket.acquire(1, block=False))
+
+    def test_rate_cant_go_below_min(self):
+        token_bucket = self.create_token_bucket(max_rate=1, min_rate=0.2)
+        self.timestamp_sequences.append(1)
+        token_bucket.max_rate = 0.1
+        self.assertEqual(token_bucket.max_rate, 0.2)
+        self.assertEqual(token_bucket.max_capacity, 1)

--- a/tests/unit/retries/test_throttling.py
+++ b/tests/unit/retries/test_throttling.py
@@ -1,0 +1,71 @@
+from tests import unittest
+
+
+from botocore.retries import throttling
+
+
+class TestCubicCalculator(unittest.TestCase):
+    def create_cubic_calculator(self, starting_max_rate=10, beta=0.7,
+                                scale_constant=0.4):
+        return throttling.CubicCalculator(starting_max_rate=starting_max_rate,
+                                          scale_constant=scale_constant,
+                                          start_time=0, beta=beta)
+
+    # For these tests, rather than duplicate the formulas in the tests,
+    # I want to check against a fixed set of inputs with by-hand verified
+    # values to ensure we're doing the calculations correctly.
+
+    def test_starting_params(self):
+        cubic = self.create_cubic_calculator(starting_max_rate=10)
+        self.assertAlmostEqual(
+            cubic.get_params_snapshot().k, 1.9574338205844317
+        )
+
+    def test_success_responses_until_max_hit(self):
+        # For this test we're interested in the behavior less so than
+        # the specific numbers.  There's a few cases we care about:
+        #
+        cubic = self.create_cubic_calculator(starting_max_rate=10)
+        params = cubic.get_params_snapshot()
+        start_k = params.k
+        start_w_max = params.w_max
+        # Before we get to t == start_k, our throttle is below our
+        # max w_max
+        assertLessEqual = self.assertLessEqual
+        assertLessEqual(cubic.success_received(start_k / 3.0), start_w_max)
+        assertLessEqual(cubic.success_received(start_k / 2.0), start_w_max)
+        assertLessEqual(cubic.success_received(start_k / 1.1), start_w_max)
+        # At t == start_k, we should be at w_max.
+        self.assertAlmostEqual(cubic.success_received(timestamp=start_k), 10.0)
+        # And once we pass start_k, we'll be above w_max.
+        self.assertGreaterEqual(
+            cubic.success_received(start_k * 1.1), start_w_max)
+        self.assertGreaterEqual(
+            cubic.success_received(start_k * 2.0), start_w_max)
+
+    def test_error_response_decreases_rate_by_beta(self):
+        # This is the default value here so we're just being explicit.
+        cubic = self.create_cubic_calculator(starting_max_rate=10, beta=0.7)
+
+        # So let's say we made it up to 8 TPS before we were throttled.
+        rate_when_throttled = 8
+        new_rate = cubic.error_received(current_rate=rate_when_throttled,
+                                        timestamp=1)
+        self.assertAlmostEqual(new_rate, rate_when_throttled * 0.7)
+
+        new_params = cubic.get_params_snapshot()
+        self.assertEqual(
+            new_params,
+            throttling.CubicParams(w_max=rate_when_throttled,
+                                   k=1.8171205928321397,
+                                   last_fail=1)
+        )
+
+    def test_t_0_should_match_beta_decrease(self):
+        # So if I have beta of 0.6
+        cubic = self.create_cubic_calculator(starting_max_rate=10, beta=0.6)
+        # When I get throttled I should decrease my rate by 60%.
+        new_rate = cubic.error_received(current_rate=10, timestamp=1)
+        self.assertEqual(new_rate, 6.0)
+        # And my starting rate at time t=1 should start at that new rate.
+        self.assertAlmostEqual(cubic.success_received(timestamp=1), 6.0)


### PR DESCRIPTION
This adds a new experimental retry mode, `adaptive`, that adds
support for client side rate limiting based on receiving
throttling responses.  `adaptive` mode includes all the behavior
on `standard` mode.