### PR TITLE
Update check_hostname setting for proxy

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -258,6 +258,9 @@ class URLLib3Session(object):
 
         context = self._get_ssl_context()
         try:
+            # urllib3 disables this by default but we need
+            # it for proper proxy tls negotiation.
+            context.check_hostname = True
             if proxy_ca_bundle is not None:
                 context.load_verify_locations(cafile=proxy_ca_bundle)
 

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -294,6 +294,20 @@ class TestURLLib3Session(unittest.TestCase):
             )
             self.assert_request_sent()
 
+    def test_proxy_ssl_context_uses_check_hostname(self):
+        cert = ('/some/cert', '/some/key')
+        proxies = {'https': 'https://proxy.com'}
+        proxies_config = {'proxy_client_cert': "path/to/cert"}
+        with patch('botocore.httpsession.create_urllib3_context'):
+            session = URLLib3Session(
+                proxies=proxies, client_cert=cert,
+                proxies_config=proxies_config
+            )
+            self.request.url = 'https://example.com/'
+            session.send(self.request.prepare())
+            last_call = self.proxy_manager_fun.call_args[-1]
+            self.assertIs(last_call['ssl_context'].check_hostname, True)
+
     def test_basic_request(self):
         session = URLLib3Session()
         session.send(self.request.prepare())


### PR DESCRIPTION
Updating usage of urllib3's SSLContext generation method when passed to our ProxyManager. This will now force the check_hostname functionality of the ssl module to be used in this case. This will fully mitigate this [urllib3 vulnerability](https://github.com/urllib3/urllib3/security/advisories/GHSA-5phf-pp7p-vc2r), regardless of urllib3 version used.