### PR TITLE
Enable the codecommit support in China regions

### DIFF
--- a/botocore/data/endpoints.json
+++ b/botocore/data/endpoints.json
@@ -5724,6 +5724,12 @@
           "cn-northwest-1" : { }
         }
       },
+      "codecommit" : {
+        "endpoints" : {
+          "cn-north-1" : { },
+          "cn-northwest-1" : { }
+        }
+      },
       "codedeploy" : {
         "endpoints" : {
           "cn-north-1" : { },


### PR DESCRIPTION
Fix the issue #2026
Here attached the announcement: https://www.amazonaws.cn/en/new/2020/aws-codecommit-available-aws-china-beijing-sinnet-ningxia-nwcd/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/boto/botocore/2027)
<!-- Reviewable:end -->
