### PR TITLE
Update _retries.json for servicequotas

### DIFF
--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -287,6 +287,20 @@
           }
         }
       }
+    },
+    "servicequotas": {
+      "__default__": {
+        "policies": {
+          "too_many_requests_400": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "TooManyRequestsException",
+                "http_status_code": 400
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -86,6 +86,14 @@
           "http_status_code": 400
         }
       }
+    },
+    "too_many_requests_400": {
+      "applies_when": {
+        "response": {
+          "service_error_code": "TooManyRequestsException",
+          "http_status_code": 400
+        }
+      }
     }
   },
   "retry": {
@@ -108,7 +116,8 @@
           "request_throttled_exception": {"$ref": "request_throttled_exception"},
           "throttling": {"$ref": "throttling"},
           "too_many_requests": {"$ref": "too_many_requests"},
-          "throughput_exceeded": {"$ref": "throughput_exceeded"}
+          "throughput_exceeded": {"$ref": "throughput_exceeded"},
+          "too_many_requests_400": {"$ref": "too_many_requests_400"}
       }
     },
     "organizations": {
@@ -281,20 +290,6 @@
             "applies_when": {
               "response": {
                 "service_error_code": "IDPCommunicationError",
-                "http_status_code": 400
-              }
-            }
-          }
-        }
-      }
-    },
-    "servicequotas": {
-      "__default__": {
-        "policies": {
-          "too_many_requests_400": {
-            "applies_when": {
-              "response": {
-                "service_error_code": "TooManyRequestsException",
                 "http_status_code": 400
               }
             }

--- a/botocore/data/_retry.json
+++ b/botocore/data/_retry.json
@@ -120,20 +120,6 @@
           "too_many_requests_400": {"$ref": "too_many_requests_400"}
       }
     },
-    "organizations": {
-      "__default__": {
-        "policies": {
-          "too_many_requests": {
-            "applies_when": {
-              "response": {
-                "service_error_code": "TooManyRequestsException",
-                "http_status_code": 400
-              }
-            }
-          }
-        }
-      }
-    },
     "dynamodb": {
       "__default__": {
         "max_attempts": 10,


### PR DESCRIPTION
We use the service-quotas API to enumerate all of the quotas in our account and noticed that boto3 was failing to retry after a `TooManyRequestsException` with HTTP status code `400`. After some digging, I realized that the retry checker was only checking for a `TooManyRequestsException` with code `429`, but not with code `400` which is what the API was giving us.

It looks like you've already added the configuration here for the `organizations` service, so I'm just adding `too_many_requests_400` as a default retry now.

Let me know what you think.

Thanks,
Noah