### PR TITLE
Escape line endings in S3 DeleteObjects requests

### DIFF
--- a/.changes/next-release/bugfix-S3-86777.json
+++ b/.changes/next-release/bugfix-S3-86777.json
@@ -1,0 +1,5 @@
+{
+  "category": "S3", 
+  "type": "bugfix", 
+  "description": "Fix an issue with XML newline normalization that could result in the DeleteObjects operation incorrectly deleting the wrong keys."
+}


### PR DESCRIPTION
This adds a customization for the S3 DeleteObjects operation to include some additional escaping of newlines to avoid XML normalization of newlines on the server side modifying the keys to be deleted. This is an issue with our XML serialization in general but currently only negatively impacts S3 DeleteObjects. Unfortunately, the stdlib XML serializer doesn't have a way to configure or opt into these escape sequences for the element text nor can we escape these prior to serialization as the escape sequences include characters that will be double escaped by the serializer. It might be worthwhile to implement our own version of `ElementTree.tostring` to give us finer control over the generated XML so we can properly implement this for our XML serializer in general.