### PR TITLE
add AWS::SNS::Topic to Config resourceType

### DIFF
--- a/botocore/data/config/2014-11-12/service-2.json
+++ b/botocore/data/config/2014-11-12/service-2.json
@@ -6061,7 +6061,8 @@
         "AWS::ServiceCatalog::Portfolio",
         "AWS::SQS::Queue",
         "AWS::KMS::Key",
-        "AWS::QLDB::Ledger"
+        "AWS::QLDB::Ledger",
+        "AWS::SNS::Topic"
       ]
     },
     "ResourceTypeList":{


### PR DESCRIPTION
AWS::SNS::Topic is an approved config resource and should be added the to resourceType shape. 

https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#amazonsimplenotificationservice