### PR TITLE
S3 arn custom endpoint support

### DIFF
--- a/.changes/next-release/enhancement-s3-38374.json
+++ b/.changes/next-release/enhancement-s3-38374.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "s3",
+  "description": "Amazon S3 now supports AWS PrivateLink, providing direct access to S3 via a private endpoint within your virtual private network."
+}

--- a/tests/functional/test_s3_control_redirects.py
+++ b/tests/functional/test_s3_control_redirects.py
@@ -420,15 +420,23 @@ class TestS3ControlRedirection(unittest.TestCase):
     def test_outpost_redirection_custom_endpoint(self):
         self._bootstrap_client(endpoint_url='https://outpost.foo.com/')
         self.stubber.add_response()
-        with self.assertRaises(UnsupportedS3ControlConfigurationError):
-            with self.stubber:
-                self.client.create_bucket(Bucket='foo', OutpostId='op-123')
+        with self.stubber:
+            self.client.create_bucket(Bucket='foo', OutpostId='op-123')
+        _assert_netloc(self.stubber, 'outpost.foo.com')
+        _assert_header(self.stubber, 'x-amz-outpost-id', 'op-123')
 
     def test_normal_ap_request_has_correct_endpoint(self):
         self.stubber.add_response()
         with self.stubber:
             self.client.get_access_point_policy(Name='MyAp', AccountId='1234')
         _assert_netloc(self.stubber, '1234.s3-control.us-west-2.amazonaws.com')
+
+    def test_normal_ap_request_custom_endpoint(self):
+        self._bootstrap_client(endpoint_url='https://example.com/')
+        self.stubber.add_response()
+        with self.stubber:
+            self.client.get_access_point_policy(Name='MyAp', AccountId='1234')
+        _assert_netloc(self.stubber, '1234.example.com')
 
     def test_normal_bucket_request_has_correct_endpoint(self):
         self.stubber.add_response()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2002,12 +2002,15 @@ class TestS3EndpointSetter(unittest.TestCase):
         )
         self.assertEqual(request.url, expected_url)
 
-    def test_accesspoint_errors_for_custom_endpoint(self):
+    def test_accesspoint_supports_custom_endpoint(self):
         endpoint_setter = self.get_endpoint_setter(
             endpoint_url='https://custom.com')
         request = self.get_s3_accesspoint_request()
-        with self.assertRaises(UnsupportedS3AccesspointConfigurationError):
-            self.call_set_endpoint(endpoint_setter, request=request)
+        self.call_set_endpoint(endpoint_setter, request=request)
+        expected_url = 'https://%s-%s.custom.com/' % (
+            self.accesspoint_name, self.account,
+        )
+        self.assertEqual(request.url, expected_url)
 
     def test_errors_for_mismatching_partition(self):
         endpoint_setter = self.get_endpoint_setter(partition='aws-cn')


### PR DESCRIPTION
This allows the S3 and S3 control clients to provide custom endpoints when providing arn based resources.