### PR TITLE
fix endpoint resolution with unknown regions

### DIFF
--- a/.changes/next-release/enchancement-Endpoints-29513.json
+++ b/.changes/next-release/enchancement-Endpoints-29513.json
@@ -1,0 +1,5 @@
+{
+  "type": "enchancement",
+  "category": "Endpoints",
+  "description": "Improved endpoint resolution for clients with unknown regions"
+}

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -359,6 +359,15 @@ class ClientEndpointBridge(object):
         region_name = self._check_default_region(service_name, region_name)
         resolved = self.endpoint_resolver.construct_endpoint(
             service_name, region_name)
+
+        # If we can't resolve the region, we'll attempt to get a global
+        # endpoint for non-regionalized services (iam, route53, etc)
+        if not resolved:
+            # TODO: fallback partition_name should be configurable in the
+            # future for users to define as needed.
+            resolved = self.endpoint_resolver.construct_endpoint(
+                service_name, region_name, partition_name='aws')
+
         if resolved:
             return self._create_endpoint(
                 resolved, service_name, region_name, endpoint_url, is_secure)

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -115,7 +115,19 @@ class EndpointResolver(BaseEndpointResolver):
                     result.append(endpoint_name)
         return result
 
-    def construct_endpoint(self, service_name, region_name=None):
+    def construct_endpoint(self, service_name, region_name=None, partition_name=None):
+        if partition_name is not None:
+            valid_partition = None
+            for partition in self._endpoint_data['partitions']:
+                if partition['partition'] == partition_name:
+                    valid_partition = partition
+
+            if valid_partition is not None:
+                result = self._endpoint_for_partition(valid_partition, service_name,
+                             region_name, True)
+                return result
+            return None
+
         # Iterate over each partition until a match is found.
         for partition in self._endpoint_data['partitions']:
             result = self._endpoint_for_partition(
@@ -123,7 +135,8 @@ class EndpointResolver(BaseEndpointResolver):
             if result:
                 return result
 
-    def _endpoint_for_partition(self, partition, service_name, region_name):
+    def _endpoint_for_partition(self, partition, service_name, region_name,
+            force_partition=False):
         # Get the service from the partition, or an empty template.
         service_data = partition['services'].get(
             service_name, DEFAULT_SERVICE_DATA)
@@ -138,7 +151,7 @@ class EndpointResolver(BaseEndpointResolver):
             return self._resolve(
                 partition, service_name, service_data, region_name)
         # Check to see if the endpoint provided is valid for the partition.
-        if self._region_match(partition, region_name):
+        if self._region_match(partition, region_name) or force_partition:
             # Use the partition endpoint if set and not regionalized.
             partition_endpoint = service_data.get('partitionEndpoint')
             is_regionalized = service_data.get('isRegionalized', True)

--- a/tests/functional/test_client_metadata.py
+++ b/tests/functional/test_client_metadata.py
@@ -41,4 +41,4 @@ class TestClientMeta(unittest.TestCase):
 
     def test_client_has_no_partition_on_meta_if_custom_region(self):
         client = self.session.create_client('s3', 'myregion')
-        self.assertEqual(client.meta.partition, None)
+        self.assertEqual(client.meta.partition, 'aws')

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -1249,6 +1249,10 @@ def test_correct_url_used_for_s3():
         s3_config=virtual_hosting,
         customer_provided_endpoint='https://foo.amazonaws.com',
         expected_url='https://bucket.foo.amazonaws.com/key')
+    yield t.case(
+        region='unknown', bucket='bucket', key='key',
+        s3_config=virtual_hosting,
+        expected_url='https://bucket.s3.unknown.amazonaws.com/key')
 
     # Test us-gov with virtual addressing.
     yield t.case(
@@ -1277,6 +1281,10 @@ def test_correct_url_used_for_s3():
         s3_config=path_style,
         customer_provided_endpoint='https://foo.amazonaws.com/',
         expected_url='https://foo.amazonaws.com/bucket/key')
+    yield t.case(
+        region='unknown', bucket='bucket', key='key',
+        s3_config=path_style,
+        expected_url='https://s3.unknown.amazonaws.com/bucket/key')
 
     # S3 accelerate
     use_accelerate = {'use_accelerate_endpoint': True}
@@ -1318,6 +1326,10 @@ def test_correct_url_used_for_s3():
         # Extra components must be whitelisted.
         customer_provided_endpoint='https://s3-accelerate.foo.amazonaws.com',
         expected_url='https://s3-accelerate.foo.amazonaws.com/bucket/key')
+    yield t.case(
+        region='unknown', bucket='bucket', key='key',
+        s3_config=use_accelerate,
+        expected_url='https://bucket.s3-accelerate.amazonaws.com/key')
     # Use virtual even if path is specified for s3 accelerate because
     # path style will not work with S3 accelerate.
     yield t.case(
@@ -1360,6 +1372,10 @@ def test_correct_url_used_for_s3():
         region='us-west-2', bucket='bucket', key='key',
         s3_config=use_dualstack, signature_version='s3v4',
         expected_url='https://bucket.s3.dualstack.us-west-2.amazonaws.com/key')
+    yield t.case(
+        region='unknown', bucket='bucket', key='key',
+        s3_config=use_dualstack, signature_version='s3v4',
+        expected_url='https://bucket.s3.dualstack.unknown.amazonaws.com/key')
     # Non DNS compatible buckets use path style for dual stack.
     yield t.case(
         region='us-west-2', bucket='bucket.dot', key='key',
@@ -1542,6 +1558,14 @@ def test_correct_url_used_for_s3():
             'unknown.amazonaws.com/key'
         )
     )
+    yield t.case(
+        region='unknown', bucket=accesspoint_arn, key='key',
+        s3_config={'use_arn_region': True},
+        expected_url=(
+            'https://myendpoint-123456789012.s3-accesspoint.'
+            'us-west-2.amazonaws.com/key'
+        )
+    )
     accesspoint_arn_cn = (
         'arn:aws-cn:s3:cn-north-1:123456789012:accesspoint:myendpoint'
     )
@@ -1682,6 +1706,11 @@ def test_correct_url_used_for_s3():
         expected_url=(
             'https://bucket.s3.amazonaws.com/key'))
     yield t.case(
+        region='unknown', bucket='bucket', key='key',
+        s3_config=us_east_1_regional_endpoint,
+        expected_url=(
+            'https://bucket.s3.unknown.amazonaws.com/key'))
+    yield t.case(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={
             'us_east_1_regional_endpoint': 'regional',
@@ -1722,6 +1751,12 @@ def test_correct_url_used_for_s3():
         s3_config=us_east_1_regional_endpoint_legacy,
         expected_url=(
             'https://bucket.s3.amazonaws.com/key'))
+
+    yield t.case(
+        region='unknown', bucket='bucket', key='key',
+        s3_config=us_east_1_regional_endpoint_legacy,
+        expected_url=(
+            'https://bucket.s3.unknown.amazonaws.com/key'))
 
 
 class S3AddressingCases(object):

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -242,3 +242,26 @@ class TestSTSEndpoints(BaseSessionTest):
             'us-west-2', use_ssl=False)
         self.assert_request_sent(
             sts, expected_url='http://sts.amazonaws.com/')
+
+    def test_client_for_unknown_region(self):
+        sts = self.create_sts_client('not-real')
+        self.assert_request_sent(
+            sts,
+            expected_url='https://sts.not-real.amazonaws.com/',
+            expected_signing_region='not-real'
+        )
+
+    def test_client_for_unknown_region_with_legacy_configured(self):
+        self.environ['AWS_STS_REGIONAL_ENDPOINTS'] = 'legacy'
+        sts = self.create_sts_client('not-real')
+        self.assert_request_sent(
+            sts,expected_url='https://sts.not-real.amazonaws.com/')
+
+    def test_client_for_unknown_region_with_regional_configured(self):
+        self.environ['AWS_STS_REGIONAL_ENDPOINTS'] = 'regional'
+        sts = self.create_sts_client('not-real')
+        self.assert_request_sent(
+            sts,
+            expected_url='https://sts.not-real.amazonaws.com/',
+            expected_signing_region='not-real'
+        )


### PR DESCRIPTION
When a client is handed an unresolvable region, we create an assumed regionalized endpoint and send a request hoping it will work. In many cases, it won't and results in extra wait time for the connection, followed by an exception. 

This patch will change the behavior to instead validate if the service being called is regionalized. If not, we can fall back to the global endpoint and continue with the call. This should prevent unnecessary failures in cases where the region isn't relevant to the service request.