### PR TITLE
Updating IMDS with new IPv6 specs

### DIFF
--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -75,10 +75,14 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         'ec2_metadata_service_endpoint',
         'AWS_EC2_METADATA_SERVICE_ENDPOINT',
         None, None),
+    'ec2_metadata_service_endpoint_mode': (
+        'ec2_metadata_service_endpoint_mode',
+        'AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE',
+        None, None),
     'imds_use_ipv6': (
         'imds_use_ipv6',
         'AWS_IMDS_USE_IPV6',
-        False, None),
+        False, utils.ensure_boolean),
     'parameter_validation': ('parameter_validation', None, True, None),
     # Client side monitoring configurations.
     # Note: These configurations are considered internal to botocore.

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -45,6 +45,7 @@ from botocore.utils import InstanceMetadataFetcher, parse_key_val_file
 from botocore.utils import ContainerMetadataFetcher
 from botocore.utils import FileWebIdentityTokenLoader
 from botocore.utils import SSOTokenLoader
+from botocore.utils import resolve_imds_endpoint_mode
 
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,8 @@ def create_credential_resolver(session, cache=None, region_name=None):
     imds_config = {
         'ec2_metadata_service_endpoint': session.get_config_variable(
             'ec2_metadata_service_endpoint'),
-        'imds_use_ipv6': session.get_config_variable('imds_use_ipv6')
+        'ec2_metadata_service_endpoint_mode': resolve_imds_endpoint_mode(
+            session)
     }
 
     if cache is None:

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -96,6 +96,11 @@ class InvalidIMDSEndpointError(BotoCoreError):
     fmt = 'Invalid endpoint EC2 Instance Metadata endpoint: {endpoint}'
 
 
+class InvalidIMDSEndpointModeError(BotoCoreError):
+    fmt = ('Invalid EC2 Instance Metadata endpoint mode: {mode}'
+        ' Valid endpoint modes (case-insensitive): {valid_modes}.')
+
+
 class EndpointConnectionError(ConnectionError):
     fmt = 'Could not connect to the endpoint URL: "{endpoint_url}"'
 


### PR DESCRIPTION
Adding additional envvar `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` to configure IMDS between IPv4 and IPv6. Remapping to `AWS_IMDS_USE_IPV6` to use the new envvar. Furthermore, updating IMDS IPv6 default address from link local to unique local address