### PR TITLE
Remove repo root from path when running tests

### DIFF
--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -13,7 +13,9 @@ os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
 
 def run(command):
-    return check_call(command, shell=True)
+    env = os.environ.copy()
+    env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
+    return check_call(command, shell=True, env=env)
 
 
 run('nosetests --with-xunit --cover-erase --with-coverage '

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -13,7 +13,9 @@ os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
 
 def run(command):
-    return check_call(command, shell=True)
+    env = os.environ.copy()
+    env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
+    return check_call(command, shell=True, env=env)
 
 
 run('nosetests --with-coverage --cover-erase --cover-package botocore '

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,6 +26,20 @@ import datetime
 from io import BytesIO
 from subprocess import Popen, PIPE
 
+# Both nose and py.test will add the first parent directory it
+# encounters that does not have a __init__.py to the sys.path. In
+# our case, this is the root of the repository. This means that Python
+# will import the botocore package from source instead of any installed
+# distribution. This environment variable provides the option to remove the
+# repository root from sys.path to be able to rely on the installed
+# distribution when running the tests.
+if os.environ.get('TESTS_REMOVE_REPO_ROOT_FROM_PATH'):
+    rootdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path = [
+        path for path in sys.path
+        if not os.path.isdir(path) or not os.path.samefile(path, rootdir)
+    ]
+
 from dateutil.tz import tzlocal
 import unittest
 


### PR DESCRIPTION
Both nose and py.test will add the first parent directory it encounters that does not have a `__init__.py` to the `sys.path`. In our case, this is the root of the repository. This means that Python will import the `botocore` package from source instead of the installed wheel distribution. So the new environment variable provides
the option to remove the repository root from `sys.path` to be able to rely on the installed distribution when running the tests.

It is also worth noting that nose has `--no-path-adjustment` to fix this, but py.test does not have an option available without large refactorings of the tests.