### PR TITLE
Don't utf-8 encode header values on python3.

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -120,7 +120,7 @@ class Endpoint(object):
     def _encode_headers(self, headers):
         # In place encoding of headers to utf-8 if they are unicode.
         for key, value in headers.items():
-            if isinstance(value, six.text_type):
+            if not isinstance(value, str):
                 headers[key] = value.encode('utf-8')
 
     def prepare_request(self, request):

--- a/tests/functional/test_apigateway.py
+++ b/tests/functional/test_apigateway.py
@@ -36,4 +36,4 @@ class TestApiGateway(BaseSessionTest):
             self.client.get_export(**params)
             request = self.http_stubber.requests[0]
             self.assertEqual(request.method, 'GET')
-            self.assertEqual(request.headers.get('Accept'), b'application/yaml')
+            self.assertEqual(request.headers.get('Accept'), 'application/yaml')

--- a/tests/functional/test_cloudsearchdomain.py
+++ b/tests/functional/test_cloudsearchdomain.py
@@ -30,5 +30,5 @@ class TestCloudsearchdomain(BaseSessionTest):
             request = self.http_stubber.requests[0]
             self.assertIn('q=foo', request.body)
             self.assertEqual(request.method, 'POST')
-            content_type = b'application/x-www-form-urlencoded'
+            content_type = 'application/x-www-form-urlencoded'
             self.assertEqual(request.headers.get('Content-Type'), content_type)

--- a/tests/functional/test_lex.py
+++ b/tests/functional/test_lex.py
@@ -48,13 +48,13 @@ class TestLex(BaseSessionTest):
         authorization = request.headers.get('authorization')
 
         expected_authorization = (
-            b'AWS4-HMAC-SHA256 '
-            b'Credential=access_key/20170322/us-west-2/lex/aws4_request, '
-            b'SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,'
-            b' Signature='
-            b'7f93fde5c36163dce6ee116fcfebab13474ab903782fea04c00bb1dedc3fc4cc'
+            'AWS4-HMAC-SHA256 '
+            'Credential=access_key/20170322/us-west-2/lex/aws4_request, '
+            'SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,'
+            ' Signature='
+            '7f93fde5c36163dce6ee116fcfebab13474ab903782fea04c00bb1dedc3fc4cc'
         )
         self.assertEqual(authorization, expected_authorization)
 
         content_header = request.headers.get('x-amz-content-sha256')
-        self.assertEqual(content_header, b'UNSIGNED-PAYLOAD')
+        self.assertEqual(content_header, 'UNSIGNED-PAYLOAD')

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -484,7 +484,7 @@ class TestAccesspointArn(BaseS3ClientConfigurationTest):
         return client, http_stubber
 
     def assert_signing_region(self, request, expected_region):
-        auth_header = request.headers['Authorization'].decode('utf-8')
+        auth_header = request.headers['Authorization']
         actual_region = self._V4_AUTH_REGEX.match(
             auth_header).group('signing_region')
         self.assertEqual(expected_region, actual_region)
@@ -767,7 +767,7 @@ class TestS3SigV4(BaseS3OperationTest):
             self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         sent_headers = self.get_sent_headers()
         sha_header = sent_headers.get('x-amz-content-sha256')
-        self.assertEqual(sha_header, b'UNSIGNED-PAYLOAD')
+        self.assertEqual(sha_header, 'UNSIGNED-PAYLOAD')
 
     def test_content_sha256_set_if_md5_is_unavailable(self):
         with mock.patch('botocore.auth.MD5_AVAILABLE', False):
@@ -794,7 +794,7 @@ class TestCanSendIntegerHeaders(BaseSessionTest):
             # Verify that the request integer value of 3 has been converted to
             # string '3'.  This also means we've made it pass the signer which
             # expects string values in order to sign properly.
-            self.assertEqual(headers['Content-Length'], b'3')
+            self.assertEqual(headers['Content-Length'], '3')
 
 
 class TestRegionRedirect(BaseS3OperationTest):

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -95,7 +95,7 @@ class TestSTSEndpoints(BaseSessionTest):
                 )
 
     def _get_signing_region(self, request):
-        authorization_val = request.headers['Authorization'].decode('utf-8')
+        authorization_val = request.headers['Authorization']
         match = _V4_SIGNING_REGION_REGEX.match(authorization_val)
         return match.group('signing_region')
 

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -125,6 +125,17 @@ class TestEndpointFeatures(TestEndpointBase):
         request = prepare.call_args[0][0]
         self.assertEqual(request.context['signing']['region'], 'us-west-2')
 
+    def test_make_request_encode_headers(self):
+        r = request_dict()
+        r['headers'] = {'User-Agent': "TestUserAgent", "Authorization":
+                        "Blaargh"}
+        self.endpoint.make_request(self.op, r)
+        prepared_request = self.http_session.send.call_args[0][0]
+        headers = prepared_request.headers
+        self.assertEqual(type(headers['User-Agent']), str)
+        self.assertEqual(type(headers['Authorization']), str)
+
+
     def test_parses_modeled_exception_fields(self):
         # Setup the service model to have exceptions to generate the mapping
         self.service_model = Mock(spec=ServiceModel)


### PR DESCRIPTION
With ``urllib3`` version 1.25.10 we're running into an issue as botocore is accidentally passing header values as bytes. The bytes are originating from ``_encode_headers`` in ``endpoint.py`` in which we are ``utf-8`` encoding ``str``s unnecessarily. ``str``s are already ``utf-8`` encoded in Python3 by default. 

The code that has the bug is meant to make sure python2 ``unicode`` type is transformed into str. We're naively checking ``six.text_type`` vs the value which will always be true. 

The test adds a repro of the problem. The stack trace I'm seeing in urllib3 is the following:

```
Traceback (most recent call last):
File "botocore/httpsession.py", line 283, in send
    chunked=self._chunked(request.headers),
  File "urllib3/connectionpool.py", line 687, in urlopen
    chunked=chunked,
  File "urllib3/connectionpool.py", line 400, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/urllib3/connection.py", line 215, in request
    elif headers["user-agent"] == SUPPRESS_USER_AGENT:
  File "urllib3/_collections.py", line 157, in __getitem__
    return ", ".join(val[1:])
TypeError: sequence item 0: expected str instance, bytes found
```
