### PR TITLE
Removed instruction from msk config to base64-encode

### DIFF
--- a/botocore/data/kafka/2018-11-14/service-2.json
+++ b/botocore/data/kafka/2018-11-14/service-2.json
@@ -1345,7 +1345,7 @@
         "ServerProperties": {
           "shape": "__blob",
           "locationName": "serverProperties",
-          "documentation": "\n            <p>Contents of the <filename>server.properties</filename> file. When using the API, you must ensure that the contents of the file are base64 encoded. \n               When using the AWS Management Console, the SDK, or the AWS CLI, the contents of <filename>server.properties</filename> can be in plaintext.</p>\n         "
+          "documentation": "\n            <p>Contents of the <filename>server.properties</filename> file in string format or sequence of bytes.</p>\n         "
         }
       },
       "required": [
@@ -1558,7 +1558,7 @@
         "ServerProperties": {
           "shape": "__blob",
           "locationName": "serverProperties",
-          "documentation": "\n            <p>Contents of the <filename>server.properties</filename> file. When using the API, you must ensure that the contents of the file are base64 encoded. \n               When using the AWS Management Console, the SDK, or the AWS CLI, the contents of <filename>server.properties</filename> can be in plaintext.</p>\n         "
+          "documentation": "\n            <p>Contents of the <filename>server.properties</filename> file in string format or sequence of bytes.</p>\n         "
         }
       }
     },


### PR DESCRIPTION
The doc for MSK (kafka) create_configuration [ServerProperties](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kafka.html#Kafka.Client.create_configuration) param incorrectly instructs the user to base64-encode the config file.  Instead, the file should be read to a string or bytes variable as shown [here](https://docs.aws.amazon.com/msk/1.0/apireference/operations.html).