### PR TITLE
Drop support for Python 2.7

### DIFF
--- a/.changes/next-release/feature-Python-84589.json
+++ b/.changes/next-release/feature-Python-84589.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Python",
+  "description": "Dropped support for Python 2.7"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest ]
 
     steps:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,7 +44,7 @@ contributions as well:
 * Code should follow `pep 8 <https://www.python.org/dev/peps/pep-0008/>`__,
   although if you are modifying an existing module, it is more important
   for the code to be consistent if there are any discrepancies.
-* Code must work on ``python2.7``, and ``python3.6`` and higher.
+* Code must work on ``python3.6`` and higher.
 * Botocore is cross platform and code must work on at least linux, Windows,
   and Mac OS X.
 * If you would like to implement support for a significant feature that is not

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ botocore package is the foundation for the
 `AWS CLI <https://github.com/aws/aws-cli>`__ as well as
 `boto3 <https://github.com/boto/boto3>`__.
 
-On 01/15/2021 deprecation for Python 2.7 was announced and support will be dropped
+On 01/15/2021 deprecation for Python 2.7 was announced and support was dropped
 on 07/15/2021. To avoid disruption, customers using Botocore on Python 2.7 may
 need to upgrade their version of Python or pin the version of Botocore. For
 more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -783,7 +783,7 @@ def datetime2timestamp(dt, default_timezone=None):
         dt = dt.replace(tzinfo=default_timezone)
     d = dt.replace(tzinfo=None) - dt.utcoffset() - epoch
     if hasattr(d, "total_seconds"):
-        return d.total_seconds()  # Works in Python 2.7+
+        return d.total_seconds()  # Works in Python 3.6+
     return (d.microseconds + (d.seconds + d.days * 24 * 3600) * 10**6) / 10**6
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,8 @@ Services.  Botocore serves as the foundation for the
 `AWS-CLI <https://github.com/aws/aws-cli/>`_ command line utilities.
 It will also play an important role in the boto3.x project.
 
-The botocore package is compatible with Python versions Python 2.7,
-Python 3.4 and higher.
+The botocore package is compatible with Python versions Python 3.6
+and higher.
 
 
 Contents:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal = 1
+universal = 0
 
 [metadata]
 requires_dist =

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     license="Apache License 2.0",
-    python_requires=">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+    python_requires=">= 3.6",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -52,8 +52,6 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38
+envlist = py36,py37,py38
 
 skipsdist = True
 


### PR DESCRIPTION
As announced in our [blog post](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/) in January, and in warning messages since Botocore 1.20.0, we will be formally dropping support for Python 2.7 on July 15, 2021. This PR will make final changes required to remove references to Python 2.7, update testing infrastructure, and wheel generation settings.

For those looking to continue receiving updates after the deprecation date, we recommend following the instructions in our [blog post](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/) to upgrade to Python 3.6 or later.