### PR TITLE
Add basic region_name validation

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -298,6 +298,17 @@ class UnknownParameterError(ValidationError):
     )
 
 
+class InvalidRegionError(ValidationError, ValueError):
+    """
+    Invalid region_name provided to client or resource.
+
+    :ivar region_name: region_name that was being validated.
+    """
+    fmt = (
+        "Provided region_name '{region_name}' doesn't match a supported format."
+    )
+
+
 class AliasConflictParameterError(ValidationError):
     """
     Error when an alias is provided for a parameter as well as the original.

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -20,6 +20,7 @@ import copy
 import logging
 import os
 import platform
+import re
 import socket
 import warnings
 
@@ -32,8 +33,10 @@ from botocore.configprovider import ConfigValueStore
 from botocore.configprovider import ConfigChainFactory
 from botocore.configprovider import create_botocore_default_config_mapping
 from botocore.configprovider import BOTOCORE_DEFAUT_SESSION_VARIABLES
-from botocore.exceptions import ConfigNotFound, ProfileNotFound
-from botocore.exceptions import UnknownServiceError, PartialCredentialsError
+from botocore.exceptions import (
+    ConfigNotFound, ProfileNotFound, UnknownServiceError,
+    PartialCredentialsError,
+)
 from botocore.errorfactory import ClientExceptionsFactory
 from botocore import handlers
 from botocore.hooks import HierarchicalEmitter, first_non_none_response
@@ -47,7 +50,7 @@ from botocore import paginate
 from botocore import waiter
 from botocore import retryhandler, translate
 from botocore import utils
-from botocore.utils import EVENT_ALIASES
+from botocore.utils import EVENT_ALIASES, validate_region_name
 from botocore.compat import MutableMapping
 
 
@@ -846,6 +849,8 @@ class Session(object):
                 region_name = config.region_name
             else:
                 region_name = self.get_config_variable('region')
+
+        validate_region_name(region_name)
         # For any client that we create in retrieving credentials
         # we want to create it using the same region as specified in
         # creating this client. It is important to note though that the

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -40,6 +40,7 @@ from botocore.exceptions import (
     MetadataRetrievalError, EndpointConnectionError, ReadTimeoutError,
     ConnectionClosedError, ConnectTimeoutError, UnsupportedS3ArnError,
     UnsupportedS3AccesspointConfigurationError, SSOTokenLoadError,
+    InvalidRegionError,
 )
 
 logger = logging.getLogger(__name__)
@@ -915,6 +916,16 @@ def is_valid_endpoint_url(endpoint_url):
         r"^((?!-)[A-Z\d-]{1,63}(?<!-)\.)*((?!-)[A-Z\d-]{1,63}(?<!-))$",
         re.IGNORECASE)
     return allowed.match(hostname)
+
+
+def validate_region_name(region_name):
+    """Provided region_name must be a valid host label."""
+    if region_name is None:
+        return
+    valid_host_label = re.compile(r'^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$')
+    valid = valid_host_label.match(region_name)
+    if not valid:
+        raise InvalidRegionError(region_name=region_name)
 
 
 def check_dns_name(bucket_name):

--- a/tests/unit/test_s3_addressing.py
+++ b/tests/unit/test_s3_addressing.py
@@ -198,7 +198,7 @@ class TestS3Addressing(BaseSessionTest):
             'https://s3.us-west-2.amazonaws.com/192.168.5.256/mykeyname')
 
     def test_invalid_endpoint_raises_exception(self):
-        with self.assertRaisesRegexp(ValueError, 'Invalid endpoint'):
+        with self.assertRaisesRegexp(ValueError, 'Invalid region'):
             self.session.create_client('s3', 'Invalid region')
 
     def test_non_existent_region(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -857,3 +857,24 @@ class TestDefaultClientConfig(BaseSessionTest):
         client_config = botocore.config.Config()
         self.session.set_default_client_config(client_config)
         self.assertIs(self.session.get_default_client_config(), client_config)
+
+
+class TestSessionRegionSetup(BaseSessionTest):
+    def test_new_session_with_valid_region(self):
+        s3_client = self.session.create_client('s3', 'us-west-2')
+        self.assertIsInstance(s3_client, client.BaseClient)
+        self.assertEquals(s3_client.meta.region_name, 'us-west-2')
+
+    def test_new_session_with_unknown_region(self):
+        s3_client = self.session.create_client('s3', 'MyCustomRegion1')
+        self.assertIsInstance(s3_client, client.BaseClient)
+        self.assertEquals(s3_client.meta.region_name, 'MyCustomRegion1')
+
+    def test_new_session_with_invalid_region(self):
+        with self.assertRaises(botocore.exceptions.InvalidRegionError):
+            s3_client = self.session.create_client('s3', 'not.a.real#region')
+
+    def test_new_session_with_none_region(self):
+        s3_client = self.session.create_client('s3', region_name=None)
+        self.assertIsInstance(s3_client, client.BaseClient)
+        self.assertTrue(s3_client.meta.region_name is not None)


### PR DESCRIPTION
This PR will add some basic validation to the region_name parameter used to create new Session and BaseClient objects. The goal is to avoid accidentally setting up clients that will either never route, or lead to unexpected request routing. The change here will bubble up to boto3 in clients and resources, as well as the AWS CLI.