### PR TITLE
Retry on ReadTimeoutError when fetching metadata tokens

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -409,8 +409,6 @@ class IMDSFetcher(object):
                     return None
                 elif response.status_code in (400,):
                     raise BadIMDSRequestError(request)
-            except ReadTimeoutError:
-                return None
             except RETRYABLE_HTTP_ERRORS as e:
                 logger.debug(
                     "Caught retryable HTTP exception while making metadata "


### PR DESCRIPTION
`ReadTimeoutError` is already covered in the `RETRYABLE_HTTP_ERRORS` case. I looked at the [PR that added it](https://github.com/boto/botocore/pull/1895).

At the time, `_fetch_metadata_token` raised `self._RETRIES_EXCEEDED_ERROR_CLS()` if retries were exhausted. It doesn't do that anymore, it just returns `None`. So the behaviour should be the same, but with retries (which are disabled on IMDS by default).