### PR TITLE
Add support for doubles in argument generation

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -939,7 +939,7 @@ class ArgumentGenerator(object):
                 return ''
             elif shape.type_name in ['integer', 'long']:
                 return 0
-            elif shape.type_name == 'float':
+            elif shape.type_name in ['float', 'double']:
                 return 0.0
             elif shape.type_name == 'boolean':
                 return True

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -488,14 +488,16 @@ class TestArgumentGenerator(unittest.TestCase):
                 'B': {'type': 'integer'},
                 'C': {'type': 'float'},
                 'D': {'type': 'boolean'},
-                'E': {'type': 'timestamp'}
+                'E': {'type': 'timestamp'},
+                'F': {'type': 'double'},
             },
             generated_skeleton={
                 'A': '',
                 'B': 0,
                 'C': 0.0,
                 'D': True,
-                'E': datetime.datetime(1970, 1, 1, 0, 0, 0)
+                'E': datetime.datetime(1970, 1, 1, 0, 0, 0),
+                'F': 0.0,
             }
         )
 


### PR DESCRIPTION
This adds support for the shape type `double` in argument generation. This ensures things like `--generate-cli-skeleton output` work as otherwise the stubbed response fails validation due to these values being generated as `None` instead of `0.0`. 