### PR TITLE
Handling document types and adding C2J protocol tests

### DIFF
--- a/botocore/docs/shape.py
+++ b/botocore/docs/shape.py
@@ -66,6 +66,8 @@ class ShapeDocumenter(object):
         else:
             history.append(shape.name)
             is_top_level_param = (len(history) == 2)
+            if hasattr(shape, 'is_document_type') and shape.is_document_type:
+                param_type = 'document'
             getattr(self, 'document_shape_type_%s' % param_type,
                     self.document_shape_default)(
                         section, shape, history=history, name=name,
@@ -90,6 +92,7 @@ class ShapeDocumenter(object):
 
     def _get_special_py_default(self, shape):
         special_defaults = {
+            'document_type': '{...}|[...]|123|123.4|\'string\'|True|None',
             'jsonvalue_header': '{...}|[...]|123|123.4|\'string\'|True|None',
             'streaming_input_shape': 'b\'bytes\'|file',
             'streaming_output_shape': 'StreamingBody()',
@@ -99,6 +102,7 @@ class ShapeDocumenter(object):
 
     def _get_special_py_type_name(self, shape):
         special_type_names = {
+            'document_type': ':ref:`document<document>`',
             'jsonvalue_header': 'JSON serializable',
             'streaming_input_shape': 'bytes or seekable file-like object',
             'streaming_output_shape': ':class:`.StreamingBody`',
@@ -109,6 +113,8 @@ class ShapeDocumenter(object):
     def _get_value_for_special_type(self, shape, special_type_map):
         if is_json_value_header(shape):
             return special_type_map['jsonvalue_header']
+        if hasattr(shape, 'is_document_type') and shape.is_document_type:
+            return special_type_map['document_type']
         for special_type, marked_shape in self._context[
                 'special_shape_types'].items():
             if special_type in special_type_map:

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -13,7 +13,8 @@
 """Abstractions to interact with service models."""
 from collections import defaultdict
 
-from botocore.utils import CachedProperty, instance_cache, hyphenize_service_id
+from botocore.utils import (CachedProperty, instance_cache,
+                            hyphenize_service_id)
 from botocore.compat import OrderedDict
 from botocore.exceptions import MissingServiceIdError
 from botocore.exceptions import UndefinedModelAttributeError
@@ -55,7 +56,7 @@ class Shape(object):
                         'jsonvalue', 'timestampFormat', 'hostLabel']
     METADATA_ATTRS = ['required', 'min', 'max', 'sensitive', 'enum',
                       'idempotencyToken', 'error', 'exception',
-                      'endpointdiscoveryid', 'retryable']
+                      'endpointdiscoveryid', 'retryable', 'document']
     MAP_TYPE = OrderedDict
 
     def __init__(self, shape_name, shape_model, shape_resolver=None):
@@ -137,6 +138,7 @@ class Shape(object):
             * sensitive
             * required
             * idempotencyToken
+            * document
 
         :rtype: dict
         :return: Metadata about the shape.
@@ -175,7 +177,7 @@ class Shape(object):
 class StructureShape(Shape):
     @CachedProperty
     def members(self):
-        members = self._shape_model['members']
+        members = self._shape_model.get('members', self.MAP_TYPE())
         # The members dict looks like:
         #    'members': {
         #        'MemberName': {'shape': 'shapeName'},
@@ -204,6 +206,10 @@ class StructureShape(Shape):
             return code
         # Use the exception name if there is no explicit code modeled
         return self.name
+
+    @CachedProperty
+    def is_document_type(self):
+        return self.metadata.get('document', False)
 
 
 class ListShape(Shape):
@@ -738,7 +744,7 @@ class DenormalizedStructureBuilder(object):
         shape = self._build_initial_shape(model)
         shape['members'] = members
 
-        for name, member_model in model['members'].items():
+        for name, member_model in model.get('members', OrderedDict()).items():
             member_shape_name = self._get_shape_name(member_model)
             members[name] = {'shape': member_shape_name}
             self._build_model(member_model, shapes, member_shape_name)

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -591,21 +591,25 @@ class EC2QueryParser(QueryParser):
 class BaseJSONParser(ResponseParser):
 
     def _handle_structure(self, shape, value):
-        member_shapes = shape.members
-        if value is None:
-            # If the comes across the wire as "null" (None in python),
-            # we should be returning this unchanged, instead of as an
-            # empty dict.
-            return None
         final_parsed = {}
-        for member_name in member_shapes:
-            member_shape = member_shapes[member_name]
-            json_name = member_shape.serialization.get('name', member_name)
-            raw_value = value.get(json_name)
-            if raw_value is not None:
-                final_parsed[member_name] = self._parse_shape(
-                    member_shapes[member_name],
-                    raw_value)
+        if shape.is_document_type:
+            final_parsed = value
+        else:
+            member_shapes = shape.members
+            if value is None:
+                # If the comes across the wire as "null" (None in python),
+                # we should be returning this unchanged, instead of as an
+                # empty dict.
+                return None
+            final_parsed = {}
+            for member_name in member_shapes:
+                member_shape = member_shapes[member_name]
+                json_name = member_shape.serialization.get('name', member_name)
+                raw_value = value.get(json_name)
+                if raw_value is not None:
+                    final_parsed[member_name] = self._parse_shape(
+                        member_shapes[member_name],
+                        raw_value)
         return final_parsed
 
     def _handle_map(self, shape, value):

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -362,21 +362,24 @@ class JSONSerializer(Serializer):
         method(serialized, value, shape, key)
 
     def _serialize_type_structure(self, serialized, value, shape, key):
-        if key is not None:
-            # If a key is provided, this is a result of a recursive
-            # call so we need to add a new child dict as the value
-            # of the passed in serialized dict.  We'll then add
-            # all the structure members as key/vals in the new serialized
-            # dictionary we just created.
-            new_serialized = self.MAP_TYPE()
-            serialized[key] = new_serialized
-            serialized = new_serialized
-        members = shape.members
-        for member_key, member_value in value.items():
-            member_shape = members[member_key]
-            if 'name' in member_shape.serialization:
-                member_key = member_shape.serialization['name']
-            self._serialize(serialized, member_value, member_shape, member_key)
+        if shape.is_document_type:
+            serialized[key] = value
+        else:
+            if key is not None:
+                # If a key is provided, this is a result of a recursive
+                # call so we need to add a new child dict as the value
+                # of the passed in serialized dict.  We'll then add
+                # all the structure members as key/vals in the new serialized
+                # dictionary we just created.
+                new_serialized = self.MAP_TYPE()
+                serialized[key] = new_serialized
+                serialized = new_serialized
+            members = shape.members
+            for member_key, member_value in value.items():
+                member_shape = members[member_key]
+                if 'name' in member_shape.serialization:
+                    member_key = member_shape.serialization['name']
+                self._serialize(serialized, member_value, member_shape, member_key)
 
     def _serialize_type_map(self, serialized, value, shape, key):
         map_obj = self.MAP_TYPE()

--- a/docs/source/topics/document_type.rst
+++ b/docs/source/topics/document_type.rst
@@ -1,0 +1,5 @@
+.. _document:
+
+==================
+Document Type Reference
+==================

--- a/docs/source/topics/index.rst
+++ b/docs/source/topics/index.rst
@@ -6,3 +6,4 @@ Botocore Topic Guides
 
    events
    paginators
+   document_type

--- a/tests/unit/protocols/input/json.json
+++ b/tests/unit/protocols/input/json.json
@@ -638,5 +638,269 @@
         }
       }
     ]
+  },
+  {
+    "description": "Serializes document with standalone primitive type in a JSON request.",
+    "metadata": {
+      "protocol": "json",
+      "jsonVersion": "1.1",
+      "targetPrefix": "com.amazonaws.foo"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+            "inlineDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "inlineDocument": "foo"
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"inlineDocument\": \"foo\"}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "inlineDocument": 123
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"inlineDocument\": 123}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "inlineDocument": 1.2
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"inlineDocument\": 1.2}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "inlineDocument": true
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"inlineDocument\": true}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "inlineDocument": ""
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"inlineDocument\": \"\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes inline document in a JSON request.",
+    "metadata": {
+      "protocol": "json",
+      "jsonVersion": "1.1",
+      "targetPrefix": "com.amazonaws.foo"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+            "inlineDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "inlineDocument": {"foo": "bar"}
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"inlineDocument\": {\"foo\": \"bar\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes aggregate documents in a JSON request.",
+    "metadata": {
+      "protocol": "json",
+      "jsonVersion": "1.1",
+      "targetPrefix": "com.amazonaws.foo"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+            "parentDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "parentDocument": {
+              "str": "test",
+              "num": 123,
+              "float": 1.2,
+              "bool": true,
+              "null": "",
+              "document": {"foo": false},
+              "list": ["myname", 321, 1.3, true, "", {"nested": true}, [200, ""]]
+          }
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"parentDocument\": {\"str\": \"test\", \"num\": 123, \"float\": 1.2, \"bool\": true, \"null\": \"\", \"document\": {\"foo\": false}, \"list\": [\"myname\", 321, 1.3, true, \"\", {\"nested\": true}, [200, \"\"]]}}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "parentDocument": [
+              "test",
+              123,
+              1.2,
+              true,
+              "",
+              {"str": "myname", "num": 321, "float": 1.3, "bool": true, "null": "", "document": {"nested": true}, "list": [200, ""]},
+              ["foo", false]
+          ]
+        },
+        "serialized": {
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/",
+          "body": "{\"parentDocument\": [\"test\", 123, 1.2, true, \"\", {\"str\": \"myname\", \"num\": 321, \"float\": 1.3, \"bool\": true, \"null\": \"\", \"document\": {\"nested\": true}, \"list\": [200, \"\"]}, [\"foo\", false]]}"
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -1476,5 +1476,242 @@
         }
       }
     ]
+  },
+  {
+    "description": "Serializes document with standalone primitive as part of the JSON request payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "documentValue": {
+            "shape": "DocumentType"
+          }
+        }
+      },
+      "DocumentType": {
+        "type": "structure",
+        "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": "foo"
+        },
+        "serialized": {
+          "body": "{\"documentValue\": \"foo\"}",
+          "uri": "/InlineDocument"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": 123
+        },
+        "serialized": {
+          "body": "{\"documentValue\": 123}",
+          "uri": "/InlineDocument"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": 1.2
+        },
+        "serialized": {
+          "body": "{\"documentValue\": 1.2}",
+          "uri": "/InlineDocument"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": true
+        },
+        "serialized": {
+          "body": "{\"documentValue\": true}",
+          "uri": "/InlineDocument"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": ""
+        },
+        "serialized": {
+          "body": "{\"documentValue\": \"\"}",
+          "uri": "/InlineDocument"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes inline documents as part of the JSON request payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "documentValue": {
+            "shape": "DocumentType"
+          }
+        }
+      },
+      "DocumentType": {
+        "type": "structure",
+        "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": {"foo": "bar"}
+        },
+        "serialized": {
+          "body": "{\"documentValue\": {\"foo\": \"bar\"}}",
+          "uri": "/InlineDocument"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes aggregate documents as part of the JSON request payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "documentValue": {
+            "shape": "DocumentType"
+          }
+        }
+      },
+      "DocumentType": {
+        "type": "structure",
+        "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": {
+              "str": "test",
+              "num": 123,
+              "float": 1.2,
+              "bool": true,
+              "null": "",
+              "document": {"foo": false},
+              "list": ["myname", 321, 1.3, true, "", {"nested": true}, [200, ""]]
+          }
+        },
+        "serialized": {
+          "body": "{\"documentValue\": {\"str\": \"test\", \"num\": 123, \"float\": 1.2, \"bool\": true, \"null\": \"\", \"document\": {\"foo\": false}, \"list\": [\"myname\", 321, 1.3, true, \"\", {\"nested\": true}, [200, \"\"]]}}",
+          "uri": "/InlineDocument"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/InlineDocument"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "documentValue": [
+              "test",
+              123,
+              1.2,
+              true,
+              "",
+              {"str": "myname", "num": 321, "float": 1.3, "bool": true, "null": "", "document": {"nested": true}, "list": [200, ""]},
+              ["foo", false]
+          ]
+        },
+        "serialized": {
+          "body": "{\"documentValue\": [\"test\", 123, 1.2, true, \"\", {\"str\": \"myname\", \"num\": 321, \"float\": 1.3, \"bool\": true, \"null\": \"\", \"document\": {\"nested\": true}, \"list\": [200, \"\"]}, [\"foo\", false]]}",
+          "uri": "/InlineDocument"
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/protocols/output/json.json
+++ b/tests/unit/protocols/output/json.json
@@ -610,5 +610,215 @@
         }
       }
     ]
+  },
+  {
+    "description": "Serialize document with standalone primitive type in a JSON response",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "inlineDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": "foo"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": \"foo\"}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": 123
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": 123}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": 1.2
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": 1.2}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": true
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": true}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": \"\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serialize inline document in a JSON response",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "inlineDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": {"foo": "bar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": {\"foo\": \"bar\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serialize aggregate documents in a JSON response",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "parentDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "parentDocument": {
+              "str": "test",
+              "num": 123,
+              "float": 1.2,
+              "bool": true,
+              "null": "",
+              "document": {"foo": false},
+              "list": ["myname", 321, 1.3, true, "", {"nested": true}, [200, ""]]
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"parentDocument\": {\"str\": \"test\", \"num\": 123, \"float\": 1.2, \"bool\": true, \"null\": \"\", \"document\": {\"foo\": false}, \"list\": [\"myname\", 321, 1.3, true, \"\", {\"nested\": true}, [200, \"\"]]}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "parentDocument": [
+              "test",
+              123,
+              1.2,
+              true,
+              "",
+              {"str": "myname", "num": 321, "float": 1.3, "bool": true, "null": "", "document": {"nested": true}, "list": [200, ""]},
+              ["foo", false]
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"parentDocument\": [\"test\", 123, 1.2, true, \"\", {\"str\": \"myname\", \"num\": 321, \"float\": 1.3, \"bool\": true, \"null\": \"\", \"document\": {\"nested\": true}, \"list\": [200, \"\"]}, [\"foo\", false]]}"
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/protocols/output/rest-json.json
+++ b/tests/unit/protocols/output/rest-json.json
@@ -913,5 +913,218 @@
         }
       }
     ]
+  },
+  {
+    "description": "Serializes document with standalone primitive as part of the JSON response payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "documentValue": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": "foo"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": \"foo\"}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": 123
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": 123}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": 1.2
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": 1.2}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": true
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": true}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": \"\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes inline documents as part of the JSON response payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "documentValue": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": {"foo": "bar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": {\"foo\": \"bar\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes aggregate documents as part of the JSON response payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "documentValue": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": {
+              "str": "test",
+              "num": 123,
+              "float": 1.2,
+              "bool": true,
+              "null": "",
+              "document": {"foo": false},
+              "list": ["myname", 321, 1.3, true, "", {"nested": true}, [200, ""]]
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": {\"str\": \"test\", \"num\": 123, \"float\": 1.2, \"bool\": true, \"null\": \"\", \"document\": {\"foo\": false}, \"list\": [\"myname\", 321, 1.3, true, \"\", {\"nested\": true}, [200, \"\"]]}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": [
+              "test",
+              123,
+              1.2,
+              true,
+              "",
+              {"str": "myname", "num": 321, "float": 1.3, "bool": true, "null": "", "document": {"nested": true}, "list": [200, ""]},
+              ["foo", false]
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": [\"test\", 123, 1.2, true, \"\", {\"str\": \"myname\", \"num\": 321, \"float\": 1.3, \"bool\": true, \"null\": \"\", \"document\": {\"nested\": true}, \"list\": [200, \"\"]}, [\"foo\", false]]}"
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -143,6 +143,69 @@ class TestValidateJSONValueTrait(BaseTestValidate):
             ])
 
 
+class TestValidateDocumentType(BaseTestValidate):
+    def test_accepts_document_type_string(self):
+        self.shapes = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'inlineDocument': {
+                        'shape': 'DocumentType',
+                    }
+                }
+            },
+            'DocumentType': {
+                'type': 'structure',
+                'document': True
+            }
+        }
+        errors = self.get_validation_error_message(
+            given_shapes=self.shapes,
+            input_params={
+                'inlineDocument': {'data': [1, 2.3, '3',
+                                            {'foo': None}],
+                                   'unicode': u'\u2713'}
+            })
+        error_msg = errors.generate_report()
+        self.assertEqual(error_msg, '')
+
+
+    def test_validate_document_type_string(self):
+        self.shapes = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'inlineDocument': {
+                        'shape': 'DocumentType',
+                    }
+                }
+            },
+            'DocumentType': {
+                'type': 'structure',
+                'document': True
+            }
+        }
+
+        invalid_document = object()
+        self.assert_has_validation_errors(
+            given_shapes=self.shapes,
+            input_params={
+                'inlineDocument': {
+                    'number': complex(1j),
+                    'date': datetime(2017, 4, 27, 0, 0),
+                    'list': [invalid_document],
+                    'dict': {'foo': (1, 2, 3)}
+                }
+            },
+            errors=[
+                ('Invalid type for document parameter number'),
+                ('Invalid type for document parameter date'),
+                ('Invalid type for document parameter list[0]'),
+                ('Invalid type for document parameter foo'),
+            ])
+
+
+
 class TestValidateTypes(BaseTestValidate):
     def setUp(self):
         self.shapes = {


### PR DESCRIPTION
Introducing changes to handle document types. Enabling potential use of arbitrary JSON documents in request/response objects. Additional protocol testing included.