### PR TITLE
Added ProgrammaticAssumeRoleProvider and Session.assume_role() for #761

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -906,6 +906,32 @@ class Session(object):
             pass
         return results
 
+    def assume_role(self, role_arn, extra_args=None):
+        """
+        :type role_arn: str
+        :param role_arn: The ARN of the role to be assumed.
+
+        :type extra_args: dict
+        :param extra_args: Any additional arguments to add to the assume
+            role request using the format of the botocore operation.
+            Possible keys include, but may not be limited to,
+            DurationSeconds, Policy, and RoleSessionName.
+        """
+        assume_role_provider = botocore.credentials.ProgrammaticAssumeRoleProvider(
+            self.client_creator,
+            self.get_credentials(),
+            role_arn,
+            extra_args=extra_args,
+        )
+
+        assumed_role_session = Session()
+        assumed_role_session.register_component(
+            'credential_provider',
+            botocore.credentials.CredentialResolver([assume_role_provider])
+        )
+
+        return assumed_role_session
+
 
 class ComponentLocator(object):
     """Service locator for session components."""


### PR DESCRIPTION
Issue #761 asks for first-class support for sts:AssumeRole, where there is a `Session.assume_role()` method that produces another session (`boto3.Session` would then also get an `assume_role()` method). To implement this, the existing `credentials.AssumeRoleProvider` seemed too intimately tied to loading credentials from config, in particular there did not seem to be a good way of injecting an arbitrary `Credentials` object, so I added a new, simpler `ProgrammaticAssumeRoleProvider` class that mainly just wraps the `AssumeRoleCredentialFetcher`. I've replicated the unit tests for `AssumeRoleProvider` except those that relate to configuration files.

I'm hoping to get feedback on whether this is a contribution that can feasibly be accepted before I add the functional tests and go to the effort of figuring out how the integration testing works.