### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest ]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import codecs
 import os.path
 import re
-import sys
 
 from setuptools import setup, find_packages
 
@@ -56,5 +55,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 
 skipsdist = True
 


### PR DESCRIPTION
Add support for Python 3.9, released October 2020.

---

And a heads-up, nose is unmaintained (last release 1.3.7 was in 2015) and will stop working in Python 3.10 (to be released October 2021 and available on GHA as `3.10-dev`) due to:

> Remove deprecated aliases to Collections Abstract Base Classes from the `collections` module. 

https://docs.python.org/3.10/whatsnew/3.10.html#removed