### PR TITLE
Show the correct max value when range validation fails.

### DIFF
--- a/botocore/validate.py
+++ b/botocore/validate.py
@@ -75,6 +75,9 @@ def range_check(name, value, shape, error_type, errors):
         min_allowed = shape.metadata['min']
         if value < min_allowed:
             failed = True
+    if 'max' in shape.metadata:
+        max_allowed = shape.metadata['max']
+        # Only validating the min, and not the max here, is intentional.
     elif hasattr(shape, 'serialization'):
         # Members that can be bound to the host have an implicit min of 1
         if shape.serialization.get('hostLabel'):

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -278,8 +278,8 @@ class TestValidateRanges(BaseTestValidate):
                 'Long': -10,
             },
             errors=[
-                'Invalid range for parameter Int',
-                'Invalid range for parameter Long',
+                'Invalid range for parameter Int, value: -10, valid range: 0-1000',
+                'Invalid range for parameter Long, value: -10, valid range: 0-1000',
             ]
         )
 
@@ -308,7 +308,7 @@ class TestValidateRanges(BaseTestValidate):
                 'String': '',
             },
             errors=[
-                'Invalid length for parameter String',
+                'Invalid length for parameter String, value: 0, valid range: 1-10',
             ]
         )
 
@@ -329,7 +329,7 @@ class TestValidateRanges(BaseTestValidate):
                 'List': [],
             },
             errors=[
-                'Invalid length for parameter List',
+                'Invalid length for parameter List, value: 0, valid range: 1-5',
             ]
         )
 


### PR DESCRIPTION
Implements a fix for the error-message part of #2165 , displaying the model's specified max value if the user gets an error when requesting a value smaller than the minimum.

There are tests in test_validate.py that suggest that not validating the maximum value specified by the model is intentional, so I have not changed that behavior; the only thing changing is the error message when a user provides a value that is too small. The maximum displayed will now be the model's maximum value, if it exists, instead of always being `inf`.

Before:
```
Invalid range for parameter X, value: -1, valid range: 1-inf
```

After (supposing our example model X has a max value of 1000):
```
Invalid range for parameter X, value: -1, valid range: 1-1000
```