### PR TITLE
Add logic to configure IPv6 env var

### DIFF
--- a/.changes/next-release/feature-imds-87700.json
+++ b/.changes/next-release/feature-imds-87700.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "imds",
+  "description": "Updated InstanceMetadataFetcher to use custom ipv6 uri as endpoint if envvar or config set"
+}

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -71,6 +71,14 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     'metadata_service_num_attempts': (
         'metadata_service_num_attempts',
         'AWS_METADATA_SERVICE_NUM_ATTEMPTS', 1, int),
+    'ec2_metadata_service_endpoint': (
+        'ec2_metadata_service_endpoint',
+        'AWS_EC2_METADATA_SERVICE_ENDPOINT',
+        None, None),
+    'imds_use_ipv6': (
+        'imds_use_ipv6',
+        'AWS_IMDS_USE_IPV6',
+        False, None),
     'parameter_validation': ('parameter_validation', None, True, None),
     # Client side monitoring configurations.
     # Note: These configurations are considered internal to botocore.

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -65,6 +65,12 @@ def create_credential_resolver(session, cache=None, region_name=None):
     num_attempts = session.get_config_variable('metadata_service_num_attempts')
     disable_env_vars = session.instance_variables().get('profile') is not None
 
+    imds_config = {
+        'ec2_metadata_service_endpoint': session.get_config_variable(
+            'ec2_metadata_service_endpoint'),
+        'imds_use_ipv6': session.get_config_variable('imds_use_ipv6')
+    }
+
     if cache is None:
         cache = {}
 
@@ -74,7 +80,8 @@ def create_credential_resolver(session, cache=None, region_name=None):
         iam_role_fetcher=InstanceMetadataFetcher(
             timeout=metadata_timeout,
             num_attempts=num_attempts,
-            user_agent=session.user_agent())
+            user_agent=session.user_agent(),
+            config=imds_config)
     )
 
     profile_provider_builder = ProfileProviderBuilder(

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -92,6 +92,10 @@ class ConnectionError(BotoCoreError):
     fmt = 'An HTTP Client failed to establish a connection: {error}'
 
 
+class InvalidIMDSEndpointError(BotoCoreError):
+    fmt = 'Invalid endpoint EC2 Instance Metadata endoints: {endpoint}'
+
+
 class EndpointConnectionError(ConnectionError):
     fmt = 'Could not connect to the endpoint URL: "{endpoint_url}"'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ universal = 1
 requires-dist =
     python-dateutil>=2.1,<3.0.0
     jmespath>=0.7.1,<1.0.0
-    urllib3>=1.20,<1.25.8; python_version=='3.4'
-    urllib3>=1.20,<1.26; python_version!='3.4'
+    urllib3>=1.25.4,<1.25.8; python_version=='3.4'
+    urllib3>=1.25.4,<1.26; python_version!='3.4'

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ requires = [
 
 if sys.version_info[:2] == (3, 4):
     # urllib3 dropped support for python 3.4 in point release 1.25.8
-    requires.append('urllib3>=1.20,<1.25.8')
+    requires.append('urllib3>=1.25.4,<1.25.8')
 else:
-    requires.append('urllib3>=1.20,<1.26')
+    requires.append('urllib3>=1.25.4,<1.26')
 
 
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1658,6 +1658,7 @@ class TestCreateCredentialResolver(BaseEnvVar):
             'config_file': 'c',
             'metadata_service_timeout': 1,
             'metadata_service_num_attempts': 1,
+            'imds_use_ipv6': 'false',
         }
         self.config_loader = ConfigValueStore()
         for name, value in self.fake_instance_variables.items():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,6 +26,7 @@ from botocore.awsrequest import AWSResponse
 from botocore.exceptions import InvalidExpressionError, ConfigNotFound
 from botocore.exceptions import ClientError, ConnectionClosedError
 from botocore.exceptions import InvalidDNSNameError, MetadataRetrievalError
+from botocore.exceptions import InvalidIMDSEndpointError
 from botocore.exceptions import ReadTimeoutError
 from botocore.exceptions import ConnectTimeoutError
 from botocore.exceptions import UnsupportedS3ArnError
@@ -68,6 +69,7 @@ from botocore.utils import S3EndpointSetter
 from botocore.utils import ContainerMetadataFetcher
 from botocore.utils import InstanceMetadataFetcher
 from botocore.utils import SSOTokenLoader
+from botocore.utils import is_valid_uri, is_valid_ipv6_endpoint_url
 from botocore.exceptions import SSOTokenLoadError
 from botocore.utils import IMDSFetcher
 from botocore.utils import BadIMDSRequestError
@@ -2292,11 +2294,25 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
     def add_imds_connection_error(self, exception):
         self._imds_responses.append(exception)
 
+    def add_default_imds_responses(self):
+        self.add_get_token_imds_response(token='token')
+        self.add_get_role_name_imds_response()
+        self.add_get_credentials_imds_response()
+
     def get_imds_response(self, request):
         response = self._imds_responses.pop(0)
         if isinstance(response, Exception):
             raise response
         return response
+
+    def _test_imds_base_url(self, config, expected_url):
+        self.add_default_imds_responses()
+
+        fetcher = InstanceMetadataFetcher(config=config)
+        result = fetcher.retrieve_iam_role_credentials()
+
+        self.assertEqual(result, self._expected_creds)
+        self.assertEqual(fetcher.get_base_url(), expected_url)
 
     def test_disabled_by_environment(self):
         env = {'AWS_EC2_METADATA_DISABLED': 'true'}
@@ -2316,20 +2332,78 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
         url = 'https://example.com/'
         env = {'AWS_EC2_METADATA_DISABLED': 'false'}
 
-        self.add_get_token_imds_response(token='token')
-        self.add_get_role_name_imds_response()
-        self.add_get_credentials_imds_response()
+        self.add_default_imds_responses()
 
         fetcher = InstanceMetadataFetcher(base_url=url, env=env)
         result = fetcher.retrieve_iam_role_credentials()
 
         self.assertEqual(result, self._expected_creds)
 
+    def test_imds_use_ipv6(self):
+        configs = [({'imds_use_ipv6': 'true'},'http://[fe80:ec2::254%eth0]/'),
+                ({'imds_use_ipv6': 'tRuE'}, 'http://[fe80:ec2::254%eth0]/'), 
+                ({'imds_use_ipv6': 'false'}, 'http://169.254.169.254/'), 
+                ({'imds_use_ipv6': 'foo'}, 'http://169.254.169.254/'),
+                ({'imds_use_ipv6': 'true',
+                'ec2_metadata_service_endpoint': 'http://[fe80:ec2::010%eth0]/'},
+                'http://[fe80:ec2::010%eth0]/')]
+
+        for config, expected_url in configs:
+            self._test_imds_base_url(config, expected_url)
+
+    def test_metadata_endpoint(self):
+        urls = ['http://fe80:ec2:0000:0000:0000:0000:0000:0000/',
+                'http://[fe80:ec2::010%eth0]/', 'http://192.168.1.1/']
+        for url in urls:
+            self.assertTrue(is_valid_uri(url))
+        
+    def test_ipv6_endpoint_no_brackets_env_var_set(self):
+        url = 'http://fe80:ec2::010/'
+        config = {'ec2_metadata_service_endpoint': url}
+        self.assertFalse(is_valid_ipv6_endpoint_url(url))
+
+    def test_ipv6_invalid_endpoint(self):
+        url = 'not.a:valid:dom@in'
+        config = {'ec2_metadata_service_endpoint': url}
+        with self.assertRaises(InvalidIMDSEndpointError):
+            InstanceMetadataFetcher(config=config)
+
+    def test_ipv6_endpoint_env_var_set_and_args(self):
+        url = 'http://[fe80:ec2::254]/'
+        url_arg = 'http://fe80:ec2:0000:0000:0000:8a2e:0370:7334/'
+        config = {'ec2_metadata_service_endpoint': url}
+
+        self.add_default_imds_responses()
+
+        fetcher = InstanceMetadataFetcher(config=config, base_url=url_arg)
+        result = fetcher.retrieve_iam_role_credentials()
+
+        self.assertEqual(result, self._expected_creds)
+        self.assertEqual(fetcher.get_base_url(), url_arg)
+
+    def test_ipv6_imds_not_allocated(self):
+        url = 'http://fe80:ec2:0000:0000:0000:0000:0000:0000/'
+        config = {'ec2_metadata_service_endpoint': url}
+
+        self.add_imds_response(
+            status_code=400, body=b'{}')
+
+        fetcher = InstanceMetadataFetcher(config=config)
+        result = fetcher.retrieve_iam_role_credentials()
+        self.assertEqual(result, {})
+
+    def test_ipv6_imds_empty_config(self):
+        configs = [({'ec2_metadata_service_endpoint': ''},'http://169.254.169.254/'),
+                ({'imds_use_ipv6': ''}, 'http://169.254.169.254/'),
+                ({}, 'http://169.254.169.254/'),
+                (None, 'http://169.254.169.254/')]
+
+        for config, expected_url in configs:
+            self._test_imds_base_url(config, expected_url)
+
     def test_includes_user_agent_header(self):
         user_agent = 'my-user-agent'
-        self.add_get_token_imds_response(token='token')
-        self.add_get_role_name_imds_response()
-        self.add_get_credentials_imds_response()
+        self.add_default_imds_responses()
 
         InstanceMetadataFetcher(
             user_agent=user_agent).retrieve_iam_role_credentials()
@@ -2442,9 +2516,7 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
 
     def test_token_is_included(self):
         user_agent = 'my-user-agent'
-        self.add_get_token_imds_response(token='token')
-        self.add_get_role_name_imds_response()
-        self.add_get_credentials_imds_response()
+        self.add_default_imds_responses()
 
         result = InstanceMetadataFetcher(
             user_agent=user_agent).retrieve_iam_role_credentials()


### PR DESCRIPTION
Enable user to set InstanceMetaDataFetcher endpoint to a custom IPv6 endpoint via environment variable or config file. Included additional functions to perform IPv6 URI validation.