### PR TITLE
Migrate v2 branch to use pytest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,14 +24,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install codecov
         python scripts/ci/install
     - name: Run tests
       run: |
         python scripts/ci/run-tests --with-cov
 
     - name: codecov
-      run: |
-        rm tests/coverage.xml
-        mv tests/.coverage ./
-        codecov
+      uses: codecov/codecov-action@v2
+      with:
+        directory: tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
         python scripts/ci/install
     - name: Run tests
       run: |
-        python scripts/ci/run-tests
+        python scripts/ci/run-tests --with-cov
 
     - name: codecov
       run: |

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -96,10 +96,13 @@ def document_custom_signature(section, name, method,
     :param exclude: The names of the parameters to exclude from
         documentation.
     """
-    args, varargs, keywords, defaults = inspect.getargspec(method)
-    args = args[1:]
+    argspec = inspect.getfullargspec(method)
     signature_params = inspect.formatargspec(
-        args, varargs, keywords, defaults)
+        args=argspec.args[1:],
+        varargs=argspec.varargs,
+        varkw=argspec.varkw,
+        defaults=argspec.defaults
+    )
     signature_params = signature_params.lstrip('(')
     signature_params = signature_params.rstrip(')')
     section.style.start_sphinx_py_method(name, signature_params)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -305,7 +305,9 @@ class IMDSFetcher(object):
         custom_metadata_endpoint = config.get('ec2_metadata_service_endpoint')
 
         if requires_ipv6 and custom_metadata_endpoint:
-            logger.warn("Custom endpoint and IMDS_USE_IPV6 are both set. Using custom endpoint.")
+            logger.warning(
+                "Custom endpoint and IMDS_USE_IPV6 are both set. Using custom endpoint."
+            )
 
         chosen_base_url = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 tox>=2.5.0,<3.0.0
-nose==1.3.7
+pytest==6.2.5
+coverage==5.5
+pytest-cov==2.12.1
 mock==1.3.0
 wheel==0.24.0
 behave==1.2.5

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -14,14 +14,7 @@ def run(command):
     return check_call(command, shell=True)
 
 
-try:
-    # Has the form "major.minor"
-    python_version = os.environ['PYTHON_VERSION']
-except KeyError:
-    python_version = '.'.join([str(i) for i in sys.version_info[:2]])
-
 run('pip install -r requirements.txt')
-run('pip install coverage')
 if os.path.isdir('dist') and os.listdir('dist'):
     shutil.rmtree('dist')
 run('python setup.py bdist_wheel')

--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -4,12 +4,23 @@
 # binary package not from the CWD.
 
 import os
+from contextlib import contextmanager
 from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+
+
+@contextmanager
+def cd(path):
+    """Change directory while inside context manager."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
 
 
 def run(command):
@@ -18,5 +29,6 @@ def run(command):
     return check_call(command, shell=True, env=env)
 
 
-run('nosetests --with-xunit --cover-erase --with-coverage '
-    '--cover-package botocore --cover-xml -v integration')
+if __name__ == "__main__":
+    with cd(os.path.join(REPO_ROOT, "tests")):
+        run(f"{REPO_ROOT}/scripts/ci/run-tests integration")

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -3,13 +3,26 @@
 # We want to ensure we're importing from the installed
 # binary package not from the CWD.
 
+import argparse
 import os
+from contextlib import contextmanager
 from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+PACKAGE = "botocore"
+
+
+@contextmanager
+def cd(path):
+    """Change directory while inside context manager."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
 
 
 def run(command):
@@ -18,5 +31,41 @@ def run(command):
     return check_call(command, shell=True, env=env)
 
 
-run('nosetests --with-coverage --cover-erase --cover-package botocore '
-    '--with-xunit --cover-xml unit/ functional/')
+def process_args(args):
+    runner = args.test_runner
+    test_args = ""
+    if args.with_cov:
+        test_args += f"--cov={PACKAGE} --cov-report xml "
+    dirs = " ".join(args.test_dirs)
+
+    return runner, test_args, dirs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "test_dirs",
+        default=["unit/", "functional/"],
+        nargs="*",
+        help="One or more directories containing tests.",
+    )
+    parser.add_argument(
+        "-r",
+        "--test-runner",
+        default="pytest",
+        help="Test runner to execute tests. Defaults to pytest.",
+    )
+    parser.add_argument(
+        "-c",
+        "--with-cov",
+        default=False,
+        action="store_true",
+        help="Run default test-runner with code coverage enabled.",
+    )
+    raw_args = parser.parse_args()
+    test_runner, test_args, test_dirs = process_args(raw_args)
+
+    cmd = f"{test_runner} {test_args}{test_dirs}"
+    print(f"Running {cmd}...")
+    with cd(os.path.join(REPO_ROOT, "tests")):
+        run(cmd)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -43,8 +43,6 @@ if os.environ.get('TESTS_REMOVE_REPO_ROOT_FROM_PATH'):
 from dateutil.tz import tzlocal
 import unittest
 
-from nose.tools import assert_equal
-
 import botocore.loaders
 import botocore.session
 from botocore.awsrequest import AWSResponse
@@ -360,16 +358,16 @@ def assert_url_equal(url1, url2):
 
     # Because the query string ordering isn't relevant, we have to parse
     # every single part manually and then handle the query string.
-    assert_equal(parts1.scheme, parts2.scheme)
-    assert_equal(parts1.netloc, parts2.netloc)
-    assert_equal(parts1.path, parts2.path)
-    assert_equal(parts1.params, parts2.params)
-    assert_equal(parts1.fragment, parts2.fragment)
-    assert_equal(parts1.username, parts2.username)
-    assert_equal(parts1.password, parts2.password)
-    assert_equal(parts1.hostname, parts2.hostname)
-    assert_equal(parts1.port, parts2.port)
-    assert_equal(parse_qs(parts1.query), parse_qs(parts2.query))
+    assert parts1.scheme == parts2.scheme
+    assert parts1.netloc == parts2.netloc
+    assert parts1.path == parts2.path
+    assert parts1.params == parts2.params
+    assert parts1.fragment == parts2.fragment
+    assert parts1.username == parts2.username
+    assert parts1.password == parts2.password
+    assert parts1.hostname == parts2.hostname
+    assert parts1.port == parts2.port
+    assert parse_qs(parts1.query) == parse_qs(parts2.query)
 
 
 class HTTPStubberException(Exception):

--- a/tests/acceptance/features/steps/base.py
+++ b/tests/acceptance/features/steps/base.py
@@ -4,7 +4,6 @@ from botocore import xform_name
 from botocore.exceptions import ClientError
 
 from behave import when, then
-from nose.tools import assert_equal
 
 
 def _params_from_table(table):
@@ -72,7 +71,7 @@ def api_call_with_json_and_error(context, operation):
 
 @then(u'I expect the response error code to be "{}"')
 def then_expected_error(context, code):
-    assert_equal(context.error_response.response['Error']['Code'], code)
+    assert context.error_response.response['Error']['Code'] == code
 
 
 @then(u'the value at "{}" should be a list')

--- a/tests/functional/csm/test_monitoring.py
+++ b/tests/functional/csm/test_monitoring.py
@@ -19,7 +19,7 @@ import socket
 import threading
 
 import mock
-from nose.tools import assert_equal
+import pytest
 
 from tests import temporary_file
 from tests import ClientHTTPStubber
@@ -47,12 +47,6 @@ EXPECTED_EXCEPTIONS_THROWN = (
     botocore.exceptions.ClientError, NonRetryableException, RetryableException)
 
 
-def test_client_monitoring():
-    test_cases = _load_test_cases()
-    for case in test_cases:
-        yield _run_test_case, case
-
-
 def _load_test_cases():
     with open(CASES_FILE) as f:
         loaded_tests = json.loads(f.read())
@@ -77,6 +71,11 @@ def _replace_expected_anys(test_cases):
             for entry, value in expected_event.items():
                 if value in ['ANY_STR', 'ANY_INT']:
                     expected_event[entry] = mock.ANY
+
+
+@pytest.mark.parametrize("test_case", _load_test_cases())
+def test_client_monitoring(test_case):
+    _run_test_case(test_case)
 
 
 @contextlib.contextmanager
@@ -121,8 +120,7 @@ def _run_test_case(case):
                 case['configuration'], listener.port) as session:
             for api_call in case['apiCalls']:
                 _make_api_call(session, api_call)
-    assert_equal(
-        listener.received_events, case['expectedMonitoringEvents'])
+    assert listener.received_events == case['expectedMonitoringEvents']
 
 
 def _make_api_call(session, api_call):

--- a/tests/functional/docs/test_shared_example_config.py
+++ b/tests/functional/docs/test_shared_example_config.py
@@ -10,12 +10,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.model import OperationNotFoundError
 from botocore.utils import parse_timestamp
 
 
-def test_lint_shared_example_configs():
+def _shared_example_configs():
     session = botocore.session.Session()
     loader = session.get_component('data_loader')
     services = loader.list_available_services('examples-1')
@@ -27,10 +29,14 @@ def test_lint_shared_example_configs():
         examples = example_config.get("examples", {})
         for operation, operation_examples in examples.items():
             for example in operation_examples:
-                yield _lint_single_example, operation, example, service_model
+                yield operation, example, service_model
 
 
-def _lint_single_example(operation_name, example_config, service_model):
+@pytest.mark.parametrize(
+    "operation_name, example_config, service_model",
+    _shared_example_configs()
+)
+def test_lint_shared_example_configs(operation_name, example_config, service_model):
     # The operation should actually exist
     assert_operation_exists(service_model, operation_name)
     operation_model = service_model.operation_model(operation_name)

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.stub import Stubber
 from botocore.exceptions import ParamValidationError
@@ -46,16 +48,16 @@ ALIAS_CASES = [
 ]
 
 
-def test_can_use_alias():
+@pytest.mark.parametrize("case", ALIAS_CASES)
+def test_can_use_alias(case):
     session = botocore.session.get_session()
-    for case in ALIAS_CASES:
-        yield _can_use_parameter_in_client_call, session, case
+    _can_use_parameter_in_client_call(session, case)
 
 
-def test_can_use_original_name():
+@pytest.mark.parametrize("case", ALIAS_CASES)
+def test_can_use_original_name(case):
     session = botocore.session.get_session()
-    for case in ALIAS_CASES:
-        yield _can_use_parameter_in_client_call, session, case, False
+    _can_use_parameter_in_client_call(session, case, False)
 
 
 def _can_use_parameter_in_client_call(session, case, use_alias=True):

--- a/tests/functional/test_client_class_names.py
+++ b/tests/functional/test_client_class_names.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from nose.tools import assert_equal
+import pytest
 
 import botocore.session
 
@@ -68,14 +68,8 @@ SERVICE_TO_CLASS_NAME = {
     'workspaces': 'WorkSpaces'
 }
 
-
-def test_client_has_correct_class_name():
+@pytest.mark.parametrize("service_name", SERVICE_TO_CLASS_NAME)
+def test_client_has_correct_class_name(service_name):
     session = botocore.session.get_session()
-    for service_name in SERVICE_TO_CLASS_NAME:
-        client = session.create_client(service_name, REGION)
-        yield (_assert_class_name_matches_ref_class_name, client,
-               SERVICE_TO_CLASS_NAME[service_name])
-
-
-def _assert_class_name_matches_ref_class_name(client, ref_class_name):
-    assert_equal(client.__class__.__name__, ref_class_name)
+    client = session.create_client(service_name, REGION)
+    assert client.__class__.__name__ == SERVICE_TO_CLASS_NAME[service_name]

--- a/tests/functional/test_cognito_idp.py
+++ b/tests/functional/test_cognito_idp.py
@@ -11,78 +11,78 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import mock
-
-from nose.tools import assert_false
+import pytest
 
 from tests import create_session, ClientHTTPStubber
 
 
-def test_unsigned_operations():
-    operation_params = {
-        'change_password': {
-            'PreviousPassword': 'myoldbadpassword',
-            'ProposedPassword': 'mynewgoodpassword',
-            'AccessToken': 'foobar'
-        },
-        'confirm_forgot_password': {
-            'ClientId': 'foo',
-            'Username': 'myusername',
-            'ConfirmationCode': 'thisismeforreal',
-            'Password': 'whydowesendpasswordsviaemail'
-        },
-        'confirm_sign_up': {
-            'ClientId': 'foo',
-            'Username': 'myusername',
-            'ConfirmationCode': 'ireallydowanttosignup'
-        },
-        'delete_user': {
-            'AccessToken': 'foobar'
-        },
-        'delete_user_attributes': {
-            'UserAttributeNames': ['myattribute'],
-            'AccessToken': 'foobar'
-        },
-        'forgot_password': {
-            'ClientId': 'foo',
-            'Username': 'myusername'
-        },
-        'get_user': {
-            'AccessToken': 'foobar'
-        },
-        'get_user_attribute_verification_code': {
-            'AttributeName': 'myattribute',
-            'AccessToken': 'foobar'
-        },
-        'resend_confirmation_code': {
-            'ClientId': 'foo',
-            'Username': 'myusername'
-        },
-        'set_user_settings': {
-            'AccessToken': 'randomtoken',
-            'MFAOptions': [{
-                'DeliveryMedium': 'SMS',
-                'AttributeName': 'someattributename'
-            }]
-        },
-        'sign_up': {
-            'ClientId': 'foo',
-            'Username': 'bar',
-            'Password': 'mysupersecurepassword',
-        },
-        'update_user_attributes': {
-            'UserAttributes': [{
-                'Name': 'someattributename',
-                'Value': 'newvalue'
-            }],
-            'AccessToken': 'foobar'
-        },
-        'verify_user_attribute': {
-            'AttributeName': 'someattributename',
-            'Code': 'someverificationcode',
-            'AccessToken': 'foobar'
-        },
-    }
+OPERATION_PARAMS = {
+    'change_password': {
+        'PreviousPassword': 'myoldbadpassword',
+        'ProposedPassword': 'mynewgoodpassword',
+        'AccessToken': 'foobar'
+    },
+    'confirm_forgot_password': {
+        'ClientId': 'foo',
+        'Username': 'myusername',
+        'ConfirmationCode': 'thisismeforreal',
+        'Password': 'whydowesendpasswordsviaemail'
+    },
+    'confirm_sign_up': {
+        'ClientId': 'foo',
+        'Username': 'myusername',
+        'ConfirmationCode': 'ireallydowanttosignup'
+    },
+    'delete_user': {
+        'AccessToken': 'foobar'
+    },
+    'delete_user_attributes': {
+        'UserAttributeNames': ['myattribute'],
+        'AccessToken': 'foobar'
+    },
+    'forgot_password': {
+        'ClientId': 'foo',
+        'Username': 'myusername'
+    },
+    'get_user': {
+        'AccessToken': 'foobar'
+    },
+    'get_user_attribute_verification_code': {
+        'AttributeName': 'myattribute',
+        'AccessToken': 'foobar'
+    },
+    'resend_confirmation_code': {
+        'ClientId': 'foo',
+        'Username': 'myusername'
+    },
+    'set_user_settings': {
+        'AccessToken': 'randomtoken',
+        'MFAOptions': [{
+            'DeliveryMedium': 'SMS',
+            'AttributeName': 'someattributename'
+        }]
+    },
+    'sign_up': {
+        'ClientId': 'foo',
+        'Username': 'bar',
+        'Password': 'mysupersecurepassword',
+    },
+    'update_user_attributes': {
+        'UserAttributes': [{
+            'Name': 'someattributename',
+            'Value': 'newvalue'
+        }],
+        'AccessToken': 'foobar'
+    },
+    'verify_user_attribute': {
+        'AttributeName': 'someattributename',
+        'Code': 'someverificationcode',
+        'AccessToken': 'foobar'
+    },
+}
 
+@pytest.mark.parametrize("operation_name, parameters", OPERATION_PARAMS.items())
+def test_unsigned_operations(operation_name, parameters):
     environ = {
         'AWS_ACCESS_KEY_ID': 'access_key',
         'AWS_SECRET_ACCESS_KEY': 'secret_key',
@@ -93,28 +93,15 @@ def test_unsigned_operations():
         session = create_session()
         session.config_filename = 'no-exist-foo'
         client = session.create_client('cognito-idp', 'us-west-2')
+        http_stubber = ClientHTTPStubber(client)
 
-        for operation, params in operation_params.items():
-            test_case = UnsignedOperationTestCase(client, operation, params)
-            yield test_case.run
+        operation = getattr(client, operation_name)
 
+        http_stubber.add_response(body=b'{}')
+        with http_stubber:
+            operation(**parameters)
+            request = http_stubber.requests[0]
 
-class UnsignedOperationTestCase(object):
-    def __init__(self, client, operation_name, parameters):
-        self._client = client
-        self._operation_name = operation_name
-        self._parameters = parameters
-        self._http_stubber = ClientHTTPStubber(self._client)
-
-    def run(self):
-        operation = getattr(self._client, self._operation_name)
-
-        self._http_stubber.add_response(body=b'{}')
-        with self._http_stubber:
-            operation(**self._parameters)
-            request = self._http_stubber.requests[0]
-
-        assert_false(
-            'authorization' in request.headers,
+        assert 'authorization' not in request.headers, (
             'authorization header found in unsigned operation'
         )

--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -10,7 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from nose.tools import assert_equal
+import pytest
+
 from botocore.session import get_session
 
 
@@ -98,7 +99,22 @@ NOT_SUPPORTED_IN_SDK = [
 ]
 
 
-def test_endpoint_matches_service():
+@pytest.fixture(scope="module")
+def known_endpoint_prefixes():
+    # The entries in endpoints.json are keyed off of the endpoint
+    # prefix.  We don't directly have that data, so we have to load
+    # every service model and look up its endpoint prefix in its
+    # ``metadata`` section.
+    session = get_session()
+    loader = session.get_component('data_loader')
+    known_services = loader.list_available_services('service-2')
+    return [
+        session.get_service_model(service_name).endpoint_prefix
+        for service_name in known_services
+    ]
+
+
+def _computed_endpoint_prefixes():
     # This verifies client names match up with data from the endpoints.json
     # file.  We want to verify that every entry in the endpoints.json
     # file corresponds to a client we can construct via
@@ -119,17 +135,6 @@ def test_endpoint_matches_service():
             if service not in NOT_SUPPORTED_IN_SDK:
                 services_in_endpoints_file.add(service)
 
-    # Now we need to cross check them against services we know about.
-    # The entries in endpoints.json are keyed off of the endpoint
-    # prefix.  We don't directly have that data, so we have to load
-    # every service model and look up its endpoint prefix in its
-    # ``metadata`` section.
-    known_services = loader.list_available_services('service-2')
-    known_endpoint_prefixes = [
-        session.get_service_model(service_name).endpoint_prefix
-        for service_name in known_services
-    ]
-
     # Now we go through every known endpoint prefix in the endpoints.json
     # file and ensure it maps to an endpoint prefix we've seen
     # in a service model.
@@ -139,43 +144,45 @@ def test_endpoint_matches_service():
         # prefix.
         endpoint_prefix = ENDPOINT_PREFIX_OVERRIDE.get(endpoint_prefix,
                                                        endpoint_prefix)
-        yield (_assert_known_endpoint_prefix,
-               endpoint_prefix,
-               known_endpoint_prefixes)
+        yield endpoint_prefix
 
 
-def _assert_known_endpoint_prefix(endpoint_prefix, known_endpoint_prefixes):
+@pytest.mark.parametrize("endpoint_prefix", _computed_endpoint_prefixes())
+def test_endpoint_matches_service(known_endpoint_prefixes, endpoint_prefix):
+    # We need to cross check all computed endpoints against our
+    # known values in endpoints.json, to ensure everything lines
+    # up correctly.
     assert endpoint_prefix in known_endpoint_prefixes
 
 
-def test_service_name_matches_endpoint_prefix():
-    # Generates tests for each service to verify that the computed service
-    # named based on the service id matches the service name used to
-    # create a client (i.e the directory name in botocore/data)
-    # unless there is an explicit exception.
-    session = get_session()
-    loader = session.get_component('data_loader')
-
+def _available_services():
     # Load the list of available services. The names here represent what
     # will become the client names.
-    services = loader.list_available_services('service-2')
+    session = get_session()
+    loader = session.get_component('data_loader')
+    return loader.list_available_services('service-2')
 
-    for service in services:
-        yield _assert_service_name_matches_endpoint_prefix, session, service
 
-
-def _assert_service_name_matches_endpoint_prefix(session, service_name):
+@pytest.mark.parametrize("service_name", _available_services())
+def test_service_name_matches_endpoint_prefix(service_name):
+    """Generates tests for each service to verify that the computed service
+    named based on the service id matches the service name used to
+    create a client (i.e the directory name in botocore/data)
+    unless there is an explicit exception.
+    """
+    session = get_session()
     service_model = session.get_service_model(service_name)
     computed_name = service_model.service_id.replace(' ', '-').lower()
 
     # Handle known exceptions where we have renamed the service directory
     # for one reason or another.
     actual_service_name = SERVICE_RENAMES.get(service_name, service_name)
-    assert_equal(
-        computed_name, actual_service_name,
-        "Actual service name `%s` does not match expected service name "
-        "we computed: `%s`" % (
-            actual_service_name, computed_name))
+
+    err_msg = (
+        f"Actual service name `{actual_service_name}` does not match "
+        f"expected service name we computed: `{computed_name}`"
+    )
+    assert computed_name == actual_service_name, err_msg
 
 
 _S3_ALLOWED_PSEUDO_FIPS_REGIONS = [
@@ -190,24 +197,7 @@ _S3_ALLOWED_PSEUDO_FIPS_REGIONS = [
 ]
 
 
-def _assert_is_not_psuedo_fips_region(region_name):
-    if region_name in _S3_ALLOWED_PSEUDO_FIPS_REGIONS:
-        return
-
-    msg = (
-        'New S3 FIPS pseudo-region added: "%s". '
-        'FIPS has compliancy requirements that may not be met in all cases '
-        'for S3 clients due to the custom endpoint resolution and '
-        'construction logic.'
-    )
-
-    if 'fips' in region_name:
-        raise RuntimeError(msg % region_name)
-
-
-def test_no_s3_fips_regions():
-    # Fail if additional FIPS pseudo-regions are added to S3.
-    # This may be removed once proper support is implemented for FIPS in S3.
+def _s3_region_names():
     session = get_session()
     loader = session.get_component('data_loader')
     endpoints = loader.load_data('endpoints')
@@ -215,5 +205,21 @@ def test_no_s3_fips_regions():
     for partition in endpoints['partitions']:
         s3_service = partition['services'].get('s3', {})
         for region_name in s3_service['endpoints']:
-            region_name = region_name.lower()
-            yield _assert_is_not_psuedo_fips_region, region_name
+            yield region_name.lower()
+
+
+@pytest.mark.parametrize("region_name", _s3_region_names())
+def test_no_s3_fips_regions(region_name):
+    # Fail if additional FIPS pseudo-regions are added to S3.
+    # This may be removed once proper support is implemented for FIPS in S3.
+    if region_name in _S3_ALLOWED_PSEUDO_FIPS_REGIONS:
+        return
+
+    err_msg = (
+        'New S3 FIPS pseudo-region added: "{region_name}". '
+        'FIPS has compliancy requirements that may not be met in all cases '
+        'for S3 clients due to the custom endpoint resolution and '
+        'construction logic.'
+    )
+
+    assert 'fips' not in region_name, err_msg

--- a/tests/functional/test_model_backcompat.py
+++ b/tests/functional/test_model_backcompat.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import os
 
-from nose.tools import assert_equal
 from botocore.session import Session
 from tests import ClientHTTPStubber
 from tests.functional import TEST_MODELS_DIR
@@ -56,21 +55,19 @@ def test_old_model_continues_to_work():
                      'Content-Type': 'application/x-amz-json-1.1'},
             body=b'{"CertificateSummaryList":[]}')
         response = client.list_certificates()
-        assert_equal(
-            response,
-            {'CertificateSummaryList': [],
-             'ResponseMetadata': {
-                 'HTTPHeaders': {
-                     'content-length': '29',
-                     'content-type': 'application/x-amz-json-1.1',
-                     'date': 'Fri, 26 Oct 2018 01:46:30 GMT',
-                     'x-amzn-requestid': 'abcd'},
-                 'HTTPStatusCode': 200,
-                 'RequestId': 'abcd',
-                 'RetryAttempts': 0}
-             }
-        )
+        assert response == {
+            'CertificateSummaryList': [],
+            'ResponseMetadata': {
+                'HTTPHeaders': {
+                    'content-length': '29',
+                    'content-type': 'application/x-amz-json-1.1',
+                    'date': 'Fri, 26 Oct 2018 01:46:30 GMT',
+                    'x-amzn-requestid': 'abcd'},
+                'HTTPStatusCode': 200,
+                'RequestId': 'abcd',
+                'RetryAttempts': 0}
+        }
 
     # Also verify we can use the paginators as well.
-    assert_equal(client.can_paginate('list_certificates'), True)
-    assert_equal(client.waiter_names, ['certificate_validated'])
+    assert client.can_paginate('list_certificates') is True
+    assert client.waiter_names == ['certificate_validated']

--- a/tests/functional/test_paginate.py
+++ b/tests/functional/test_paginate.py
@@ -10,11 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from __future__ import division
 from math import ceil
 from datetime import datetime
 
-from nose.tools import assert_equal
+import pytest
 
 from tests import random_chars
 from tests import BaseSessionTest
@@ -217,22 +216,19 @@ class TestCloudwatchLogsPagination(BaseSessionTest):
         self.assertEqual(len(result['events']), 1)
 
 
-def test_token_encoding():
-    cases = [
+@pytest.mark.parametrize(
+    "token_dict",
+    (
         {'foo': 'bar'},
         {'foo': b'bar'},
         {'foo': {'bar': b'baz'}},
         {'foo': ['bar', b'baz']},
         {'foo': b'\xff'},
         {'foo': {'bar': b'baz', 'bin': [b'bam']}},
-    ]
-
-    for token_dict in cases:
-        yield assert_token_encodes_and_decodes, token_dict
-
-
-def assert_token_encodes_and_decodes(token_dict):
+    )
+)
+def test_token_encoding(token_dict):
     encoded = TokenEncoder().encode(token_dict)
     assert isinstance(encoded, six.string_types)
     decoded = TokenDecoder().decode(encoded)
-    assert_equal(decoded, token_dict)
+    assert decoded == token_dict

--- a/tests/functional/test_paginator_config.py
+++ b/tests/functional/test_paginator_config.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import string
 
+import pytest
 import jmespath
 from jmespath.exceptions import JMESPathError
 
@@ -130,7 +131,7 @@ KNOWN_EXTRA_OUTPUT_KEYS = [
 ]
 
 
-def test_lint_pagination_configs():
+def _pagination_configs():
     session = botocore.session.get_session()
     loader = session.get_component('data_loader')
     services = loader.list_available_services('paginators-1')
@@ -140,15 +141,16 @@ def test_lint_pagination_configs():
                                                 'paginators-1')
         for op_name, single_config in page_config['pagination'].items():
             yield (
-                _lint_single_paginator,
                 op_name,
                 single_config,
                 service_model
             )
 
-
-def _lint_single_paginator(operation_name, page_config,
-                           service_model):
+@pytest.mark.parametrize(
+    "operation_name, page_config, service_model",
+    _pagination_configs()
+)
+def test_lint_pagination_configs(operation_name, page_config, service_model):
     _validate_known_pagination_keys(page_config)
     _valiate_result_key_exists(page_config)
     _validate_referenced_operation_exists(operation_name, service_model)

--- a/tests/functional/test_public_apis.py
+++ b/tests/functional/test_public_apis.py
@@ -13,6 +13,7 @@
 from collections import defaultdict
 
 import mock
+import pytest
 
 from tests import ClientHTTPStubber
 from botocore.session import Session
@@ -46,23 +47,7 @@ class EarlyExit(Exception):
     pass
 
 
-def _test_public_apis_will_not_be_signed(client, operation, kwargs):
-    with ClientHTTPStubber(client) as http_stubber:
-        http_stubber.responses.append(EarlyExit())
-        try:
-            operation(**kwargs)
-        except EarlyExit:
-            pass
-        request = http_stubber.requests[0]
-    sig_v2_disabled = 'SignatureVersion=2' not in request.url
-    assert sig_v2_disabled, "SigV2 is incorrectly enabled"
-    sig_v3_disabled = 'X-Amzn-Authorization' not in request.headers
-    assert sig_v3_disabled, "SigV3 is incorrectly enabled"
-    sig_v4_disabled = 'Authorization' not in request.headers
-    assert sig_v4_disabled, "SigV4 is incorrectly enabled"
-
-
-def test_public_apis_will_not_be_signed():
+def _public_apis():
     session = Session()
 
     # Mimic the scenario that user does not have aws credentials setup
@@ -73,4 +58,22 @@ def test_public_apis_will_not_be_signed():
         for operation_name in PUBLIC_API_TESTS[service_name]:
             kwargs = PUBLIC_API_TESTS[service_name][operation_name]
             method = getattr(client, xform_name(operation_name))
-            yield _test_public_apis_will_not_be_signed, client, method, kwargs
+            yield client, method, kwargs
+
+
+@pytest.mark.parametrize("client, operation, kwargs", _public_apis())
+def test_public_apis_will_not_be_signed(client, operation, kwargs):
+    with ClientHTTPStubber(client) as http_stubber:
+        http_stubber.responses.append(EarlyExit())
+        try:
+            operation(**kwargs)
+        except EarlyExit:
+            pass
+        request = http_stubber.requests[0]
+
+    sig_v2_disabled = 'SignatureVersion=2' not in request.url
+    assert sig_v2_disabled, "SigV2 is incorrectly enabled"
+    sig_v3_disabled = 'X-Amzn-Authorization' not in request.headers
+    assert sig_v3_disabled, "SigV3 is incorrectly enabled"
+    sig_v4_disabled = 'Authorization' not in request.headers
+    assert sig_v4_disabled, "SigV4 is incorrectly enabled"

--- a/tests/functional/test_response_shadowing.py
+++ b/tests/functional/test_response_shadowing.py
@@ -10,40 +10,52 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from botocore.session import Session
-from nose.tools import assert_false
 
 
 def _all_services():
     session = Session()
     service_names = session.get_available_services()
-    for service_name in service_names:
-        yield session.get_service_model(service_name)
+    return [session.get_service_model(name) for name in service_names]
+
+
+# Only compute our service models once
+ALL_SERVICES = _all_services()
+
+
+def _all_service_error_shapes():
+    for service_model in ALL_SERVICES:
+        for shape in service_model.error_shapes:
+            yield shape
 
 
 def _all_operations():
-    for service_model in _all_services():
+    for service_model in ALL_SERVICES:
         for operation_name in service_model.operation_names:
-            yield service_model.operation_model(operation_name)
+            yield service_model.operation_model(operation_name).output_shape
 
 
 def _assert_not_shadowed(key, shape):
     if not shape:
         return
-    msg = (
-        'Found shape "%s" that shadows the botocore response key "%s"'
+
+    assert key not in shape.members, (
+        f'Found shape "{shape.name}" that shadows the botocore response key "{key}"'
     )
-    assert_false(key in shape.members, msg % (shape.name, key))
 
 
-def test_response_metadata_is_not_shadowed():
-    for operation_model in _all_operations():
-        shape = operation_model.output_shape
-        yield _assert_not_shadowed, 'ResponseMetadata', shape
+@pytest.mark.parametrize("operation_output_shape", _all_operations())
+def test_response_metadata_is_not_shadowed(operation_output_shape):
+    _assert_not_shadowed('ResponseMetadata', operation_output_shape)
 
 
-def test_exceptions_do_not_shadow():
-    for service_model in _all_services():
-        for shape in service_model.error_shapes:
-            yield _assert_not_shadowed, 'ResponseMetadata', shape
-            yield _assert_not_shadowed, 'Error', shape
+@pytest.mark.parametrize("error_shape", _all_service_error_shapes())
+def test_exceptions_do_not_shadow_response_metadata(error_shape):
+    _assert_not_shadowed('ResponseMetadata', error_shape)
+
+
+@pytest.mark.parametrize("error_shape", _all_service_error_shapes())
+def test_exceptions_do_not_shadow_error(error_shape):
+    _assert_not_shadowed('Error', error_shape)

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -13,9 +13,10 @@
 import base64
 import re
 
+import pytest
+
 from tests import temporary_file
 from tests import unittest, mock, BaseSessionTest, create_session, ClientHTTPStubber
-from nose.tools import assert_equal
 
 import botocore.session
 from botocore.config import Config
@@ -1095,7 +1096,7 @@ class TestS3GetBucketLifecycle(BaseS3OperationTest):
 
 class TestS3PutObject(BaseS3OperationTest):
     def test_500_error_with_non_xml_body(self):
-        # Note: This exact test case may not be applicable from
+        # Note: This exact tesdict may not be applicable from
         # an integration standpoint if the issue is fixed in the future.
         #
         # The issue is that:
@@ -1535,51 +1536,51 @@ class TestGeneratePresigned(BaseS3OperationTest):
         self.assertEqual(parts, expected)
 
 
-def test_checksums_included_in_expected_operations():
-    """Validate expected calls include Content-MD5 header"""
 
-    t = S3ChecksumCases(_verify_checksum_in_headers)
-    yield t.case('put_bucket_tagging',
+def _checksum_test_cases():
+    yield ('put_bucket_tagging',
             {"Bucket": "foo", "Tagging":{"TagSet":[]}})
-    yield t.case('put_bucket_lifecycle',
+    yield ('put_bucket_lifecycle',
             {"Bucket": "foo", "LifecycleConfiguration":{"Rules":[]}})
-    yield t.case('put_bucket_lifecycle_configuration',
+    yield ('put_bucket_lifecycle_configuration',
             {"Bucket": "foo", "LifecycleConfiguration":{"Rules":[]}})
-    yield t.case('put_bucket_cors',
+    yield ('put_bucket_cors',
             {"Bucket": "foo", "CORSConfiguration":{"CORSRules": []}})
-    yield t.case('delete_objects',
+    yield ('delete_objects',
             {"Bucket": "foo", "Delete": {"Objects": [{"Key": "bar"}]}})
-    yield t.case('put_bucket_replication',
+    yield ('put_bucket_replication',
             {"Bucket": "foo",
              "ReplicationConfiguration": {"Role":"", "Rules": []}})
-    yield t.case('put_bucket_acl',
+    yield ('put_bucket_acl',
             {"Bucket": "foo", "AccessControlPolicy":{}})
-    yield t.case('put_bucket_logging',
+    yield ('put_bucket_logging',
             {"Bucket": "foo",
              "BucketLoggingStatus":{}})
-    yield t.case('put_bucket_notification',
+    yield ('put_bucket_notification',
             {"Bucket": "foo", "NotificationConfiguration":{}})
-    yield t.case('put_bucket_policy',
+    yield ('put_bucket_policy',
             {"Bucket": "foo", "Policy": "<bucket-policy>"})
-    yield t.case('put_bucket_request_payment',
+    yield ('put_bucket_request_payment',
             {"Bucket": "foo", "RequestPaymentConfiguration":{"Payer": ""}})
-    yield t.case('put_bucket_versioning',
+    yield ('put_bucket_versioning',
             {"Bucket": "foo", "VersioningConfiguration":{}})
-    yield t.case('put_bucket_website',
+    yield ('put_bucket_website',
             {"Bucket": "foo",
              "WebsiteConfiguration":{}})
-    yield t.case('put_object_acl',
+    yield ('put_object_acl',
             {"Bucket": "foo", "Key": "bar", "AccessControlPolicy":{}})
-    yield t.case('put_object_legal_hold',
+    yield ('put_object_legal_hold',
             {"Bucket": "foo", "Key": "bar", "LegalHold":{"Status": "ON"}})
-    yield t.case('put_object_retention',
+    yield ('put_object_retention',
             {"Bucket": "foo", "Key": "bar",
              "Retention":{"RetainUntilDate":"2020-11-05"}})
-    yield t.case('put_object_lock_configuration',
+    yield ('put_object_lock_configuration',
             {"Bucket": "foo", "ObjectLockConfiguration":{}})
 
 
-def _verify_checksum_in_headers(operation, operation_kwargs):
+@pytest.mark.parametrize("operation, operation_kwargs", _checksum_test_cases())
+def test_checksums_included_in_expected_operations(operation, operation_kwargs):
+    """Validate expected calls include Content-MD5 header"""
     environ = {}
     with mock.patch('os.environ', environ):
         environ['AWS_ACCESS_KEY_ID'] = 'access_key'
@@ -1595,42 +1596,38 @@ def _verify_checksum_in_headers(operation, operation_kwargs):
             assert 'Content-MD5' in stub.requests[-1].headers
 
 
-def test_correct_url_used_for_s3():
-    # Test that given various sets of config options and bucket names,
-    # we construct the expect endpoint url.
-    t = S3AddressingCases(_verify_expected_endpoint_url)
-
+def _s3_addressing_test_cases():
     # The default behavior for DNS compatible buckets
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
+    yield dict(region='us-west-2', bucket='bucket', key='key',
                  expected_url='https://bucket.s3.us-west-2.amazonaws.com/key')
-    yield t.case(region='us-east-1', bucket='bucket', key='key',
+    yield dict(region='us-east-1', bucket='bucket', key='key',
                  expected_url='https://bucket.s3.us-east-1.amazonaws.com/key')
-    yield t.case(region='us-west-1', bucket='bucket', key='key',
+    yield dict(region='us-west-1', bucket='bucket', key='key',
                  expected_url='https://bucket.s3.us-west-1.amazonaws.com/key')
-    yield t.case(region='us-west-1', bucket='bucket', key='key',
+    yield dict(region='us-west-1', bucket='bucket', key='key',
                  is_secure=False,
                  expected_url='http://bucket.s3.us-west-1.amazonaws.com/key')
 
     # Virtual host addressing is independent of signature version.
-    yield t.case(region='aws-global', bucket='bucket', key='key',
+    yield dict(region='aws-global', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url='https://bucket.s3.amazonaws.com/key')
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
+    yield dict(region='us-west-2', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url=(
                      'https://bucket.s3.us-west-2.amazonaws.com/key'))
-    yield t.case(region='us-east-1', bucket='bucket', key='key',
+    yield dict(region='us-east-1', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url='https://bucket.s3.us-east-1.amazonaws.com/key')
-    yield t.case(region='us-west-1', bucket='bucket', key='key',
+    yield dict(region='us-west-1', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url=(
                      'https://bucket.s3.us-west-1.amazonaws.com/key'))
-    yield t.case(region='us-west-1', bucket='bucket', key='key',
+    yield dict(region='us-west-1', bucket='bucket', key='key',
                  signature_version='s3v4', is_secure=False,
                  expected_url=(
                      'http://bucket.s3.us-west-1.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region='us-west-1', bucket='bucket-with-num-1', key='key',
         signature_version='s3v4', is_secure=False,
         expected_url='http://bucket-with-num-1.s3.us-west-1.amazonaws.com/key')
@@ -1638,187 +1635,187 @@ def test_correct_url_used_for_s3():
     # Regions outside of the 'aws' partition.
     # These should still default to virtual hosted addressing
     # unless explicitly configured otherwise.
-    yield t.case(region='cn-north-1', bucket='bucket', key='key',
+    yield dict(region='cn-north-1', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url=(
                      'https://bucket.s3.cn-north-1.amazonaws.com.cn/key'))
     # If the request is unsigned, we should have the default
     # fix_s3_host behavior which is to use virtual hosting where
     # possible but fall back to path style when needed.
-    yield t.case(region='cn-north-1', bucket='bucket', key='key',
+    yield dict(region='cn-north-1', bucket='bucket', key='key',
                  signature_version=UNSIGNED,
                  expected_url=(
                      'https://bucket.s3.cn-north-1.amazonaws.com.cn/key'))
-    yield t.case(region='cn-north-1', bucket='bucket.dot', key='key',
+    yield dict(region='cn-north-1', bucket='bucket.dot', key='key',
                  signature_version=UNSIGNED,
                  expected_url=(
                      'https://s3.cn-north-1.amazonaws.com.cn/bucket.dot/key'))
 
     # And of course you can explicitly specify which style to use.
     virtual_hosting = {'addressing_style': 'virtual'}
-    yield t.case(region='cn-north-1', bucket='bucket', key='key',
+    yield dict(region='cn-north-1', bucket='bucket', key='key',
                  signature_version=UNSIGNED,
                  s3_config=virtual_hosting,
                  expected_url=(
                      'https://bucket.s3.cn-north-1.amazonaws.com.cn/key'))
     path_style = {'addressing_style': 'path'}
-    yield t.case(region='cn-north-1', bucket='bucket', key='key',
+    yield dict(region='cn-north-1', bucket='bucket', key='key',
                  signature_version=UNSIGNED,
                  s3_config=path_style,
                  expected_url=(
                      'https://s3.cn-north-1.amazonaws.com.cn/bucket/key'))
 
     # If you don't have a DNS compatible bucket, we use path style.
-    yield t.case(
+    yield dict(
         region='aws-global', bucket='bucket.dot', key='key',
         expected_url='https://s3.amazonaws.com/bucket.dot/key')
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket.dot', key='key',
         expected_url='https://s3.us-west-2.amazonaws.com/bucket.dot/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket.dot', key='key',
         expected_url='https://s3.us-east-1.amazonaws.com/bucket.dot/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='BucketName', key='key',
         expected_url='https://s3.us-east-1.amazonaws.com/BucketName/key')
-    yield t.case(
+    yield dict(
         region='us-west-1', bucket='bucket_name', key='key',
         expected_url='https://s3.us-west-1.amazonaws.com/bucket_name/key')
-    yield t.case(
+    yield dict(
         region='us-west-1', bucket='-bucket-name', key='key',
         expected_url='https://s3.us-west-1.amazonaws.com/-bucket-name/key')
-    yield t.case(
+    yield dict(
         region='us-west-1', bucket='bucket-name-', key='key',
         expected_url='https://s3.us-west-1.amazonaws.com/bucket-name-/key')
-    yield t.case(
+    yield dict(
         region='us-west-1', bucket='aa', key='key',
         expected_url='https://s3.us-west-1.amazonaws.com/aa/key')
-    yield t.case(
+    yield dict(
         region='us-west-1', bucket='a'*64, key='key',
         expected_url=('https://s3.us-west-1.amazonaws.com/%s/key' % ('a' * 64))
     )
 
     # Custom endpoint url should always be used.
-    yield t.case(
+    yield dict(
         customer_provided_endpoint='https://my-custom-s3/',
         bucket='foo', key='bar',
         expected_url='https://my-custom-s3/foo/bar')
-    yield t.case(
+    yield dict(
         customer_provided_endpoint='https://my-custom-s3/',
         bucket='bucket.dots', key='bar',
         expected_url='https://my-custom-s3/bucket.dots/bar')
     # Doesn't matter what region you specify, a custom endpoint url always
     # wins.
-    yield t.case(
+    yield dict(
         customer_provided_endpoint='https://my-custom-s3/',
         region='us-west-2', bucket='foo', key='bar',
         expected_url='https://my-custom-s3/foo/bar')
 
     # Explicitly configuring "virtual" addressing_style.
     virtual_hosting = {'addressing_style': 'virtual'}
-    yield t.case(
+    yield dict(
         region='aws-global', bucket='bucket', key='key',
         s3_config=virtual_hosting,
         expected_url='https://bucket.s3.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=virtual_hosting,
         expected_url='https://bucket.s3.us-east-1.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket', key='key',
         s3_config=virtual_hosting,
         expected_url='https://bucket.s3.us-west-2.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='eu-central-1', bucket='bucket', key='key',
         s3_config=virtual_hosting,
         expected_url='https://bucket.s3.eu-central-1.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=virtual_hosting,
         customer_provided_endpoint='https://foo.amazonaws.com',
         expected_url='https://bucket.foo.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='unknown', bucket='bucket', key='key',
         s3_config=virtual_hosting,
         expected_url='https://bucket.s3.unknown.amazonaws.com/key')
 
     # Test us-gov with virtual addressing.
-    yield t.case(
+    yield dict(
         region='us-gov-west-1', bucket='bucket', key='key',
         s3_config=virtual_hosting,
         expected_url='https://bucket.s3.us-gov-west-1.amazonaws.com/key')
 
     # Test path style addressing.
     path_style = {'addressing_style': 'path'}
-    yield t.case(
+    yield dict(
         region='aws-global', bucket='bucket', key='key',
         s3_config=path_style,
         expected_url='https://s3.amazonaws.com/bucket/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=path_style,
         expected_url='https://s3.us-east-1.amazonaws.com/bucket/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=path_style,
         customer_provided_endpoint='https://foo.amazonaws.com/',
         expected_url='https://foo.amazonaws.com/bucket/key')
-    yield t.case(
+    yield dict(
         region='unknown', bucket='bucket', key='key',
         s3_config=path_style,
         expected_url='https://s3.unknown.amazonaws.com/bucket/key')
 
     # S3 accelerate
     use_accelerate = {'use_accelerate_endpoint': True}
-    yield t.case(
+    yield dict(
         region='aws-global', bucket='bucket', key='key',
         s3_config=use_accelerate,
         expected_url='https://bucket.s3-accelerate.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=use_accelerate,
         expected_url='https://bucket.s3-accelerate.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         # region is ignored with S3 accelerate.
         region='us-west-2', bucket='bucket', key='key',
         s3_config=use_accelerate,
         expected_url='https://bucket.s3-accelerate.amazonaws.com/key')
     # Provided endpoints still get recognized as accelerate endpoints.
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         customer_provided_endpoint='https://s3-accelerate.amazonaws.com',
         expected_url='https://bucket.s3-accelerate.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         customer_provided_endpoint='http://s3-accelerate.amazonaws.com',
         expected_url='http://bucket.s3-accelerate.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=use_accelerate, is_secure=False,
         # Note we're using http://  because is_secure=False.
         expected_url='http://bucket.s3-accelerate.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         # s3-accelerate must be the first part of the url.
         customer_provided_endpoint='https://foo.s3-accelerate.amazonaws.com',
         expected_url='https://foo.s3-accelerate.amazonaws.com/bucket/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         # The endpoint must be an Amazon endpoint.
         customer_provided_endpoint='https://s3-accelerate.notamazon.com',
         expected_url='https://s3-accelerate.notamazon.com/bucket/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         # Extra components must be whitelisted.
         customer_provided_endpoint='https://s3-accelerate.foo.amazonaws.com',
         expected_url='https://s3-accelerate.foo.amazonaws.com/bucket/key')
-    yield t.case(
+    yield dict(
         region='unknown', bucket='bucket', key='key',
         s3_config=use_accelerate,
         expected_url='https://bucket.s3-accelerate.amazonaws.com/key')
     # Use virtual even if path is specified for s3 accelerate because
     # path style will not work with S3 accelerate.
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={'use_accelerate_endpoint': True,
                    'addressing_style': 'path'},
@@ -1826,12 +1823,12 @@ def test_correct_url_used_for_s3():
 
     # S3 dual stack endpoints.
     use_dualstack = {'use_dualstack_endpoint': True}
-    yield t.case(
+    yield dict(
         region=None, bucket='bucket', key='key',
         s3_config=use_dualstack,
         # Uses us-east-1 for no region set.
         expected_url='https://bucket.s3.dualstack.us-east-1.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='aws-global', bucket='bucket', key='key',
         s3_config=use_dualstack,
         # Pseudo-regions should not have any special resolving logic even when
@@ -1840,35 +1837,35 @@ def test_correct_url_used_for_s3():
         # region name.
         expected_url=(
             'https://bucket.s3.dualstack.aws-global.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region=None, bucket='bucket', key='key',
         s3_config=use_dualstack, signature_version='s3v4',
         expected_url='https://bucket.s3.dualstack.us-east-1.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='aws-global', bucket='bucket', key='key',
         s3_config=use_dualstack, signature_version='s3v4',
         expected_url='https://bucket.s3.dualstack.aws-global.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=use_dualstack, signature_version='s3v4',
         expected_url='https://bucket.s3.dualstack.us-east-1.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket', key='key',
         s3_config=use_dualstack, signature_version='s3v4',
         expected_url='https://bucket.s3.dualstack.us-west-2.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='unknown', bucket='bucket', key='key',
         s3_config=use_dualstack, signature_version='s3v4',
         expected_url='https://bucket.s3.dualstack.unknown.amazonaws.com/key')
     # Non DNS compatible buckets use path style for dual stack.
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket.dot', key='key',
         s3_config=use_dualstack,
         # Still default to virtual hosted when possible.
         expected_url=(
             'https://s3.dualstack.us-west-2.amazonaws.com/bucket.dot/key'))
     # Supports is_secure (use_ssl=False in create_client()).
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket.dot', key='key', is_secure=False,
         s3_config=use_dualstack,
         # Still default to virtual hosted when possible.
@@ -1881,7 +1878,7 @@ def test_correct_url_used_for_s3():
         'use_dualstack_endpoint': True,
         'addressing_style': 'path',
     }
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket', key='key',
         s3_config=force_path_style,
         # Still default to virtual hosted when possible.
@@ -1892,32 +1889,32 @@ def test_correct_url_used_for_s3():
         'use_accelerate_endpoint': True,
         'use_dualstack_endpoint': True,
     }
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=use_accelerate_dualstack,
         expected_url=(
             'https://bucket.s3-accelerate.dualstack.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         # Region is ignored with S3 accelerate.
         region='us-west-2', bucket='bucket', key='key',
         s3_config=use_accelerate_dualstack,
         expected_url=(
             'https://bucket.s3-accelerate.dualstack.amazonaws.com/key'))
     # Only s3-accelerate overrides a customer endpoint.
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=use_dualstack,
         customer_provided_endpoint='https://s3-accelerate.amazonaws.com',
         expected_url=(
             'https://bucket.s3-accelerate.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         # Dualstack is whitelisted.
         customer_provided_endpoint=(
             'https://s3-accelerate.dualstack.amazonaws.com'),
         expected_url=(
             'https://bucket.s3-accelerate.dualstack.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         # Even whitelisted parts cannot be duplicated.
         customer_provided_endpoint=(
@@ -1925,7 +1922,7 @@ def test_correct_url_used_for_s3():
         expected_url=(
             'https://s3-accelerate.dualstack.dualstack'
             '.amazonaws.com/bucket/key'))
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         # More than two extra parts is not allowed.
         customer_provided_endpoint=(
@@ -1934,12 +1931,12 @@ def test_correct_url_used_for_s3():
         expected_url=(
             'https://s3-accelerate.dualstack.dualstack.dualstack.amazonaws.com'
             '/bucket/key'))
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         # Extra components must be whitelisted.
         customer_provided_endpoint='https://s3-accelerate.foo.amazonaws.com',
         expected_url='https://s3-accelerate.foo.amazonaws.com/bucket/key')
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=use_accelerate_dualstack, is_secure=False,
         # Note we're using http://  because is_secure=False.
@@ -1948,7 +1945,7 @@ def test_correct_url_used_for_s3():
     # Use virtual even if path is specified for s3 accelerate because
     # path style will not work with S3 accelerate.
     use_accelerate_dualstack['addressing_style'] = 'path'
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=use_accelerate_dualstack,
         expected_url=(
@@ -1958,14 +1955,14 @@ def test_correct_url_used_for_s3():
     accesspoint_arn = (
         'arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint'
     )
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='key',
         s3_config={'use_arn_region': True},
         expected_url=(
@@ -1973,30 +1970,30 @@ def test_correct_url_used_for_s3():
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='myendpoint/key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/myendpoint/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='foo/myendpoint/key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/foo/myendpoint/key'
         )
     )
-    yield t.case(
+    yield dict(
         # Note: The access-point arn has us-west-2 and the client's region is
-        # us-east-1, for the default case the access-point arn region is used.
+        # us-east-1, for the defauldict the access-point arn region is used.
         region='us-east-1', bucket=accesspoint_arn, key='key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket=accesspoint_arn, key='key',
         s3_config={'use_arn_region': False},
         expected_url=(
@@ -2004,7 +2001,7 @@ def test_correct_url_used_for_s3():
             'us-east-1.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='s3-external-1', bucket=accesspoint_arn, key='key',
         s3_config={'use_arn_region': True},
         expected_url=(
@@ -2013,7 +2010,7 @@ def test_correct_url_used_for_s3():
         )
     )
 
-    yield t.case(
+    yield dict(
         region='aws-global', bucket=accesspoint_arn, key='key',
         s3_config={'use_arn_region': True},
         expected_url=(
@@ -2021,7 +2018,7 @@ def test_correct_url_used_for_s3():
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='unknown', bucket=accesspoint_arn, key='key',
         s3_config={'use_arn_region': False},
         expected_url=(
@@ -2029,7 +2026,7 @@ def test_correct_url_used_for_s3():
             'unknown.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='unknown', bucket=accesspoint_arn, key='key',
         s3_config={'use_arn_region': True},
         expected_url=(
@@ -2040,21 +2037,21 @@ def test_correct_url_used_for_s3():
     accesspoint_arn_cn = (
         'arn:aws-cn:s3:cn-north-1:123456789012:accesspoint:myendpoint'
     )
-    yield t.case(
+    yield dict(
         region='cn-north-1', bucket=accesspoint_arn_cn, key='key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'cn-north-1.amazonaws.com.cn/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='cn-northwest-1', bucket=accesspoint_arn_cn, key='key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'cn-north-1.amazonaws.com.cn/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='cn-northwest-1', bucket=accesspoint_arn_cn, key='key',
         s3_config={'use_arn_region': False},
         expected_url=(
@@ -2065,21 +2062,21 @@ def test_correct_url_used_for_s3():
     accesspoint_arn_gov = (
         'arn:aws-us-gov:s3:us-gov-west-1:123456789012:accesspoint:myendpoint'
     )
-    yield t.case(
+    yield dict(
         region='us-gov-west-1', bucket=accesspoint_arn_gov, key='key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-gov-west-1.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='fips-us-gov-west-1', bucket=accesspoint_arn_gov, key='key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint-fips.'
             'us-gov-west-1.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='fips-us-gov-west-1', bucket=accesspoint_arn_gov, key='key',
         s3_config={'use_arn_region': False},
         expected_url=(
@@ -2088,7 +2085,7 @@ def test_correct_url_used_for_s3():
         )
     )
 
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='key', is_secure=False,
         expected_url=(
             'http://myendpoint-123456789012.s3-accesspoint.'
@@ -2096,9 +2093,9 @@ def test_correct_url_used_for_s3():
         )
     )
     # Dual-stack with access-point arn
-    yield t.case(
+    yield dict(
         # Note: The access-point arn has us-west-2 and the client's region is
-        # us-east-1, for the default case the access-point arn region is used.
+        # us-east-1, for the defauldict the access-point arn region is used.
         region='us-east-1', bucket=accesspoint_arn, key='key',
         s3_config={
             'use_dualstack_endpoint': True,
@@ -2108,7 +2105,7 @@ def test_correct_url_used_for_s3():
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket=accesspoint_arn, key='key',
         s3_config={
             'use_dualstack_endpoint': True,
@@ -2119,7 +2116,7 @@ def test_correct_url_used_for_s3():
             'us-east-1.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-gov-west-1', bucket=accesspoint_arn_gov, key='key',
         s3_config={
             'use_dualstack_endpoint': True,
@@ -2129,7 +2126,7 @@ def test_correct_url_used_for_s3():
             'us-gov-west-1.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='fips-us-gov-west-1', bucket=accesspoint_arn_gov, key='key',
         s3_config={
             'use_arn_region': True,
@@ -2142,58 +2139,58 @@ def test_correct_url_used_for_s3():
     )
     # None of the various s3 settings related to paths should affect what
     # endpoint to use when an access-point is provided.
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='key',
-        s3_config={'adressing_style': 'auto'},
+        s3_config={'addressing_style': 'auto'},
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='key',
-        s3_config={'adressing_style': 'virtual'},
+        s3_config={'addressing_style': 'virtual'},
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='key',
-        s3_config={'adressing_style': 'path'},
+        s3_config={'addressing_style': 'path'},
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/key'
         )
     )
 
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         expected_url=(
             'https://bucket.s3.us-east-1.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket', key='key',
         expected_url=(
             'https://bucket.s3.us-west-2.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region=None, bucket='bucket', key='key',
         expected_url=(
             'https://bucket.s3.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={
             'use_dualstack_endpoint': True,
         },
         expected_url=(
             'https://bucket.s3.dualstack.us-east-1.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={
             'use_accelerate_endpoint': True,
         },
         expected_url=(
             'https://bucket.s3-accelerate.amazonaws.com/key'))
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config={
             'use_accelerate_endpoint': True,
@@ -2206,7 +2203,7 @@ def test_correct_url_used_for_s3():
         'arn:aws-us-gov:s3-object-lambda:us-gov-west-1:'
         '123456789012:accesspoint:mybanner'
     )
-    yield t.case(
+    yield dict(
         region='fips-us-gov-west-1', bucket=s3_object_lambda_arn_gov, key='key',
         expected_url=(
             'https://mybanner-123456789012.s3-object-lambda-fips.'
@@ -2217,7 +2214,7 @@ def test_correct_url_used_for_s3():
         'arn:aws:s3-object-lambda:us-east-1:'
         '123456789012:accesspoint:mybanner'
     )
-    yield t.case(
+    yield dict(
         region='aws-global', bucket=s3_object_lambda_arn, key='key',
         s3_config={'use_arn_region': True},
         expected_url=(
@@ -2227,33 +2224,17 @@ def test_correct_url_used_for_s3():
     )
 
 
-class BaseTestCase:
-    def __init__(self, verify_function):
-        self._verify = verify_function
-
-    def case(self, **kwargs):
-        return self._verify, kwargs
-
-
-class S3AddressingCases(BaseTestCase):
-    def case(self, region=None, bucket='bucket', key='key',
-             s3_config=None, is_secure=True, customer_provided_endpoint=None,
-             expected_url=None, signature_version=None):
-        return (
-            self._verify, region, bucket, key, s3_config, is_secure,
-            customer_provided_endpoint, expected_url, signature_version
-        )
+@pytest.mark.parametrize("test_case", _s3_addressing_test_cases())
+def test_correct_url_used_for_s3(test_case):
+    # Test that given various sets of config options and bucket names,
+    # we construct the expect endpoint url.
+    _verify_expected_endpoint_url(**test_case)
 
 
-class S3ChecksumCases(BaseTestCase):
-    def case(self, operation, operation_args):
-        return self._verify, operation, operation_args
-
-
-def _verify_expected_endpoint_url(region, bucket, key, s3_config,
-                                  is_secure=True,
-                                  customer_provided_endpoint=None,
-                                  expected_url=None, signature_version=None):
+def _verify_expected_endpoint_url(
+    region=None, bucket='bucket', key='key', s3_config=None, is_secure=True,
+    customer_provided_endpoint=None, expected_url=None, signature_version=None
+):
     environ = {}
     with mock.patch('os.environ', environ):
         environ['AWS_ACCESS_KEY_ID'] = 'access_key'
@@ -2272,7 +2253,7 @@ def _verify_expected_endpoint_url(region, bucket, key, s3_config,
         with ClientHTTPStubber(s3) as http_stubber:
             http_stubber.add_response()
             s3.put_object(Bucket=bucket, Key=key, Body=b'bar')
-            assert_equal(http_stubber.requests[0].url, expected_url)
+            assert http_stubber.requests[0].url == expected_url
 
 
 def _create_s3_client(region, is_secure, endpoint_url, s3_config,
@@ -2295,79 +2276,74 @@ def _create_s3_client(region, is_secure, endpoint_url, s3_config,
         return s3
 
 
-def test_addressing_for_presigned_urls():
-    # See TestGeneratePresigned for more detailed test cases
-    # on presigned URLs.  Here's we're just focusing on the
-    # adddressing mode used for presigned URLs.
-    # We special case presigned URLs due to backwards
-    # compatibility.
-    t = S3AddressingCases(_verify_presigned_url_addressing)
 
-    yield t.case(region=None, bucket='bucket', key='key',
+def _addressing_for_presigned_url_test_cases():
+
+    yield dict(region=None, bucket='bucket', key='key',
                  signature_version=None,
                  expected_url='https://bucket.s3.amazonaws.com/key')
-    yield t.case(region='aws-global', bucket='bucket', key='key',
+    yield dict(region='aws-global', bucket='bucket', key='key',
                  signature_version=None,
                  expected_url='https://bucket.s3.amazonaws.com/key')
-    yield t.case(region='us-east-1', bucket='bucket', key='key',
+    yield dict(region='us-east-1', bucket='bucket', key='key',
                  signature_version=None,
                  expected_url='https://bucket.s3.us-east-1.amazonaws.com/key')
-    yield t.case(region='us-east-1', bucket='bucket', key='key',
+    yield dict(region='us-east-1', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url='https://bucket.s3.us-east-1.amazonaws.com/key')
-    yield t.case(region='us-east-1', bucket='bucket', key='key',
+    yield dict(region='us-east-1', bucket='bucket', key='key',
                  signature_version='s3v4',
                  s3_config={'addressing_style': 'path'},
                  expected_url='https://s3.us-east-1.amazonaws.com/bucket/key')
 
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
+    yield dict(region='us-west-2', bucket='bucket', key='key',
                  signature_version=None,
                  expected_url='https://bucket.s3.us-west-2.amazonaws.com/key')
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
+    yield dict(region='us-west-2', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url='https://bucket.s3.us-west-2.amazonaws.com/key')
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
+    yield dict(region='us-west-2', bucket='bucket', key='key',
                  signature_version='s3v4',
                  s3_config={'addressing_style': 'path'},
                  expected_url='https://s3.us-west-2.amazonaws.com/bucket/key')
 
     # An 's3v4' only region.
-    yield t.case(region='us-east-2', bucket='bucket', key='key',
+    yield dict(region='us-east-2', bucket='bucket', key='key',
                  signature_version=None,
                  expected_url='https://bucket.s3.us-east-2.amazonaws.com/key')
-    yield t.case(region='us-east-2', bucket='bucket', key='key',
+    yield dict(region='us-east-2', bucket='bucket', key='key',
                  signature_version='s3v4',
                  expected_url='https://bucket.s3.us-east-2.amazonaws.com/key')
-    yield t.case(region='us-east-2', bucket='bucket', key='key',
+    yield dict(region='us-east-2', bucket='bucket', key='key',
                  signature_version='s3v4',
                  s3_config={'addressing_style': 'path'},
                  expected_url='https://s3.us-east-2.amazonaws.com/bucket/key')
 
     # Dualstack endpoints
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket', key='key',
         signature_version=None,
         s3_config={'use_dualstack_endpoint': True},
         expected_url='https://bucket.s3.dualstack.us-west-2.amazonaws.com/key')
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket='bucket', key='key',
         signature_version='s3v4',
         s3_config={'use_dualstack_endpoint': True},
         expected_url='https://bucket.s3.dualstack.us-west-2.amazonaws.com/key')
 
     # Accelerate
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
+    yield dict(region='us-west-2', bucket='bucket', key='key',
                  signature_version=None,
                  s3_config={'use_accelerate_endpoint': True},
                  expected_url='https://bucket.s3-accelerate.amazonaws.com/key')
 
     # A region that we don't know about.
-    yield t.case(region='us-west-50', bucket='bucket', key='key',
+    yield dict(region='us-west-50', bucket='bucket', key='key',
                  signature_version=None,
                  expected_url='https://bucket.s3.us-west-50.amazonaws.com/key')
 
     # Customer provided URL results in us leaving the host untouched.
-    yield t.case(region='us-west-2', bucket='bucket', key='key',
+    yield dict(region='us-west-2', bucket='bucket', key='key',
                  signature_version=None,
                  customer_provided_endpoint='https://foo.com/',
                  expected_url='https://foo.com/bucket/key')
@@ -2376,14 +2352,14 @@ def test_addressing_for_presigned_urls():
     accesspoint_arn = (
         'arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint'
     )
-    yield t.case(
+    yield dict(
         region='us-west-2', bucket=accesspoint_arn, key='key',
         expected_url=(
             'https://myendpoint-123456789012.s3-accesspoint.'
             'us-west-2.amazonaws.com/key'
         )
     )
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket=accesspoint_arn, key='key',
         s3_config={'use_arn_region': False},
         expected_url=(
@@ -2396,18 +2372,24 @@ def test_addressing_for_presigned_urls():
     us_east_1_regional_endpoint = {
         'us_east_1_regional_endpoint': 'regional'
     }
-    yield t.case(
+    yield dict(
         region='us-east-1', bucket='bucket', key='key',
         s3_config=us_east_1_regional_endpoint, signature_version='s3v4',
         expected_url=(
             'https://bucket.s3.us-east-1.amazonaws.com/key'))
 
 
-def _verify_presigned_url_addressing(region, bucket, key, s3_config,
-                                     is_secure=True,
-                                     customer_provided_endpoint=None,
-                                     expected_url=None,
-                                     signature_version=None):
+@pytest.mark.parametrize("test_case", _addressing_for_presigned_url_test_cases())
+def test_addressing_for_presigned_urls(test_case):
+    # Here's we're just focusing on the addressing mode used for presigned URLs.
+    # We special case presigned URLs due to backward compatibility.
+    _verify_presigned_url_addressing(**test_case)
+
+
+def _verify_presigned_url_addressing(
+    region=None, bucket='bucket', key='key', s3_config=None, is_secure=True,
+    customer_provided_endpoint=None, expected_url=None, signature_version=None
+):
     s3 = _create_s3_client(region=region, is_secure=is_secure,
                            endpoint_url=customer_provided_endpoint,
                            s3_config=s3_config,
@@ -2418,7 +2400,7 @@ def _verify_presigned_url_addressing(region, bucket, key, s3_config,
     # those are tested elsewhere.  We just care about the hostname/path.
     parts = urlsplit(url)
     actual = '%s://%s%s' % parts[:3]
-    assert_equal(actual, expected_url)
+    assert actual == expected_url
 
 
 class TestRequestPayerObjectTagging(BaseS3OperationTest):

--- a/tests/functional/test_service_alias.py
+++ b/tests/functional/test_service_alias.py
@@ -10,24 +10,31 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.handlers import SERVICE_NAME_ALIASES
 
 
-def test_can_use_service_alias():
+CLIENT_KWARGS = {
+    "region_name": "us-east-1",
+    "aws_access_key_id": "foo",
+    "aws_secret_access_key": "bar",
+}
+
+
+def _service_alias_test_cases():
     session = botocore.session.get_session()
     for (alias, name) in SERVICE_NAME_ALIASES.items():
-        yield _instantiates_the_same_client, session, name, alias
+        yield session, name, alias
 
 
-def _instantiates_the_same_client(session, service_name, service_alias):
-    client_kwargs = {
-        'region_name': 'us-east-1',
-        'aws_access_key_id': 'foo',
-        'aws_secret_access_key': 'bar',
-    }
-    original_client = session.create_client(service_name, **client_kwargs)
-    aliased_client = session.create_client(service_alias, **client_kwargs)
+@pytest.mark.parametrize(
+    "session, service_name, service_alias", _service_alias_test_cases()
+)
+def test_can_use_service_alias(session, service_name, service_alias):
+    original_client = session.create_client(service_name, **CLIENT_KWARGS)
+    aliased_client = session.create_client(service_alias, **CLIENT_KWARGS)
     original_model_name = original_client.meta.service_model.service_name
     aliased_model_name = aliased_client.meta.service_model.service_name
     assert original_model_name == aliased_model_name

--- a/tests/functional/test_six_imports.py
+++ b/tests/functional/test_six_imports.py
@@ -2,11 +2,13 @@ import os
 import botocore
 import ast
 
+import pytest
+
 
 ROOTDIR = os.path.dirname(botocore.__file__)
 
 
-def test_no_bare_six_imports():
+def _all_files():
     for rootdir, dirnames, filenames in os.walk(ROOTDIR):
         if 'vendored' in dirnames:
             # We don't need to lint our vendored packages.
@@ -14,11 +16,11 @@ def test_no_bare_six_imports():
         for filename in filenames:
             if not filename.endswith('.py'):
                 continue
-            fullname = os.path.join(rootdir, filename)
-            yield _assert_no_bare_six_imports, fullname
+            yield os.path.join(rootdir, filename)
 
 
-def _assert_no_bare_six_imports(filename):
+@pytest.mark.parametrize("filename", _all_files())
+def test_no_bare_six_imports(filename):
     with open(filename) as f:
         contents = f.read()
         parsed = ast.parse(contents, filename)

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -13,8 +13,6 @@
 from tests import unittest
 import itertools
 
-from nose.plugins.attrib import attr
-
 import botocore.session
 from botocore.exceptions import ClientError
 

--- a/tests/integration/test_emr.py
+++ b/tests/integration/test_emr.py
@@ -10,31 +10,41 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
+import pytest
 
-from nose.tools import assert_true
+from tests import unittest
 
 import botocore.session
 from botocore.paginate import PageIterator
 from botocore.exceptions import OperationNotPageableError
 
 
-def test_emr_endpoints_work_with_py26():
+@pytest.fixture()
+def botocore_session():
+    return botocore.session.get_session()
+
+@pytest.mark.parametrize(
+    "region",
+    [
+        'us-east-1',
+        'us-west-2',
+        'us-west-2',
+        'ap-northeast-1',
+        'ap-southeast-1',
+        'ap-southeast-2',
+        'sa-east-1',
+        'eu-west-1',
+        'eu-central-1'
+    ]
+)
+def test_emr_endpoints_work_with_py26(botocore_session, region):
     # Verify that we can talk to all currently supported EMR endpoints.
     # Python2.6 has an SSL cert bug where it can't read the SAN of
     # certain SSL certs.  We therefore need to always use the CN
     # as the hostname.
-    session = botocore.session.get_session()
-    for region in ['us-east-1', 'us-west-2', 'us-west-2', 'ap-northeast-1',
-                   'ap-southeast-1', 'ap-southeast-2', 'sa-east-1', 'eu-west-1',
-                   'eu-central-1']:
-        yield _test_can_list_clusters_in_region, session, region
-
-
-def _test_can_list_clusters_in_region(session, region):
-    client = session.create_client('emr', region_name=region)
+    client = botocore_session.create_client('emr', region_name=region)
     response = client.list_clusters()
-    assert_true('Clusters' in response)
+    assert 'Clusters' in response
 
 
 # I consider these integration tests because they're

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -26,7 +26,7 @@ import mock
 from tarfile import TarFile
 from contextlib import closing
 
-from nose.plugins.attrib import attr
+import pytest
 import urllib3
 
 from botocore.endpoint import Endpoint
@@ -322,7 +322,7 @@ class TestS3Objects(TestS3BaseWithBucket):
             Bucket=self.bucket_name, Key=key_name)
         self.assert_status_code(response, 204)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_can_paginate(self):
         for i in range(5):
             key_name = 'key%s' % i
@@ -338,7 +338,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                      for el in responses]
         self.assertEqual(key_names, ['key0', 'key1', 'key2', 'key3', 'key4'])
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_can_paginate_with_page_size(self):
         for i in range(5):
             key_name = 'key%s' % i
@@ -355,7 +355,7 @@ class TestS3Objects(TestS3BaseWithBucket):
                      for el in data]
         self.assertEqual(key_names, ['key0', 'key1', 'key2', 'key3', 'key4'])
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_result_key_iters(self):
         for i in range(5):
             key_name = 'key/%s/%s' % (i, i)
@@ -378,7 +378,7 @@ class TestS3Objects(TestS3BaseWithBucket):
         self.assertIn('Contents', response)
         self.assertIn('CommonPrefixes', response)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_can_get_and_put_object(self):
         self.create_object('foobarbaz', body='body contents')
         time.sleep(3)
@@ -841,7 +841,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
                                               Key='foo.txt', Body=body)
             self.assert_status_code(response, 200)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_paginate_list_objects_unicode(self):
         key_names = [
             u'non-ascii-key-\xe4\xf6\xfc-01.txt',
@@ -864,7 +864,7 @@ class TestS3SigV4Client(BaseS3ClientTest):
 
         self.assertEqual(key_names, key_refs)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_paginate_list_objects_safe_chars(self):
         key_names = [
             u'-._~safe-chars-key-01.txt',

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -15,7 +15,8 @@ import mock
 from pprint import pformat
 import warnings
 import logging
-from nose.tools import assert_equal, assert_true
+
+import pytest
 
 from tests import ClientHTTPStubber
 from botocore import xform_name
@@ -246,60 +247,55 @@ def _list_services(dict_entries):
         return [key for key in dict_entries if key in wanted_services]
 
 
-def test_can_make_request_with_client():
-    # Same as test_can_make_request, but with Client objects
-    # instead of service/operations.
-    session = botocore.session.get_session()
+@pytest.fixture()
+def botocore_session():
+    return botocore.session.get_session()
+
+
+def _smoke_tests():
     for service_name in _list_services(SMOKE_TESTS):
-        client = _get_client(session, service_name)
         for operation_name in SMOKE_TESTS[service_name]:
             kwargs = SMOKE_TESTS[service_name][operation_name]
-            method_name = xform_name(operation_name)
-            yield _make_client_call, client, method_name, kwargs
+            yield service_name, operation_name, kwargs
 
 
-def _make_client_call(client, operation_name, kwargs):
-    method = getattr(client, operation_name)
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        response = method(**kwargs)
-        assert_equal(len(caught_warnings), 0,
-                     "Warnings were emitted during smoke test: %s"
-                     % caught_warnings)
-        assert_true('Errors' not in response)
-
-
-def test_can_make_request_and_understand_errors_with_client():
-    session = botocore.session.get_session()
+def _error_tests():
     for service_name in _list_services(ERROR_TESTS):
-        client = _get_client(session, service_name)
         for operation_name in ERROR_TESTS[service_name]:
             kwargs = ERROR_TESTS[service_name][operation_name]
-            method_name = xform_name(operation_name)
-            yield _make_error_client_call, client, method_name, kwargs
+            yield service_name, operation_name, kwargs
 
 
-def _make_error_client_call(client, operation_name, kwargs):
-    method = getattr(client, operation_name)
-    try:
+@pytest.mark.parametrize("service_name, operation_name, kwargs", _smoke_tests())
+def test_can_make_request_with_client(
+    botocore_session, service_name, operation_name, kwargs
+):
+    # Same as test_can_make_request, but with Client objects
+    # instead of service/operations.
+    client = _get_client(botocore_session, service_name)
+    method = getattr(client, xform_name(operation_name))
+    with warnings.catch_warnings(record=True) as caught_warnings:
         response = method(**kwargs)
-    except ClientError as e:
-        pass
-    else:
-        raise AssertionError("Expected client error was not raised "
-                             "for %s.%s" % (client, operation_name))
+        err_msg = f"Warnings were emitted during smoke test: {caught_warnings}"
+        assert len(caught_warnings) == 0, err_msg
+        assert 'Errors' not in response
 
 
-def test_client_can_retry_request_properly():
-    session = botocore.session.get_session()
-    for service_name in _list_services(SMOKE_TESTS):
-        client = _get_client(session, service_name)
-        for operation_name in SMOKE_TESTS[service_name]:
-            kwargs = SMOKE_TESTS[service_name][operation_name]
-            yield (_make_client_call_with_errors, client,
-                   operation_name, kwargs)
+@pytest.mark.parametrize("service_name, operation_name, kwargs", _error_tests())
+def test_can_make_request_and_understand_errors_with_client(
+    botocore_session, service_name, operation_name, kwargs
+):
+    client = _get_client(botocore_session, service_name)
+    method = getattr(client, xform_name(operation_name))
+    with pytest.raises(ClientError):
+        response = method(**kwargs)
 
 
-def _make_client_call_with_errors(client, operation_name, kwargs):
+@pytest.mark.parametrize("service_name, operation_name, kwargs", _smoke_tests())
+def test_client_can_retry_request_properly(
+    botocore_session, service_name, operation_name, kwargs
+):
+    client = _get_client(botocore_session, service_name)
     operation = getattr(client, xform_name(operation_name))
     exception = ConnectionClosedError(endpoint_url='https://mock.eror')
     with ClientHTTPStubber(client, strict=False) as http_stubber:

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -10,45 +10,36 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import botocore.session
 from botocore.utils import ArgumentGenerator
 
 
-class ArgumentGeneratorError(AssertionError):
-    def __init__(self, service_name, operation_name,
-                 generated, message):
-        full_msg = (
-            'Error generating skeleton for %s:%s, %s\nActual:\n%s' % (
-                service_name, operation_name, message, generated))
-        super(AssertionError, self).__init__(full_msg)
+@pytest.fixture(scope="module")
+def generator():
+    return ArgumentGenerator()
 
 
-def test_can_generate_all_inputs():
+def _all_inputs():
     session = botocore.session.get_session()
-    generator = ArgumentGenerator()
     for service_name in session.get_available_services():
         service_model = session.get_service_model(service_name)
         for operation_name in service_model.operation_names:
             operation_model = service_model.operation_model(operation_name)
             input_shape = operation_model.input_shape
             if input_shape is not None and input_shape.members:
-                yield (_test_can_generate_skeleton, generator,
-                       input_shape, service_name, operation_name)
+                yield input_shape, service_name, operation_name
 
 
-def _test_can_generate_skeleton(generator, shape, service_name,
-                                operation_name):
-    generated = generator.generate_skeleton(shape)
+@pytest.mark.parametrize("input_shape, service_name, operation_name", _all_inputs())
+def test_can_generate_all_inputs(generator, input_shape, service_name, operation_name):
+    generated = generator.generate_skeleton(input_shape)
     # Do some basic sanity checks to make sure the generated shape
     # looks right.  We're mostly just ensuring that the generate_skeleton
     # doesn't throw an exception.
-    if not isinstance(generated, dict):
-        raise ArgumentGeneratorError(
-            service_name, operation_name,
-            generated, 'expected a dict')
+    assert isinstance(generated, dict)
+
     # The generated skeleton also shouldn't be empty (the test
     # generator has already filtered out input_shapes of None).
-    if len(generated) == 0:
-        raise ArgumentGeneratorError(
-            service_name, operation_name,
-            generated, "generated arguments were empty")
+    assert len(generated) > 0

--- a/tests/integration/test_waiters.py
+++ b/tests/integration/test_waiters.py
@@ -10,16 +10,15 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest, random_chars
+import pytest
 
-from nose.plugins.attrib import attr
+from tests import unittest, random_chars
 
 import botocore.session
 from botocore.exceptions import WaiterError
 
 
-# This is the same test as above, except using the client interface.
-@attr('slow')
+@pytest.mark.slow
 class TestWaiterForDynamoDB(unittest.TestCase):
     def setUp(self):
         self.session = botocore.session.get_session()

--- a/tests/unit/retries/test_special.py
+++ b/tests/unit/retries/test_special.py
@@ -1,7 +1,6 @@
 from tests import unittest
 
 import mock
-from nose.tools import assert_equal, assert_is_instance
 
 from botocore.compat import six
 from botocore.awsrequest import AWSResponse

--- a/tests/unit/retries/test_standard.py
+++ b/tests/unit/retries/test_standard.py
@@ -1,7 +1,7 @@
 from tests import unittest
 
 import mock
-from nose.tools import assert_equal, assert_is_instance
+import pytest
 
 from botocore.retries import standard
 from botocore.retries import quota
@@ -150,43 +150,46 @@ SERVICE_DESCRIPTION_WITH_RETRIES = {
     },
 }
 
-
-def test_can_detect_retryable_transient_errors():
+@pytest.mark.parametrize('case', RETRYABLE_TRANSIENT_ERRORS)
+def test_can_detect_retryable_transient_errors(case):
     transient_checker = standard.TransientRetryableChecker()
-    for case in RETRYABLE_TRANSIENT_ERRORS:
-        yield (_verify_retryable, transient_checker, None) + case
+    _verify_retryable(transient_checker, None, *case)
 
 
-def test_can_detect_retryable_throttled_errors():
+@pytest.mark.parametrize('case', RETRYABLE_THROTTLED_RESPONSES)
+def test_can_detect_retryable_throttled_errors(case):
     throttled_checker = standard.ThrottledRetryableChecker()
-    for case in RETRYABLE_THROTTLED_RESPONSES:
-        yield (_verify_retryable, throttled_checker, None) + case
+    _verify_retryable(throttled_checker, None, *case)
 
 
-def test_can_detect_modeled_retryable_errors():
+@pytest.mark.parametrize('case', RETRYABLE_MODELED_ERRORS)
+def test_can_detect_modeled_retryable_errors(case):
     modeled_retry_checker = standard.ModeledRetryableChecker()
-    test_params = (_verify_retryable, modeled_retry_checker,
-                   get_operation_model_with_retries())
-    for case in RETRYABLE_MODELED_ERRORS:
-        test_case = test_params + case
-        yield test_case
+    _verify_retryable(
+        modeled_retry_checker, get_operation_model_with_retries(), *case
+    )
 
 
-def test_standard_retry_conditions():
-    # This is verifying that the high level object used for checking
-    # retry conditions still handles all the individual testcases.
+@pytest.mark.parametrize('case',
+    [
+        case for case in
+        RETRYABLE_TRANSIENT_ERRORS +
+        RETRYABLE_THROTTLED_RESPONSES +
+        RETRYABLE_MODELED_ERRORS
+        if case[2]
+    ]
+)
+def test_standard_retry_conditions(case):
+    """This is verifying that the high level object used for checking
+    retry conditions still handles all the individual testcases.
+
+    It's possible that cases that are retryable for an individual checker
+    aren't retryable for a different checker.  We need to filter out all
+    the False cases (if case[2]).
+    """
     standard_checker = standard.StandardRetryConditions()
     op_model = get_operation_model_with_retries()
-    all_cases = (
-        RETRYABLE_TRANSIENT_ERRORS + RETRYABLE_THROTTLED_RESPONSES +
-        RETRYABLE_MODELED_ERRORS)
-    # It's possible that cases that are retryable for an individual checker
-    # are retryable for a different checker.  We need to filter out all
-    # the False cases.
-    all_cases = [c for c in all_cases if c[2]]
-    test_params = (_verify_retryable, standard_checker, op_model)
-    for case in all_cases:
-        yield test_params + case
+    _verify_retryable(standard_checker, op_model, *case)
 
 
 def get_operation_model_with_retries():
@@ -213,7 +216,7 @@ def _verify_retryable(checker, operation_model,
         http_response=http_response,
         caught_exception=caught_exception,
     )
-    assert_equal(checker.is_retryable(context), is_retryable)
+    assert checker.is_retryable(context) == is_retryable
 
 
 def arbitrary_retry_context():
@@ -233,36 +236,38 @@ def test_can_honor_max_attempts():
     checker = standard.MaxAttemptsChecker(max_attempts=3)
     context = arbitrary_retry_context()
     context.attempt_number = 1
-    assert_equal(checker.is_retryable(context), True)
+    assert checker.is_retryable(context) is True
 
     context.attempt_number = 2
-    assert_equal(checker.is_retryable(context), True)
+    assert checker.is_retryable(context) is True
 
     context.attempt_number = 3
-    assert_equal(checker.is_retryable(context), False)
+    assert checker.is_retryable(context) is False
 
 
 def test_max_attempts_adds_metadata_key_when_reached():
     checker = standard.MaxAttemptsChecker(max_attempts=3)
     context = arbitrary_retry_context()
     context.attempt_number = 3
-    assert_equal(checker.is_retryable(context), False)
-    assert_equal(context.get_retry_metadata(), {'MaxAttemptsReached': True})
+    assert checker.is_retryable(context) is False
+    assert context.get_retry_metadata() == {'MaxAttemptsReached': True}
 
 
 def test_can_create_default_retry_handler():
     mock_client = mock.Mock()
     mock_client.meta.service_model.service_id = model.ServiceId('my-service')
-    assert_is_instance(standard.register_retry_handler(mock_client),
-                       standard.RetryHandler)
+    assert isinstance(
+        standard.register_retry_handler(mock_client),
+        standard.RetryHandler
+    )
     call_args_list = mock_client.meta.events.register.call_args_list
     # We should have registered the retry quota to after-calls
     first_call = call_args_list[0][0]
     second_call = call_args_list[1][0]
     # Not sure if there's a way to verify the class associated with the
     # bound method matches what we expect.
-    assert_equal(first_call[0], 'after-call.my-service')
-    assert_equal(second_call[0], 'needs-retry.my-service')
+    assert first_call[0] == 'after-call.my-service'
+    assert second_call[0] == 'needs-retry.my-service'
 
 
 class TestRetryHandler(unittest.TestCase):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -13,7 +13,7 @@
 import datetime
 import mock
 
-from nose.tools import assert_equal, assert_raises
+import pytest
 
 from botocore.exceptions import MD5UnavailableError
 from botocore.compat import (
@@ -98,7 +98,13 @@ class TestGetMD5(unittest.TestCase):
                 get_md5()
 
 
-def test_compat_shell_split_windows():
+@pytest.fixture
+def shell_split_runner():
+    # Single runner fixture for all tests
+    return ShellSplitTestRunner()
+
+
+def get_windows_test_cases():
     windows_cases = {
         r'': [],
         r'spam \\': [r'spam', '\\\\'],
@@ -121,14 +127,21 @@ def test_compat_shell_split_windows():
         r'a\\\"b c d': [r'a\"b', r'c', r'd'],
         r'a\\\\"b c" d e': [r'a\\b c', r'd', r'e']
     }
-    runner = ShellSplitTestRunner()
-    for input_string, expected_output in windows_cases.items():
-        yield runner.assert_equal, input_string, expected_output, "win32"
-
-    yield runner.assert_raises, r'"', ValueError, "win32"
+    return windows_cases.items()
 
 
-def test_compat_shell_split_unix():
+@pytest.mark.parametrize("input_string, expected_output", get_windows_test_cases())
+def test_compat_shell_split_windows(
+    shell_split_runner, input_string, expected_output
+):
+    shell_split_runner.assert_equal(input_string, expected_output, "win32")
+
+
+def test_compat_shell_split_windows_raises_error(shell_split_runner):
+    shell_split_runner.assert_raises(r'"', ValueError, "win32")
+
+
+def get_unix_test_cases():
     unix_cases = {
         r'': [],
         r'spam \\': [r'spam', '\\'],
@@ -151,21 +164,38 @@ def test_compat_shell_split_unix():
         r'a\\\"b c d': [r'a\"b', r'c', r'd'],
         r'a\\\\"b c" d e': [r'a\\b c', r'd', r'e']
     }
-    runner = ShellSplitTestRunner()
-    for input_string, expected_output in unix_cases.items():
-        yield runner.assert_equal, input_string, expected_output, "linux2"
-        yield runner.assert_equal, input_string, expected_output, "darwin"
+    return unix_cases.items()
 
-    yield runner.assert_raises, r'"', ValueError, "linux2"
-    yield runner.assert_raises, r'"', ValueError, "darwin"
+
+@pytest.mark.parametrize("input_string, expected_output", get_unix_test_cases())
+def test_compat_shell_split_unix_linux2(
+    shell_split_runner, input_string, expected_output
+):
+    shell_split_runner.assert_equal(input_string, expected_output, "linux2")
+
+
+@pytest.mark.parametrize("input_string, expected_output", get_unix_test_cases())
+def test_compat_shell_split_unix_darwin(
+    shell_split_runner, input_string, expected_output
+):
+    shell_split_runner.assert_equal(input_string, expected_output, "darwin")
+
+
+def test_compat_shell_split_unix_linux2_raises_error(shell_split_runner):
+    shell_split_runner.assert_raises(r'"', ValueError, "linux2")
+
+
+def test_compat_shell_split_unix_darwin_raises_error(shell_split_runner):
+    shell_split_runner.assert_raises(r'"', ValueError, "darwin")
 
 
 class ShellSplitTestRunner(object):
     def assert_equal(self, s, expected, platform):
-        assert_equal(compat_shell_split(s, platform), expected)
+        assert compat_shell_split(s, platform) == expected
 
     def assert_raises(self, s, exception_cls, platform):
-        assert_raises(exception_cls, compat_shell_split, s, platform)
+        with pytest.raises(exception_cls):
+            compat_shell_split(s, platform)
 
 
 class TestTimezoneOperations(unittest.TestCase):

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import unittest
 import mock
-from nose.tools import assert_equal
+import pytest
 
 import botocore
 import botocore.session as session
@@ -447,15 +447,12 @@ def assert_chain_does_provide(providers, expected_value):
     provider = ChainProvider(
         providers=providers,
     )
-    value = provider.provide()
-    assert_equal(value, expected_value)
+    assert provider.provide() == expected_value
 
 
-def test_chain_provider():
-    # Each case is a tuple with the first element being the expected return
-    # value form the ChainProvider. The second value being a list of return
-    # values from the individual providers that are in the chain.
-    cases = [
+@pytest.mark.parametrize(
+    'case',
+    (
         (None, []),
         (None, [None]),
         ('foo', ['foo']),
@@ -466,11 +463,16 @@ def test_chain_provider():
         ('bar', [None, 'bar', None]),
         ('foo', ['foo', 'bar', None]),
         ('foo', ['foo', 'bar', 'baz']),
-    ]
-    for case in cases:
-        yield assert_chain_does_provide, \
-            _make_providers_that_return(case[1]), \
-            case[0]
+    )
+)
+def test_chain_provider(case):
+    # Each case is a tuple with the first element being the expected return
+    # value from the ChainProvider. The second value being a list of return
+    # values from the individual providers that are in the chain.
+    assert_chain_does_provide(
+        _make_providers_that_return(case[1]),
+        case[0]
+    )
 
 
 class TestChainProvider(unittest.TestCase):

--- a/tests/unit/test_eventstream.py
+++ b/tests/unit/test_eventstream.py
@@ -11,9 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Unit tests for the binary event stream decoder. """
-
+import pytest
 from mock import Mock
-from nose.tools import assert_equal, raises
 
 from botocore.parsers import EventStreamXMLParser
 from botocore.eventstream import (
@@ -240,18 +239,12 @@ NEGATIVE_CASES = [
 
 def assert_message_equal(message_a, message_b):
     """Asserts all fields for two messages are equal. """
-    assert_equal(
-        message_a.prelude.total_length,
-        message_b.prelude.total_length
-    )
-    assert_equal(
-        message_a.prelude.headers_length,
-        message_b.prelude.headers_length
-    )
-    assert_equal(message_a.prelude.crc, message_b.prelude.crc)
-    assert_equal(message_a.headers, message_b.headers)
-    assert_equal(message_a.payload, message_b.payload)
-    assert_equal(message_a.crc, message_b.crc)
+    assert message_a.prelude.total_length == message_b.prelude.total_length
+    assert message_a.prelude.headers_length == message_b.prelude.headers_length
+    assert message_a.prelude.crc == message_b.prelude.crc
+    assert message_a.headers == message_b.headers
+    assert message_a.payload == message_b.payload
+    assert message_a.crc == message_b.crc
 
 
 def test_partial_message():
@@ -262,7 +255,7 @@ def test_partial_message():
     mid_point = 15
     event_buffer.add_data(data[:mid_point])
     messages = list(event_buffer)
-    assert_equal(messages, [])
+    assert messages == []
     event_buffer.add_data(data[mid_point:len(data)])
     for message in event_buffer:
         assert_message_equal(message, EMPTY_MESSAGE[1])
@@ -277,10 +270,10 @@ def check_message_decodes(encoded, decoded):
     assert_message_equal(messages[0], decoded)
 
 
-def test_positive_cases():
+@pytest.mark.parametrize("encoded, decoded", POSITIVE_CASES)
+def test_positive_cases(encoded, decoded):
     """Test that all positive cases decode how we expect. """
-    for (encoded, decoded) in POSITIVE_CASES:
-        yield check_message_decodes, encoded, decoded
+    check_message_decodes(encoded, decoded)
 
 
 def test_all_positive_cases():
@@ -298,11 +291,11 @@ def test_all_positive_cases():
         assert_message_equal(expected, decoded)
 
 
-def test_negative_cases():
+@pytest.mark.parametrize("encoded, exception", NEGATIVE_CASES)
+def test_negative_cases(encoded, exception):
     """Test that all negative cases raise the expected exception. """
-    for (encoded, exception) in NEGATIVE_CASES:
-        test_function = raises(exception)(check_message_decodes)
-        yield test_function, encoded, None
+    with pytest.raises(exception):
+        check_message_decodes(encoded, None)
 
 
 def test_header_parser():
@@ -329,87 +322,88 @@ def test_header_parser():
 
     parser = EventStreamHeaderParser()
     headers = parser.parse(headers_data)
-    assert_equal(headers, expected_headers)
+    assert headers == expected_headers
 
 
 def test_message_prelude_properties():
     """Test that calculated properties from the payload are correct. """
     # Total length: 40, Headers Length: 15, random crc
     prelude = MessagePrelude(40, 15, 0x00000000)
-    assert_equal(prelude.payload_length, 9)
-    assert_equal(prelude.headers_end, 27)
-    assert_equal(prelude.payload_end, 36)
+    assert prelude.payload_length == 9
+    assert prelude.headers_end == 27
+    assert prelude.payload_end == 36
 
 
 def test_message_to_response_dict():
     response_dict = PAYLOAD_ONE_STR_HEADER[1].to_response_dict()
-    assert_equal(response_dict['status_code'], 200)
+    assert response_dict['status_code'] ==200
+
     expected_headers = {'content-type': 'application/json'}
-    assert_equal(response_dict['headers'], expected_headers)
-    assert_equal(response_dict['body'], b"{'foo':'bar'}")
+    assert response_dict['headers'] == expected_headers
+    assert response_dict['body'] == b"{'foo':'bar'}"
 
 
 def test_message_to_response_dict_error():
     response_dict = ERROR_EVENT_MESSAGE[1].to_response_dict()
-    assert_equal(response_dict['status_code'], 400)
+    assert response_dict['status_code'] == 400
     headers = {
         ':message-type': 'error',
         ':error-code': 'code',
         ':error-message': 'message',
     }
-    assert_equal(response_dict['headers'], headers)
-    assert_equal(response_dict['body'], b'')
+    assert response_dict['headers'] == headers
+    assert response_dict['body'] == b''
 
 
 def test_unpack_uint8():
     (value, bytes_consumed) = DecodeUtils.unpack_uint8(b'\xDE')
-    assert_equal(bytes_consumed, 1)
-    assert_equal(value, 0xDE)
+    assert bytes_consumed == 1
+    assert value == 0xDE
 
 
 def test_unpack_uint32():
     (value, bytes_consumed) = DecodeUtils.unpack_uint32(b'\xDE\xAD\xBE\xEF')
-    assert_equal(bytes_consumed, 4)
-    assert_equal(value, 0xDEADBEEF)
+    assert bytes_consumed == 4
+    assert value == 0xDEADBEEF
 
 
 def test_unpack_int8():
     (value, bytes_consumed) = DecodeUtils.unpack_int8(b'\xFE')
-    assert_equal(bytes_consumed, 1)
-    assert_equal(value, -2)
+    assert bytes_consumed == 1
+    assert value == -2
 
 
 def test_unpack_int16():
     (value, bytes_consumed) = DecodeUtils.unpack_int16(b'\xFF\xFE')
-    assert_equal(bytes_consumed, 2)
-    assert_equal(value, -2)
+    assert bytes_consumed == 2
+    assert value == -2
 
 
 def test_unpack_int32():
     (value, bytes_consumed) = DecodeUtils.unpack_int32(b'\xFF\xFF\xFF\xFE')
-    assert_equal(bytes_consumed, 4)
-    assert_equal(value, -2)
+    assert bytes_consumed == 4
+    assert value == -2
 
 
 def test_unpack_int64():
     test_bytes = b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE'
     (value, bytes_consumed) = DecodeUtils.unpack_int64(test_bytes)
-    assert_equal(bytes_consumed, 8)
-    assert_equal(value, -2)
+    assert bytes_consumed == 8
+    assert value == -2
 
 
 def test_unpack_array_short():
     test_bytes = b'\x00\x10application/json'
     (value, bytes_consumed) = DecodeUtils.unpack_byte_array(test_bytes)
-    assert_equal(bytes_consumed, 18)
-    assert_equal(value, b'application/json')
+    assert bytes_consumed == 18
+    assert value == b'application/json'
 
 
 def test_unpack_byte_array_int():
     (value, array_bytes_consumed) = DecodeUtils.unpack_byte_array(
         b'\x00\x00\x00\x10application/json', length_byte_size=4)
-    assert_equal(array_bytes_consumed, 20)
-    assert_equal(value, b'application/json')
+    assert array_bytes_consumed == 20
+    assert value == b'application/json'
 
 
 def test_unpack_utf8_string():
@@ -417,14 +411,14 @@ def test_unpack_utf8_string():
     utf8_string = b'\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e'
     encoded = length + utf8_string
     (value, bytes_consumed) = DecodeUtils.unpack_utf8_string(encoded)
-    assert_equal(bytes_consumed, 11)
-    assert_equal(value, utf8_string.decode('utf-8'))
+    assert bytes_consumed == 11
+    assert value == utf8_string.decode('utf-8')
 
 
 def test_unpack_prelude():
     data = b'\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03'
     prelude = DecodeUtils.unpack_prelude(data)
-    assert_equal(prelude, ((1, 2, 3), 12))
+    assert prelude == ((1, 2, 3), 12)
 
 
 def create_mock_raw_stream(*data):
@@ -445,7 +439,7 @@ def test_event_stream_wrapper_iteration():
     output_shape = Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
     events = list(event_stream)
-    assert_equal(len(events), 1)
+    assert len(events) == 1
 
     response_dict = {
         'headers': {'event-id': 0x0000a00c},
@@ -455,14 +449,14 @@ def test_event_stream_wrapper_iteration():
     parser.parse.assert_called_with(response_dict, output_shape)
 
 
-@raises(EventStreamError)
 def test_eventstream_wrapper_iteration_error():
     raw_stream = create_mock_raw_stream(ERROR_EVENT_MESSAGE[0])
     parser = Mock(spec=EventStreamXMLParser)
     parser.parse.return_value = {}
     output_shape = Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
-    list(event_stream)
+    with pytest.raises(EventStreamError):
+        list(event_stream)
 
 
 def test_event_stream_wrapper_close():
@@ -492,7 +486,6 @@ def test_event_stream_initial_response():
     assert event.payload == payload
 
 
-@raises(NoInitialResponseError)
 def test_event_stream_initial_response_wrong_type():
     raw_stream = create_mock_raw_stream(
         b"\x00\x00\x00+\x00\x00\x00\x0e4\x8b\xec{\x08event-id\x04\x00",
@@ -501,13 +494,14 @@ def test_event_stream_initial_response_wrong_type():
     parser = Mock(spec=EventStreamXMLParser)
     output_shape = Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
-    event_stream.get_initial_response()
+    with pytest.raises(NoInitialResponseError):
+        event_stream.get_initial_response()
 
 
-@raises(NoInitialResponseError)
 def test_event_stream_initial_response_no_event():
     raw_stream = create_mock_raw_stream(b'')
     parser = Mock(spec=EventStreamXMLParser)
     output_shape = Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
-    event_stream.get_initial_response()
+    with pytest.raises(NoInitialResponseError):
+        event_stream.get_initial_response()

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -14,8 +14,6 @@
 import pickle
 from tests import unittest
 
-from nose.tools import assert_equal
-
 import botocore.awsrequest
 import botocore.session
 from botocore import exceptions
@@ -24,7 +22,7 @@ from botocore import exceptions
 def test_client_error_can_handle_missing_code_or_message():
     response = {'Error': {}}
     expect = 'An error occurred (Unknown) when calling the blackhole operation: Unknown'
-    assert_equal(str(exceptions.ClientError(response, 'blackhole')), expect)
+    assert str(exceptions.ClientError(response, 'blackhole')) == expect
 
 
 def test_client_error_has_operation_name_set():
@@ -36,7 +34,7 @@ def test_client_error_has_operation_name_set():
 def test_client_error_set_correct_operation_name():
     response = {'Error': {}}
     exception = exceptions.ClientError(response, 'blackhole')
-    assert_equal(exception.operation_name, 'blackhole')
+    assert exception.operation_name == 'blackhole'
 
 
 def test_retry_info_added_when_present():

--- a/tests/unit/test_http_client_exception_mapping.py
+++ b/tests/unit/test_http_client_exception_mapping.py
@@ -1,22 +1,16 @@
-from nose.tools import assert_raises
+import pytest
 
 from botocore import exceptions as botocore_exceptions
 from botocore.vendored.requests.packages.urllib3 import exceptions as urllib3_exceptions
 
-EXCEPTION_MAPPING = [
-    (botocore_exceptions.ReadTimeoutError, urllib3_exceptions.ReadTimeoutError),
-]
 
-
-def _raise_exception(exception):
-    raise exception(endpoint_url=None, proxy_url=None, error=None)
-
-
-def _test_exception_mapping(new_exception, old_exception):
+@pytest.mark.parametrize(
+    "new_exception, old_exception",
+    (
+        (botocore_exceptions.ReadTimeoutError, urllib3_exceptions.ReadTimeoutError),
+    ),
+)
+def test_http_client_exception_mapping(new_exception, old_exception):
     # assert that the new exception can still be caught by the old vendored one
-    assert_raises(old_exception, _raise_exception, new_exception)
-
-
-def test_http_client_exception_mapping():
-    for new_exception, old_exception in EXCEPTION_MAPPING:
-        yield _test_exception_mapping, new_exception, old_exception
+    with pytest.raises(old_exception):
+        raise new_exception(endpoint_url=None, proxy_url=None, error=None)

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -2,7 +2,7 @@ import socket
 
 from mock import patch, Mock, ANY
 from tests import unittest
-from nose.tools import raises
+import pytest
 from urllib3.exceptions import NewConnectionError, ProtocolError
 
 from botocore.vendored import six
@@ -390,15 +390,15 @@ class TestURLLib3Session(unittest.TestCase):
         session = URLLib3Session()
         session.send(self.request.prepare())
 
-    @raises(EndpointConnectionError)
     def test_catches_new_connection_error(self):
         error = NewConnectionError(None, None)
-        self.make_request_with_error(error)
+        with pytest.raises(EndpointConnectionError):
+           self.make_request_with_error(error)
 
-    @raises(ConnectionClosedError)
     def test_catches_bad_status_line(self):
         error = ProtocolError(None)
-        self.make_request_with_error(error)
+        with pytest.raises(ConnectionClosedError):
+            self.make_request_with_error(error)
 
     def test_aws_connection_classes_are_used(self):
         session = URLLib3Session()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests import unittest
 
 from botocore import model
@@ -5,30 +7,11 @@ from botocore.compat import OrderedDict
 from botocore.exceptions import MissingServiceIdError
 
 
-def test_missing_model_attribute_raises_exception():
-    # We're using a nose test generator here to cut down
-    # on the duplication.  The property names below
-    # all have the same test logic.
+@pytest.mark.parametrize("property_name", ['api_version', 'protocol'])
+def test_missing_model_attribute_raises_exception(property_name):
     service_model = model.ServiceModel({'metadata': {'endpointPrefix': 'foo'}})
-    property_names = ['api_version', 'protocol']
-
-    def _test_attribute_raise_exception(attr_name):
-        try:
-            getattr(service_model, attr_name)
-        except model.UndefinedModelAttributeError:
-            # This is what we expect, so the test passes.
-            pass
-        except Exception as e:
-            raise AssertionError("Expected UndefinedModelAttributeError to "
-                                 "be raised, but %s was raised instead" %
-                                 (e.__class__))
-        else:
-            raise AssertionError(
-                "Expected UndefinedModelAttributeError to "
-                "be raised, but no exception was raised for: %s" % attr_name)
-
-    for name in property_names:
-        yield _test_attribute_raise_exception, name
+    with pytest.raises(model.UndefinedModelAttributeError):
+        getattr(service_model, property_name)
 
 
 class TestServiceId(unittest.TestCase):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -20,6 +20,7 @@ import tempfile
 import shutil
 
 import mock
+import pytest
 
 import botocore.session
 import botocore.exceptions
@@ -639,21 +640,29 @@ class TestSessionComponent(BaseSessionTest):
         self.assertIs(
             self.session._get_internal_component('internal'), component)
         with self.assertRaises(ValueError):
-            self.session.get_component('internal')
+            # get_component has been deprecated to the public
+            with pytest.warns(DeprecationWarning):
+                self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(
             'endpoint_resolver')
-        self.assertIs(
-            self.session.get_component('endpoint_resolver'), endpoint_resolver)
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('endpoint_resolver'),
+                endpoint_resolver
+            )
 
     def test_internal_exceptions_factory_is_same_as_deprecated_public(self):
         exceptions_factory = self.session._get_internal_component(
             'exceptions_factory')
-        self.assertIs(
-            self.session.get_component('exceptions_factory'),
-            exceptions_factory
-        )
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('exceptions_factory'),
+                exceptions_factory
+            )
 
 
 class TestClientMonitoring(BaseSessionTest):

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -20,6 +20,7 @@ import tempfile
 import shutil
 
 import mock
+import pytest
 
 import botocore.session
 import botocore.exceptions
@@ -630,21 +631,29 @@ class TestSessionComponent(BaseSessionTest):
         self.assertIs(
             self.session._get_internal_component('internal'), component)
         with self.assertRaises(ValueError):
-            self.session.get_component('internal')
+            # get_component has been deprecated to the public
+            with pytest.warns(DeprecationWarning):
+                self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(
             'endpoint_resolver')
-        self.assertIs(
-            self.session.get_component('endpoint_resolver'), endpoint_resolver)
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('endpoint_resolver'),
+                endpoint_resolver
+            )
 
     def test_internal_exceptions_factory_is_same_as_deprecated_public(self):
         exceptions_factory = self.session._get_internal_component(
             'exceptions_factory')
-        self.assertIs(
-            self.session.get_component('exceptions_factory'),
-            exceptions_factory
-        )
+        # get_component has been deprecated to the public
+        with pytest.warns(DeprecationWarning):
+            self.assertIs(
+                self.session.get_component('exceptions_factory'),
+                exceptions_factory
+            )
 
 
 class TestComponentLocator(unittest.TestCase):


### PR DESCRIPTION
This corresponds to this PR for the develop branch: https://github.com/boto/botocore/pull/2495

With regards to comparing tests between `nosetests` and `pytest`, these were the numbers:

| Test directory | `nosetests` results | `pytest` results
| --- | --- | --- |
| `unit/` | 2806 total with 1 skip | 2806 total with 1 skip |
| `functional/` | 23064 | 22863 total with 1 skip |
| `integration/` | 10324 total with 3 skips | 10324 total with 3 skips |

The only difference in the number of tests ran is in with the functional tests. The new implementation has **201 less test cases** and **1 new skip**. This is accounted for in the following test updates from the original PR:

* `tests/functional/test_h2_required.py`: The `test_all_uses_of_h2_are_known`  was previously never being run because nothing was yielded. The test cases are still empty, but pytest is now creating a skip saying there's nothing to do. This also counts as an extra test case. **(Net gain: +1 total and +1 skip)**
* `tests/functional/test_waiter_config.py`: The waiter tests here were collapsed into a single test per waiter file. **(Net gain: -202 total)**

This together adds up correctly to **-201 total test cases** and **+1 skip** based on the differences in the table.

In addition, I pulled in test script updates from this PR to be consistent between the branches: https://github.com/boto/botocore/pull/2484