### PR TITLE
Add support for signed CloudFront cookies.

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -401,6 +401,36 @@ class CloudFrontSigner(object):
         return base64.b64encode(
             data).replace(b'+', b'-').replace(b'=', b'_').replace(b'/', b'~')
 
+    def generate_signed_cookies(self, resource, date_less_than, date_greater_than=None, ip_address=None):
+        """Creates signed CloudFront cookies based on given parameters.
+
+        :type resource: str
+        :param resource: URL of the file
+
+        :type date_less_than: datetime
+        :param date_less_than: The permission will expire after that date and time
+
+        :type date_greater_than: datetime
+        :param date_greater_than: The permission will start after that date and time
+
+        :type ip_address: str
+        :param ip_address: IP address
+
+        :rtype: dict
+        :return: Signed cookies.
+        """
+        policy = self.build_policy(resource,
+                                   date_less_than,
+                                   date_greater_than=date_greater_than,
+                                   ip_address=ip_address).encode('utf8')
+        signature = self.rsa_signer(policy)
+
+        return {
+            "CloudFront-Policy": self._url_b64encode(policy).decode('utf8'),
+            "CloudFront-Signature": self._url_b64encode(signature).decode('utf8'),
+            "CloudFront-Key-Pair-Id": self.key_id,
+        }
+
 
 def add_generate_db_auth_token(class_attributes, **kwargs):
     class_attributes['generate_db_auth_token'] = generate_db_auth_token

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -589,6 +589,20 @@ class TestCloudfrontSigner(BaseSignerTest):
         result = self.signer.generate_signed_cookies(
             'foo',
             datetime.datetime(2016, 1, 1),
+        )
+        cf_policy = 'eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiZm9vIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY' \
+                    '2hUaW1lIjoxNDUxNjA2NDAwfX19XX0_'
+        expected = {
+            'CloudFront-Policy': cf_policy,
+            'CloudFront-Signature': 'c2lnbmVk',
+            'CloudFront-Key-Pair-Id': 'MY_KEY_ID'
+        }
+        self.assertDictEqual(result, expected)
+
+    def test_generate_signed_cookies_with_custom_policy(self):
+        result = self.signer.generate_signed_cookies(
+            'foo',
+            datetime.datetime(2016, 1, 1),
             date_greater_than=datetime.datetime(2015, 12, 1),
             ip_address='12.34.56.78/9',
         )

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -585,6 +585,23 @@ class TestCloudfrontSigner(BaseSignerTest):
             '&Signature=c2lnbmVk&Key-Pair-Id=MY_KEY_ID')
         assert_url_equal(signed_url, expected)
 
+    def test_generate_signed_cookies(self):
+        result = self.signer.generate_signed_cookies(
+            'foo',
+            datetime.datetime(2016, 1, 1),
+            date_greater_than=datetime.datetime(2015, 12, 1),
+            ip_address='12.34.56.78/9',
+        )
+        cf_policy = 'eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiZm9vIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY' \
+                    '2hUaW1lIjoxNDUxNjA2NDAwfSwiSXBBZGRyZXNzIjp7IkFXUzpTb3VyY2VJcCI6IjEyLjM0LjU2Ljc4LzkifSwiRGF0ZU' \
+                    'dyZWF0ZXJUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE0NDg5MjgwMDB9fX1dfQ__'
+        expected = {
+            'CloudFront-Policy': cf_policy,
+            'CloudFront-Signature': 'c2lnbmVk',
+            'CloudFront-Key-Pair-Id': 'MY_KEY_ID'
+        }
+        self.assertDictEqual(result, expected)
+
 
 class TestS3PostPresigner(BaseSignerTest):
     def setUp(self):


### PR DESCRIPTION
I added a method to CloudFrontSigner that allows signed cookies creation.
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-cookies.html