### PR TITLE
Move to pytest

### DIFF
--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -96,10 +96,13 @@ def document_custom_signature(section, name, method,
     :param exclude: The names of the parameters to exclude from
         documentation.
     """
-    args, varargs, keywords, defaults = inspect.getargspec(method)
-    args = args[1:]
+    argspec = inspect.getfullargspec(method)
     signature_params = inspect.formatargspec(
-        args, varargs, keywords, defaults)
+        args=argspec.args[1:],
+        varargs=argspec.varargs,
+        varkw=argspec.varkw,
+        defaults=argspec.defaults
+    )
     signature_params = signature_params.lstrip('(')
     signature_params = signature_params.rstrip(')')
     section.style.start_sphinx_py_method(name, signature_params)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -380,7 +380,9 @@ class IMDSFetcher(object):
         custom_metadata_endpoint = config.get('ec2_metadata_service_endpoint')
 
         if requires_ipv6 and custom_metadata_endpoint:
-            logger.warn("Custom endpoint and IMDS_USE_IPV6 are both set. Using custom endpoint.")
+            logger.warning(
+                "Custom endpoint and IMDS_USE_IPV6 are both set. Using custom endpoint."
+            )
 
         chosen_base_url = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+]

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -33,10 +33,7 @@ def process_args(args):
     runner = args.test_runner
     test_args = ""
     if args.with_cov:
-        test_args += (
-            f"--with-xunit --cover-erase --with-coverage "
-            f"--cover-package {PACKAGE} --cover-xml -v "
-        )
+        test_args += f"--cov={PACKAGE} --cov-report xml "
     dirs = " ".join(args.test_dirs)
 
     return runner, test_args, dirs
@@ -53,8 +50,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-r",
         "--test-runner",
-        default="nosetests",
-        help="Test runner to execute tests. Defaults to nose.",
+        default="pytest",
+        help="Test runner to execute tests. Defaults to pytest.",
     )
     parser.add_argument(
         "-c",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,7 +28,6 @@ from io import BytesIO
 from subprocess import Popen, PIPE
 
 from dateutil.tz import tzlocal
-from nose.tools import assert_equal
 
 import botocore.loaders
 import botocore.session
@@ -354,16 +353,16 @@ def assert_url_equal(url1, url2):
 
     # Because the query string ordering isn't relevant, we have to parse
     # every single part manually and then handle the query string.
-    assert_equal(parts1.scheme, parts2.scheme)
-    assert_equal(parts1.netloc, parts2.netloc)
-    assert_equal(parts1.path, parts2.path)
-    assert_equal(parts1.params, parts2.params)
-    assert_equal(parts1.fragment, parts2.fragment)
-    assert_equal(parts1.username, parts2.username)
-    assert_equal(parts1.password, parts2.password)
-    assert_equal(parts1.hostname, parts2.hostname)
-    assert_equal(parts1.port, parts2.port)
-    assert_equal(parse_qs(parts1.query), parse_qs(parts2.query))
+    assert parts1.scheme == parts2.scheme
+    assert parts1.netloc == parts2.netloc
+    assert parts1.path == parts2.path
+    assert parts1.params == parts2.params
+    assert parts1.fragment == parts2.fragment
+    assert parts1.username == parts2.username
+    assert parts1.password == parts2.password
+    assert parts1.hostname == parts2.hostname
+    assert parts1.port == parts2.port
+    assert parse_qs(parts1.query) == parse_qs(parts2.query)
 
 
 class HTTPStubberException(Exception):

--- a/tests/acceptance/features/steps/base.py
+++ b/tests/acceptance/features/steps/base.py
@@ -4,7 +4,6 @@ from botocore import xform_name
 from botocore.exceptions import ClientError
 
 from behave import when, then
-from nose.tools import assert_equal
 
 
 def _params_from_table(table):
@@ -72,7 +71,7 @@ def api_call_with_json_and_error(context, operation):
 
 @then(u'I expect the response error code to be "{}"')
 def then_expected_error(context, code):
-    assert_equal(context.error_response.response['Error']['Code'], code)
+    assert context.error_response.response['Error']['Code'] == code
 
 
 @then(u'the value at "{}" should be a list')

--- a/tests/functional/docs/test_shared_example_config.py
+++ b/tests/functional/docs/test_shared_example_config.py
@@ -10,12 +10,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.model import OperationNotFoundError
 from botocore.utils import parse_timestamp
 
 
-def test_lint_shared_example_configs():
+def _shared_example_configs():
     session = botocore.session.Session()
     loader = session.get_component('data_loader')
     services = loader.list_available_services('examples-1')
@@ -27,10 +29,14 @@ def test_lint_shared_example_configs():
         examples = example_config.get("examples", {})
         for operation, operation_examples in examples.items():
             for example in operation_examples:
-                yield _lint_single_example, operation, example, service_model
+                yield operation, example, service_model
 
 
-def _lint_single_example(operation_name, example_config, service_model):
+@pytest.mark.parametrize(
+    "operation_name, example_config, service_model",
+    _shared_example_configs()
+)
+def test_lint_shared_example_configs(operation_name, example_config, service_model):
     # The operation should actually exist
     assert_operation_exists(service_model, operation_name)
     operation_model = service_model.operation_model(operation_name)

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.stub import Stubber
 from botocore.exceptions import ParamValidationError
@@ -46,16 +48,16 @@ ALIAS_CASES = [
 ]
 
 
-def test_can_use_alias():
+@pytest.mark.parametrize("case", ALIAS_CASES)
+def test_can_use_alias(case):
     session = botocore.session.get_session()
-    for case in ALIAS_CASES:
-        yield _can_use_parameter_in_client_call, session, case
+    _can_use_parameter_in_client_call(session, case)
 
 
-def test_can_use_original_name():
+@pytest.mark.parametrize("case", ALIAS_CASES)
+def test_can_use_original_name(case):
     session = botocore.session.get_session()
-    for case in ALIAS_CASES:
-        yield _can_use_parameter_in_client_call, session, case, False
+    _can_use_parameter_in_client_call(session, case, False)
 
 
 def _can_use_parameter_in_client_call(session, case, use_alias=True):

--- a/tests/functional/test_client_class_names.py
+++ b/tests/functional/test_client_class_names.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from nose.tools import assert_equal
+import pytest
 
 import botocore.session
 
@@ -68,14 +68,8 @@ SERVICE_TO_CLASS_NAME = {
     'workspaces': 'WorkSpaces'
 }
 
-
-def test_client_has_correct_class_name():
+@pytest.mark.parametrize("service_name", SERVICE_TO_CLASS_NAME)
+def test_client_has_correct_class_name(service_name):
     session = botocore.session.get_session()
-    for service_name in SERVICE_TO_CLASS_NAME:
-        client = session.create_client(service_name, REGION)
-        yield (_assert_class_name_matches_ref_class_name, client,
-               SERVICE_TO_CLASS_NAME[service_name])
-
-
-def _assert_class_name_matches_ref_class_name(client, ref_class_name):
-    assert_equal(client.__class__.__name__, ref_class_name)
+    client = session.create_client(service_name, REGION)
+    assert client.__class__.__name__ == SERVICE_TO_CLASS_NAME[service_name]

--- a/tests/functional/test_cognito_idp.py
+++ b/tests/functional/test_cognito_idp.py
@@ -10,77 +10,78 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from nose.tools import assert_false
+import pytest
 
 from tests import create_session, mock, ClientHTTPStubber
 
 
-def test_unsigned_operations():
-    operation_params = {
-        'change_password': {
-            'PreviousPassword': 'myoldbadpassword',
-            'ProposedPassword': 'mynewgoodpassword',
-            'AccessToken': 'foobar'
-        },
-        'confirm_forgot_password': {
-            'ClientId': 'foo',
-            'Username': 'myusername',
-            'ConfirmationCode': 'thisismeforreal',
-            'Password': 'whydowesendpasswordsviaemail'
-        },
-        'confirm_sign_up': {
-            'ClientId': 'foo',
-            'Username': 'myusername',
-            'ConfirmationCode': 'ireallydowanttosignup'
-        },
-        'delete_user': {
-            'AccessToken': 'foobar'
-        },
-        'delete_user_attributes': {
-            'UserAttributeNames': ['myattribute'],
-            'AccessToken': 'foobar'
-        },
-        'forgot_password': {
-            'ClientId': 'foo',
-            'Username': 'myusername'
-        },
-        'get_user': {
-            'AccessToken': 'foobar'
-        },
-        'get_user_attribute_verification_code': {
-            'AttributeName': 'myattribute',
-            'AccessToken': 'foobar'
-        },
-        'resend_confirmation_code': {
-            'ClientId': 'foo',
-            'Username': 'myusername'
-        },
-        'set_user_settings': {
-            'AccessToken': 'randomtoken',
-            'MFAOptions': [{
-                'DeliveryMedium': 'SMS',
-                'AttributeName': 'someattributename'
-            }]
-        },
-        'sign_up': {
-            'ClientId': 'foo',
-            'Username': 'bar',
-            'Password': 'mysupersecurepassword',
-        },
-        'update_user_attributes': {
-            'UserAttributes': [{
-                'Name': 'someattributename',
-                'Value': 'newvalue'
-            }],
-            'AccessToken': 'foobar'
-        },
-        'verify_user_attribute': {
-            'AttributeName': 'someattributename',
-            'Code': 'someverificationcode',
-            'AccessToken': 'foobar'
-        },
-    }
+OPERATION_PARAMS = {
+    'change_password': {
+        'PreviousPassword': 'myoldbadpassword',
+        'ProposedPassword': 'mynewgoodpassword',
+        'AccessToken': 'foobar'
+    },
+    'confirm_forgot_password': {
+        'ClientId': 'foo',
+        'Username': 'myusername',
+        'ConfirmationCode': 'thisismeforreal',
+        'Password': 'whydowesendpasswordsviaemail'
+    },
+    'confirm_sign_up': {
+        'ClientId': 'foo',
+        'Username': 'myusername',
+        'ConfirmationCode': 'ireallydowanttosignup'
+    },
+    'delete_user': {
+        'AccessToken': 'foobar'
+    },
+    'delete_user_attributes': {
+        'UserAttributeNames': ['myattribute'],
+        'AccessToken': 'foobar'
+    },
+    'forgot_password': {
+        'ClientId': 'foo',
+        'Username': 'myusername'
+    },
+    'get_user': {
+        'AccessToken': 'foobar'
+    },
+    'get_user_attribute_verification_code': {
+        'AttributeName': 'myattribute',
+        'AccessToken': 'foobar'
+    },
+    'resend_confirmation_code': {
+        'ClientId': 'foo',
+        'Username': 'myusername'
+    },
+    'set_user_settings': {
+        'AccessToken': 'randomtoken',
+        'MFAOptions': [{
+            'DeliveryMedium': 'SMS',
+            'AttributeName': 'someattributename'
+        }]
+    },
+    'sign_up': {
+        'ClientId': 'foo',
+        'Username': 'bar',
+        'Password': 'mysupersecurepassword',
+    },
+    'update_user_attributes': {
+        'UserAttributes': [{
+            'Name': 'someattributename',
+            'Value': 'newvalue'
+        }],
+        'AccessToken': 'foobar'
+    },
+    'verify_user_attribute': {
+        'AttributeName': 'someattributename',
+        'Code': 'someverificationcode',
+        'AccessToken': 'foobar'
+    },
+}
 
+@pytest.mark.parametrize("operation_name, parameters", OPERATION_PARAMS.items())
+def test_unsigned_operations(operation_name, parameters):
     environ = {
         'AWS_ACCESS_KEY_ID': 'access_key',
         'AWS_SECRET_ACCESS_KEY': 'secret_key',
@@ -91,28 +92,15 @@ def test_unsigned_operations():
         session = create_session()
         session.config_filename = 'no-exist-foo'
         client = session.create_client('cognito-idp', 'us-west-2')
+        http_stubber = ClientHTTPStubber(client)
 
-        for operation, params in operation_params.items():
-            test_case = UnsignedOperationTestCase(client, operation, params)
-            yield test_case.run
+        operation = getattr(client, operation_name)
 
+        http_stubber.add_response(body=b'{}')
+        with http_stubber:
+            operation(**parameters)
+            request = http_stubber.requests[0]
 
-class UnsignedOperationTestCase(object):
-    def __init__(self, client, operation_name, parameters):
-        self._client = client
-        self._operation_name = operation_name
-        self._parameters = parameters
-        self._http_stubber = ClientHTTPStubber(self._client)
-
-    def run(self):
-        operation = getattr(self._client, self._operation_name)
-
-        self._http_stubber.add_response(body=b'{}')
-        with self._http_stubber:
-            operation(**self._parameters)
-            request = self._http_stubber.requests[0]
-
-        assert_false(
-            'authorization' in request.headers,
+        assert 'authorization' not in request.headers, (
             'authorization header found in unsigned operation'
         )

--- a/tests/functional/test_event_alias.py
+++ b/tests/functional/test_event_alias.py
@@ -1,3 +1,5 @@
+import pytest
+
 from botocore.session import Session
 
 
@@ -578,14 +580,43 @@ SERVICES = {
 }
 
 
-def test_event_alias():
+def _event_aliases():
+    for client_name in SERVICES.keys():
+        endpoint_prefix = SERVICES[client_name].get('endpoint_prefix')
+        service_id = SERVICES[client_name]['service_id']
+        yield client_name, service_id
+
+
+def _event_aliases_with_endpoint_prefix():
     for client_name in SERVICES.keys():
         endpoint_prefix = SERVICES[client_name].get('endpoint_prefix')
         service_id = SERVICES[client_name]['service_id']
         if endpoint_prefix is not None:
-            yield _assert_handler_called, client_name, endpoint_prefix
-        yield _assert_handler_called, client_name, service_id
-        yield _assert_handler_called, client_name, client_name
+            yield client_name, endpoint_prefix
+
+
+@pytest.mark.parametrize(
+    "client_name, endpoint_prefix",
+    _event_aliases_with_endpoint_prefix()
+)
+def test_event_alias_by_endpoint_prefix(client_name, endpoint_prefix):
+    _assert_handler_called(client_name, endpoint_prefix)
+
+
+@pytest.mark.parametrize(
+    "client_name, service_id",
+    _event_aliases()
+)
+def test_event_alias_by_service_id(client_name, service_id):
+    _assert_handler_called(client_name, service_id)
+
+
+@pytest.mark.parametrize(
+    "client_name, service_id",
+    _event_aliases()
+)
+def test_event_alias_by_client_name(client_name, service_id):
+    _assert_handler_called(client_name, client_name)
 
 
 def _assert_handler_called(client_name, event_part):

--- a/tests/functional/test_model_backcompat.py
+++ b/tests/functional/test_model_backcompat.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import os
 
-from nose.tools import assert_equal
 from botocore.session import Session
 from tests import ClientHTTPStubber
 from tests.functional import TEST_MODELS_DIR
@@ -56,21 +55,19 @@ def test_old_model_continues_to_work():
                      'Content-Type': 'application/x-amz-json-1.1'},
             body=b'{"CertificateSummaryList":[]}')
         response = client.list_certificates()
-        assert_equal(
-            response,
-            {'CertificateSummaryList': [],
-             'ResponseMetadata': {
-                 'HTTPHeaders': {
-                     'content-length': '29',
-                     'content-type': 'application/x-amz-json-1.1',
-                     'date': 'Fri, 26 Oct 2018 01:46:30 GMT',
-                     'x-amzn-requestid': 'abcd'},
-                 'HTTPStatusCode': 200,
-                 'RequestId': 'abcd',
-                 'RetryAttempts': 0}
-             }
-        )
+        assert response == {
+            'CertificateSummaryList': [],
+            'ResponseMetadata': {
+                'HTTPHeaders': {
+                    'content-length': '29',
+                    'content-type': 'application/x-amz-json-1.1',
+                    'date': 'Fri, 26 Oct 2018 01:46:30 GMT',
+                    'x-amzn-requestid': 'abcd'},
+                'HTTPStatusCode': 200,
+                'RequestId': 'abcd',
+                'RetryAttempts': 0}
+        }
 
     # Also verify we can use the paginators as well.
-    assert_equal(client.can_paginate('list_certificates'), True)
-    assert_equal(client.waiter_names, ['certificate_validated'])
+    assert client.can_paginate('list_certificates') is True
+    assert client.waiter_names == ['certificate_validated']

--- a/tests/functional/test_model_completeness.py
+++ b/tests/functional/test_model_completeness.py
@@ -10,33 +10,43 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from botocore.session import Session
 from botocore.loaders import Loader
 from botocore.exceptions import DataNotFoundError
 
 
-def _test_model_is_not_lost(service_name, type_name,
-                            previous_version, latest_version):
+def _paginators_and_waiters_test_cases():
+    for service_name in Session().get_available_services():
+        versions = Loader().list_api_versions(service_name, 'service-2')
+        if len(versions) > 1:
+            for type_name in ['paginators-1', 'waiters-2']:
+                yield service_name, type_name, versions[-2], versions[-1]
+
+
+@pytest.mark.parametrize(
+    "service_name, type_name, previous_version, latest_version",
+    _paginators_and_waiters_test_cases()
+)
+def test_paginators_and_waiters_are_not_lost_in_new_version(
+    service_name, type_name, previous_version, latest_version
+):
     # Make sure if a paginator and/or waiter exists in previous version,
     # there will be a successor existing in latest version.
     loader = Loader()
     try:
         previous = loader.load_service_model(
-            service_name, type_name, previous_version)
+            service_name, type_name, previous_version
+        )
     except DataNotFoundError:
         pass
     else:
         try:
             latest = loader.load_service_model(
-                service_name, type_name, latest_version)
+                service_name, type_name, latest_version
+            )
         except DataNotFoundError as e:
             raise AssertionError(
-                "%s must exist for %s: %s" % (type_name, service_name, e))
-
-def test_paginators_and_waiters_are_not_lost_in_new_version():
-    for service_name in Session().get_available_services():
-        versions = Loader().list_api_versions(service_name, 'service-2')
-        if len(versions) > 1:
-            for type_name in ['paginators-1', 'waiters-2']:
-                yield (_test_model_is_not_lost, service_name,
-                       type_name, versions[-2], versions[-1])
+                f"{type_name} must exist for {service_name}: {e}"
+            )

--- a/tests/functional/test_paginate.py
+++ b/tests/functional/test_paginate.py
@@ -10,11 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from __future__ import division
 from math import ceil
 from datetime import datetime
 
-from nose.tools import assert_equal
+import pytest
 
 from tests import random_chars
 from tests import BaseSessionTest
@@ -217,22 +216,19 @@ class TestCloudwatchLogsPagination(BaseSessionTest):
         self.assertEqual(len(result['events']), 1)
 
 
-def test_token_encoding():
-    cases = [
+@pytest.mark.parametrize(
+    "token_dict",
+    (
         {'foo': 'bar'},
         {'foo': b'bar'},
         {'foo': {'bar': b'baz'}},
         {'foo': ['bar', b'baz']},
         {'foo': b'\xff'},
         {'foo': {'bar': b'baz', 'bin': [b'bam']}},
-    ]
-
-    for token_dict in cases:
-        yield assert_token_encodes_and_decodes, token_dict
-
-
-def assert_token_encodes_and_decodes(token_dict):
+    )
+)
+def test_token_encoding(token_dict):
     encoded = TokenEncoder().encode(token_dict)
     assert isinstance(encoded, six.string_types)
     decoded = TokenDecoder().decode(encoded)
-    assert_equal(decoded, token_dict)
+    assert decoded == token_dict

--- a/tests/functional/test_paginator_config.py
+++ b/tests/functional/test_paginator_config.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import string
 
+import pytest
 import jmespath
 from jmespath.exceptions import JMESPathError
 
@@ -130,7 +131,7 @@ KNOWN_EXTRA_OUTPUT_KEYS = [
 ]
 
 
-def test_lint_pagination_configs():
+def _pagination_configs():
     session = botocore.session.get_session()
     loader = session.get_component('data_loader')
     services = loader.list_available_services('paginators-1')
@@ -141,15 +142,16 @@ def test_lint_pagination_configs():
                                                 service_model.api_version)
         for op_name, single_config in page_config['pagination'].items():
             yield (
-                _lint_single_paginator,
                 op_name,
                 single_config,
                 service_model
             )
 
-
-def _lint_single_paginator(operation_name, page_config,
-                           service_model):
+@pytest.mark.parametrize(
+    "operation_name, page_config, service_model",
+    _pagination_configs()
+)
+def test_lint_pagination_configs(operation_name, page_config, service_model):
     _validate_known_pagination_keys(page_config)
     _valiate_result_key_exists(page_config)
     _validate_referenced_operation_exists(operation_name, service_model)

--- a/tests/functional/test_regions.py
+++ b/tests/functional/test_regions.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from nose.tools import assert_equal, assert_raises
+import pytest
 
 from botocore.client import ClientEndpointBridge
 from botocore.exceptions import NoRegionError
@@ -55,13 +55,13 @@ KNOWN_REGIONS = {
         'monitoring': 'monitoring.ap-northeast-1.amazonaws.com',
         'rds': 'rds.ap-northeast-1.amazonaws.com',
         'redshift': 'redshift.ap-northeast-1.amazonaws.com',
-        's3': 's3-ap-northeast-1.amazonaws.com',
+        's3': 's3.ap-northeast-1.amazonaws.com',
         'sdb': 'sdb.ap-northeast-1.amazonaws.com',
         'sns': 'sns.ap-northeast-1.amazonaws.com',
         'sqs': 'ap-northeast-1.queue.amazonaws.com',
         'storagegateway': 'storagegateway.ap-northeast-1.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.ap-northeast-1.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.ap-northeast-1.amazonaws.com',
         'swf': 'swf.ap-northeast-1.amazonaws.com',
         'workspaces': 'workspaces.ap-northeast-1.amazonaws.com'
     },
@@ -87,13 +87,13 @@ KNOWN_REGIONS = {
         'monitoring': 'monitoring.ap-southeast-1.amazonaws.com',
         'rds': 'rds.ap-southeast-1.amazonaws.com',
         'redshift': 'redshift.ap-southeast-1.amazonaws.com',
-        's3': 's3-ap-southeast-1.amazonaws.com',
+        's3': 's3.ap-southeast-1.amazonaws.com',
         'sdb': 'sdb.ap-southeast-1.amazonaws.com',
         'sns': 'sns.ap-southeast-1.amazonaws.com',
         'sqs': 'ap-southeast-1.queue.amazonaws.com',
         'storagegateway': 'storagegateway.ap-southeast-1.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.ap-southeast-1.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.ap-southeast-1.amazonaws.com',
         'swf': 'swf.ap-southeast-1.amazonaws.com',
         'workspaces': 'workspaces.ap-southeast-1.amazonaws.com'
     },
@@ -122,13 +122,13 @@ KNOWN_REGIONS = {
         'monitoring': 'monitoring.ap-southeast-2.amazonaws.com',
         'rds': 'rds.ap-southeast-2.amazonaws.com',
         'redshift': 'redshift.ap-southeast-2.amazonaws.com',
-        's3': 's3-ap-southeast-2.amazonaws.com',
+        's3': 's3.ap-southeast-2.amazonaws.com',
         'sdb': 'sdb.ap-southeast-2.amazonaws.com',
         'sns': 'sns.ap-southeast-2.amazonaws.com',
         'sqs': 'ap-southeast-2.queue.amazonaws.com',
         'storagegateway': 'storagegateway.ap-southeast-2.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.ap-southeast-2.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.ap-southeast-2.amazonaws.com',
         'swf': 'swf.ap-southeast-2.amazonaws.com',
         'workspaces': 'workspaces.ap-southeast-2.amazonaws.com'
     },
@@ -186,7 +186,7 @@ KNOWN_REGIONS = {
         'sqs': 'eu-central-1.queue.amazonaws.com',
         'storagegateway': 'storagegateway.eu-central-1.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.eu-central-1.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.eu-central-1.amazonaws.com',
         'swf': 'swf.eu-central-1.amazonaws.com'
     },
     'eu-west-1': {
@@ -222,22 +222,19 @@ KNOWN_REGIONS = {
         'monitoring': 'monitoring.eu-west-1.amazonaws.com',
         'rds': 'rds.eu-west-1.amazonaws.com',
         'redshift': 'redshift.eu-west-1.amazonaws.com',
-        's3': 's3-eu-west-1.amazonaws.com',
+        's3': 's3.eu-west-1.amazonaws.com',
         'sdb': 'sdb.eu-west-1.amazonaws.com',
         'sns': 'sns.eu-west-1.amazonaws.com',
         'sqs': 'eu-west-1.queue.amazonaws.com',
         'ssm': 'ssm.eu-west-1.amazonaws.com',
         'storagegateway': 'storagegateway.eu-west-1.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.eu-west-1.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.eu-west-1.amazonaws.com',
         'swf': 'swf.eu-west-1.amazonaws.com',
         'workspaces': 'workspaces.eu-west-1.amazonaws.com'
     },
     'fips-us-gov-west-1': {
-        's3': 's3-fips-us-gov-west-1.amazonaws.com'
-    },
-    'local': {
-        'dynamodb': 'localhost:8000'
+        's3': 's3-fips.us-gov-west-1.amazonaws.com'
     },
     's3-external-1': {
         's3': 's3-external-1.amazonaws.com'
@@ -258,13 +255,13 @@ KNOWN_REGIONS = {
         'kms': 'kms.sa-east-1.amazonaws.com',
         'monitoring': 'monitoring.sa-east-1.amazonaws.com',
         'rds': 'rds.sa-east-1.amazonaws.com',
-        's3': 's3-sa-east-1.amazonaws.com',
+        's3': 's3.sa-east-1.amazonaws.com',
         'sdb': 'sdb.sa-east-1.amazonaws.com',
         'sns': 'sns.sa-east-1.amazonaws.com',
         'sqs': 'sa-east-1.queue.amazonaws.com',
         'storagegateway': 'storagegateway.sa-east-1.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.sa-east-1.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.sa-east-1.amazonaws.com',
         'swf': 'swf.sa-east-1.amazonaws.com'
     },
     'us-east-1': {
@@ -310,14 +307,14 @@ KNOWN_REGIONS = {
         'redshift': 'redshift.us-east-1.amazonaws.com',
         'route53': 'route53.amazonaws.com',
         'route53domains': 'route53domains.us-east-1.amazonaws.com',
-        's3': 's3.amazonaws.com',
+        's3': 's3.us-east-1.amazonaws.com',
         'sdb': 'sdb.amazonaws.com',
         'sns': 'sns.us-east-1.amazonaws.com',
         'sqs': 'queue.amazonaws.com',
         'ssm': 'ssm.us-east-1.amazonaws.com',
         'storagegateway': 'storagegateway.us-east-1.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.us-east-1.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.us-east-1.amazonaws.com',
         'support': 'support.us-east-1.amazonaws.com',
         'swf': 'swf.us-east-1.amazonaws.com',
         'workspaces': 'workspaces.us-east-1.amazonaws.com',
@@ -339,7 +336,7 @@ KNOWN_REGIONS = {
         'monitoring': 'monitoring.us-gov-west-1.amazonaws.com',
         'rds': 'rds.us-gov-west-1.amazonaws.com',
         'redshift': 'redshift.us-gov-west-1.amazonaws.com',
-        's3': 's3-us-gov-west-1.amazonaws.com',
+        's3': 's3.us-gov-west-1.amazonaws.com',
         'sns': 'sns.us-gov-west-1.amazonaws.com',
         'sqs': 'us-gov-west-1.queue.amazonaws.com',
         'sts': 'sts.us-gov-west-1.amazonaws.com',
@@ -366,13 +363,13 @@ KNOWN_REGIONS = {
         'logs': 'logs.us-west-1.amazonaws.com',
         'monitoring': 'monitoring.us-west-1.amazonaws.com',
         'rds': 'rds.us-west-1.amazonaws.com',
-        's3': 's3-us-west-1.amazonaws.com',
+        's3': 's3.us-west-1.amazonaws.com',
         'sdb': 'sdb.us-west-1.amazonaws.com',
         'sns': 'sns.us-west-1.amazonaws.com',
         'sqs': 'us-west-1.queue.amazonaws.com',
         'storagegateway': 'storagegateway.us-west-1.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.us-west-1.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.us-west-1.amazonaws.com',
         'swf': 'swf.us-west-1.amazonaws.com'
     },
     'us-west-2': {
@@ -408,14 +405,14 @@ KNOWN_REGIONS = {
         'monitoring': 'monitoring.us-west-2.amazonaws.com',
         'rds': 'rds.us-west-2.amazonaws.com',
         'redshift': 'redshift.us-west-2.amazonaws.com',
-        's3': 's3-us-west-2.amazonaws.com',
+        's3': 's3.us-west-2.amazonaws.com',
         'sdb': 'sdb.us-west-2.amazonaws.com',
         'sns': 'sns.us-west-2.amazonaws.com',
         'sqs': 'us-west-2.queue.amazonaws.com',
         'ssm': 'ssm.us-west-2.amazonaws.com',
         'storagegateway': 'storagegateway.us-west-2.amazonaws.com',
         'streams.dynamodb': 'streams.dynamodb.us-west-2.amazonaws.com',
-        'sts': 'sts.amazonaws.com',
+        'sts': 'sts.us-west-2.amazonaws.com',
         'swf': 'swf.us-west-2.amazonaws.com',
         'workspaces': 'workspaces.us-west-2.amazonaws.com'
     }
@@ -445,7 +442,17 @@ def _get_patched_session():
     return session
 
 
-def test_known_endpoints():
+def _known_endpoints_by_region():
+    for region_name, service_dict in KNOWN_REGIONS.items():
+        for service_name, endpoint in service_dict.items():
+            yield service_name, region_name, endpoint
+
+
+@pytest.mark.parametrize(
+    "service_name, region_name, expected_endpoint",
+    _known_endpoints_by_region()
+)
+def test_single_service_region_endpoint(service_name, region_name, expected_endpoint):
     # Verify the actual values from the partition files.  While
     # TestEndpointHeuristics verified the generic functionality given any
     # endpoints file, this test actually verifies the partition data against a
@@ -454,18 +461,10 @@ def test_known_endpoints():
     # logic evolves.
     resolver = _get_patched_session()._get_internal_component(
         'endpoint_resolver')
-    for region_name, service_dict in KNOWN_REGIONS.items():
-        for service_name, endpoint in service_dict.items():
-            yield (_test_single_service_region, service_name,
-                   region_name, endpoint, resolver)
-
-
-def _test_single_service_region(service_name, region_name,
-                                expected_endpoint, resolver):
     bridge = ClientEndpointBridge(resolver, None, None)
     result = bridge.resolve(service_name, region_name)
     expected = 'https://%s' % expected_endpoint
-    assert_equal(result['endpoint_url'], expected)
+    assert result['endpoint_url'] == expected
 
 
 # Ensure that all S3 regions use s3v4 instead of v4
@@ -480,25 +479,23 @@ def test_all_s3_endpoints_have_s3v4():
             assert 'v4' not in resolved['signatureVersions']
 
 
-def test_known_endpoints():
+@pytest.mark.parametrize(
+    "service_name, expected_endpoint",
+    KNOWN_AWS_PARTITION_WIDE.items()
+)
+def test_single_service_partition_endpoint(service_name, expected_endpoint):
     resolver = _get_patched_session()._get_internal_component(
         'endpoint_resolver')
-    for service_name, endpoint in KNOWN_AWS_PARTITION_WIDE.items():
-        yield (_test_single_service_partition_endpoint, service_name,
-               endpoint, resolver)
-
-
-def _test_single_service_partition_endpoint(service_name, expected_endpoint,
-                                            resolver):
     bridge = ClientEndpointBridge(resolver)
     result = bridge.resolve(service_name)
-    assert_equal(result['endpoint_url'], expected_endpoint)
+    assert result['endpoint_url'] == expected_endpoint
 
 
 def test_non_partition_endpoint_requires_region():
     resolver = _get_patched_session()._get_internal_component(
         'endpoint_resolver')
-    assert_raises(NoRegionError, resolver.construct_endpoint, 'ec2')
+    with pytest.raises(NoRegionError):
+        resolver.construct_endpoint('ec2')
 
 
 class TestEndpointResolution(BaseSessionTest):

--- a/tests/functional/test_response_shadowing.py
+++ b/tests/functional/test_response_shadowing.py
@@ -10,40 +10,52 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from botocore.session import Session
-from nose.tools import assert_false
 
 
 def _all_services():
     session = Session()
     service_names = session.get_available_services()
-    for service_name in service_names:
-        yield session.get_service_model(service_name)
+    return [session.get_service_model(name) for name in service_names]
+
+
+# Only compute our service models once
+ALL_SERVICES = _all_services()
+
+
+def _all_service_error_shapes():
+    for service_model in ALL_SERVICES:
+        for shape in service_model.error_shapes:
+            yield shape
 
 
 def _all_operations():
-    for service_model in _all_services():
+    for service_model in ALL_SERVICES:
         for operation_name in service_model.operation_names:
-            yield service_model.operation_model(operation_name)
+            yield service_model.operation_model(operation_name).output_shape
 
 
 def _assert_not_shadowed(key, shape):
     if not shape:
         return
-    msg = (
-        'Found shape "%s" that shadows the botocore response key "%s"'
+
+    assert key not in shape.members, (
+        f'Found shape "{shape.name}" that shadows the botocore response key "{key}"'
     )
-    assert_false(key in shape.members, msg % (shape.name, key))
 
 
-def test_response_metadata_is_not_shadowed():
-    for operation_model in _all_operations():
-        shape = operation_model.output_shape
-        yield _assert_not_shadowed, 'ResponseMetadata', shape
+@pytest.mark.parametrize("operation_output_shape", _all_operations())
+def test_response_metadata_is_not_shadowed(operation_output_shape):
+    _assert_not_shadowed('ResponseMetadata', operation_output_shape)
 
 
-def test_exceptions_do_not_shadow():
-    for service_model in _all_services():
-        for shape in service_model.error_shapes:
-            yield _assert_not_shadowed, 'ResponseMetadata', shape
-            yield _assert_not_shadowed, 'Error', shape
+@pytest.mark.parametrize("error_shape", _all_service_error_shapes())
+def test_exceptions_do_not_shadow_response_metadata(error_shape):
+    _assert_not_shadowed('ResponseMetadata', error_shape)
+
+
+@pytest.mark.parametrize("error_shape", _all_service_error_shapes())
+def test_exceptions_do_not_shadow_error(error_shape):
+    _assert_not_shadowed('Error', error_shape)

--- a/tests/functional/test_service_alias.py
+++ b/tests/functional/test_service_alias.py
@@ -10,24 +10,31 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.handlers import SERVICE_NAME_ALIASES
 
 
-def test_can_use_service_alias():
+CLIENT_KWARGS = {
+    "region_name": "us-east-1",
+    "aws_access_key_id": "foo",
+    "aws_secret_access_key": "bar",
+}
+
+
+def _service_alias_test_cases():
     session = botocore.session.get_session()
     for (alias, name) in SERVICE_NAME_ALIASES.items():
-        yield _instantiates_the_same_client, session, name, alias
+        yield session, name, alias
 
 
-def _instantiates_the_same_client(session, service_name, service_alias):
-    client_kwargs = {
-        'region_name': 'us-east-1',
-        'aws_access_key_id': 'foo',
-        'aws_secret_access_key': 'bar',
-    }
-    original_client = session.create_client(service_name, **client_kwargs)
-    aliased_client = session.create_client(service_alias, **client_kwargs)
+@pytest.mark.parametrize(
+    "session, service_name, service_alias", _service_alias_test_cases()
+)
+def test_can_use_service_alias(session, service_name, service_alias):
+    original_client = session.create_client(service_name, **CLIENT_KWARGS)
+    aliased_client = session.create_client(service_alias, **CLIENT_KWARGS)
     original_model_name = original_client.meta.service_model.service_name
     aliased_model_name = aliased_client.meta.service_model.service_name
     assert original_model_name == aliased_model_name

--- a/tests/functional/test_six_imports.py
+++ b/tests/functional/test_six_imports.py
@@ -2,11 +2,13 @@ import os
 import botocore
 import ast
 
+import pytest
+
 
 ROOTDIR = os.path.dirname(botocore.__file__)
 
 
-def test_no_bare_six_imports():
+def _all_files():
     for rootdir, dirnames, filenames in os.walk(ROOTDIR):
         if 'vendored' in dirnames:
             # We don't need to lint our vendored packages.
@@ -14,11 +16,11 @@ def test_no_bare_six_imports():
         for filename in filenames:
             if not filename.endswith('.py'):
                 continue
-            fullname = os.path.join(rootdir, filename)
-            yield _assert_no_bare_six_imports, fullname
+            yield os.path.join(rootdir, filename)
 
 
-def _assert_no_bare_six_imports(filename):
+@pytest.mark.parametrize("filename", _all_files())
+def test_no_bare_six_imports(filename):
     with open(filename) as f:
         contents = f.read()
         parsed = ast.parse(contents, filename)

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -13,8 +13,6 @@
 from tests import unittest
 import itertools
 
-from nose.plugins.attrib import attr
-
 import botocore.session
 from botocore.exceptions import ClientError
 

--- a/tests/integration/test_emr.py
+++ b/tests/integration/test_emr.py
@@ -10,31 +10,41 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
+import pytest
 
-from nose.tools import assert_true
+from tests import unittest
 
 import botocore.session
 from botocore.paginate import PageIterator
 from botocore.exceptions import OperationNotPageableError
 
 
-def test_emr_endpoints_work_with_py26():
+@pytest.fixture()
+def botocore_session():
+    return botocore.session.get_session()
+
+@pytest.mark.parametrize(
+    "region",
+    [
+        'us-east-1',
+        'us-west-2',
+        'us-west-2',
+        'ap-northeast-1',
+        'ap-southeast-1',
+        'ap-southeast-2',
+        'sa-east-1',
+        'eu-west-1',
+        'eu-central-1'
+    ]
+)
+def test_emr_endpoints_work_with_py26(botocore_session, region):
     # Verify that we can talk to all currently supported EMR endpoints.
     # Python2.6 has an SSL cert bug where it can't read the SAN of
     # certain SSL certs.  We therefore need to always use the CN
     # as the hostname.
-    session = botocore.session.get_session()
-    for region in ['us-east-1', 'us-west-2', 'us-west-2', 'ap-northeast-1',
-                   'ap-southeast-1', 'ap-southeast-2', 'sa-east-1', 'eu-west-1',
-                   'eu-central-1']:
-        yield _test_can_list_clusters_in_region, session, region
-
-
-def _test_can_list_clusters_in_region(session, region):
-    client = session.create_client('emr', region_name=region)
+    client = botocore_session.create_client('emr', region_name=region)
     response = client.list_clusters()
-    assert_true('Clusters' in response)
+    assert 'Clusters' in response
 
 
 # I consider these integration tests because they're

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -25,7 +25,7 @@ import logging
 from tarfile import TarFile
 from contextlib import closing
 
-from nose.plugins.attrib import attr
+import pytest
 import urllib3
 
 from botocore.endpoint import Endpoint
@@ -323,7 +323,7 @@ class TestS3Objects(TestS3BaseWithBucket):
             Bucket=self.bucket_name, Key=key_name)
         self.assert_status_code(response, 204)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_can_paginate(self):
         for i in range(5):
             key_name = 'key%s' % i
@@ -339,7 +339,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                      for el in responses]
         self.assertEqual(key_names, ['key0', 'key1', 'key2', 'key3', 'key4'])
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_can_paginate_with_page_size(self):
         for i in range(5):
             key_name = 'key%s' % i
@@ -356,7 +356,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                      for el in data]
         self.assertEqual(key_names, ['key0', 'key1', 'key2', 'key3', 'key4'])
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_result_key_iters(self):
         for i in range(5):
             key_name = 'key/%s/%s' % (i, i)
@@ -379,7 +379,7 @@ class TestS3Objects(TestS3BaseWithBucket):
         self.assertIn('Contents', response)
         self.assertIn('CommonPrefixes', response)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_can_get_and_put_object(self):
         self.create_object('foobarbaz', body='body contents')
         time.sleep(3)
@@ -929,7 +929,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
                                               Key='foo.txt', Body=body)
             self.assert_status_code(response, 200)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_paginate_list_objects_unicode(self):
         key_names = [
             u'non-ascii-key-\xe4\xf6\xfc-01.txt',
@@ -952,7 +952,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
 
         self.assertEqual(key_names, key_refs)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_paginate_list_objects_safe_chars(self):
         key_names = [
             u'-._~safe-chars-key-01.txt',

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -10,45 +10,36 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.utils import ArgumentGenerator
 
 
-class ArgumentGeneratorError(AssertionError):
-    def __init__(self, service_name, operation_name,
-                 generated, message):
-        full_msg = (
-            'Error generating skeleton for %s:%s, %s\nActual:\n%s' % (
-                service_name, operation_name, message, generated))
-        super(AssertionError, self).__init__(full_msg)
+@pytest.fixture(scope="module")
+def generator():
+    return ArgumentGenerator()
 
 
-def test_can_generate_all_inputs():
+def _all_inputs():
     session = botocore.session.get_session()
-    generator = ArgumentGenerator()
     for service_name in session.get_available_services():
         service_model = session.get_service_model(service_name)
         for operation_name in service_model.operation_names:
             operation_model = service_model.operation_model(operation_name)
             input_shape = operation_model.input_shape
             if input_shape is not None and input_shape.members:
-                yield (_test_can_generate_skeleton, generator,
-                       input_shape, service_name, operation_name)
+                yield input_shape, service_name, operation_name
 
 
-def _test_can_generate_skeleton(generator, shape, service_name,
-                                operation_name):
-    generated = generator.generate_skeleton(shape)
+@pytest.mark.parametrize("input_shape, service_name, operation_name", _all_inputs())
+def test_can_generate_all_inputs(generator, input_shape, service_name, operation_name):
+    generated = generator.generate_skeleton(input_shape)
     # Do some basic sanity checks to make sure the generated shape
     # looks right.  We're mostly just ensuring that the generate_skeleton
     # doesn't throw an exception.
-    if not isinstance(generated, dict):
-        raise ArgumentGeneratorError(
-            service_name, operation_name,
-            generated, 'expected a dict')
+    assert isinstance(generated, dict)
+
     # The generated skeleton also shouldn't be empty (the test
     # generator has already filtered out input_shapes of None).
-    if len(generated) == 0:
-        raise ArgumentGeneratorError(
-            service_name, operation_name,
-            generated, "generated arguments were empty")
+    assert len(generated) > 0

--- a/tests/integration/test_waiters.py
+++ b/tests/integration/test_waiters.py
@@ -10,16 +10,15 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest, random_chars
+import pytest
 
-from nose.plugins.attrib import attr
+from tests import unittest, random_chars
 
 import botocore.session
 from botocore.exceptions import WaiterError
 
 
-# This is the same test as above, except using the client interface.
-@attr('slow')
+@pytest.mark.slow
 class TestWaiterForDynamoDB(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -18,8 +18,8 @@ AWS provides a test suite for signature version 4:
 https://github.com/awslabs/aws-c-auth/tree/v0.3.15/tests/aws-sig-v4-test-suite
 
 This module contains logic to run these tests.  The test files were
-placed in ./aws4_testsuite, and we're using nose's test generators to
-dynamically generate testcases based on these files.
+placed in ./aws4_testsuite, and we're using those to dynamically
+generate testcases based on these files.
 
 """
 import os
@@ -27,6 +27,8 @@ import logging
 import io
 import datetime
 import re
+
+import pytest
 
 from tests import mock
 
@@ -80,13 +82,7 @@ class RawHTTPRequest(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
         self.error_message = message
 
 
-def test_generator():
-    datetime_patcher = mock.patch.object(
-        botocore.auth.datetime, 'datetime',
-        mock.Mock(wraps=datetime.datetime)
-    )
-    mocked_datetime = datetime_patcher.start()
-    mocked_datetime.utcnow.return_value = DATE
+def generate_test_cases():
     for (dirpath, dirnames, filenames) in os.walk(TESTSUITE_DIR):
         if not any(f.endswith('.req') for f in filenames):
             continue
@@ -96,10 +92,20 @@ def test_generator():
             log.debug("Skipping test: %s", test_case)
             continue
 
-        if HAS_CRT:
-            yield (_test_crt_signature_version_4, test_case)
-        else:
-            yield (_test_signature_version_4, test_case)
+        yield test_case
+
+
+@pytest.mark.parametrize("test_case", generate_test_cases())
+def test_signature_version_4(test_case):
+    datetime_patcher = mock.patch.object(
+        botocore.auth.datetime, 'datetime',
+        mock.Mock(wraps=datetime.datetime)
+    )
+    mocked_datetime = datetime_patcher.start()
+    mocked_datetime.utcnow.return_value = DATE
+
+    _test_signature_version_4(test_case)
+
     datetime_patcher.stop()
 
 
@@ -132,7 +138,7 @@ def create_request_from_raw_request(raw_request):
 
 
 def _test_signature_version_4(test_case):
-    test_case = _SignatureTestCase(test_case)
+    test_case = SignatureTestCase(test_case)
     request = create_request_from_raw_request(test_case.raw_request)
 
     auth = botocore.auth.SigV4Auth(test_case.credentials, SERVICE, REGION)
@@ -156,7 +162,7 @@ def _test_signature_version_4(test_case):
 
 
 def _test_crt_signature_version_4(test_case):
-    test_case = _SignatureTestCase(test_case)
+    test_case = SignatureTestCase(test_case)
     request = create_request_from_raw_request(test_case.raw_request)
 
     # Use CRT logging to diagnose interim steps (canonical request, etc)
@@ -178,7 +184,7 @@ def assert_equal(actual, expected, raw_request, part):
         raise AssertionError(message)
 
 
-class _SignatureTestCase(object):
+class SignatureTestCase(object):
     def __init__(self, test_case):
         filepath = os.path.join(TESTSUITE_DIR, test_case,
                                 os.path.basename(test_case))

--- a/tests/unit/crt/auth/test_crt_sigv4.py
+++ b/tests/unit/crt/auth/test_crt_sigv4.py
@@ -1,4 +1,48 @@
-# This will run the CRT version of the test_generator
-# on import. When we're off nose, we should split this
-# yield test into two and have the CRT portion here.
-from tests.unit.auth.test_sigv4 import test_generator
+import datetime
+
+import pytest
+
+from tests import mock, requires_crt
+from tests.unit.auth.test_sigv4 import (
+    DATE,
+    SERVICE,
+    REGION,
+    SignatureTestCase,
+    assert_equal,
+    create_request_from_raw_request,
+    generate_test_cases,
+)
+
+import botocore
+
+
+def _test_crt_signature_version_4(test_case):
+    test_case = SignatureTestCase(test_case)
+    request = create_request_from_raw_request(test_case.raw_request)
+
+    # Use CRT logging to diagnose interim steps (canonical request, etc)
+    # import awscrt.io
+    # awscrt.io.init_logging(awscrt.io.LogLevel.Trace, 'stdout')
+    auth = botocore.crt.auth.CrtSigV4Auth(test_case.credentials, SERVICE, REGION)
+    auth.add_auth(request)
+    actual_auth_header = request.headers["Authorization"]
+    assert_equal(
+        actual_auth_header,
+        test_case.authorization_header,
+        test_case.raw_request,
+        "authheader",
+    )
+
+
+@requires_crt()
+@pytest.mark.parametrize("test_case", generate_test_cases())
+def test_signature_version_4(test_case):
+    datetime_patcher = mock.patch.object(
+        botocore.auth.datetime, "datetime", mock.Mock(wraps=datetime.datetime)
+    )
+    mocked_datetime = datetime_patcher.start()
+    mocked_datetime.utcnow.return_value = DATE
+
+    _test_crt_signature_version_4(test_case)
+
+    datetime_patcher.stop()

--- a/tests/unit/retries/test_special.py
+++ b/tests/unit/retries/test_special.py
@@ -1,8 +1,6 @@
 from tests import mock
 from tests import unittest
 
-from nose.tools import assert_equal, assert_is_instance
-
 from botocore.compat import six
 from botocore.awsrequest import AWSResponse
 from botocore.retries import standard, special

--- a/tests/unit/retries/test_standard.py
+++ b/tests/unit/retries/test_standard.py
@@ -1,7 +1,7 @@
+import pytest
+
 from tests import mock
 from tests import unittest
-
-from nose.tools import assert_equal, assert_is_instance
 
 from botocore.retries import standard
 from botocore.retries import quota
@@ -150,43 +150,46 @@ SERVICE_DESCRIPTION_WITH_RETRIES = {
     },
 }
 
-
-def test_can_detect_retryable_transient_errors():
+@pytest.mark.parametrize('case', RETRYABLE_TRANSIENT_ERRORS)
+def test_can_detect_retryable_transient_errors(case):
     transient_checker = standard.TransientRetryableChecker()
-    for case in RETRYABLE_TRANSIENT_ERRORS:
-        yield (_verify_retryable, transient_checker, None) + case
+    _verify_retryable(transient_checker, None, *case)
 
 
-def test_can_detect_retryable_throttled_errors():
+@pytest.mark.parametrize('case', RETRYABLE_THROTTLED_RESPONSES)
+def test_can_detect_retryable_throttled_errors(case):
     throttled_checker = standard.ThrottledRetryableChecker()
-    for case in RETRYABLE_THROTTLED_RESPONSES:
-        yield (_verify_retryable, throttled_checker, None) + case
+    _verify_retryable(throttled_checker, None, *case)
 
 
-def test_can_detect_modeled_retryable_errors():
+@pytest.mark.parametrize('case', RETRYABLE_MODELED_ERRORS)
+def test_can_detect_modeled_retryable_errors(case):
     modeled_retry_checker = standard.ModeledRetryableChecker()
-    test_params = (_verify_retryable, modeled_retry_checker,
-                   get_operation_model_with_retries())
-    for case in RETRYABLE_MODELED_ERRORS:
-        test_case = test_params + case
-        yield test_case
+    _verify_retryable(
+        modeled_retry_checker, get_operation_model_with_retries(), *case
+    )
 
 
-def test_standard_retry_conditions():
-    # This is verifying that the high level object used for checking
-    # retry conditions still handles all the individual testcases.
+@pytest.mark.parametrize('case',
+    [
+        case for case in
+        RETRYABLE_TRANSIENT_ERRORS +
+        RETRYABLE_THROTTLED_RESPONSES +
+        RETRYABLE_MODELED_ERRORS
+        if case[2]
+    ]
+)
+def test_standard_retry_conditions(case):
+    """This is verifying that the high level object used for checking
+    retry conditions still handles all the individual testcases.
+
+    It's possible that cases that are retryable for an individual checker
+    aren't retryable for a different checker.  We need to filter out all
+    the False cases (if case[2]).
+    """
     standard_checker = standard.StandardRetryConditions()
     op_model = get_operation_model_with_retries()
-    all_cases = (
-        RETRYABLE_TRANSIENT_ERRORS + RETRYABLE_THROTTLED_RESPONSES +
-        RETRYABLE_MODELED_ERRORS)
-    # It's possible that cases that are retryable for an individual checker
-    # are retryable for a different checker.  We need to filter out all
-    # the False cases.
-    all_cases = [c for c in all_cases if c[2]]
-    test_params = (_verify_retryable, standard_checker, op_model)
-    for case in all_cases:
-        yield test_params + case
+    _verify_retryable(standard_checker, op_model, *case)
 
 
 def get_operation_model_with_retries():
@@ -213,7 +216,7 @@ def _verify_retryable(checker, operation_model,
         http_response=http_response,
         caught_exception=caught_exception,
     )
-    assert_equal(checker.is_retryable(context), is_retryable)
+    assert checker.is_retryable(context) == is_retryable
 
 
 def arbitrary_retry_context():
@@ -233,36 +236,38 @@ def test_can_honor_max_attempts():
     checker = standard.MaxAttemptsChecker(max_attempts=3)
     context = arbitrary_retry_context()
     context.attempt_number = 1
-    assert_equal(checker.is_retryable(context), True)
+    assert checker.is_retryable(context) is True
 
     context.attempt_number = 2
-    assert_equal(checker.is_retryable(context), True)
+    assert checker.is_retryable(context) is True
 
     context.attempt_number = 3
-    assert_equal(checker.is_retryable(context), False)
+    assert checker.is_retryable(context) is False
 
 
 def test_max_attempts_adds_metadata_key_when_reached():
     checker = standard.MaxAttemptsChecker(max_attempts=3)
     context = arbitrary_retry_context()
     context.attempt_number = 3
-    assert_equal(checker.is_retryable(context), False)
-    assert_equal(context.get_retry_metadata(), {'MaxAttemptsReached': True})
+    assert checker.is_retryable(context) is False
+    assert context.get_retry_metadata() == {'MaxAttemptsReached': True}
 
 
 def test_can_create_default_retry_handler():
     mock_client = mock.Mock()
     mock_client.meta.service_model.service_id = model.ServiceId('my-service')
-    assert_is_instance(standard.register_retry_handler(mock_client),
-                       standard.RetryHandler)
+    assert isinstance(
+        standard.register_retry_handler(mock_client),
+        standard.RetryHandler
+    )
     call_args_list = mock_client.meta.events.register.call_args_list
     # We should have registered the retry quota to after-calls
     first_call = call_args_list[0][0]
     second_call = call_args_list[1][0]
     # Not sure if there's a way to verify the class associated with the
     # bound method matches what we expect.
-    assert_equal(first_call[0], 'after-call.my-service')
-    assert_equal(second_call[0], 'needs-retry.my-service')
+    assert first_call[0] == 'after-call.my-service'
+    assert second_call[0] == 'needs-retry.my-service'
 
 
 class TestRetryHandler(unittest.TestCase):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import datetime
 
-from nose.tools import assert_equal, assert_raises
+import pytest
 
 from botocore.exceptions import MD5UnavailableError
 from botocore.compat import (
@@ -97,7 +97,13 @@ class TestGetMD5(unittest.TestCase):
                 get_md5()
 
 
-def test_compat_shell_split_windows():
+@pytest.fixture
+def shell_split_runner():
+    # Single runner fixture for all tests
+    return ShellSplitTestRunner()
+
+
+def get_windows_test_cases():
     windows_cases = {
         r'': [],
         r'spam \\': [r'spam', '\\\\'],
@@ -120,14 +126,21 @@ def test_compat_shell_split_windows():
         r'a\\\"b c d': [r'a\"b', r'c', r'd'],
         r'a\\\\"b c" d e': [r'a\\b c', r'd', r'e']
     }
-    runner = ShellSplitTestRunner()
-    for input_string, expected_output in windows_cases.items():
-        yield runner.assert_equal, input_string, expected_output, "win32"
-
-    yield runner.assert_raises, r'"', ValueError, "win32"
+    return windows_cases.items()
 
 
-def test_compat_shell_split_unix():
+@pytest.mark.parametrize("input_string, expected_output", get_windows_test_cases())
+def test_compat_shell_split_windows(
+    shell_split_runner, input_string, expected_output
+):
+    shell_split_runner.assert_equal(input_string, expected_output, "win32")
+
+
+def test_compat_shell_split_windows_raises_error(shell_split_runner):
+    shell_split_runner.assert_raises(r'"', ValueError, "win32")
+
+
+def get_unix_test_cases():
     unix_cases = {
         r'': [],
         r'spam \\': [r'spam', '\\'],
@@ -150,21 +163,38 @@ def test_compat_shell_split_unix():
         r'a\\\"b c d': [r'a\"b', r'c', r'd'],
         r'a\\\\"b c" d e': [r'a\\b c', r'd', r'e']
     }
-    runner = ShellSplitTestRunner()
-    for input_string, expected_output in unix_cases.items():
-        yield runner.assert_equal, input_string, expected_output, "linux2"
-        yield runner.assert_equal, input_string, expected_output, "darwin"
+    return unix_cases.items()
 
-    yield runner.assert_raises, r'"', ValueError, "linux2"
-    yield runner.assert_raises, r'"', ValueError, "darwin"
+
+@pytest.mark.parametrize("input_string, expected_output", get_unix_test_cases())
+def test_compat_shell_split_unix_linux2(
+    shell_split_runner, input_string, expected_output
+):
+    shell_split_runner.assert_equal(input_string, expected_output, "linux2")
+
+
+@pytest.mark.parametrize("input_string, expected_output", get_unix_test_cases())
+def test_compat_shell_split_unix_darwin(
+    shell_split_runner, input_string, expected_output
+):
+    shell_split_runner.assert_equal(input_string, expected_output, "darwin")
+
+
+def test_compat_shell_split_unix_linux2_raises_error(shell_split_runner):
+    shell_split_runner.assert_raises(r'"', ValueError, "linux2")
+
+
+def test_compat_shell_split_unix_darwin_raises_error(shell_split_runner):
+    shell_split_runner.assert_raises(r'"', ValueError, "darwin")
 
 
 class ShellSplitTestRunner(object):
     def assert_equal(self, s, expected, platform):
-        assert_equal(compat_shell_split(s, platform), expected)
+        assert compat_shell_split(s, platform) == expected
 
     def assert_raises(self, s, exception_cls, platform):
-        assert_raises(exception_cls, compat_shell_split, s, platform)
+        with pytest.raises(exception_cls):
+            compat_shell_split(s, platform)
 
 
 class TestTimezoneOperations(unittest.TestCase):

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -10,9 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from tests import mock
 from tests import unittest
-from nose.tools import assert_equal
 
 import botocore
 import botocore.session as session
@@ -447,15 +448,12 @@ def assert_chain_does_provide(providers, expected_value):
     provider = ChainProvider(
         providers=providers,
     )
-    value = provider.provide()
-    assert_equal(value, expected_value)
+    assert provider.provide() == expected_value
 
 
-def test_chain_provider():
-    # Each case is a tuple with the first element being the expected return
-    # value form the ChainProvider. The second value being a list of return
-    # values from the individual providers that are in the chain.
-    cases = [
+@pytest.mark.parametrize(
+    'case',
+    (
         (None, []),
         (None, [None]),
         ('foo', ['foo']),
@@ -466,11 +464,16 @@ def test_chain_provider():
         ('bar', [None, 'bar', None]),
         ('foo', ['foo', 'bar', None]),
         ('foo', ['foo', 'bar', 'baz']),
-    ]
-    for case in cases:
-        yield assert_chain_does_provide, \
-            _make_providers_that_return(case[1]), \
-            case[0]
+    )
+)
+def test_chain_provider(case):
+    # Each case is a tuple with the first element being the expected return
+    # value from the ChainProvider. The second value being a list of return
+    # values from the individual providers that are in the chain.
+    assert_chain_does_provide(
+        _make_providers_that_return(case[1]),
+        case[0]
+    )
 
 
 class TestChainProvider(unittest.TestCase):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -14,8 +14,6 @@
 import pickle
 from tests import unittest
 
-from nose.tools import assert_equal
-
 import botocore.awsrequest
 import botocore.session
 from botocore import exceptions
@@ -24,7 +22,7 @@ from botocore import exceptions
 def test_client_error_can_handle_missing_code_or_message():
     response = {'Error': {}}
     expect = 'An error occurred (Unknown) when calling the blackhole operation: Unknown'
-    assert_equal(str(exceptions.ClientError(response, 'blackhole')), expect)
+    assert str(exceptions.ClientError(response, 'blackhole')) == expect
 
 
 def test_client_error_has_operation_name_set():
@@ -36,7 +34,7 @@ def test_client_error_has_operation_name_set():
 def test_client_error_set_correct_operation_name():
     response = {'Error': {}}
     exception = exceptions.ClientError(response, 'blackhole')
-    assert_equal(exception.operation_name, 'blackhole')
+    assert exception.operation_name == 'blackhole'
 
 
 def test_retry_info_added_when_present():

--- a/tests/unit/test_http_client_exception_mapping.py
+++ b/tests/unit/test_http_client_exception_mapping.py
@@ -1,27 +1,21 @@
-from nose.tools import assert_raises
+import pytest
 
 from botocore import exceptions as botocore_exceptions
 from botocore.vendored.requests import exceptions as requests_exceptions
 from botocore.vendored.requests.packages.urllib3 import exceptions as urllib3_exceptions
 
-EXCEPTION_MAPPING = [
-    (botocore_exceptions.ReadTimeoutError, requests_exceptions.ReadTimeout),
-    (botocore_exceptions.ReadTimeoutError, urllib3_exceptions.ReadTimeoutError),
-    (botocore_exceptions.ConnectTimeoutError, requests_exceptions.ConnectTimeout),
-    (botocore_exceptions.ProxyConnectionError, requests_exceptions.ProxyError),
-    (botocore_exceptions.SSLError, requests_exceptions.SSLError),
-]
 
-
-def _raise_exception(exception):
-    raise exception(endpoint_url=None, proxy_url=None, error=None)
-
-
-def _test_exception_mapping(new_exception, old_exception):
+@pytest.mark.parametrize(
+    "new_exception, old_exception",
+    (
+        (botocore_exceptions.ReadTimeoutError, requests_exceptions.ReadTimeout),
+        (botocore_exceptions.ReadTimeoutError, urllib3_exceptions.ReadTimeoutError),
+        (botocore_exceptions.ConnectTimeoutError, requests_exceptions.ConnectTimeout),
+        (botocore_exceptions.ProxyConnectionError, requests_exceptions.ProxyError),
+        (botocore_exceptions.SSLError, requests_exceptions.SSLError),
+    ),
+)
+def test_http_client_exception_mapping(new_exception, old_exception):
     # assert that the new exception can still be caught by the old vendored one
-    assert_raises(old_exception, _raise_exception, new_exception)
-
-
-def test_http_client_exception_mapping():
-    for new_exception, old_exception in EXCEPTION_MAPPING:
-        yield _test_exception_mapping, new_exception, old_exception
+    with pytest.raises(old_exception):
+        raise new_exception(endpoint_url=None, proxy_url=None, error=None)

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -1,8 +1,9 @@
 import socket
 
-from tests import mock, unittest
-from nose.tools import raises
+import pytest
 from urllib3.exceptions import NewConnectionError, ProtocolError
+
+from tests import mock, unittest
 
 from botocore.vendored import six
 from botocore.awsrequest import AWSRequest
@@ -389,15 +390,15 @@ class TestURLLib3Session(unittest.TestCase):
         session = URLLib3Session()
         session.send(self.request.prepare())
 
-    @raises(EndpointConnectionError)
     def test_catches_new_connection_error(self):
         error = NewConnectionError(None, None)
-        self.make_request_with_error(error)
+        with pytest.raises(EndpointConnectionError):
+           self.make_request_with_error(error)
 
-    @raises(ConnectionClosedError)
     def test_catches_bad_status_line(self):
         error = ProtocolError(None)
-        self.make_request_with_error(error)
+        with pytest.raises(ConnectionClosedError):
+            self.make_request_with_error(error)
 
     def test_aws_connection_classes_are_used(self):
         session = URLLib3Session()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests import unittest
 
 from botocore import model
@@ -5,30 +7,11 @@ from botocore.compat import OrderedDict
 from botocore.exceptions import MissingServiceIdError
 
 
-def test_missing_model_attribute_raises_exception():
-    # We're using a nose test generator here to cut down
-    # on the duplication.  The property names below
-    # all have the same test logic.
+@pytest.mark.parametrize("property_name", ['api_version', 'protocol'])
+def test_missing_model_attribute_raises_exception(property_name):
     service_model = model.ServiceModel({'metadata': {'endpointPrefix': 'foo'}})
-    property_names = ['api_version', 'protocol']
-
-    def _test_attribute_raise_exception(attr_name):
-        try:
-            getattr(service_model, attr_name)
-        except model.UndefinedModelAttributeError:
-            # This is what we expect, so the test passes.
-            pass
-        except Exception as e:
-            raise AssertionError("Expected UndefinedModelAttributeError to "
-                                 "be raised, but %s was raised instead" %
-                                 (e.__class__))
-        else:
-            raise AssertionError(
-                "Expected UndefinedModelAttributeError to "
-                "be raised, but no exception was raised for: %s" % attr_name)
-
-    for name in property_names:
-        yield _test_attribute_raise_exception, name
+    with pytest.raises(model.UndefinedModelAttributeError):
+        getattr(service_model, property_name)
 
 
 class TestServiceId(unittest.TestCase):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -19,6 +19,8 @@ import logging
 import tempfile
 import shutil
 
+import pytest
+
 
 import botocore.session
 import botocore.exceptions
@@ -718,21 +720,29 @@ class TestSessionComponent(BaseSessionTest):
         self.assertIs(
             self.session._get_internal_component('internal'), component)
         with self.assertRaises(ValueError):
-            self.session.get_component('internal')
+            # get_component has been deprecated to the public
+            with pytest.warns(DeprecationWarning):
+                self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(
             'endpoint_resolver')
-        self.assertIs(
-            self.session.get_component('endpoint_resolver'), endpoint_resolver)
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('endpoint_resolver'),
+                endpoint_resolver
+            )
 
     def test_internal_exceptions_factory_is_same_as_deprecated_public(self):
         exceptions_factory = self.session._get_internal_component(
             'exceptions_factory')
-        self.assertIs(
-            self.session.get_component('exceptions_factory'),
-            exceptions_factory
-        )
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('exceptions_factory'),
+                exceptions_factory
+            )
 
 
 class TestClientMonitoring(BaseSessionTest):

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -19,6 +19,8 @@ import logging
 import tempfile
 import shutil
 
+import pytest
+
 import botocore.session
 import botocore.exceptions
 from botocore.model import ServiceModel
@@ -702,21 +704,29 @@ class TestSessionComponent(BaseSessionTest):
         self.assertIs(
             self.session._get_internal_component('internal'), component)
         with self.assertRaises(ValueError):
-            self.session.get_component('internal')
+            # get_component has been deprecated to the public
+            with pytest.warns(DeprecationWarning):
+                self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(
             'endpoint_resolver')
-        self.assertIs(
-            self.session.get_component('endpoint_resolver'), endpoint_resolver)
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('endpoint_resolver'),
+                endpoint_resolver
+            )
 
     def test_internal_exceptions_factory_is_same_as_deprecated_public(self):
         exceptions_factory = self.session._get_internal_component(
             'exceptions_factory')
-        self.assertIs(
-            self.session.get_component('exceptions_factory'),
-            exceptions_factory
-        )
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('exceptions_factory'),
+                exceptions_factory
+            )
 
 
 class TestComponentLocator(unittest.TestCase):


### PR DESCRIPTION
This PR will move botocore from `nosetests` to `pytest`. The change requires us to move off of `yield` tests which introduced some additional complexity. I spent a considerable amount of time trying to get our `pytest_migration` branch back into working order, but the conflicts from the last year, along with some inefficencies in the testing changes made it difficult. This branch is a pared down version of the absolute minimum to get us migrated. We'll look at moving over the other changes in a separate PR.

For this patch, we have a total difference of 169 tests which I'll walk through along with some other possibly non-obvious changes that were made.

## Differences
Note: Nose provides the total tests run, then buckets them. Pytest only returns bucketed categories, which requires adding all tests together for totals.

### Unit/Functional:
* pytest: `26177 passed, 72 skipped` (26249 total)
* nose: `Ran 26085 tests (SKIP=41)` (26085 total) 

**Total difference: +164**

The differences here stem from 3 main changes:
* **tests/unit/crt/auth/test_crt_sigv4.py:** We are now properly skipping CRT tests that weren't possible before. This saves us from rerunning tests/unit/auth/test_sigv4.py twice which accounts for the 30 of the 31 skip increase. These are a wash because we're moving 30 successes to 30 skips.
* **tests/functional/test_h2_required.py**: The last skip increase is from `test_all_uses_of_h2_are_known`. This test was previously never being run because nothing was yeilded. The test cases are still empty, but pytest is now creating a skip saying there's nothing to do.
* **tests/functional/test_regions.py:** This file had two tests sharing the same name, leaving the first `test_known_endpoints` disabled for 6+ years. I've renabled the test by fixing the name, adding 365 new tests. If you remove this test, we match nose with 13 tests.
* **tests/functional/test_waiter_config.py:** The waiter tests here were collapsed into a single test per waiter file. This decreased total tests by 202 but saves us from ~40s of extra test time on this test alone.

365+1-202 = 164; Q.E.D.

### Integration:
* pytest: `10334 passed, 4 skipped` (10338 total)
* nose: `Ran 10338 tests (SKIP=4)` (10338 total)

**Total difference: 0**

**Pytest Unit/Functional**
------
```
=================== 26177 passed, 72 skipped in 279.38s (0:04:39) ===================
```

**Nose Unit/Functional:**
-------
```
Ran 26085 tests in 208.456s

OK (SKIP=41)
```

**Pytest Integration:**
----
```
=================== 10334 passed, 4 skipped ===================
```

**Nose Integration:**
----
```
Ran 10338 tests

OK (SKIP=4)
```
