### PR TITLE
[v2-branch only] Require Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     package_data={'botocore': ['cacert.pem', 'data/*.json', 'data/*/*.json'],
                   'botocore.vendored.requests': ['*.pem']},
     include_package_data=True,
+    python_requires='>=3.7',
     install_requires=requires,
     extras_require={},
     license="Apache License 2.0",


### PR DESCRIPTION
Supported by setuptools since v24.2.0 ([commit](https://github.com/pypa/setuptools/commit/b2f50d5ddf0be280d0b0106f178437a4aad1b306)) and pip since [v9.0.0](https://pip.pypa.io/en/stable/news/#id403) ([commit](https://github.com/pypa/pip/commit/8df742e56db99c48f7ad85085501fe23456b419c)).

See also PR boto/botocore#2170 and [PEP 345](https://www.python.org/dev/peps/pep-0345/#requires-python).