### PR TITLE
Unify json imports.

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -22,7 +22,6 @@ from operator import itemgetter
 import functools
 import time
 import calendar
-import json
 
 from botocore.exceptions import NoCredentialsError
 from botocore.utils import normalize_url_path, percent_encode_sequence

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -17,7 +17,6 @@ import logging
 import os
 import getpass
 import threading
-import json
 import subprocess
 from collections import namedtuple
 from copy import deepcopy
@@ -31,6 +30,7 @@ import botocore.compat
 from botocore import UNSIGNED
 from botocore.compat import total_seconds
 from botocore.compat import compat_shell_split
+from botocore.compat import json
 from botocore.config import Config
 from botocore.exceptions import UnknownCredentialError
 from botocore.exceptions import PartialCredentialsError

--- a/botocore/monitoring.py
+++ b/botocore/monitoring.py
@@ -10,12 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import json
 import logging
 import re
 import time
 
-from botocore.compat import ensure_unicode, ensure_bytes, urlparse
+from botocore.compat import ensure_unicode, ensure_bytes, urlparse, json
 from botocore.retryhandler import EXCEPTION_MAP as RETRYABLE_EXCEPTIONS
 
 

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -16,11 +16,10 @@ from itertools import tee
 from botocore.compat import six
 
 import jmespath
-import json
 import base64
 import logging
 from botocore.exceptions import PaginationError
-from botocore.compat import zip
+from botocore.compat import zip, json
 from botocore.utils import set_value_from_jmespath, merge_dicts
 
 

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -116,10 +116,9 @@ Each call to ``parse()`` returns a dict has this form::
 """
 import re
 import base64
-import json
 import logging
 
-from botocore.compat import six, ETree, XMLParseError
+from botocore.compat import six, json, ETree, XMLParseError
 from botocore.eventstream import EventStream, NoInitialResponseError
 
 from botocore.utils import parse_timestamp, merge_dicts, \

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -12,12 +12,11 @@
 # language governing permissions and limitations under the License.
 import datetime
 import weakref
-import json
 import base64
 
 import botocore
 import botocore.auth
-from botocore.compat import six, OrderedDict
+from botocore.compat import six, json, OrderedDict
 from botocore.awsrequest import create_request_object, prepare_request_dict
 from botocore.exceptions import UnknownSignatureVersionError
 from botocore.exceptions import UnknownClientMethodError

--- a/botocore/validate.py
+++ b/botocore/validate.py
@@ -15,9 +15,9 @@ Validation Errors
 
 from botocore.compat import six
 import decimal
-import json
 from datetime import datetime
 
+from botocore.compat import json
 from botocore.utils import parse_to_aware_datetime
 from botocore.utils import is_json_value_header
 from botocore.exceptions import ParamValidationError

--- a/tests/acceptance/features/steps/base.py
+++ b/tests/acceptance/features/steps/base.py
@@ -1,5 +1,4 @@
-import json
-
+from botocore.compat import json
 from botocore import xform_name
 from botocore.exceptions import ClientError
 

--- a/tests/functional/csm/test_monitoring.py
+++ b/tests/functional/csm/test_monitoring.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under thimport mock
 import contextlib
 import copy
-import json
 import logging
 import os
 import socket
@@ -24,6 +23,7 @@ from nose.tools import assert_equal
 from tests import temporary_file
 from tests import ClientHTTPStubber
 from botocore import xform_name
+from botocore.compat import json
 import botocore.session
 import botocore.config
 import botocore.exceptions

--- a/tests/functional/test_kinesis.py
+++ b/tests/functional/test_kinesis.py
@@ -10,10 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import json
 import time
 from base64 import b64decode
 from uuid import uuid4
+
+from botocore.compat import json
 from tests import unittest, BaseSessionTest, ClientHTTPStubber
 
 

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -11,9 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import contextlib
-import json
 from tests import BaseSessionTest, mock, ClientHTTPStubber
 
+from botocore.compat import json
 from botocore.exceptions import ClientError
 from botocore.config import Config
 

--- a/tests/functional/utils/credentialprocess.py
+++ b/tests/functional/utils/credentialprocess.py
@@ -12,7 +12,8 @@
 # language governing permissions and limitations under the License.
 """This is a dummy implementation of a credential provider process."""
 import argparse
-import json
+
+from botocore.compat import json
 
 
 def main():

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -14,10 +14,10 @@ import os
 import mock
 import tempfile
 import shutil
-import json
 import time
 from uuid import uuid4
 
+from botocore.compat import json
 from botocore.session import Session
 from botocore.exceptions import ClientError
 from tests import BaseEnvVar, temporary_file, random_chars

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -16,13 +16,12 @@ from tests import unittest
 import datetime
 import time
 import base64
-import json
 
 import mock
 
 import botocore.auth
 import botocore.credentials
-from botocore.compat import HTTPHeaders, urlsplit, parse_qs, six
+from botocore.compat import HTTPHeaders, urlsplit, parse_qs, six, json
 from botocore.awsrequest import AWSRequest
 
 

--- a/tests/unit/docs/__init__.py
+++ b/tests/unit/docs/__init__.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import json
 import tempfile
 import shutil
 
@@ -19,7 +18,7 @@ from botocore.docs.bcdoc.restdoc import DocumentStructure
 import mock
 
 from tests import unittest
-from botocore.compat import OrderedDict
+from botocore.compat import OrderedDict, json
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel, OperationModel
 from botocore.client import ClientCreator

--- a/tests/unit/response_parsing/test_response_parsing.py
+++ b/tests/unit/response_parsing/test_response_parsing.py
@@ -13,13 +13,13 @@
 
 import os
 import glob
-import json
 import pprint
 import logging
 import difflib
 from tests import create_session
 
 import botocore.session
+from botocore.compat import json
 from botocore import xform_name
 from botocore import parsers
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -17,7 +17,6 @@ import mock
 import os
 import tempfile
 import shutil
-import json
 import copy
 
 from dateutil.tz import tzlocal, tzutc

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -17,11 +17,10 @@ import base64
 import mock
 import copy
 import os
-import json
 
 import botocore
 import botocore.session
-from botocore.compat import OrderedDict
+from botocore.compat import OrderedDict, json
 from botocore.exceptions import ParamValidationError, MD5UnavailableError
 from botocore.exceptions import AliasConflictParameterError
 from botocore.exceptions import MissingServiceIdError

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -11,13 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from tests import mock, unittest
-import json
 import re
 import socket
 import time
 
 from botocore.awsrequest import AWSRequest
-from botocore.compat import six
+from botocore.compat import six, json
 from botocore.exceptions import ConnectionError
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import OperationModel

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -12,14 +12,13 @@ spec.  This can happen for a number of reasons:
 
 """
 import base64
-import json
 import datetime
 import dateutil.tz
 from tests import unittest
 
 from botocore.model import ServiceModel
 from botocore import serialize
-from botocore.compat import six
+from botocore.compat import six, json
 from botocore.exceptions import ParamValidationError
 from botocore.serialize import SERIALIZERS
 

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import mock
 import datetime
-import json
 
 from dateutil.tz import tzutc
 
@@ -20,6 +19,7 @@ import botocore
 import botocore.session
 import botocore.auth
 import botocore.awsrequest
+from botocore.compat import json
 from botocore.config import Config
 from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials


### PR DESCRIPTION
Hey, I've found that `json` imports don't follow same approach

Sometimes it is directly `import json`, but sometimes `from botocore.compat import json`

This PR unifies json imports across all modules

Using local `compat` module looks better for me, as allows to change json behavior in one place if it is eventually needed