### PR TITLE
For SigV4 canonical query str, encode then sort.

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -212,10 +212,15 @@ class SigV4Auth(BaseSigner):
 
     def _canonical_query_string_params(self, params):
         l = []
-        for param in sorted(params):
+        # Encode params before sorting.
+        encoded_params = {}
+        for param in params:
             value = str(params[param])
-            l.append('%s=%s' % (quote(param, safe='-_.~'),
-                                quote(value, safe='-_.~')))
+            encoded_params[quote(param, safe='-_.~')] = quote(value,
+                                                              safe='-_.~')
+        for param in sorted(encoded_params):
+            value = encoded_params[param]
+            l.append('%s=%s' % (param, value))
         cqs = '&'.join(l)
         return cqs
 


### PR DESCRIPTION
Fixes #1951, which describes that the library is currently sorting
before encoding. The S3 docs linked below explicitly say to encode
params before sorting them when creating the canonical query string:
https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html