### PR TITLE
Remove redirection of stderr when calling credential_process

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -964,13 +964,11 @@ class ProcessProvider(CredentialProvider):
         # We're not using shell=True, so we need to pass the
         # command and all arguments as a list.
         process_list = compat_shell_split(credential_process)
-        p = self._popen(process_list,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE)
-        stdout, stderr = p.communicate()
+        p = self._popen(process_list, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
         if p.returncode != 0:
             raise CredentialRetrievalError(
-                provider=self.METHOD, error_msg=stderr.decode('utf-8'))
+                provider=self.METHOD, error_msg=("non-zero exit code '%s'" % p.returncode))
         parsed = botocore.compat.json.loads(stdout.decode('utf-8'))
         version = parsed.get('Version', '<Version key not provided>')
         if version != 1:

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -2999,10 +2999,7 @@ class TestProcessProvider(BaseEnvVar):
         self.assertEqual(creds.secret_key, 'bar')
         self.assertEqual(creds.token, 'baz')
         self.assertEqual(creds.method, 'custom-process')
-        self.popen_mock.assert_called_with(
-            ['my-process'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
+        self.popen_mock.assert_called_with(['my-process'], stdout=subprocess.PIPE)
 
     def test_can_pass_arguments_through(self):
         self.loaded_config['profiles'] = {
@@ -3022,8 +3019,7 @@ class TestProcessProvider(BaseEnvVar):
         creds = provider.load()
         self.assertIsNotNone(creds)
         self.popen_mock.assert_called_with(
-            ['my-process', '--foo', '--bar', 'one two'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ['my-process', '--foo', '--bar', 'one two'], stdout=subprocess.PIPE
         )
 
     def test_can_refresh_credentials(self):
@@ -3069,7 +3065,7 @@ class TestProcessProvider(BaseEnvVar):
 
         provider = self.create_process_provider()
         exception = botocore.exceptions.CredentialRetrievalError
-        with self.assertRaisesRegexp(exception, 'Error Message'):
+        with self.assertRaisesRegexp(exception, 'non-zero exit code \'1\''):
             provider.load()
 
     def test_unsupported_version_raises_mismatch(self):


### PR DESCRIPTION
This PR closes #2090 by removing the redirection of stderr when spawning a new `subprocess` with the `credential_process` command. Since stderr will now be output to the console, we are including the exit code in the error message from `botocore`.