### PR TITLE
Move client creation integ tests to functional

### DIFF
--- a/tests/functional/test_client.py
+++ b/tests/functional/test_client.py
@@ -1,0 +1,19 @@
+import unittest
+
+import botocore
+
+class TestCreateClients(unittest.TestCase):
+    def setUp(self):
+        self.session = botocore.session.get_session()
+
+    def test_client_can_clone_with_service_events(self):
+        # We should also be able to create a client object.
+        client = self.session.create_client('s3', region_name='us-west-2')
+        # We really just want to ensure create_client doesn't raise
+        # an exception, but we'll double check that the client looks right.
+        self.assertTrue(hasattr(client, 'list_buckets'))
+
+    def test_client_raises_exception_invalid_region(self):
+        with self.assertRaisesRegexp(ValueError, ('invalid region name')):
+            self.session.create_client(
+                'cloudformation', region_name='invalid region name')

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -72,23 +72,6 @@ class TestAcceptedDateTimeFormats(unittest.TestCase):
         self.assertIn('Clusters', response)
 
 
-class TestCreateClients(unittest.TestCase):
-    def setUp(self):
-        self.session = botocore.session.get_session()
-
-    def test_client_can_clone_with_service_events(self):
-        # We should also be able to create a client object.
-        client = self.session.create_client('s3', region_name='us-west-2')
-        # We really just want to ensure create_client doesn't raise
-        # an exception, but we'll double check that the client looks right.
-        self.assertTrue(hasattr(client, 'list_buckets'))
-
-    def test_client_raises_exception_invalid_region(self):
-        with self.assertRaisesRegexp(ValueError, ('Invalid endpoint')):
-            self.session.create_client(
-                'cloudformation', region_name='invalid region name')
-
-
 class TestClientErrors(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()


### PR DESCRIPTION
This PR is moving a test class out of our integration tests and putting it in the functional directory where it belongs. We have a handful of tests in the code base that are getting missed on PRs and don't surface until after merge because they're misclassified as integration. This is the first step to get a common set moved over and will have follow up to migrate some of the other offenders.