### PR TITLE
Return generic error response for errors with non-xml bodies

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -281,7 +281,11 @@ class ResponseParser(object):
                 return True
 
             body = response['body'].strip()
-            return body.startswith(b'<html>') or not body
+            return (
+                body.startswith(b"<html>")
+                or not body.startswith(b"<")
+                or not body
+            )
 
     def _do_generic_error_parse(self, response):
         # There's not really much we can do when we get a generic

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1308,9 +1308,11 @@ def test_can_handle_generic_error_message():
         generic_html_body =  (
             '<html><body><b>Http/1.1 Service Unavailable</b></body></html>'
         ).encode('utf-8')
+        generic_string_body = "Not HTML or XML".encode("utf-8")
         empty_body = b''
         none_body = None
         yield _assert_parses_generic_error, parser_cls(), generic_html_body
+        yield _assert_parses_generic_error, parser_cls(), generic_string_body
         yield _assert_parses_generic_error, parser_cls(), empty_body
         yield _assert_parses_generic_error, parser_cls(), none_body
 


### PR DESCRIPTION
Some proxies may return a custom response in the HTTP body when
encountering an error response such as an HTTP/503.

Currently we assume that any error response with a body that does not
begin with "<html>" is XML which can lead to unhandled ResponseParserError
errors on proxies with custom body responses for things like a transient timeout.

Lets expand what we consider a "generic" error to include responses whose
body is not XML by ensuring it must start with a leading "<".
`
The other implementation option is to handle ResponseParserErrors in
botocore.parsers.QueryParser._do_error_parse and return _do_generic_error_parse
instead which I'd be happy to implement instead of preferred 