### PR TITLE
Fix document CodeCommit get_file response

### DIFF
--- a/botocore/data/codecommit/2015-04-13/service-2.json
+++ b/botocore/data/codecommit/2015-04-13/service-2.json
@@ -4414,7 +4414,7 @@
         },
         "fileContent":{
           "shape":"FileContent",
-          "documentation":"<p>The base-64 encoded binary data object that represents the content of the file.</p>"
+          "documentation":"<p>The content of the file, in binary object format. </p>"
         }
       }
     },


### PR DESCRIPTION
Fix https://github.com/boto/boto3/issues/2329

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit.html#CodeCommit.Client.get_file
```
fileContent (bytes) --
The base-64 encoded binary data object that represents the content of the file.
```
But `fileContent` returns as base64 decoded binary data.
```python
import boto3
client = boto3.client('codecommit')
client.put_file(repositoryName='repo', filePath='path', branchName='main', parentCommitId='', fileContent='test')
client.get_file(repositoryName='repo', filePath='path')['fileContent'] 
# => b'test'
```