### PR TITLE
Add SOCKS proxy support

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -225,6 +225,28 @@ class AWSHTTPConnectionPool(HTTPConnectionPool):
 class AWSHTTPSConnectionPool(HTTPSConnectionPool):
     ConnectionCls = AWSHTTPSConnection
 
+# To avoid dependency warnings from urllib3.contrib.socks, we only create SOCKS-related classes if socks module is available
+try:
+    import socks
+    from urllib3.contrib.socks import SOCKSConnection, SOCKSHTTPSConnection, SOCKSHTTPConnectionPool, SOCKSHTTPSConnectionPool
+
+    class AWSSOCKSHTTPConnection(AWSConnection, SOCKSConnection):
+        """ An HTTPConnection that supports 100 Continue behavior. """
+
+
+    class AWSSOCKSHTTPSConnection(AWSConnection, SOCKSHTTPSConnection):
+        """ An HTTPSConnection that supports 100 Continue behavior. """
+
+
+    class AWSSOCKSHTTPConnectionPool(SOCKSHTTPConnectionPool):
+        ConnectionCls = AWSSOCKSHTTPConnection
+
+
+    class AWSSOCKSHTTPSConnectionPool(SOCKSHTTPSConnectionPool):
+        ConnectionCls = AWSSOCKSHTTPSConnection
+
+except ImportError:
+    pass
 
 def prepare_request_dict(request_dict, endpoint_url, context=None,
                          user_agent=None):

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -45,6 +45,11 @@ class TestProxyConfiguration(unittest.TestCase):
         proxy_url = self.proxy_config.proxy_url_for(self.url)
         self.assertEqual('http://localhost:8081/', proxy_url)
 
+    def test_proxy_for_socks5(self):
+        self.update_http_proxy('socks5://localhost:8081/')
+        proxy_url = self.proxy_config.proxy_url_for(self.url)
+        self.assertEqual('socks5://localhost:8081/', proxy_url)
+
     def test_fix_proxy_url_has_protocol_http(self):
         proxy_url = self.proxy_config.proxy_url_for(self.url)
         self.assertEqual('http://localhost:8081/', proxy_url)


### PR DESCRIPTION
Although this "works for me", it's still work in progress and needs at least some more tests in `test_http_session.py` to cover cases where `URLLib3Session` is configured with SOCKS proxies. Before going any further I wanted to verify the general approach.

One particular question is how to avoid warnings from importing `urlib3.contrib.socks` when `socks` (an optional dependency) is not available.