### PR TITLE
[v2-branch only] Only support Python3.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,6 @@
 language: python
 matrix:
   include:
-    - python: 2.7
-      dist: trusty
-      sudo: false
-    - python: 3.4
-      dist: trusty
-      sudo: false
-    - python: 3.5
-      dist: trusty
-      sudo: false
-    - python: 3.6
-      dist: trusty
-      sudo: false
     - python: 3.7
       dist: xenial
       sudo: true

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,7 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ]


### PR DESCRIPTION
This branch is really only used for the CLI v2 which already only supports Python3.7+ so this will allow us to pull in more
dependencies that do not support those previous Python versions and also make our Travis builds faster.