### PR TITLE
Avoid traversing unused model during endpoint discovery setup

### DIFF
--- a/botocore/discovery.py
+++ b/botocore/discovery.py
@@ -85,7 +85,7 @@ class EndpointDiscoveryModel(object):
         for member_name, member_shape in shape.members.items():
             if member_shape.metadata.get('endpointdiscoveryid'):
                 ids[member_name] = params[member_name]
-            elif member_shape.type_name == 'structure':
+            elif member_shape.type_name == 'structure' and member_name in params:
                 self._gather_ids(member_shape, params[member_name], ids)
         return ids
 

--- a/tests/functional/models/test-discovery-endpoint/2020-08-20/service-2.json
+++ b/tests/functional/models/test-discovery-endpoint/2020-08-20/service-2.json
@@ -100,7 +100,8 @@
                             "shape": "String",
                             "endpointdiscoveryid": true
                         },
-                        "Baz": {"shape": "String"}
+                        "Baz": {"shape": "String"},
+                        "Empty": {"shape": "EmptyStruct"}
                     }
                 },
                 "EmptyStruct": {


### PR DESCRIPTION
When performing setup on our `EndpointDiscoveryHandler`, we traverse our model to determine if any identifiers are required for performing endpoint discovery. This had previously only been done on operations where all members were required. In new releases, these members may become optional, requiring us to ignore them during setup.

This PR will properly scope model traversal in this case and avoid considering information that isn't relevant to the operation.