### PR TITLE
Fix Session.user_agent docstring

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -438,7 +438,7 @@ class Session(object):
         Where:
 
          - agent_name is the value of the `user_agent_name` attribute
-           of the session object (`Boto` by default).
+           of the session object (`Botocore` by default).
          - agent_version is the value of the `user_agent_version`
            attribute of the session object (the botocore version by default).
            by default.


### PR DESCRIPTION
The docstring of `Session.user_agent()` says the `user_agent_name` attribute is "Boto" by default, however `__init__` is actually setting it to "Botocore". Fix the docstring to reflect the real default value.