### PR TITLE
Handling S3 connection drops

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -434,7 +434,8 @@ class BaseXMLResponseParser(ResponseParser):
         except XMLParseError as e:
             raise ResponseParserError(
                 "Unable to parse response (%s), "
-                "invalid XML received:\n%s" % (e, xml_string))
+                "invalid XML received. Further retries may succeed:\n%s" %
+                (e, xml_string))
         return root
 
     def _replace_nodes(self, parsed):


### PR DESCRIPTION
There are some operations where S3 streams data to us to keep a connection alive while waiting for a long running operation to complete. In cases where the client drops the connection or has other intermittent network connection issues, we need to be more resilient.

This patch will attempt to retry these cases where they're recoverable, and prompt the client application to retry the operation again if we're unable to recover. This will also avoid leaking exceptions from the underlying xml library which we'd been doing before in these rare cases.