### PR TITLE
Update Endpoint Discovery to enable for required operations

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -14,22 +14,22 @@ import logging
 import functools
 
 from botocore import waiter, xform_name
+from botocore.args import ClientArgsCreator
 from botocore.auth import AUTH_TYPE_MAPS
 from botocore.awsrequest import prepare_request_dict
 from botocore.docs.docstring import ClientMethodDocstring
 from botocore.docs.docstring import PaginatorDocstring
-from botocore.exceptions import ClientError, DataNotFoundError
-from botocore.exceptions import OperationNotPageableError
-from botocore.exceptions import UnknownSignatureVersionError
+from botocore.exceptions import (
+    ClientError, DataNotFoundError, OperationNotPageableError,
+    UnknownSignatureVersionError, InvalidEndpointDiscoveryConfigurationError
+)
 from botocore.hooks import first_non_none_response
 from botocore.model import ServiceModel
 from botocore.paginate import Paginator
-from botocore.utils import CachedProperty
-from botocore.utils import get_service_module_name
-from botocore.utils import S3RegionRedirector
-from botocore.utils import S3ArnParamHandler
-from botocore.utils import S3EndpointSetter
-from botocore.args import ClientArgsCreator
+from botocore.utils import (
+    CachedProperty, get_service_module_name, S3RegionRedirector,
+    S3ArnParamHandler, S3EndpointSetter, ensure_boolean
+)
 from botocore import UNSIGNED
 # Keep this imported.  There's pre-existing code that uses
 # "from botocore.client import Config".
@@ -197,13 +197,34 @@ class ClientCreator(object):
         elif self._config_store:
             enabled = self._config_store.get_config_variable(
                 'endpoint_discovery_enabled')
-        if enabled:
-            manager = EndpointDiscoveryManager(client)
+
+        enabled = self._normalize_endpoint_discovery_config(enabled)
+        if enabled and self._requires_endpoint_discovery(client, enabled):
+            discover = enabled is True
+            manager = EndpointDiscoveryManager(client, always_discover=discover)
             handler = EndpointDiscoveryHandler(manager)
             handler.register(events, service_id)
         else:
             events.register('before-parameter-build',
                             block_endpoint_discovery_required_operations)
+
+    def _normalize_endpoint_discovery_config(self, enabled):
+        """Config must either be a boolean-string or string-literal 'auto'"""
+        if isinstance(enabled, str):
+            enabled = enabled.lower().strip()
+            if enabled == 'auto':
+                return enabled
+            elif enabled in ('true', 'false'):
+                return ensure_boolean(enabled)
+        elif isinstance(enabled, bool):
+            return enabled
+
+        raise InvalidEndpointDiscoveryConfigurationError(config_value=enabled)
+
+    def _requires_endpoint_discovery(self, client, enabled):
+        if enabled == "auto":
+            return client.meta.service_model.endpoint_discovery_required
+        return enabled
 
     def _register_s3_events(self, client, endpoint_bridge, endpoint_url,
                             client_config, scoped_config):

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -83,7 +83,7 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # Endpoint discovery configuration
     'endpoint_discovery_enabled': (
         'endpoint_discovery_enabled', 'AWS_ENDPOINT_DISCOVERY_ENABLED',
-        False, utils.ensure_boolean),
+        'auto', None),
     'sts_regional_endpoints': (
         'sts_regional_endpoints', 'AWS_STS_REGIONAL_ENDPOINTS', 'legacy',
         None

--- a/botocore/discovery.py
+++ b/botocore/discovery.py
@@ -16,6 +16,7 @@ import weakref
 
 from botocore import xform_name
 from botocore.exceptions import BotoCoreError, HTTPClientError, ConnectionError
+from botocore.model import OperationNotFoundError
 from botocore.utils import CachedProperty
 
 logger = logging.getLogger(__name__)
@@ -59,8 +60,11 @@ class EndpointDiscoveryModel(object):
         return keys
 
     def discovery_required_for(self, operation_name):
-        operation_model = self._service_model.operation_model(operation_name)
-        return operation_model.endpoint_discovery.get('required', False)
+        try:
+            operation_model = self._service_model.operation_model(operation_name)
+            return operation_model.endpoint_discovery.get('required', False)
+        except OperationNotFoundError:
+            return False
 
     def discovery_operation_kwargs(self, **kwargs):
         input_keys = self.discovery_operation_keys
@@ -87,7 +91,7 @@ class EndpointDiscoveryModel(object):
 
 
 class EndpointDiscoveryManager(object):
-    def __init__(self, client, cache=None, current_time=None):
+    def __init__(self, client, cache=None, current_time=None, always_discover=True):
         if cache is None:
             cache = {}
         self._cache = cache
@@ -95,6 +99,7 @@ class EndpointDiscoveryManager(object):
         if current_time is None:
             current_time = time.time
         self._time = current_time
+        self._always_discover = always_discover
 
         # This needs to be a weak ref in order to prevent memory leaks on
         # python 2.6
@@ -166,6 +171,17 @@ class EndpointDiscoveryManager(object):
         return endpoints[0]['Address']
 
     def describe_endpoint(self, **kwargs):
+        operation = kwargs['Operation']
+        discovery_required = self._model.discovery_required_for(operation)
+
+        if not self._always_discover and not discovery_required:
+            # Discovery set to only run on required operations
+            logger.debug(
+                'Optional discovery disabled. Skipping discovery for Operation: %s'
+                % operation
+            )
+            return None
+
         # Get the endpoint for the provided operation and identifiers
         cache_key = self._create_cache_key(**kwargs)
         endpoints = self._get_current_endpoints(cache_key)
@@ -184,7 +200,7 @@ class EndpointDiscoveryManager(object):
         if stale_entries:
             # We have stale entries, use those while discovery is failing
             return self._select_endpoint(stale_entries)
-        if self._model.discovery_required_for(kwargs['Operation']):
+        if discovery_required:
             # It looks strange to be checking recently_failed again but,
             # this informs us as to whether or not we tried to refresh earlier
             if recently_failed:

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -478,6 +478,12 @@ class UnsupportedS3AccesspointConfigurationError(BotoCoreError):
         'Unsupported configuration when using S3 access-points: {msg}'
     )
 
+class InvalidEndpointDiscoveryConfigurationError(BotoCoreError):
+    """Error when invalid value supplied for endpoint_discovery_enabled"""
+    fmt = (
+        'Unsupported configuration value for endpoint_discovery_enabled. '
+        'Expected one of ("true", "false", "auto") but got {config_value}.'
+    )
 
 class InvalidRetryConfigurationError(BotoCoreError):
     """Error when invalid retry configuration is specified"""

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -369,6 +369,15 @@ class ServiceModel(object):
             if model.is_endpoint_discovery_operation:
                 return model
 
+    @CachedProperty
+    def endpoint_discovery_required(self):
+        for operation in self.operation_names:
+            model = self.operation_model(operation)
+            if (model.endpoint_discovery is not None and
+                    model.endpoint_discovery.get('required')):
+                return True
+        return False
+
     def _get_metadata_property(self, name):
         try:
             return self.metadata[name]

--- a/tests/functional/models/test-discovery-endpoint/2020-08-20/service-2.json
+++ b/tests/functional/models/test-discovery-endpoint/2020-08-20/service-2.json
@@ -1,0 +1,121 @@
+{
+            "version": "2.0",
+            "metadata": {
+                "apiVersion": "2018-08-31",
+                "endpointPrefix": "fooendpoint",
+                "jsonVersion": "1.1",
+                "protocol": "json",
+                "serviceAbbreviation": "TDES",
+                "serviceId": "TDEService",
+                "serviceFullName": "TestEndpointDiscoveryService",
+                "signatureVersion": "v4",
+                "signingName": "test-discovery-endpoint",
+                "targetPrefix": "test-discovery-endpoint"
+            },
+            "operations": {
+                "DescribeEndpoints": {
+                    "name": "DescribeEndpoints",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {"shape": "DescribeEndpointsRequest"},
+                    "output": {"shape": "DescribeEndpointsResponse"},
+                    "endpointoperation": true
+                },
+                "TestDiscoveryRequired": {
+                    "name": "TestDiscoveryRequired",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {"shape": "TestDiscoveryIdsRequest"},
+                    "output": {"shape": "EmptyStruct"},
+                    "endpointdiscovery": {"required": true}
+                },
+                "TestDiscoveryOptional": {
+                    "name": "TestDiscoveryOptional",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {"shape": "TestDiscoveryIdsRequest"},
+                    "output": {"shape": "EmptyStruct"},
+                    "endpointdiscovery": {}
+                },
+                "TestDiscovery": {
+                    "name": "TestDiscovery",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {"shape": "EmptyStruct"},
+                    "output": {"shape": "EmptyStruct"},
+                    "endpointdiscovery": {}
+                }
+            },
+            "shapes": {
+               "Boolean": {"type": "boolean"},
+                "DescribeEndpointsRequest": {
+                    "type": "structure",
+                    "members": {
+                        "Operation": {"shape": "String"},
+                        "Identifiers": {"shape": "Identifiers"}
+                    }
+                },
+                "DescribeEndpointsResponse": {
+                    "type": "structure",
+                    "required": ["Endpoints"],
+                    "members": {
+                        "Endpoints": {"shape": "Endpoints"}
+                    }
+                },
+                "Endpoint": {
+                    "type": "structure",
+                    "required": [
+                        "Address",
+                        "CachePeriodInMinutes"
+                    ],
+                    "members": {
+                        "Address": {"shape": "String"},
+                        "CachePeriodInMinutes": {"shape": "Long"}
+                    }
+                },
+                "Endpoints": {
+                    "type": "list",
+                    "member": {"shape": "Endpoint"}
+                },
+                "Identifiers": {
+                    "type": "map",
+                    "key": {"shape": "String"},
+                    "value": {"shape": "String"}
+                },
+                "Long": {"type": "long"},
+                "String": {"type": "string"},
+                "TestDiscoveryIdsRequest": {
+                    "type": "structure",
+                    "required": ["Foo"],
+                    "members": {
+                        "Foo": {
+                            "shape": "String",
+                            "endpointdiscoveryid": true
+                        },
+                        "Baz": {"shape": "String"}
+                    }
+                },
+                "EmptyStruct": {
+                    "type": "structure",
+                    "members": {}
+                },
+                "Nested": {
+                    "type": "structure",
+                    "required": "Bar",
+                    "members": {
+                        "Bar": {
+                            "shape": "String",
+                            "endpointdiscoveryid": true
+                        }
+                    }
+                }
+            }
+        }

--- a/tests/functional/test_discovery.py
+++ b/tests/functional/test_discovery.py
@@ -1,0 +1,355 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+
+from tests import ClientHTTPStubber, temporary_file
+from tests.functional import FunctionalSessionTest
+
+import botocore
+from botocore.config import Config
+from botocore.compat import json
+from botocore.discovery import EndpointDiscoveryRequired
+from botocore.exceptions import ClientError, InvalidEndpointDiscoveryConfigurationError
+
+
+class TestEndpointDiscovery(FunctionalSessionTest):
+    def setUp(self):
+        super(TestEndpointDiscovery, self).setUp()
+        self.region = 'us-west-2'
+
+    def create_client(
+        self,
+        service_name='dynamodb',
+        region=None,
+        config=None,
+        endpoint_url=None
+    ):
+        if region is None:
+            region = self.region
+        client = self.session.create_client(
+            service_name, region, config=config, endpoint_url=endpoint_url
+        )
+        http_stubber = ClientHTTPStubber(client)
+
+        return client, http_stubber
+
+    def add_describe_endpoints_response(self, stubber, discovered_endpoint):
+        response = {
+            'Endpoints': [{
+                'Address': discovered_endpoint,
+                'CachePeriodInMinutes': 1,
+            }]
+        }
+        response_body = json.dumps(response).encode()
+        stubber.add_response(status=200, body=response_body)
+        stubber.add_response(status=200, body=b'{}')
+
+    def set_endpoint_discovery_config_file(self, fileobj, config_val):
+        fileobj.write(
+            '[default]\n'
+            'endpoint_discovery_enabled=%s\n' % config_val
+        )
+        fileobj.flush()
+        self.environ['AWS_CONFIG_FILE'] = fileobj.name
+
+    def assert_endpoint_discovery_used(self, stubber, discovered_endpoint):
+        self.assertEqual(len(stubber.requests), 2)
+        discover_request = stubber.requests[1]
+        self.assertEqual(discover_request.url, discovered_endpoint)
+
+    def assert_discovery_skipped(self, stubber, operation):
+        self.assertEqual(len(stubber.requests), 1)
+        self.assertEqual(
+            stubber.requests[0].headers.get('X-Amz-Target'),
+            operation
+        )
+
+    def assert_endpoint_used(self, actual_url, expected_url):
+        self.assertEqual(actual_url, expected_url)
+
+    def test_endpoint_discovery_enabled(self):
+        discovered_endpoint = 'https://discovered.domain'
+        config = Config(endpoint_discovery_enabled=True)
+        client, http_stubber = self.create_client(config=config)
+        with http_stubber as stubber:
+            self.add_describe_endpoints_response(stubber, discovered_endpoint)
+            client.describe_table(TableName='sometable')
+            self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_with_invalid_endpoint(self):
+        discovered_endpoint = 'https://discovered.domain'
+        response = {
+            'Error': {
+                'Code': 'InvalidEndpointException',
+                'Message': 'Test Error',
+            }
+        }
+        response_body = json.dumps(response).encode()
+
+        config = Config(endpoint_discovery_enabled=True)
+        client, http_stubber = self.create_client(config=config)
+        with http_stubber as stubber:
+            stubber.add_response(status=421, body=response_body)
+            with self.assertRaises(ClientError):
+                client.describe_table(TableName='sometable')
+
+    def test_endpoint_discovery_disabled(self):
+        config = Config(endpoint_discovery_enabled=False)
+        client, http_stubber = self.create_client(config=config)
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.describe_table(TableName='sometable')
+            self.assertEqual(len(stubber.requests), 1)
+
+    def test_endpoint_discovery_no_config_default(self):
+        client, http_stubber = self.create_client()
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.describe_table(TableName='sometable')
+            self.assertEqual(len(stubber.requests), 1)
+
+    def test_endpoint_discovery_default_required_endpoint(self):
+        discovered_endpoint = "https://discovered.domain"
+        client, http_stubber = self.create_client(service_name="test-discovery-endpoint")
+        with http_stubber as stubber:
+            self.add_describe_endpoints_response(stubber, discovered_endpoint)
+            client.test_discovery_required(Foo="bar")
+            self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_required_with_discovery_enabled(self):
+        discovered_endpoint = "https://discovered.domain"
+        config = Config(endpoint_discovery_enabled=True)
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", config=config
+        )
+        with http_stubber as stubber:
+            self.add_describe_endpoints_response(stubber, discovered_endpoint)
+            client.test_discovery_required(Foo="bar")
+            self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_required_with_discovery_disabled(self):
+        discovered_endpoint = "https://discovered.domain"
+        config = Config(endpoint_discovery_enabled=False)
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", config=config
+        )
+        self.add_describe_endpoints_response(http_stubber, discovered_endpoint)
+        with self.assertRaises(EndpointDiscoveryRequired):
+            client.test_discovery_required(Foo="bar")
+
+    def test_endpoint_discovery_required_with_custom_endpoint(self):
+        endpoint = "https://custom.domain/"
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", endpoint_url=endpoint
+        )
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.test_discovery_required(Foo="bar")
+            self.assert_discovery_skipped(
+                stubber,
+                b"test-discovery-endpoint.TestDiscoveryRequired"
+            )
+            self.assert_endpoint_used(stubber.requests[0].url, endpoint)
+
+    def test_endpoint_discovery_disabled_with_custom_endpoint(self):
+        endpoint = "https://custom.domain/"
+        config = Config(endpoint_discovery_enabled=False)
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint",
+            config=config,
+            endpoint_url=endpoint
+        )
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.test_discovery_required(Foo="bar")
+            self.assert_discovery_skipped(
+                stubber,
+                b"test-discovery-endpoint.TestDiscoveryRequired"
+            )
+            self.assert_endpoint_used(stubber.requests[0].url, endpoint)
+
+    def test_endpoint_discovery_enabled_with_custom_endpoint(self):
+        endpoint = "https://custom.domain/"
+        config = Config(endpoint_discovery_enabled=True)
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint",
+            config=config,
+            endpoint_url=endpoint
+        )
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.test_discovery_required(Foo="bar")
+            self.assert_discovery_skipped(
+                stubber,
+                b"test-discovery-endpoint.TestDiscoveryRequired"
+            )
+            self.assert_endpoint_used(stubber.requests[0].url, endpoint)
+
+    def test_endpoint_discovery_optional_with_custom_endpoint(self):
+        endpoint = "https://custom.domain/"
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", endpoint_url=endpoint
+        )
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.test_discovery_optional(Foo="bar")
+            self.assert_discovery_skipped(
+                stubber,
+                b"test-discovery-endpoint.TestDiscoveryOptional"
+            )
+            self.assert_endpoint_used(stubber.requests[0].url, endpoint)
+
+    def test_endpoint_discovery_optional_disabled_with_custom_endpoint(self):
+        endpoint = "https://custom.domain/"
+        config = Config(endpoint_discovery_enabled=False)
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint",
+            config=config,
+            endpoint_url=endpoint
+        )
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.test_discovery_optional(Foo="bar")
+            self.assert_discovery_skipped(
+                stubber,
+                b"test-discovery-endpoint.TestDiscoveryOptional",
+            )
+            self.assert_endpoint_used(stubber.requests[0].url, endpoint)
+
+    def test_endpoint_discovery_default_optional_endpoint(self):
+        client, http_stubber = self.create_client(service_name="test-discovery-endpoint")
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.test_discovery_optional(Foo="bar")
+            self.assertEqual(len(stubber.requests), 1)
+
+    def test_endpoint_discovery_enabled_optional_endpoint(self):
+        discovered_endpoint = 'https://discovered.domain'
+        config = Config(endpoint_discovery_enabled=True)
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", config=config
+        )
+        with http_stubber as stubber:
+            self.add_describe_endpoints_response(stubber, discovered_endpoint)
+            client.test_discovery_optional(Foo="bar")
+            self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_manual_auto_on_required_endpoint(self):
+        discovered_endpoint = 'https://discovered.domain'
+        config = Config(endpoint_discovery_enabled=" aUto  \n")
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", config=config
+        )
+        with http_stubber as stubber:
+            self.add_describe_endpoints_response(stubber, discovered_endpoint)
+            client.test_discovery_required(Foo="bar")
+            self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_enabled_with_random_string(self):
+        config = Config(endpoint_discovery_enabled="bad value")
+        with self.assertRaises(InvalidEndpointDiscoveryConfigurationError):
+            client, http_stubber = self.create_client(
+                service_name="test-discovery-endpoint", config=config
+            )
+
+    def test_endpoint_discovery_required_with_env_var_default(self):
+        self.environ['AWS_ENDPOINT_DISCOVERY_ENABLED'] = 'auto'
+        discovered_endpoint = 'https://discovered.domain'
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", config=None
+        )
+        with http_stubber as stubber:
+            self.add_describe_endpoints_response(stubber, discovered_endpoint)
+            client.test_discovery_required(Foo="bar")
+            self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_optional_with_env_var_default(self):
+        self.environ['AWS_ENDPOINT_DISCOVERY_ENABLED'] = 'auto'
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint", config=None
+        )
+        with http_stubber as stubber:
+            stubber.add_response(status=200, body=b'{}')
+            client.test_discovery_optional(Foo="bar")
+            self.assert_discovery_skipped(
+                stubber,
+                b"test-discovery-endpoint.TestDiscoveryOptional"
+            )
+
+    def test_endpoint_discovery_optional_with_env_var_enabled(self):
+        self.environ['AWS_ENDPOINT_DISCOVERY_ENABLED'] = "True"
+        discovered_endpoint = 'https://discovered.domain'
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint"
+        )
+        with http_stubber as stubber:
+            self.add_describe_endpoints_response(stubber, discovered_endpoint)
+            client.test_discovery_optional(Foo="bar")
+            self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_required_with_env_var_disabled(self):
+        self.environ['AWS_ENDPOINT_DISCOVERY_ENABLED'] = "False"
+        discovered_endpoint = 'https://discovered.domain'
+        client, http_stubber = self.create_client(
+            service_name="test-discovery-endpoint"
+        )
+        self.add_describe_endpoints_response(http_stubber, discovered_endpoint)
+        with self.assertRaises(EndpointDiscoveryRequired):
+            client.test_discovery_required(Foo="bar")
+
+    def test_endpoint_discovery_with_config_file_enabled(self):
+        with temporary_file('w') as f:
+            self.set_endpoint_discovery_config_file(f, "True")
+            discovered_endpoint = 'https://discovered.domain'
+            client, http_stubber = self.create_client(
+                service_name="test-discovery-endpoint"
+            )
+            with http_stubber as stubber:
+                self.add_describe_endpoints_response(stubber, discovered_endpoint)
+                client.test_discovery_required(Foo="bar")
+                self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_with_config_file_enabled_lowercase(self):
+        with temporary_file('w') as f:
+            self.set_endpoint_discovery_config_file(f, "true")
+            discovered_endpoint = 'https://discovered.domain'
+            client, http_stubber = self.create_client(
+                service_name="test-discovery-endpoint"
+            )
+            with http_stubber as stubber:
+                self.add_describe_endpoints_response(stubber, discovered_endpoint)
+                client.test_discovery_required(Foo="bar")
+                self.assert_endpoint_discovery_used(stubber, discovered_endpoint)
+
+    def test_endpoint_discovery_with_config_file_disabled(self):
+        with temporary_file('w') as f:
+            self.set_endpoint_discovery_config_file(f, "false")
+            discovered_endpoint = 'https://discovered.domain'
+            client, http_stubber = self.create_client(
+                service_name="test-discovery-endpoint"
+            )
+            self.add_describe_endpoints_response(http_stubber, discovered_endpoint)
+            with self.assertRaises(EndpointDiscoveryRequired):
+                client.test_discovery_required(Foo="bar")
+
+    def test_endpoint_discovery_with_config_file_auto(self):
+        with temporary_file('w') as f:
+            self.set_endpoint_discovery_config_file(f, "AUTO")
+            discovered_endpoint = 'https://discovered.domain'
+            client, http_stubber = self.create_client(
+                service_name="test-discovery-endpoint"
+            )
+            with http_stubber as stubber:
+                self.add_describe_endpoints_response(stubber, discovered_endpoint)
+                client.test_discovery_required(Foo="bar")
+                self.assert_endpoint_discovery_used(stubber, discovered_endpoint)

--- a/tests/functional/test_model_backcompat.py
+++ b/tests/functional/test_model_backcompat.py
@@ -15,11 +15,7 @@ import os
 from nose.tools import assert_equal
 from botocore.session import Session
 from tests import ClientHTTPStubber
-
-
-FIXED_MODELS_DIR = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), 'models',
-)
+from tests.functional import TEST_MODELS_DIR
 
 
 def test_old_model_continues_to_work():
@@ -34,15 +30,15 @@ def test_old_model_continues_to_work():
     session = Session()
     loader = session.get_component('data_loader')
     # We're adding our path to the existing search paths so we don't have to
-    # copy additional data files such as _retry.json to our FIXED_MODELS_DIR.
+    # copy additional data files such as _retry.json to our TEST_MODELS_DIR.
     # We only care about the service model and endpoints file not changing.
     # This also prevents us from having to make any changes to this models dir
     # if we end up adding a new data file that's needed to create clients.
-    # We're adding our FIXED_MODELS_DIR as the first element in the list to
-    # ensure we load the endpoints.json file from FIXED_MODELS_DIR.  For the
+    # We're adding our TEST_MODELS_DIR as the first element in the list to
+    # ensure we load the endpoints.json file from TEST_MODELS_DIR.  For the
     # service model we have an extra safety net where we can choose a custom
     # client name.
-    loader.search_paths.insert(0, FIXED_MODELS_DIR)
+    loader.search_paths.insert(0, TEST_MODELS_DIR)
 
     # The model dir we copied was renamed to 'custom-lambda'
     # to ensure we're loading our version of the model and not

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -331,6 +331,23 @@ class TestOperationModelFromService(unittest.TestCase):
         operation_two = self.service_model.operation_model('OperationName')
         self.assertFalse(operation_two.is_endpoint_discovery_operation)
 
+    def test_endpoint_discovery_required(self):
+        operation = self.model['operations']['OperationName']
+        operation['endpointdiscovery'] = {'required': True}
+        service_model = model.ServiceModel(self.model)
+        self.assertTrue(service_model.endpoint_discovery_required)
+
+    def test_endpoint_discovery_required_false(self):
+        self.model['operations']['OperationName']['endpointdiscovery'] = {}
+        service_model = model.ServiceModel(self.model)
+        self.assertFalse(service_model.endpoint_discovery_required)
+
+    def test_endpoint_discovery_required_no_value(self):
+        operation = self.model['operations']['OperationName']
+        self.assertTrue(operation.get('endpointdiscovery') is None)
+        service_model = model.ServiceModel(self.model)
+        self.assertFalse(service_model.endpoint_discovery_required)
+
     def test_endpoint_discovery_present(self):
         operation = self.model['operations']['OperationName']
         operation['endpointdiscovery'] = {'required': True}


### PR DESCRIPTION
When using services with endpoint discovery as a requirement, botocore currently throws an exception by default. This was originally intended to prompt users to opt in for this feature. As more services start to use this, we're switching the default to use endpoint_discovery automatically when required and opt-out when it's optional. This will maintain backwards compatibility, but allow users to not have to worry about configuration in the common case.

You can still explicitly disable this behavior with `endpoint_discovery_enabled=False` in your Config object, or with the `AWS_ENDPOINT_DISCOVERY_ENABLED` environment variable. Similarly, it can be used in all requests where endpoint discovery is available (optional or required) when explicitly set to `True`.