### PR TITLE
fix-credential-process-without-stdin

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -980,6 +980,7 @@ class ProcessProvider(CredentialProvider):
         # command and all arguments as a list.
         process_list = compat_shell_split(credential_process)
         p = self._popen(process_list,
+                        stdin=subprocess.PIPE,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()


### PR DESCRIPTION
in the ProcessProvider class, the _retrieve_credentials_using method uses the self._popen to open a subprocess. If there is no stdin attached to currently running program, then this call can result in an "handle is invalid" error on Windows. Adding the parameter stdin=subprocess.PIPE fixes the issue for this case.