### PR TITLE
Update deprecation notice to 3.4/3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,11 +13,11 @@ botocore package is the foundation for the
 `AWS CLI <https://github.com/aws/aws-cli>`__ as well as
 `boto3 <https://github.com/boto/boto3>`__.
 
-On 10/09/2019 support for Python 2.6 and Python 3.3 was deprecated and support
-was dropped on 01/10/2020. To avoid disruption, customers using Botocore
-on Python 2.6 or 3.3 will need to upgrade their version of Python or pin the
-version of Botocore in use prior to 01/10/2020. For more information, see
-this `blog post <https://aws.amazon.com/blogs/developer/deprecation-of-python-2-6-and-python-3-3-in-botocore-boto3-and-the-aws-cli/>`__.
+On 10/29/2020 deprecation for Python 3.4 and Python 3.5 was announced and support
+will be dropped on 02/01/2021. To avoid disruption, customers using Botocore
+on Python 3.4 or 3.5 may need to upgrade their version of Python or pin the
+version of Botocore in use prior to 02/01/2021. For more information, see
+this `blog post <https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
 Getting Started
 ---------------


### PR DESCRIPTION
### Deprecation of Python 3.4 and 3.5 for Botocore

As announced in today's blog post, Botocore will be deprecating support for Python 3.4 and 3.5 on 02/01/2021. Users are encouraged to migrate to Python 3.6 or later. This PR will update the README to alert users about the news.

Most users will not need to take action about botocore directly, and can follow steps directly for AWS CLI v1 or Boto3. For customers building directly on top of botocore, you may want to pin to a specific version prior to the deprecation date.

Full details can be found at: https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/