### PR TITLE
revamp the stale issue bot.

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -10,19 +10,27 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v3
+    - uses: aws-actions/stale-issue-cleanup@v4
       with:
-        # Setting messages to an empty string will cause the automation to skip
-        # that category
-        ancient-issue-message: Greetings! It looks like this issue hasn’t been active in longer than one year. We encourage you to check if this is still an issue in the latest release. Because it has been longer than one year since the last update on this, and in the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment to prevent automatic closure, or if the issue is already closed, please feel free to reopen it.
-        stale-issue-message: Greetings! It looks like this issue hasn’t been active in longer than a week. We encourage you to check if this is still an issue in the latest release. Because it has been longer than a week since the last update on this, and in the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment or add an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
-        stale-pr-message: Greetings! It looks like this PR hasn’t been active in longer than a week, add a comment or an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
+        issue-types: issues
+        ancient-issue-message: Greetings! It looks like this issue hasn’t been 
+          active in longer than one year. We encourage you to check if this is 
+          still an issue in the latest release. Because it has been longer 
+          than one year since the last update on this, we will be closing this 
+          issue soon. If you find that this is still a problem, please feel 
+          free to provide a comment to prevent automatic closure, or if the 
+          issue is already closed, please feel free to open a new one.
+        stale-issue-message: Greetings! It looks like this issue hasn’t been 
+          active in longer than a week. We encourage you to check if this is 
+          still an issue in the latest release. Because it has been longer than 
+          a week since the last update on this, we will be closing this issue soon.
+          If you find that this is still a problem, please feel free to provide a 
+          comment or add an upvote to prevent automatic closure, or if the issue 
+          is already closed, please feel free to open a new one.
 
         # These labels are required
         stale-issue-label: closing-soon
-        exempt-issue-label: auto-label-exempt
-        stale-pr-label: closing-soon
-        exempt-pr-label: pr/needs-review,auto-label-exempt
+        exempt-issue-labels: automation-exempt,needs-review,bug
         response-requested-label: response-requested
 
         # Don't set closed-for-staleness label to skip closing very old issues
@@ -33,13 +41,12 @@ jobs:
         days-before-stale: 7
         days-before-close: 4
         days-before-ancient: 365
+
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is
         # the total number of +1, heart, hooray, and rocket reactions
         # on an issue.
-        minimum-upvotes-to-exempt: 1
+        minimum-upvotes-to-exempt: 2
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
-        # Set dry-run to true to not perform label or close actions.
-        # dry-run: true


### PR DESCRIPTION
Changes:

- Bumps the version to v4
- removes PRs from automatically closing
- Minor wording changes and formatting to messages
- Adjust labels in use: standardizing on `automation-exempt` instead of `auto-label-exempt`, add `needs-review` and `bug` to exemption list.
- Bump up minimum votes to 2