### PR TITLE
Don't modify original condition for s3 generate_presigned_post

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -674,6 +674,8 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
 
     if fields is None:
         fields = {}
+    else:
+        fields = fields.copy()
 
     if conditions is None:
         conditions = []

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -923,6 +923,8 @@ class TestGeneratePresignedPost(unittest.TestCase):
         self.client.generate_presigned_post(
             self.bucket, self.key, Fields=fields, Conditions=conditions)
 
+        self.assertEqual(fields, {'acl': 'public-read'})
+
         _, post_kwargs = self.presign_post_mock.call_args
         request_dict = post_kwargs['request_dict']
         fields = post_kwargs['fields']


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/1103