### PR TITLE
Update pin for urllib3 1.26.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info[:2] == (3, 4):
     # urllib3 dropped support for python 3.4 in point release 1.25.8
     requires.append('urllib3>=1.25.4,<1.25.8')
 else:
-    requires.append('urllib3>=1.25.4,<1.26')
+    requires.append('urllib3>=1.25.4,<1.27')
 
 
 


### PR DESCRIPTION
urllib3 released 1.26.0 today. This will raise our pin to avoid pip conflicts for users installing the latest version.