### PR TITLE
use httpChecksumRequired trait for S3 MD5 checksums

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -41,6 +41,7 @@ from botocore.exceptions import MissingServiceIdError
 from botocore.utils import percent_encode, SAFE_CHARS
 from botocore.utils import switch_host_with_param
 from botocore.utils import hyphenize_service_id
+from botocore.utils import conditionally_calculate_md5
 
 from botocore import retryhandler
 from botocore import utils
@@ -190,38 +191,6 @@ def json_decode_template_body(parsed, **kwargs):
             parsed['TemplateBody'] = value
         except (ValueError, TypeError):
             logger.debug('error loading JSON', exc_info=True)
-
-
-def calculate_md5(params, **kwargs):
-    request_dict = params
-    if request_dict['body'] and 'Content-MD5' not in params['headers']:
-        body = request_dict['body']
-        if isinstance(body, (bytes, bytearray)):
-            binary_md5 = _calculate_md5_from_bytes(body)
-        else:
-            binary_md5 = _calculate_md5_from_file(body)
-        base64_md5 = base64.b64encode(binary_md5).decode('ascii')
-        params['headers']['Content-MD5'] = base64_md5
-
-
-def _calculate_md5_from_bytes(body_bytes):
-    md5 = get_md5(body_bytes)
-    return md5.digest()
-
-
-def _calculate_md5_from_file(fileobj):
-    start_position = fileobj.tell()
-    md5 = get_md5()
-    for chunk in iter(lambda: fileobj.read(1024 * 1024), b''):
-        md5.update(chunk)
-    fileobj.seek(start_position)
-    return md5.digest()
-
-
-def conditionally_calculate_md5(params, context, request_signer, **kwargs):
-    """Only add a Content-MD5 if the system supports it."""
-    if MD5_AVAILABLE:
-        calculate_md5(params, **kwargs)
 
 
 def validate_bucket_name(params, **kwargs):
@@ -949,26 +918,6 @@ BUILTIN_HANDLERS = [
      set_list_objects_encoding_type_url),
     ('before-parameter-build.s3.ListObjectVersions',
      set_list_objects_encoding_type_url),
-    ('before-call.s3.PutBucketTagging', calculate_md5),
-    ('before-call.s3.PutBucketLifecycle', calculate_md5),
-    ('before-call.s3.PutBucketLifecycleConfiguration', calculate_md5),
-    ('before-call.s3.PutBucketCors', calculate_md5),
-    ('before-call.s3.DeleteObjects', calculate_md5),
-    ('before-call.s3.PutBucketReplication', calculate_md5),
-    ('before-call.s3.PutObject', conditionally_calculate_md5),
-    ('before-call.s3.UploadPart', conditionally_calculate_md5),
-    ('before-call.s3.PutBucketAcl', conditionally_calculate_md5),
-    ('before-call.s3.PutBucketLogging', conditionally_calculate_md5),
-    ('before-call.s3.PutBucketNotification', conditionally_calculate_md5),
-    ('before-call.s3.PutBucketPolicy', conditionally_calculate_md5),
-    ('before-call.s3.PutBucketRequestPayment', conditionally_calculate_md5),
-    ('before-call.s3.PutBucketVersioning', conditionally_calculate_md5),
-    ('before-call.s3.PutBucketWebsite', conditionally_calculate_md5),
-    ('before-call.s3.PutObjectAcl', conditionally_calculate_md5),
-    ('before-call.s3.PutObjectLegalHold', calculate_md5),
-    ('before-call.s3.PutObjectRetention', calculate_md5),
-    ('before-call.s3.PutObjectLockConfiguration', calculate_md5),
-
     ('before-parameter-build.s3.CopyObject',
      handle_copy_source_param),
     ('before-parameter-build.s3.UploadPartCopy',
@@ -983,6 +932,8 @@ BUILTIN_HANDLERS = [
     ('before-call.s3', add_expect_header),
     ('before-call.glacier', add_glacier_version),
     ('before-call.apigateway', add_accept_header),
+    ('before-call.s3.PutObject', conditionally_calculate_md5),
+    ('before-call.s3.UploadPart', conditionally_calculate_md5),
     ('before-call.glacier.UploadArchive', add_glacier_checksums),
     ('before-call.glacier.UploadMultipartPart', add_glacier_checksums),
     ('before-call.ec2.CopySnapshot', inject_presigned_url_ec2),

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -520,6 +520,10 @@ class OperationModel(object):
         return self._operation_model.get('endpoint')
 
     @CachedProperty
+    def http_checksum_required(self):
+        return self._operation_model.get('httpChecksumRequired', False)
+
+    @CachedProperty
     def has_event_stream_input(self):
         return self.get_event_stream_input() is not None
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -38,6 +38,7 @@ from botocore.model import DenormalizedStructureBuilder
 from botocore.session import Session
 from botocore.signers import RequestSigner
 from botocore.credentials import Credentials
+from botocore.utils import conditionally_calculate_md5
 from botocore import handlers
 
 
@@ -1124,7 +1125,7 @@ class TestAddMD5(BaseMD5Test):
                         'method': 'PUT',
                         'headers': {}}
         context = self.get_context()
-        handlers.conditionally_calculate_md5(
+        conditionally_calculate_md5(
             request_dict, request_signer=request_signer, context=context)
         self.assertTrue('Content-MD5' in request_dict['headers'])
 
@@ -1138,7 +1139,7 @@ class TestAddMD5(BaseMD5Test):
                         'method': 'PUT',
                         'headers': {}}
         context = self.get_context({'payload_signing_enabled': False})
-        handlers.conditionally_calculate_md5(
+        conditionally_calculate_md5(
             request_dict, request_signer=request_signer, context=context)
         self.assertTrue('Content-MD5' in request_dict['headers'])
 
@@ -1153,8 +1154,8 @@ class TestAddMD5(BaseMD5Test):
 
         context = self.get_context()
         self.set_md5_available(False)
-        with mock.patch('botocore.handlers.MD5_AVAILABLE', False):
-            handlers.conditionally_calculate_md5(
+        with mock.patch('botocore.utils.MD5_AVAILABLE', False):
+            conditionally_calculate_md5(
                 request_dict, request_signer=request_signer, context=context)
             self.assertFalse('Content-MD5' in request_dict['headers'])
 
@@ -1169,7 +1170,7 @@ class TestAddMD5(BaseMD5Test):
 
         self.set_md5_available(False)
         with self.assertRaises(MD5UnavailableError):
-            handlers.calculate_md5(
+            conditionally_calculate_md5(
                 request_dict, request_signer=request_signer)
 
     def test_adds_md5_when_s3v2(self):
@@ -1181,7 +1182,7 @@ class TestAddMD5(BaseMD5Test):
                         'method': 'PUT',
                         'headers': {}}
         context = self.get_context()
-        handlers.conditionally_calculate_md5(
+        conditionally_calculate_md5(
             request_dict, request_signer=request_signer, context=context)
         self.assertTrue('Content-MD5' in request_dict['headers'])
 
@@ -1191,7 +1192,7 @@ class TestAddMD5(BaseMD5Test):
             'headers': {}
         }
         self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
-        handlers.calculate_md5(request_dict)
+        conditionally_calculate_md5(request_dict)
         self.assertEqual(request_dict['headers']['Content-MD5'],
                          'OFj2IjCsPJFfMAxmQxLGPw==')
 
@@ -1201,7 +1202,7 @@ class TestAddMD5(BaseMD5Test):
             'headers': {}
         }
         self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
-        handlers.calculate_md5(request_dict)
+        conditionally_calculate_md5(request_dict)
         self.assertEqual(
             request_dict['headers']['Content-MD5'],
             'OFj2IjCsPJFfMAxmQxLGPw==')
@@ -1212,7 +1213,7 @@ class TestAddMD5(BaseMD5Test):
             'headers': {}
         }
         self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
-        handlers.calculate_md5(request_dict)
+        conditionally_calculate_md5(request_dict)
         self.assertEqual(
             request_dict['headers']['Content-MD5'],
             'OFj2IjCsPJFfMAxmQxLGPw==')


### PR DESCRIPTION
Converting our historic hardcoded handlers for s3 operations that require a checksum to using new modeled trait. This will allow dynamically updating which calls calculate and include this metadata, avoiding manual code updates.

Note: We'll be leaving the handlers for PutObject and UploadPart. These are optional in some SDKs but we'll be maintaining them as required for backwards compatibility.