### PR TITLE
Allow use with docutils >=0.16 for Python 2.7 and 3.5+

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
-docutils>=0.10,<0.16
+docutils>=0.10,<0.16; python_version=='3.4'
+docutils>=0.10; python_version=='2.7' or python_version>='3.5'
 Sphinx>=1.1.3,<1.3
 guzzle_sphinx_theme>=0.7.10,<0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ tox>=2.5.0,<3.0.0
 nose==1.3.7
 mock==1.3.0
 wheel==0.24.0
-docutils>=0.10,<0.16
+docutils>=0.10,<0.16; python_version=='3.4'
+docutils>=0.10; python_version=='2.7' or python_version>='3.5'
 behave==1.2.5
 jsonschema==2.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ universal = 1
 requires-dist =
     python-dateutil>=2.1,<3.0.0
     jmespath>=0.7.1,<1.0.0
-    docutils>=0.10,<0.16
+    docutils>=0.10,<0.16; python_version=='3.4'
+    docutils>=0.10; python_version=='2.7' or python_version>='3.5'
     urllib3>=1.20,<1.25.8; python_version=='3.4'
     urllib3>=1.20,<1.26; python_version!='3.4'

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ def find_version(*file_paths):
 
 requires = [
     'jmespath>=0.7.1,<1.0.0',
-    'docutils>=0.10,<0.16',
     'python-dateutil>=2.1,<3.0.0',
 ]
 
@@ -33,8 +32,11 @@ requires = [
 if sys.version_info[:2] == (3, 4):
     # urllib3 dropped support for python 3.4 in point release 1.25.8
     requires.append('urllib3>=1.20,<1.25.8')
+    # docutils dropped support for python 3.4 in release 0.16
+    requires.append('docutils>=0.10,<0.16')
 else:
     requires.append('urllib3>=1.20,<1.26')
+    requires.append('docutils>=0.10')
 
 
 


### PR DESCRIPTION
For #1942. Rebased from #1944.