### PR TITLE
Fix Content-MD5 header for s3transfer

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -25,7 +25,7 @@ import uuid
 
 from botocore.compat import (
     unquote, json, six, unquote_str, ensure_bytes, get_md5,
-    MD5_AVAILABLE, OrderedDict, urlsplit, urlunsplit, XMLParseError,
+    OrderedDict, urlsplit, urlunsplit, XMLParseError,
     ETree,
 )
 from botocore.docs.utils import AutoPopulatedParam
@@ -37,15 +37,11 @@ from botocore.signers import add_generate_db_auth_token
 from botocore.exceptions import ParamValidationError
 from botocore.exceptions import AliasConflictParameterError
 from botocore.exceptions import UnsupportedTLSVersionWarning
-from botocore.exceptions import MissingServiceIdError
 from botocore.utils import percent_encode, SAFE_CHARS
 from botocore.utils import switch_host_with_param
-from botocore.utils import hyphenize_service_id
 from botocore.utils import conditionally_calculate_md5
 
-from botocore import retryhandler
 from botocore import utils
-from botocore import translate
 import botocore
 import botocore.auth
 

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -25,7 +25,7 @@ import uuid
 
 from botocore.compat import (
     unquote, json, six, unquote_str, ensure_bytes, get_md5,
-    OrderedDict, urlsplit, urlunsplit, XMLParseError,
+    MD5_AVAILABLE, OrderedDict, urlsplit, urlunsplit, XMLParseError,
     ETree,
 )
 from botocore.docs.utils import AutoPopulatedParam
@@ -37,11 +37,15 @@ from botocore.signers import add_generate_db_auth_token
 from botocore.exceptions import ParamValidationError
 from botocore.exceptions import AliasConflictParameterError
 from botocore.exceptions import UnsupportedTLSVersionWarning
+from botocore.exceptions import MissingServiceIdError
 from botocore.utils import percent_encode, SAFE_CHARS
 from botocore.utils import switch_host_with_param
+from botocore.utils import hyphenize_service_id
 from botocore.utils import conditionally_calculate_md5
 
+from botocore import retryhandler
 from botocore import utils
+from botocore import translate
 import botocore
 import botocore.auth
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -2215,7 +2215,7 @@ def conditionally_calculate_md5(params, **kwargs):
     """Only add a Content-MD5 if the system supports it."""
     headers = params['headers']
     body = params['body']
-    if MD5_AVAILABLE and body and 'Content-MD5' not in headers:
+    if MD5_AVAILABLE and body is not None and 'Content-MD5' not in headers:
         md5_digest = calculate_md5(body, **kwargs)
         params['headers']['Content-MD5'] = md5_digest
 

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -919,6 +919,18 @@ class TestS3SigV4(BaseS3OperationTest):
             self.client.put_object(Bucket='foo', Key='bar', Body='baz')
         self.assertIn('content-md5', self.get_sent_headers())
 
+    def test_content_md5_set_empty_body(self):
+        with self.http_stubber:
+            self.client.put_object(Bucket='foo', Key='bar', Body='')
+        self.assertIn('content-md5', self.get_sent_headers())
+
+    def test_content_md5_set_empty_file(self):
+        with self.http_stubber:
+            with temporary_file('rb') as f:
+                assert f.read() == b''
+                self.client.put_object(Bucket='foo', Key='bar', Body=f)
+        self.assertIn('content-md5', self.get_sent_headers())
+
     def test_content_sha256_set_if_config_value_is_true(self):
         config = Config(signature_version='s3v4', s3={
             'payload_signing_enabled': True

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1217,6 +1217,17 @@ class TestAddMD5(BaseMD5Test):
             request_dict['headers']['Content-MD5'],
             'OFj2IjCsPJFfMAxmQxLGPw==')
 
+    def test_add_md5_with_empty_body(self):
+        request_dict = {
+            'body': b'',
+            'headers': {}
+        }
+        self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
+        conditionally_calculate_md5(request_dict)
+        self.assertEqual(
+            request_dict['headers']['Content-MD5'],
+            'OFj2IjCsPJFfMAxmQxLGPw==')
+
     def test_add_md5_with_bytearray_object(self):
         request_dict = {
             'body': bytearray(b'foobar'),


### PR DESCRIPTION
### Overview

This is a continuation of #1985 to resolve #1979. We're adding two additional tests to prevent future regression with empty bodies, and adding some more info on the underlying issue.

### Bug
While the initial PR was addressing a lack of `Content-MD5` headers being added for empty files going to s3, the bug is little more subtle. Currently, using the low level API for `PutBucket` will ensure all input, regardless of length, is transformed into a file-like object. When this is passed to our MD5 checksum function, it will always be `True` and get the header added correctly. These always evaluate to `True` because `bool` resolves "truthiness" to be if the file-object exists or not.

The bug enters when the higher level s3 APIs are being invoked like `s3 sync` in the AWS CLI. This replaces our standard file-like wrappers (StringIO, BytesIO) with s3transfer's [`ReadFileChunk`](https://github.com/boto/s3transfer/blob/b2b6c44cb283e134f6bf9fecad7ff5ee28df793d/s3transfer/utils.py#L387). Due to s3transfer implementing [`__len__`](https://github.com/boto/s3transfer/blob/b2b6c44cb283e134f6bf9fecad7ff5ee28df793d/s3transfer/utils.py#L519-L525) on what would otherwise appear to be a file-like object, we now get different criteria for what makes it truthy. `bool` will choose `__len__` > 0 as being more specific than if the file exists. That broke our previous assumptions on what would be coming through to `conditionally_calculate_md5`.

### Outcome
We probably *should* make `ReadFileChunk` adhere closer to the file-like object spec, but at this point it would be a backwards incompatible change. I think the original proposal from @wimglenn is the safest bet to make things operate as expected.