### PR TITLE
Revert "implemented IOBase functions and included unit tests"

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -14,7 +14,6 @@
 
 import sys
 import logging
-from io import IOBase
 
 from botocore import ScalarTypes
 from botocore.hooks import first_non_none_response
@@ -27,7 +26,7 @@ from botocore import parsers
 logger = logging.getLogger(__name__)
 
 
-class StreamingBody(IOBase):
+class StreamingBody(object):
     """Wrapper class for an http response body.
 
     This provides a few additional conveniences that do not exist
@@ -45,10 +44,6 @@ class StreamingBody(IOBase):
         self._raw_stream = raw_stream
         self._content_length = content_length
         self._amount_read = 0
-
-    def __del__(self):
-        # Stubbing destructor in order to preserve the underlying raw_stream.
-        pass
 
     def set_socket_timeout(self, timeout):
         """Set the timeout seconds on the socket."""
@@ -73,12 +68,6 @@ class StreamingBody(IOBase):
                          "the interface has changed.", exc_info=True)
             raise
 
-    def readable(self):
-        try:
-            return self._raw_stream.readable()
-        except AttributeError:
-            return False
-
     def read(self, amt=None):
         """Read at most amt bytes from the stream.
 
@@ -96,9 +85,6 @@ class StreamingBody(IOBase):
             # we need to verify the content length.
             self._verify_content_length()
         return chunk
-    
-    def readlines(self):
-        return self._raw_stream.readlines()
 
     def __iter__(self):
         """Return an iterator to yield 1k chunks from the raw stream.
@@ -149,9 +135,6 @@ class StreamingBody(IOBase):
             raise IncompleteReadError(
                 actual_bytes=self._amount_read,
                 expected_bytes=int(self._content_length))
-
-    def tell(self):
-        return self._raw_stream.tell()
 
     def close(self):
         """Close the underlying http response stream."""

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -14,7 +14,6 @@ from tests import unittest
 from tests.unit import BaseResponseTest
 import datetime
 
-from io import BytesIO
 from dateutil.tz import tzutc
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 
@@ -55,12 +54,12 @@ class TestStreamWrapper(unittest.TestCase):
             next(line_iterator)
 
     def test_streaming_wrapper_validates_content_length(self):
-        body = BytesIO(b'1234567890')
+        body = six.BytesIO(b'1234567890')
         stream = response.StreamingBody(body, content_length=10)
         self.assertEqual(stream.read(), b'1234567890')
 
     def test_streaming_body_with_invalid_length(self):
-        body = BytesIO(b'123456789')
+        body = six.BytesIO(b'123456789')
         stream = response.StreamingBody(body, content_length=10)
         with self.assertRaises(IncompleteReadError):
             self.assertEqual(stream.read(9), b'123456789')
@@ -68,64 +67,35 @@ class TestStreamWrapper(unittest.TestCase):
             # an IncompleteReadError because we were expectd 10 bytes, not 9.
             stream.read()
 
-    def test_streaming_body_readable(self):
-        body = BytesIO(b'1234567890')
-        stream = response.StreamingBody(body, content_length=10)
-        self.assertTrue(stream.readable())
-        stream.close()
-        with self.assertRaises(ValueError):
-            stream.readable()
-
     def test_streaming_body_with_zero_read(self):
-        body = BytesIO(b'1234567890')
+        body = six.BytesIO(b'1234567890')
         stream = response.StreamingBody(body, content_length=10)
         chunk = stream.read(0)
         self.assertEqual(chunk, b'')
         self.assertEqual(stream.read(), b'1234567890')
 
     def test_streaming_body_with_single_read(self):
-        body = BytesIO(b'123456789')
+        body = six.BytesIO(b'123456789')
         stream = response.StreamingBody(body, content_length=10)
         with self.assertRaises(IncompleteReadError):
             stream.read()
 
-    def test_streaming_body_readline(self):
-        body = BytesIO(b'1234567890\n1234567\n12345\n')
-        stream = response.StreamingBody(body, content_length=25)
-        chunk = stream.readline()
-        self.assertEqual(chunk, b'1234567890\n')
-        chunk = stream.readline()
-        self.assertEqual(chunk, b'1234567\n')
-
-    def test_streaming_body_readlines(self):
-        body = BytesIO(b'1234567890\n1234567890\n12345')
-        stream = response.StreamingBody(body, content_length=27)
-        chunks = [b'1234567890\n', b'1234567890\n', b'12345']
-        self.assertEqual(stream.readlines(), chunks)
-
-    def test_streaming_body_tell(self):
-        body = BytesIO(b'1234567890')
-        stream = response.StreamingBody(body, content_length=10)
-        self.assertEqual(stream.tell(), 0)
-        stream.read(5)
-        self.assertEqual(stream.tell(), 5)
-
     def test_streaming_body_closes(self):
-        body = BytesIO(b'1234567890')
+        body = six.BytesIO(b'1234567890')
         stream = response.StreamingBody(body, content_length=10)
         self.assertFalse(body.closed)
         stream.close()
         self.assertTrue(body.closed)
 
     def test_default_iter_behavior(self):
-        body = BytesIO(b'a' * 2048)
+        body = six.BytesIO(b'a' * 2048)
         stream = response.StreamingBody(body, content_length=2048)
         chunks = list(stream)
         self.assertEqual(len(chunks), 2)
         self.assertEqual(chunks, [b'a' * 1024, b'a' * 1024])
 
     def test_streaming_body_is_an_iterator(self):
-        body = BytesIO(b'a' * 1024 + b'b' * 1024 + b'c' * 2)
+        body = six.BytesIO(b'a' * 1024 + b'b' * 1024 + b'c' * 2)
         stream = response.StreamingBody(body, content_length=2050)
         self.assertEqual(b'a' * 1024, next(stream))
         self.assertEqual(b'b' * 1024, next(stream))
@@ -134,25 +104,25 @@ class TestStreamWrapper(unittest.TestCase):
             next(stream)
 
     def test_iter_chunks_single_byte(self):
-        body = BytesIO(b'abcde')
+        body = six.BytesIO(b'abcde')
         stream = response.StreamingBody(body, content_length=5)
         chunks = list(stream.iter_chunks(chunk_size=1))
         self.assertEqual(chunks, [b'a', b'b', b'c', b'd', b'e'])
 
     def test_iter_chunks_with_leftover(self):
-        body = BytesIO(b'abcde')
+        body = six.BytesIO(b'abcde')
         stream = response.StreamingBody(body, content_length=5)
         chunks = list(stream.iter_chunks(chunk_size=2))
         self.assertEqual(chunks, [b'ab', b'cd', b'e'])
 
     def test_iter_chunks_single_chunk(self):
-        body = BytesIO(b'abcde')
+        body = six.BytesIO(b'abcde')
         stream = response.StreamingBody(body, content_length=5)
         chunks = list(stream.iter_chunks(chunk_size=1024))
         self.assertEqual(chunks, [b'abcde'])
 
     def test_streaming_line_iterator(self):
-        body = BytesIO(b'1234567890\n1234567890\n12345')
+        body = six.BytesIO(b'1234567890\n1234567890\n12345')
         stream = response.StreamingBody(body, content_length=27)
         self.assert_lines(
             stream.iter_lines(),
@@ -160,7 +130,7 @@ class TestStreamWrapper(unittest.TestCase):
         )
 
     def test_streaming_line_iterator_ends_newline(self):
-        body = BytesIO(b'1234567890\n1234567890\n12345\n')
+        body = six.BytesIO(b'1234567890\n1234567890\n12345\n')
         stream = response.StreamingBody(body, content_length=28)
         self.assert_lines(
             stream.iter_lines(),
@@ -169,7 +139,7 @@ class TestStreamWrapper(unittest.TestCase):
 
     def test_streaming_line_iter_chunk_sizes(self):
         for chunk_size in range(1, 30):
-            body = BytesIO(b'1234567890\n1234567890\n12345')
+            body = six.BytesIO(b'1234567890\n1234567890\n12345')
             stream = response.StreamingBody(body, content_length=27)
             self.assert_lines(
                 stream.iter_lines(chunk_size),
@@ -190,7 +160,7 @@ class TestStreamWrapper(unittest.TestCase):
 
     def test_streaming_line_abstruse_newline_standard(self):
         for chunk_size in range(1, 30):
-            body = BytesIO(b'1234567890\r\n1234567890\r\n12345\r\n')
+            body = six.BytesIO(b'1234567890\r\n1234567890\r\n12345\r\n')
             stream = response.StreamingBody(body, content_length=31)
             self.assert_lines(
                 stream.iter_lines(chunk_size),
@@ -199,12 +169,12 @@ class TestStreamWrapper(unittest.TestCase):
 
     def test_streaming_line_empty_body(self):
         stream = response.StreamingBody(
-            BytesIO(b''), content_length=0,
+            six.BytesIO(b''), content_length=0,
         )
         self.assert_lines(stream.iter_lines(), [])
 
 
-class FakeRawResponse(BytesIO):
+class FakeRawResponse(six.BytesIO):
     def stream(self, amt=1024, decode_content=None):
         while True:
             chunk = self.read(amt)


### PR DESCRIPTION
Reverts boto/botocore#2156

Changes appear to be incompatible with s3transfer. Rolling back for release while it's investigated.