### PR TITLE
Handle top level Error key for non-error responses

### DIFF
--- a/.changes/next-release/bugfix-Retry-72000.json
+++ b/.changes/next-release/bugfix-Retry-72000.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Retry",
+  "description": "Fix bug where retries were attempted on any response with an \"Error\" key."
+}

--- a/botocore/retries/standard.py
+++ b/botocore/retries/standard.py
@@ -198,7 +198,10 @@ class RetryContext(object):
         """
         if self.parsed_response is None:
             return
-        return self.parsed_response.get('Error', {}).get('Code')
+        error = self.parsed_response.get('Error', {})
+        if not isinstance(error, dict):
+            return
+        return error.get('Code')
 
     def add_retry_metadata(self, **kwargs):
         """Add key/value pairs to the retry metadata.

--- a/tests/unit/retries/test_standard.py
+++ b/tests/unit/retries/test_standard.py
@@ -572,6 +572,24 @@ class TestRetryContext(unittest.TestCase):
         self.assertEqual(context.get_retry_metadata(),
                          {'MaxAttemptsReached': True})
 
+    def test_handles_non_error_top_level_error_key_get_error_code(self):
+        response = AWSResponse(
+            status_code=200,
+            raw=None,
+            headers={},
+            url='https://foo',
+        )
+        # A normal response can have a top level "Error" key that doesn't map
+        # to an error code and should be ignored
+        context = standard.RetryContext(
+            attempt_number=1,
+            operation_model=None,
+            parsed_response={'Error': 'This is a 200 response body'},
+            http_response=response,
+            caught_exception=None,
+        )
+        self.assertEqual(context.get_error_code(), None)
+
 
 class TestThrottlingErrorDetector(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The `standard` retry mode will attempt to introspect any parsed response
for a top level `"Error"` key. If present the standard retry strategy
assumes that the response is an error response and that there will be a
nested dictionary under the `"Code"` key. This assumption is not
generally safe as standard responses can also contain a top level
`"Error"` key.

Fixes https://github.com/aws/aws-cli/issues/5644