### PR TITLE
Add support for Python 3.9 & 3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
         os: [ubuntu-latest, macOS-latest ]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39,py310
 
 skipsdist = True
 


### PR DESCRIPTION
This PR will start testing us on what is hopefully the final release candidate for Python 3.10. Release is currently scheduled for October 4th, so we'll start regularly testing now to make sure things remaining functioning smoothly.

This PR does not update the run-crt-tests workflow due to wheel unavailability for CRT currently. We've opened awslabs/aws-crt-python#312 to track that request, and hopefully it will help create abi3 wheels which will avoid this issue in the future.