### PR TITLE
Add `tcp_keepalive` as AWS_TCP_KEEPALIVE env var

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -398,8 +398,12 @@ class ClientArgsCreator:
         scoped_keepalive = scoped_config and self._ensure_boolean(
             scoped_config.get("tcp_keepalive", False)
         )
-        # Enables TCP Keepalive if specified in client config object or shared config file.
-        if client_keepalive or scoped_keepalive:
+        envvar_keepalive = self._config_store.get_config_variable(
+            'tcp_keepalive'
+        )
+        # Enables TCP Keepalive if specified in client environment, config
+        # object, or shared config file.
+        if client_keepalive or scoped_keepalive or envvar_keepalive:
             socket_options.append((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1))
         return socket_options
 

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -139,6 +139,9 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # We can't have a default here for v1 because we need to defer to
     # whatever the defaults are in _retry.json.
     'max_attempts': ('max_attempts', 'AWS_MAX_ATTEMPTS', None, int),
+    'tcp_keepalive': (
+        'tcp_keepalive', 'AWS_TCP_KEEPALIVE', False, utils.ensure_boolean
+    ),
 }
 # A mapping for the s3 specific configuration vars. These are the configuration
 # vars that typically go in the s3 section of the config file. This mapping


### PR DESCRIPTION
Related to #2249 - adds tcp_keepalive as an environment variable via the new `config_store` way of handling variables. 