### PR TITLE
Update tagged union message with clearer description

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -335,8 +335,8 @@ class ResponseParser(object):
         if shape.is_tagged_union:
             if len(value) != 1:
                 error_msg = (
-                    "Invalid service response: %s must only have one member "
-                    "set."
+                    "Invalid service response: %s must have one and only "
+                    "one member set."
                 )
                 raise ResponseParserError(error_msg % shape.name)
             tag = self._get_first_key(value)


### PR DESCRIPTION
From some recent feedback, we're making this message more explicit when receiving responses from external services. Tagged Union members MUST provide one and only one member in the response. Values such as `null`, `{}`, or multiple keys are not valid for the `union` trait.