### PR TITLE
Tagged Union Support

### DIFF
--- a/.changes/next-release/enhancement-TaggedUnions-30097.json
+++ b/.changes/next-release/enhancement-TaggedUnions-30097.json
@@ -1,0 +1,5 @@
+{
+  "category": "Tagged Unions", 
+  "type": "enhancement", 
+  "description": "Introducing support for the `union` trait on structures in request and response objects."
+}

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -141,6 +141,28 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
         documentation_section = section.add_new_section('param-documentation')
         if shape.documentation:
             documentation_section.style.indent()
+            if getattr(shape, 'is_tagged_union', False):
+                tagged_union_docs = section.add_new_section(
+                    'param-tagged-union-docs'
+                )
+                note = (
+                    '.. note::'
+                    '    This is a Tagged Union structure. Only one of the '
+                    '    following top level keys will be set: %s. '
+                    '    If a client receives an unknown member it will '
+                    '    set ``SDK_UNKNOWN_MEMBER`` as the top level key, '
+                    '    which maps to the name or tag of the unknown '
+                    '    member. The structure of ``SDK_UNKNOWN_MEMBER`` is '
+                    '    as follows'
+                )
+                tagged_union_members_str = ', '.join(
+                    ['``%s``' % key for key in shape.members.keys()]
+                )
+                unknown_code_example = ('\'SDK_UNKNOWN_MEMBER\': '
+                                        '{\'name\': \'UnknownMemberName\'}')
+                tagged_union_docs.write(note % (tagged_union_members_str))
+                example = section.add_new_section('param-unknown-example')
+                example.style.codeblock(unknown_code_example)
             documentation_section.include_doc_string(shape.documentation)
         section.style.new_paragraph()
 
@@ -206,6 +228,19 @@ class RequestParamsDocumenter(BaseParamsDocumenter):
             documentation_section = section.add_new_section(
                 'param-documentation')
             documentation_section.style.indent()
+            if getattr(shape, 'is_tagged_union', False):
+                tagged_union_docs = section.add_new_section(
+                    'param-tagged-union-docs'
+                )
+                note = (
+                    '.. note::'
+                    '    This is a Tagged Union structure. Only one of the '
+                    '    following top level keys can be set: %s. '
+                )
+                tagged_union_members_str = ', '.join(
+                    ['``%s``' % key for key in shape.members.keys()]
+                )
+                tagged_union_docs.write(note % (tagged_union_members_str))
             documentation_section.include_doc_string(shape.documentation)
             self._add_special_trait_documentation(documentation_section, shape)
         end_param_section = section.add_new_section('end-param')

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -56,7 +56,7 @@ class Shape(object):
                         'jsonvalue', 'timestampFormat', 'hostLabel']
     METADATA_ATTRS = ['required', 'min', 'max', 'sensitive', 'enum',
                       'idempotencyToken', 'error', 'exception',
-                      'endpointdiscoveryid', 'retryable', 'document']
+                      'endpointdiscoveryid', 'retryable', 'document', 'union']
     MAP_TYPE = OrderedDict
 
     def __init__(self, shape_name, shape_model, shape_resolver=None):
@@ -139,6 +139,7 @@ class Shape(object):
             * required
             * idempotencyToken
             * document
+            * union
 
         :rtype: dict
         :return: Metadata about the shape.
@@ -210,6 +211,10 @@ class StructureShape(Shape):
     @CachedProperty
     def is_document_type(self):
         return self.metadata.get('document', False)
+
+    @CachedProperty
+    def is_tagged_union(self):
+        return self.metadata.get('union', False)
 
 
 class ListShape(Shape):

--- a/tests/functional/test_tagged_unions_unknown.py
+++ b/tests/functional/test_tagged_unions_unknown.py
@@ -1,0 +1,29 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.session import Session
+from tests import unittest
+
+
+class TestTaggedUnionsUnknown(unittest.TestCase):
+    def test_tagged_union_member_name_does_not_coincide_with_unknown_key(self):
+        # This test ensures that operation models do not use SDK_UNKNOWN_MEMBER
+        # as a member name. Thereby reserving SDK_UNKNOWN_MEMBER for the parser to
+        # set as a key on the reponse object. This is necessary when the client
+        # encounters a member that it is unaware of or not modeled.
+        session = Session()
+        for service_name in session.get_available_services():
+            service_model = session.get_service_model(service_name)
+            for shape_name in service_model.shape_names:
+                shape = service_model.shape_for(shape_name)
+                if hasattr(shape, 'is_tagged_union') and shape.is_tagged_union:
+                    self.assertNotIn('SDK_UNKNOWN_MEMBER', shape.members)

--- a/tests/unit/protocols/output/rest-json.json
+++ b/tests/unit/protocols/output/rest-json.json
@@ -1126,5 +1126,88 @@
         }
       }
     ]
-  }
+  },
+    {
+        "description": "Tagged Unions",
+        "metadata": {
+            "protocol": "rest-json"
+        },
+        "shapes": {
+            "OutputShape": {
+                "type": "structure",
+                "members": {
+                    "UnionMember": {
+                        "shape": "UnionType"
+                    }
+                }
+            },
+            "UnionType": {
+                "type": "structure",
+                "members": {
+                    "S":{"shape":"StringType"},
+                    "L": {"shape": "ListType"}
+                },
+                "union": true
+            },
+            "ListType": {
+                "type": "list",
+                "member": {
+                    "shape": "StringType"
+                }
+            },
+            "StringType": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "given": {
+                    "output": {
+                        "shape": "OutputShape"
+                    },
+                    "name": "OperationName"
+                },
+                "result": {
+                    "UnionMember": {"S":  "mystring"}
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {},
+                    "body": "{\"UnionMember\": {\"S\": \"mystring\"}}"
+                }
+            },
+            {
+                "given": {
+                    "output": {
+                        "shape": "OutputShape"
+                    },
+                    "name": "OperationName"
+                },
+                "result": {
+                    "UnionMember": {"L":  ["a", "b"]}
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {},
+                    "body": "{\"UnionMember\": {\"L\": [\"a\", \"b\"]}}"
+                }
+            },
+            {
+                "given": {
+                    "output": {
+                        "shape": "OutputShape"
+                    },
+                    "name": "OperationName"
+                },
+                "result": {
+                    "UnionMember": {"SDK_UNKNOWN_MEMBER":  {"name": "SomeUnknownMember"}}
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {},
+                    "body": "{\"UnionMember\": {\"SomeUnknownMember\": \"foo\"}}"
+                }
+            }
+        ]
+    }
 ]

--- a/tests/unit/protocols/output/rest-xml.json
+++ b/tests/unit/protocols/output/rest-xml.json
@@ -1138,5 +1138,88 @@
         }
       }
     ]
+  },
+  {
+      "description": "Unions",
+      "metadata": {
+          "protocol": "rest-xml"
+      },
+      "shapes": {
+          "OutputShape": {
+              "type": "structure",
+              "members": {
+                  "UnionMember": {
+                      "shape": "UnionType"
+                  }
+              }
+          },
+          "UnionType": {
+              "type": "structure",
+              "members": {
+                  "S":{"shape":"StringType"},
+                  "L": {"shape": "ListType"}
+              },
+              "union": true
+          },
+          "ListType": {
+              "type": "list",
+              "member": {
+                  "shape": "StringType"
+              }
+          },
+          "StringType": {
+              "type": "string"
+          }
+      },
+      "cases": [
+          {
+              "given": {
+                  "output": {
+                      "shape": "OutputShape"
+                  },
+                  "name": "OperationName"
+              },
+              "result": {
+                  "UnionMember": {"S":  "string value"}
+              },
+              "response": {
+                  "status_code": 200,
+                  "headers": {},
+                  "body": "<OperationNameResponse><UnionMember><S>string value</S></UnionMember></OperationNameResponse>"
+              }
+          },
+          {
+              "given": {
+                  "output": {
+                      "shape": "OutputShape"
+                  },
+                  "name": "OperationName"
+              },
+              "result": {
+                  "UnionMember": {"L":  ["a", "b"]}
+              },
+              "response": {
+                  "status_code": 200,
+                  "headers": {},
+                  "body": "<OperationNameResponse><UnionMember><L><member>a</member><member>b</member></L></UnionMember></OperationNameResponse>"
+              }
+          },
+          {
+              "given": {
+                  "output": {
+                      "shape": "OutputShape"
+                  },
+                  "name": "OperationName"
+              },
+              "result": {
+                  "UnionMember": {"SDK_UNKNOWN_MEMBER":  {"name": "SomeUnknownMember"}}
+              },
+              "response": {
+                  "status_code": 200,
+                  "headers": {},
+                  "body": "<OperationNameResponse><UnionMember><SomeUnknownMember>foo</SomeUnknownMember></UnionMember></OperationNameResponse>"
+              }
+          }
+      ]
   }
 ]

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -205,6 +205,129 @@ class TestValidateDocumentType(BaseTestValidate):
             ])
 
 
+class TestValidateTaggedUnion(BaseTestValidate):
+    def test_accepts_one_member(self):
+        self.shapes = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'taggedUnion': {
+                        'shape': 'TaggedUnionType',
+                    }
+                }
+            },
+            'TaggedUnionType': {
+                'type': 'structure',
+                'union': True,
+                'members': {
+                    'Foo': {'shape': 'StringType'},
+                    'Bar': {'shape': 'StringType'},
+                }
+            },
+            'StringType': {'type': 'string'}
+        }
+        errors = self.get_validation_error_message(
+            given_shapes=self.shapes,
+            input_params={
+                'taggedUnion': {'Foo': "mystring"}
+            }
+        )
+        error_msg = errors.generate_report()
+        self.assertEqual(error_msg, '')
+
+
+    def test_validate_one_member_is_set(self):
+        self.shapes = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'taggedUnion': {
+                        'shape': 'TaggedUnionType',
+                    }
+                }
+            },
+            'TaggedUnionType': {
+                'type': 'structure',
+                'union': True,
+                'members': {
+                    'Foo': {'shape': 'StringType'},
+                    'Bar': {'shape': 'StringType'},
+                }
+            },
+            'StringType': {'type': 'string'}
+        }
+        errors = self.get_validation_error_message(
+            given_shapes=self.shapes,
+            input_params={
+                'taggedUnion': {'Foo': "mystring",
+                                'Bar': "mystring2"
+                                }
+            }
+        )
+        error_msg = errors.generate_report()
+        self.assertIn(
+            'Invalid number of parameters set for tagged union structure',
+            error_msg
+        )
+
+    def test_validate_known_member_is_set(self):
+        self.shapes = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'taggedUnion': {
+                        'shape': 'TaggedUnionType',
+                    }
+                }
+            },
+            'TaggedUnionType': {
+                'type': 'structure',
+                'union': True,
+                'members': {
+                    'Foo': {'shape': 'StringType'},
+                    'Bar': {'shape': 'StringType'},
+                }
+            },
+            'StringType': {'type': 'string'}
+        }
+        errors = self.get_validation_error_message(
+            given_shapes=self.shapes,
+            input_params={
+                'taggedUnion': {'unknown': "mystring"}
+            }
+        )
+        error_msg = errors.generate_report()
+        self.assertIn('Unknown parameter in taggedUnion', error_msg)
+
+    def test_validate_structure_is_not_empty(self):
+        self.shapes = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'taggedUnion': {
+                        'shape': 'TaggedUnionType',
+                    }
+                }
+            },
+            'TaggedUnionType': {
+                'type': 'structure',
+                'union': True,
+                'members': {
+                    'Foo': {'shape': 'StringType'},
+                    'Bar': {'shape': 'StringType'},
+                }
+            },
+            'StringType': {'type': 'string'}
+        }
+        errors = self.get_validation_error_message(
+            given_shapes=self.shapes,
+            input_params={
+                'taggedUnion': {}
+            }
+        )
+        error_msg = errors.generate_report()
+        self.assertIn('Must set one of the following keys', error_msg)
+
 
 class TestValidateTypes(BaseTestValidate):
     def setUp(self):


### PR DESCRIPTION
Introducing support of the `union` trait on structures. Following additions made:
- Input validation that checks that only one member is set on a Tagged Union structure.
- If a client receives an unknown member it will set `SDK_UNKNOWN_MEMBER` as the top level key, which maps to the name or tag of the unknown member.