### PR TITLE
Expand s3-outpost presign tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,6 +23,7 @@ import platform
 import select
 import datetime
 import unittest
+from contextlib import ContextDecorator
 from unittest import mock
 from io import BytesIO
 from subprocess import Popen, PIPE
@@ -533,3 +534,32 @@ class StubbedSession(botocore.session.Session):
     def verify_stubs(self):
         for stub in self._client_stubs.values():
             stub.assert_no_pending_responses()
+
+
+class FreezeTime(ContextDecorator):
+    """
+    Context manager for mocking out datetime in arbitrary modules when creating
+    performing actions like signing which require point in time specificity.
+
+    :type module: module
+    :param module: reference to imported module to patch (e.g. botocore.auth.datetime)
+
+    :type date: datetime.datetime
+    :param date: datetime object specifying the output for utcnow()
+    """
+
+    def __init__(self, module, date=None):
+        if date is None:
+            date = datetime.datetime.utcnow()
+        self.date = date
+        self.datetime_patcher = mock.patch.object(
+            module, 'datetime',
+            mock.Mock(wraps=datetime.datetime)
+        )
+
+    def __enter__(self, *args, **kwargs):
+        mock = self.datetime_patcher.start()
+        mock.utcnow.return_value = self.date
+
+    def __exit__(self, *args, **kwargs):
+        self.datetime_patcher.stop()

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -30,7 +30,7 @@ import re
 
 import pytest
 
-from tests import mock
+from tests import mock, FreezeTime
 
 import botocore.auth
 from botocore.awsrequest import AWSRequest
@@ -96,17 +96,9 @@ def generate_test_cases():
 
 
 @pytest.mark.parametrize("test_case", generate_test_cases())
+@FreezeTime(module=botocore.auth.datetime, date=DATE)
 def test_signature_version_4(test_case):
-    datetime_patcher = mock.patch.object(
-        botocore.auth.datetime, 'datetime',
-        mock.Mock(wraps=datetime.datetime)
-    )
-    mocked_datetime = datetime_patcher.start()
-    mocked_datetime.utcnow.return_value = DATE
-
     _test_signature_version_4(test_case)
-
-    datetime_patcher.stop()
 
 
 def create_request_from_raw_request(raw_request):

--- a/tests/unit/crt/auth/test_crt_sigv4.py
+++ b/tests/unit/crt/auth/test_crt_sigv4.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from tests import mock, requires_crt
+from tests import mock, requires_crt, FreezeTime
 from tests.unit.auth.test_sigv4 import (
     DATE,
     SERVICE,
@@ -36,13 +36,6 @@ def _test_crt_signature_version_4(test_case):
 
 @requires_crt()
 @pytest.mark.parametrize("test_case", generate_test_cases())
+@FreezeTime(module=botocore.auth.datetime, date=DATE)
 def test_signature_version_4(test_case):
-    datetime_patcher = mock.patch.object(
-        botocore.auth.datetime, "datetime", mock.Mock(wraps=datetime.datetime)
-    )
-    mocked_datetime = datetime_patcher.start()
-    mocked_datetime.utcnow.return_value = DATE
-
     _test_crt_signature_version_4(test_case)
-
-    datetime_patcher.stop()


### PR DESCRIPTION
This is a follow up to #2513 after getting some additional requirements for testing uniformity across SDKs. We expand our tests to do cross region and arn region validation, as well as abstract a `FreezeTime` construct out of classes that have been implementing the same datetime mocking logic.