### PR TITLE
Add extras_require for CRT

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -1,0 +1,30 @@
+
+name: Run CRT tests
+
+on:
+  push:
+  pull_request:
+    branches-ignore: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies and CRT
+      run: |
+        python scripts/ci/install --extras crt
+    - name: Run tests
+      run: |
+        python scripts/ci/run-crt-tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tox>=2.5.0,<3.0.0
 nose==1.3.7
 mock==1.3.0
-wheel==0.24.0
+wheel==0.36.2
 behave==1.2.5
 jsonschema==2.5.1

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import os
 import sys
 from subprocess import check_call
@@ -13,17 +14,20 @@ os.chdir(REPO_ROOT)
 def run(command):
     return check_call(command, shell=True)
 
-
-try:
-    # Has the form "major.minor"
-    python_version = os.environ['PYTHON_VERSION']
-except KeyError:
-    python_version = '.'.join([str(i) for i in sys.version_info[:2]])
-
-run('pip install -r requirements.txt')
-run('pip install coverage')
-if os.path.isdir('dist') and os.listdir('dist'):
-    shutil.rmtree('dist')
-run('python setup.py bdist_wheel')
-wheel_dist = os.listdir('dist')[0]
-run('pip install %s' % (os.path.join('dist', wheel_dist)))
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '-e', '--extras', help='Install extras_require along with normal install'
+    )
+    args = parser.parse_args()
+    run('pip install -r requirements.txt')
+    run('pip install coverage')
+    if os.path.isdir('dist') and os.listdir('dist'):
+        shutil.rmtree('dist')
+    run('python setup.py bdist_wheel')
+    wheel_dist = os.listdir('dist')[0]
+    package = os.path.join('dist', wheel_dist)
+    if args.extras:
+        package = "'%s[%s]'" % (package, args.extras)
+    run('pip install %s' % package)

--- a/scripts/ci/run-crt-tests
+++ b/scripts/ci/run-crt-tests
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Don't run tests from the root repo dir.
+# We want to ensure we're importing from the installed
+# binary package not from the CWD.
+
+import os
+import sys
+from subprocess import check_call
+
+_dname = os.path.dirname
+
+REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
+os.chdir(os.path.join(REPO_ROOT, 'tests'))
+
+
+def run(command):
+    return check_call(command, shell=True)
+
+try:
+    import awscrt
+except ImportError:
+    print("MISSING DEPENDENCY: awscrt must be installed to run the crt tests.")
+    sys.exit(1)
+
+run('nosetests botocore --with-xunit unit/ functional/')

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ requires_dist =
     python-dateutil>=2.1,<3.0.0
     jmespath>=0.7.1,<1.0.0
     urllib3>=1.25.4,<1.27
+
+[options.extras_require]
+crt = awscrt==0.10.8

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
                   'botocore.vendored.requests': ['*.pem']},
     include_package_data=True,
     install_requires=requires,
-    extras_require={},
     license="Apache License 2.0",
     python_requires=">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     classifiers=[


### PR DESCRIPTION
**Note: This is a beta feature that will be seeing iteration in the near future and should not be considered "stable". We _strongly_ recommend not installing with "botocore[crt]" in a production environment. The current `extras_require` will not affect existing installations but will be used to enable features in future builds.**

### Overview
This change will add basic setup for us to start adding opt-in features based on the [AWS CRT](https://github.com/awslabs/aws-crt-python). The extra currently has no effects on our infrastructure but allows us to start testing changes as we merge future PRs integrating with the CRT. Installation with this extra will be an "opt-in" to start replacing portions of SDK functionality with the unified C runtime for AWS SDKs.

More information on changes will be provided in upcoming pull requests.