### PR TITLE
Add changes for Python 3.4/3.5 removal

### DIFF
--- a/.changes/next-release/feature-Python-10095.json
+++ b/.changes/next-release/feature-Python-10095.json
@@ -1,0 +1,5 @@
+{
+  "category": "Python", 
+  "type": "feature", 
+  "description": "Dropped support for Python 3.4 and 3.5"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest ]
-        include:
-          # Python 3.4 is not available on mac and windows so it needs to to
-          # be manually added to the matrix for linux.
-          - python-version: 3.4
-            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,7 +44,7 @@ contributions as well:
 * Code should follow `pep 8 <https://www.python.org/dev/peps/pep-0008/>`__,
   although if you are modifying an existing module, it is more important
   for the code to be consistent if there are any discrepancies.
-* Code must work on ``python2.7``, and ``python3.4`` and higher.
+* Code must work on ``python2.7``, and ``python3.6`` and higher.
 * Botocore is cross platform and code must work on at least linux, Windows,
   and Mac OS X.
 * If you would like to implement support for a significant feature that is not

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ botocore package is the foundation for the
 `boto3 <https://github.com/boto/boto3>`__.
 
 On 10/29/2020 deprecation for Python 3.4 and Python 3.5 was announced and support
-will be dropped on 02/01/2021. To avoid disruption, customers using Botocore
+was dropped on 02/01/2021. To avoid disruption, customers using Botocore
 on Python 3.4 or 3.5 may need to upgrade their version of Python or pin the
-version of Botocore in use prior to 02/01/2021. For more information, see
+version of Botocore. For more information, see
 this `blog post <https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
 Getting Started

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,4 @@ universal = 1
 requires-dist =
     python-dateutil>=2.1,<3.0.0
     jmespath>=0.7.1,<1.0.0
-    urllib3>=1.25.4,<1.25.8; python_version=='3.4'
-    urllib3>=1.25.4,<1.27; python_version!='3.4'
+    urllib3>=1.25.4,<1.27

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     install_requires=requires,
     extras_require={},
     license="Apache License 2.0",
+    python_requires=">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -62,8 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = py27,py36,py37,py38
 
 skipsdist = True
 


### PR DESCRIPTION
This is a draft PR with the list of possible cleanup changes we can make with the deprecation of Python 3.4 and 3.5 on Feb 1, 2021. This should cover the full scope of 3.4/3.5 specific code but not all of these are strictly required. Looking for feedback before we merge.

### Changes
- [x] Add `python_requires` to setup.py to inform pip of compatibility
- [x] Updated trove classifiers
- [x] Removed versions from GHA CI
- [x] Removed version from tox.ini
- [x] Updated README.rst and CONTRIBUTING.rst references
- [x] Updated Setup.* requirements