### PR TITLE
Fix timestamp format for SSOCredentialFetcher

### DIFF
--- a/.changes/next-release/bugfix-SSO-69789.json
+++ b/.changes/next-release/bugfix-SSO-69789.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fixed timestamp format for SSO credential expirations",
+  "type": "bugfix",
+  "category": "SSO"
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1980,6 +1980,8 @@ class CredentialResolver(object):
 
 
 class SSOCredentialFetcher(CachedCredentialFetcher):
+    _UTC_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
     def __init__(self, start_url, sso_region, role_name, account_id,
                  client_creator, token_loader=None, cache=None,
                  expiry_window_seconds=None):
@@ -1989,7 +1991,6 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         self._account_id = account_id
         self._start_url = start_url
         self._token_loader = token_loader
-
         super(SSOCredentialFetcher, self).__init__(
             cache, expiry_window_seconds
         )
@@ -2017,7 +2018,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         # fromtimestamp expects seconds so: milliseconds / 1000 = seconds
         timestamp_seconds = timestamp_ms / 1000.0
         timestamp = datetime.datetime.fromtimestamp(timestamp_seconds, tzutc())
-        return _serialize_if_needed(timestamp)
+        return timestamp.strftime(self._UTC_DATE_FORMAT)
 
     def _get_credentials(self):
         """Get credentials by calling SSO get role credentials."""

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3271,7 +3271,7 @@ class TestSSOCredentialFetcher(unittest.TestCase):
         self.assertEqual(credentials['access_key'], 'foo')
         self.assertEqual(credentials['secret_key'], 'bar')
         self.assertEqual(credentials['token'], 'baz')
-        self.assertEqual(credentials['expiry_time'], '2008-09-23T12:43:20UTC')
+        self.assertEqual(credentials['expiry_time'], '2008-09-23T12:43:20Z')
         cache_key = '048db75bbe50955c16af7aba6ff9c41a3131bb7e'
         expected_cached_credentials = {
             'ProviderType': 'sso',
@@ -3279,7 +3279,7 @@ class TestSSOCredentialFetcher(unittest.TestCase):
                 'AccessKeyId': 'foo',
                 'SecretAccessKey': 'bar',
                 'SessionToken': 'baz',
-                'Expiration': '2008-09-23T12:43:20UTC',
+                'Expiration': '2008-09-23T12:43:20Z',
             }
         }
         self.assertEqual(self.cache[cache_key], expected_cached_credentials)


### PR DESCRIPTION
The timestamp format for SSO credentials was originally intended to be an [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) style timestamp in UTC. Due to a typo in the original AssumeRole implementation, the timezone is being converted to `UTC` instead of a literal `Z`. We're going to correct the SSO implementation since the current timestamp is incompatible with the other AWS SDKs. The AssumeRole timestamp will be left unchanged for now to preserve as much backwards compatibility as possible.

Customers that are upgrading should have their timestamp format updated on their next login or credential refresh with SSO.