### PR TITLE
Support RequestPayer for Get/PutObjectTagging

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.sdk-extras.json
+++ b/botocore/data/s3/2006-03-01/service-2.sdk-extras.json
@@ -1,0 +1,25 @@
+{
+    "version": 1.0,
+    "merge": {
+        "shapes": {
+            "GetObjectTaggingRequest":{
+                "members":{
+                    "RequestPayer":{
+                        "shape":"RequestPayer",
+                        "location":"header",
+                        "locationName":"x-amz-request-payer"
+                    }
+                }
+            },
+            "PutObjectTaggingRequest":{
+                "members":{
+                    "RequestPayer":{
+                        "shape":"RequestPayer",
+                        "location":"header",
+                        "locationName":"x-amz-request-payer"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -21,6 +21,7 @@ from botocore.config import Config
 from botocore.compat import datetime, urlsplit, parse_qs
 from botocore.exceptions import ParamValidationError, ClientError
 from botocore.parsers import ResponseParserError
+from botocore.loaders import Loader
 from botocore import UNSIGNED
 
 
@@ -1813,3 +1814,48 @@ def _verify_presigned_url_addressing(region, bucket, key, s3_config,
     parts = urlsplit(url)
     actual = '%s://%s%s' % parts[:3]
     assert_equal(actual, expected_url)
+
+
+class TestRequestPayerObjectTagging(BaseS3OperationTest):
+    def test_request_payer_not_in_model(self):
+        # Explicit loader for only the included models
+        loader = Loader(
+            include_default_extras=False,
+            include_default_search_paths=False,
+            extra_search_paths=[Loader.BUILTIN_DATA_PATH],
+        )
+        model = loader.load_service_model('s3', 'service-2')
+        fail_msg = (
+            'RequestPayer found in "%s" members, s3 service-2.sdk-extras.json '
+            'entry for this shape is no longer needed and should be removed.'
+        )
+        errors = []
+        request_shapes = ['GetObjectTaggingRequest', 'PutObjectTaggingRequest']
+        for request_shape in request_shapes:
+            members = model['shapes'][request_shape]['members']
+            if 'RequestPayer' in members:
+                errors.append(fail_msg % request_shape)
+        if errors:
+            self.fail('\n'.join(errors))
+
+    def _assert_request_payer_header(self, op_name, **kwargs):
+        self.http_stubber.add_response()
+        with self.http_stubber:
+            getattr(self.client, op_name)(**kwargs)
+        request = self.http_stubber.requests[0]
+        self.assertIn('x-amz-request-payer', request.headers)
+
+    def test_can_provide_request_payer_put_tagging(self):
+        self._assert_request_payer_header('put_object_tagging',
+            Bucket='bucket',
+            Key='key',
+            RequestPayer='requester',
+            Tagging={'TagSet': []},
+        )
+
+    def test_can_provide_request_payer_get_tagging(self):
+        self._assert_request_payer_header('get_object_tagging',
+            Bucket='bucket',
+            Key='key',
+            RequestPayer='requester',
+        )


### PR DESCRIPTION
This is a temporary workaround for a bug fix upstream in AWS CLI V2's cp functionality. 