### PR TITLE
Temporarily skip proxy test due to CodeBuild issues

### DIFF
--- a/tests/integration/test_client_http.py
+++ b/tests/integration/test_client_http.py
@@ -45,6 +45,7 @@ class TestClientHTTPBehavior(unittest.TestCase):
         except BackgroundTaskFailed:
             self.fail('Background task did not exit, proxy was not used.')
 
+    @unittest.skip('Proxy cannot connect to service when run in CodeBuild.')
     def test_proxy_request_includes_host_header(self):
         proxy_url = 'http://user:pass@localhost:%s/' % self.port
         config = Config(


### PR DESCRIPTION
Disabling proxy test due to platform issues with CONNECT tunneling. Will revisit with alternative testing options for all platforms as this works outside of container based environments.