### PR TITLE
Add support for SSLKEYLOGFILE environment variable

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -2,6 +2,7 @@ import os.path
 import logging
 import socket
 from base64 import b64encode
+import sys
 
 from urllib3 import PoolManager, ProxyManager, proxy_from_url, Timeout
 from urllib3.util.retry import Retry
@@ -81,6 +82,14 @@ def create_urllib3_context(ssl_version=None, cert_reqs=None,
         # We do our own verification, including fingerprints and alternative
         # hostnames. So disable it here
         context.check_hostname = False
+
+    # Enable logging of TLS session keys via defacto standard environment variable
+    # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+). Skip empty values.
+    if hasattr(context, 'keylog_filename'):
+        keylogfile = os.environ.get('SSLKEYLOGFILE')
+        if keylogfile and not sys.flags.ignore_environment:
+            context.keylog_filename = keylogfile
+
     return context
 
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I am debugging an issue where S3 closes the connection during a download. To gather exact timing information, it would be useful to capture a network dump (e.g. tcpdump) and be able to inspect *inside* the TLS layer.

**Describe the solution you'd like**
 A lot of applications (Firefox, Chrome) support the SSLKEYLOGFILE environment variable that will dump the needed key material in a standardized format to the given file. Since Python 3.8, Python supports this as well when using `ssl.create_default_context()`. Botocore, however, creates its own `SSLContext()` object, so this feature is not activated.

Would this be an acceptable feature to include in botocore?

References:
* https://pypi.org/project/sslkeylog/
* https://python.libhunt.com/urllib3-changelog (added in 1.25.10)