### PR TITLE
Made it possible to specify UNSIGNED using a string

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -63,15 +63,7 @@ BOTOCORE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 # Used to specify anonymous (unsigned) request signature
-class UNSIGNED(object):
-    def __copy__(self):
-        return self
-
-    def __deepcopy__(self, memodict):
-        return self
-
-
-UNSIGNED = UNSIGNED()
+UNSIGNED = "unsigned"
 
 
 def xform_name(name, sep='_', _xform_cache=_xform_cache):


### PR DESCRIPTION
This fixes some incorrect type signatures and makes botocore easier to use in CLIs and other libraries that deal with non-Python input.

Fixes https://github.com/boto/botocore/issues/2442