### PR TITLE
feat: Adds keepends option to iter_lines in StreamingResponse

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -101,7 +101,7 @@ class StreamingBody(object):
 
     next = __next__
 
-    def iter_lines(self, chunk_size=1024):
+    def iter_lines(self, chunk_size=1024, keepends=False):
         """Return an iterator to yield lines from the raw stream.
 
         This is achieved by reading chunk of bytes (of size chunk_size) at a
@@ -111,10 +111,10 @@ class StreamingBody(object):
         for chunk in self.iter_chunks(chunk_size):
             lines = (pending + chunk).splitlines(True)
             for line in lines[:-1]:
-                yield line.splitlines()[0]
+                yield line.splitlines(keepends)[0]
             pending = lines[-1]
         if pending:
-            yield pending.splitlines()[0]
+            yield pending.splitlines(keepends)[0]
 
     def iter_chunks(self, chunk_size=_DEFAULT_CHUNK_SIZE):
         """Return an iterator to yield chunks of chunk_size bytes from the raw

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -146,6 +146,14 @@ class TestStreamWrapper(unittest.TestCase):
                 [b'1234567890', b'1234567890', b'12345'],
             )
 
+    def test_streaming_line_iterator_keepends(self):
+        body = six.BytesIO(b'1234567890\n1234567890\n12345')
+        stream = response.StreamingBody(body, content_length=27)
+        self.assert_lines(
+            stream.iter_lines(keepends=True),
+            [b'1234567890\n', b'1234567890\n', b'12345'],
+        )
+
     def test_catches_urllib3_read_timeout(self):
         class TimeoutBody(object):
             def read(*args, **kwargs):


### PR DESCRIPTION
This PR aims to add an optional `keepends` parameter to the `iter_lines` in `StreamingResponse`

From the python documentation `readline` and `readlines` should keep new line characters at the end of the string:

> f.readline() reads a single line from the file; a newline character (\n) is left at the end of the string, and is only omitted on the last line of the file if the file doesn’t end in a newline.

See https://docs.python.org/3/tutorial/inputoutput.html#methods-of-file-objects

Adding this option would make it easier to get this behavior for classes relying on `StreamingResponse`.

To not break the current implementation, this parameter is set to `False` by default.