### PR TITLE
Add support for HTTPS proxies

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -104,7 +104,8 @@ class ClientArgsCreator(object):
             proxies=new_config.proxies,
             timeout=(new_config.connect_timeout, new_config.read_timeout),
             socket_options=socket_options,
-            client_cert=new_config.client_cert)
+            client_cert=new_config.client_cert,
+            proxies_kwargs=new_config.proxies_kwargs)
 
         serializer = botocore.serialize.create_serializer(
             protocol, parameter_validation)
@@ -165,6 +166,7 @@ class ClientArgsCreator(object):
                 read_timeout=client_config.read_timeout,
                 max_pool_connections=client_config.max_pool_connections,
                 proxies=client_config.proxies,
+                proxies_kwargs=client_config.proxies_kwargs,
                 retries=client_config.retries,
                 client_cert=client_config.client_cert,
                 inject_host_prefix=client_config.inject_host_prefix,

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -160,6 +160,7 @@ class Config(object):
         ('parameter_validation', True),
         ('max_pool_connections', MAX_POOL_CONNECTIONS),
         ('proxies', None),
+        ('proxies_kwargs', None),
         ('s3', None),
         ('retries', None),
         ('client_cert', None),

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -280,7 +280,8 @@ class EndpointCreator(object):
                         http_session_cls=URLLib3Session,
                         proxies=None,
                         socket_options=None,
-                        client_cert=None):
+                        client_cert=None,
+                        proxies_kwargs=None):
         if not is_valid_endpoint_url(endpoint_url):
 
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
@@ -296,6 +297,7 @@ class EndpointCreator(object):
             max_pool_connections=max_pool_connections,
             socket_options=socket_options,
             client_cert=client_cert,
+            proxies_kwargs=proxies_kwargs
         )
 
         return Endpoint(

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -91,6 +91,7 @@ class TestCreateClientArgs(unittest.TestCase):
             'verify': True,
             'max_pool_connections': 10,
             'proxies': None,
+            'proxies_kwargs': None,
             'socket_options': self.default_socket_options,
             'client_cert': None,
         }


### PR DESCRIPTION
Starting with 1.26 urllib3 now supports HTTPS proxies. To enable the support two changes are needed:

* An additional ``proxy_kwargs`` argument that can be passed from client config. This dictionary will be used to pass any arguments needed to the underlying httpsession.
* The ``use_forwarding_for_https`` mode requires us to send the absolute URI when enabled.