### PR TITLE
support event stream for s3 select

### DIFF
--- a/botocore/data/s3/2006-03-01/service-2.json
+++ b/botocore/data/s3/2006-03-01/service-2.json
@@ -1680,8 +1680,7 @@
     "ContentType":{"type":"string"},
     "ContinuationEvent":{
       "type":"structure",
-      "members":{
-      },
+      "members":{},
       "documentation":"<p/>",
       "event":true
     },
@@ -2994,8 +2993,7 @@
     "End":{"type":"long"},
     "EndEvent":{
       "type":"structure",
-      "members":{
-      },
+      "members":{},
       "documentation":"<p>A message that indicates the request is complete and no more messages will be sent. You should not assume that the request is complete until the client receives an <code>EndEvent</code>.</p>",
       "event":true
     },
@@ -6485,11 +6483,11 @@
     },
     "ProgressEvent":{
       "type":"structure",
+      "required":["Progress"],
       "members":{
-        "Details":{
+        "Progress":{
           "shape":"Progress",
-          "documentation":"<p>The Progress event details.</p>",
-          "eventpayload":true
+          "documentation":"<p>The Progress event details.</p>"
         }
       },
       "documentation":"<p>This data type contains information about the progress event of an operation.</p>",
@@ -7917,11 +7915,11 @@
     "RecordDelimiter":{"type":"string"},
     "RecordsEvent":{
       "type":"structure",
+      "required":["Records"],
       "members":{
-        "Payload":{
+        "Records":{
           "shape":"Body",
-          "documentation":"<p>The byte array of partial, one or more result records.</p>",
-          "eventpayload":true
+          "documentation":"<p>The byte array of partial, one or more result records.</p>"
         }
       },
       "documentation":"<p>The container for the records event.</p>",
@@ -8417,6 +8415,7 @@
     },
     "SelectObjectContentEventStream":{
       "type":"structure",
+      "required":["Records"],
       "members":{
         "Records":{
           "shape":"RecordsEvent",
@@ -8444,13 +8443,13 @@
     },
     "SelectObjectContentOutput":{
       "type":"structure",
+      "required":["EventStream"],
       "members":{
-        "Payload":{
+        "EventStream":{
           "shape":"SelectObjectContentEventStream",
-          "documentation":"<p>The array of results.</p>"
+          "documentation":"<p>The event stream that your consumer can use to read records.</p>"
         }
-      },
-      "payload":"Payload"
+      }
     },
     "SelectObjectContentRequest":{
       "type":"structure",
@@ -8655,11 +8654,11 @@
     },
     "StatsEvent":{
       "type":"structure",
+      "required": ["Stats"],
       "members":{
-        "Details":{
+        "Stats":{
           "shape":"Stats",
-          "documentation":"<p>The Stats event details.</p>",
-          "eventpayload":true
+          "documentation":"<p>The Stats event details.</p>"
         }
       },
       "documentation":"<p>Container for the Stats Event.</p>",


### PR DESCRIPTION
Refacto the code in order to handle S3 Select with event stream :

example of S3 select event streams:

*For minio*
```minio
-U��ӱ
:message-typeevent
:content-typeapplication/octet-stream:event-typeRecords{"number":10,"group":1456,"string":"value to test","long-string":"Long val\nto test","boolean":true,"special_char":"é"}
{"number":20,"group":1456,"string":"value to test 2","long-string":"Long val\nto test 2","boolean":true,"special_char":"à"}
{"number":30,"group":1456,"string":"value to test 3","long-string":"Long val\nto test 3","boolean":true,"special_char":"€"}
P2�s�C�ß
:message-typeevent
:content-typetext/xml:event-typeStats<?xml version="1.0" encoding="UTF-8"?><Stats><BytesScanned>1139</BytesScanned><BytesProcessed>1139</BytesProcessed><BytesReturned>968</BytesReturned></Stats>i.��8(�Ƅ�
:message-typeevent:event-typeEndϗӒ
```
*For AWS*
```AWS
�U�G��
:message-typeevent:event-typeRecords
:content-typeapplication/octet-stream{"name":"jmtest","tetet":"qzdqzd","uuid":"4c0e5e6a88094a019b05999ba582872d"}
{"name":"jmtest","tetet":"qzdqzd","uuid":"683ce5dfc3bc4f33bf9b40ba9b431c83"}
u��$�C>b��
:message-typeevent:event-typeStats
:content-typetext/xml<Stats xmlns=""><BytesScanned>534</BytesScanned><BytesProcessed>534</BytesProcessed><BytesReturned>154</BytesReturned></Stats>8R8(�Ƅ�
:message-typeevent:event-typeEndϗӒ
```