### PR TITLE
Update supported Python versions in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,8 @@ Services.  Botocore serves as the foundation for the
 `AWS-CLI <https://github.com/aws/aws-cli/>`_ command line utilities.
 It will also play an important role in the boto3.x project.
 
-The botocore package is compatible with Python versions 2.6.5, Python 2.7.x,
-and Python 3.3.x and higher.
+The botocore package is compatible with Python versions Python 2.7,
+Python 3.4 and higher.
 
 
 Contents:


### PR DESCRIPTION
Current Botocore docs don't reflect the versions that are supported. Bringing things up to date.