### PR TITLE
Add callback to waiter

### DIFF
--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -291,10 +291,13 @@ class Waiter(object):
         config = kwargs.pop('WaiterConfig', {})
         sleep_amount = config.get('Delay', self.config.delay)
         max_attempts = config.get('MaxAttempts', self.config.max_attempts)
+        callback = kwargs.get('WaiterCallback')
         num_attempts = 0
 
         while True:
             response = self._operation_method(**kwargs)
+            if callable(callback):
+                callback(response)
             num_attempts += 1
             for acceptor in acceptors:
                 if acceptor.matcher_func(response):


### PR DESCRIPTION
Proposed solution add a `WaiterCallback` argument to wait:
```python
def waiter_callback(response):
    log.info(response)
waiter.wait(WaiterCallback=waiter_callback)
```

My current a bit ugly solution is to patch `_operation_method`:

```python
# wrapper
def wrap_waiter(waiter, callback):
    orig_func = waiter._operation_method

    def wrapper(**kwargs):
        response = orig_func(**kwargs)
        callback(response)
        return response

    waiter._operation_method = wrapper

    return waiter

...
# Usage

def waiter_callback(response):
      log.info(response)

cf.create_stack(**params)
waiter = cf.get_waiter('stack_create_complete')
waiter = wrap_waiter(waiter, waiter_callback)
waiter.wait(StackName=stack_name)
```