### PR TITLE
Cache event_name aliases for EventAliaser

### DIFF
--- a/.changes/next-release/enchancement-Client-18622.json
+++ b/.changes/next-release/enchancement-Client-18622.json
@@ -1,0 +1,5 @@
+{
+  "type": "enchancement",
+  "category": "Client",
+  "description": "Improve client performance by caching _alias_event_name on EventAliaser"
+}

--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -349,6 +349,7 @@ class EventAliaser(BaseEventHooks):
         self._event_aliases = event_aliases
         if event_aliases is None:
             self._event_aliases = EVENT_ALIASES
+        self._alias_name_cache = {}
         self._emitter = event_emitter
 
     def emit(self, event_name, **kwargs):
@@ -388,6 +389,9 @@ class EventAliaser(BaseEventHooks):
         )
 
     def _alias_event_name(self, event_name):
+        if event_name in self._alias_name_cache:
+            return self._alias_name_cache[event_name]
+
         for old_part, new_part in self._event_aliases.items():
 
             # We can't simply do a string replace for everything, otherwise we
@@ -416,7 +420,10 @@ class EventAliaser(BaseEventHooks):
             logger.debug("Changing event name from %s to %s" % (
                 event_name, new_name
             ))
+            self._alias_name_cache[event_name] = new_name
             return new_name
+
+        self._alias_name_cache[event_name] = event_name
         return event_name
 
     def _replace_subsection(self, sections, old_parts, new_part):


### PR DESCRIPTION
When performing calls with a client in Boto3/Botocore, we spend a non-trivial amount of time in our Event system determining if a given event_name has a required alias to function correctly. This data structure iteration is performed with every call a client makes, accounting for a significant portion the runtime in low or no network latency workflows. The case where it's most noticeable is with `generate_presigned_url` which can be performed entirely without network I/O.

This patch proposes a simplified alternative to #1956. The goal of this change is to avoid known memory leaks when using the `lru_cache` decorator on class methods which requires the cache to keep a reference to each class instantiation. We'd encourage customers interested in seeing some of the performance benefits in #1956 to test this patch and leave feedback on if it satisfies your current use cases.