### PR TITLE
Add paginator config - GetDiscoveredResourceCounts

### DIFF
--- a/botocore/data/config/2014-11-12/paginators-1.json
+++ b/botocore/data/config/2014-11-12/paginators-1.json
@@ -94,6 +94,12 @@
       "limit_key": "Limit",
       "output_token": "NextToken",
       "result_key": "RemediationExecutionStatuses"
+    },
+    "GetDiscoveredResourceCounts": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "resourceCounts"
     }
   }
 }


### PR DESCRIPTION
#1462 notes many missing paginators.
config / get_discovered_resource_counts is not listed because it uses "nextToken" instead of "NextToken".

[CONTRIBUTING.rst](https://github.com/boto/botocore/blob/develop/CONTRIBUTING.rst#contributing-code) says these type of PRs may be rejected, but others have been merged.