### PR TITLE
Revert "Bump CRT to 0.11.23"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ requires_dist =
     urllib3>=1.25.4,<1.27
 
 [options.extras_require]
-crt = awscrt==0.11.23
+crt = awscrt==0.11.15


### PR DESCRIPTION
Removing the upgrade from today's release while CRT works out some issues.