### PR TITLE
make StreamingBody file-like

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -44,6 +44,7 @@ class StreamingBody(object):
         self._raw_stream = raw_stream
         self._content_length = content_length
         self._amount_read = 0
+        self.closed = False
 
     def set_socket_timeout(self, timeout):
         """Set the timeout seconds on the socket."""
@@ -86,6 +87,15 @@ class StreamingBody(object):
             self._verify_content_length()
         return chunk
 
+    def readable(self):
+        return True
+        
+    def writable(self):
+        return False
+        
+    def seekable(self):
+        return False
+        
     def __iter__(self):
         """Return an iterator to yield 1k chunks from the raw stream.
         """
@@ -139,6 +149,7 @@ class StreamingBody(object):
     def close(self):
         """Close the underlying http response stream."""
         self._raw_stream.close()
+        self.closed = True
 
 
 def get_response(operation_model, http_response):

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -16,6 +16,7 @@ import datetime
 
 from dateutil.tz import tzutc
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
+from io import TextIOWrapper
 
 import botocore
 from botocore import response
@@ -102,6 +103,12 @@ class TestStreamWrapper(unittest.TestCase):
         self.assertEqual(b'c' * 2, next(stream))
         with self.assertRaises(StopIteration):
             next(stream)
+
+    def test_streaming_body_is_file_like(self):
+        body = six.BytesIO(b'1234567890')
+        stream = response.StreamingBody(body, content_length=10)
+        t = TextIOWrapper(stream, encoding="utf-8")
+        self.assertEqual(t.read(), '1234567890')
 
     def test_iter_chunks_single_byte(self):
         body = six.BytesIO(b'abcde')


### PR DESCRIPTION
This is a short-term solution to #879 .

It seems that converting StreamingBody to a subclass of an `io.IOBase` would take a while. In the mean time, let's just make `t = TextIOWrapper(StreamingBody(), encoding="utf-8")` work, by adding `readable()` and other attributes/methods.

