### PR TITLE
Bump CRT to 0.11.24

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ requires_dist =
     urllib3>=1.25.4,<1.27
 
 [options.extras_require]
-crt = awscrt==0.11.15
+crt = awscrt==0.11.24


### PR DESCRIPTION
Moving the version requirement for [AWSCRT](https://pypi.org/project/awscrt/) to 0.11.24