### PR TITLE
Prefer tzwinlocal over tzlocal in parse_timestamp to handle negative timestamps

### DIFF
--- a/.changes/next-release/enhancement-timezones-38018.json
+++ b/.changes/next-release/enhancement-timezones-38018.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "timezones",
+  "description": "Improved timezone parsing for Windows with new fallback method (#1939)"
+}

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -23,6 +23,7 @@ from math import floor
 
 from botocore.vendored import six
 from botocore.exceptions import MD5UnavailableError
+from dateutil.tz import tzlocal
 from urllib3 import exceptions
 
 logger = logging.getLogger(__name__)
@@ -327,6 +328,17 @@ def _windows_shell_split(s):
         components.append(''.join(buff))
 
     return components
+
+
+def get_tzinfo_options():
+    # Due to dateutil/dateutil#197, Windows may fail to parse times in the past
+    # with the system clock. We can alternatively fallback to tzwininfo when
+    # this happens, which will get time info from the Windows registry.
+    if sys.platform == 'win32':
+        from dateutil.tz import tzwinlocal
+        return (tzlocal, tzwinlocal)
+    else:
+        return (tzlocal,)
 
 
 try:

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -24,7 +24,7 @@ import socket
 import cgi
 
 import dateutil.parser
-from dateutil.tz import tzlocal, tzutc
+from dateutil.tz import tzlocal, tzutc, tzwinlocal
 
 import botocore
 import botocore.awsrequest
@@ -602,6 +602,8 @@ def parse_timestamp(value):
     This will return a ``datetime.datetime`` object.
 
     """
+    # Prefer tzwinlocal when available to handle negative timestamps.
+    tzlocal = tzwinlocal or tzlocal
     if isinstance(value, (int, float)):
         # Possibly an epoch time.
         return datetime.datetime.fromtimestamp(value, tzlocal())

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -24,13 +24,13 @@ import socket
 import cgi
 
 import dateutil.parser
-from dateutil.tz import tzlocal, tzutc, tzwinlocal
+from dateutil.tz import tzutc
 
 import botocore
 import botocore.awsrequest
 import botocore.httpsession
 from botocore.compat import json, quote, zip_longest, urlsplit, urlunsplit
-from botocore.compat import OrderedDict, six, urlparse
+from botocore.compat import OrderedDict, six, urlparse, get_tzinfo_options
 from botocore.vendored.six.moves.urllib.request import getproxies, proxy_bypass
 from botocore.exceptions import (
     InvalidExpressionError, ConfigNotFound, InvalidDNSNameError, ClientError,
@@ -590,6 +590,25 @@ def percent_encode(input_str, safe=SAFE_CHARS):
     return quote(input_str, safe=safe)
 
 
+def _parse_timestamp_with_tzinfo(value, tzinfo):
+    """Parse timestamp with pluggable tzinfo options."""
+    if isinstance(value, (int, float)):
+        # Possibly an epoch time.
+        return datetime.datetime.fromtimestamp(value, tzinfo())
+    else:
+        try:
+            return datetime.datetime.fromtimestamp(float(value), tzinfo())
+        except (TypeError, ValueError):
+            pass
+    try:
+        # In certain cases, a timestamp marked with GMT can be parsed into a
+        # different time zone, so here we provide a context which will
+        # enforce that GMT == UTC.
+        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
+    except (TypeError, ValueError) as e:
+        raise ValueError('Invalid timestamp "%s": %s' % (value, e))
+
+
 def parse_timestamp(value):
     """Parse a timestamp into a datetime object.
 
@@ -602,23 +621,14 @@ def parse_timestamp(value):
     This will return a ``datetime.datetime`` object.
 
     """
-    # Prefer tzwinlocal when available to handle negative timestamps.
-    tzlocal = tzwinlocal or tzlocal
-    if isinstance(value, (int, float)):
-        # Possibly an epoch time.
-        return datetime.datetime.fromtimestamp(value, tzlocal())
-    else:
+    for tzinfo in get_tzinfo_options():
         try:
-            return datetime.datetime.fromtimestamp(float(value), tzlocal())
-        except (TypeError, ValueError):
-            pass
-    try:
-        # In certain cases, a timestamp marked with GMT can be parsed into a
-        # different time zone, so here we provide a context which will
-        # enforce that GMT == UTC.
-        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
-    except (TypeError, ValueError) as e:
-        raise ValueError('Invalid timestamp "%s": %s' % (value, e))
+            return _parse_timestamp_with_tzinfo(value, tzinfo)
+        except OSError as e:
+            logger.debug('Unable to parse timestamp with "%s" timezone info.',
+                         tzinfo.__name__, exc_info=e)
+    raise RuntimeError('Unable to calculate correct timezone offset for '
+                       '"%s"' % value)
 
 
 def parse_to_aware_datetime(value):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -17,7 +17,8 @@ from nose.tools import assert_equal, assert_raises
 
 from botocore.exceptions import MD5UnavailableError
 from botocore.compat import (
-    total_seconds, unquote_str, six, ensure_bytes, get_md5, compat_shell_split
+    total_seconds, unquote_str, six, ensure_bytes, get_md5,
+    compat_shell_split, get_tzinfo_options
 )
 from tests import BaseEnvVar, unittest
 
@@ -165,3 +166,12 @@ class ShellSplitTestRunner(object):
 
     def assert_raises(self, s, exception_cls, platform):
         assert_raises(exception_cls, compat_shell_split, s, platform)
+
+
+class TestTimezoneOperations(unittest.TestCase):
+    def test_get_tzinfo_options(self):
+        options = get_tzinfo_options()
+        self.assertTrue(len(options) > 0)
+
+        for tzinfo in options:
+            self.assertIsInstance(tzinfo(), datetime.tzinfo)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -354,6 +354,16 @@ class TestParseTimestamps(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_timestamp('invalid date')
 
+    def test_parse_timestamp_fails_with_bad_tzinfo(self):
+        mock_tzinfo = mock.Mock()
+        mock_tzinfo.__name__ = 'tzinfo'
+        mock_tzinfo.side_effect = OSError()
+        mock_get_tzinfo_options = mock.MagicMock(return_value=(mock_tzinfo,))
+
+        with mock.patch('botocore.utils.get_tzinfo_options', mock_get_tzinfo_options):
+            with self.assertRaises(RuntimeError):
+                parse_timestamp(0)
+
 
 class TestDatetime2Timestamp(unittest.TestCase):
     def test_datetime2timestamp_naive(self):


### PR DESCRIPTION
Issue #1939 draws attention to an `OSError` that is raised on Windows in some timezones when `botocore.utils.parse_timestamp` relies on `tzlocal()` instead of using `tzwinlocal()` during this operation:
```python
datetime.datetime.fromtimestamp(value, tzlocal())
```

The **dateutil** maintainers are aware of this interoperability issue and have created issue [#848](https://github.com/dateutil/dateutil/issues/848) against **dateutil** to propose a change to make `tz.gettz()` conditionally return `tzwinlocal()` on Windows.

@pganssle discusses this motivation in [this comment](https://github.com/dateutil/dateutil/issues/197#issuecomment-448681838):

> I think my preferred solution to the very real UX challenge you have identified, @h-vetinari, is to make tz.gettz() return tz.tzwinlocal instead of tz.tzlocal. In general, I think that tz.gettz is intended to get you the "right time zone object" for the job, and it may make sense to make tz.tzwinlocal the default "local time" on platforms where it's available.

Since the proposed upstream changes for **dateutil** may involve them bumping their major version of the library (due to breaking changes), I am proposing a more targeted patch to resolve the Windows issue in **botocore** today. It may also be worth marking this change with a `TODO` to later use the new `tz.gettz()` call when **dateutil** eventually resolves their issue.