### PR TITLE
Correct the spelling of endpoints for the Invalid IDMS Endpoint Error

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -93,7 +93,7 @@ class ConnectionError(BotoCoreError):
 
 
 class InvalidIMDSEndpointError(BotoCoreError):
-    fmt = 'Invalid endpoint EC2 Instance Metadata endoints: {endpoint}'
+    fmt = 'Invalid endpoint EC2 Instance Metadata endpoint: {endpoint}'
 
 
 class EndpointConnectionError(ConnectionError):


### PR DESCRIPTION
Correct the spelling of `endoints` to `endpoint` when raising an Invalid IDMS Endpoint Error