### PR TITLE
Start using __version__ instead of pkg_resources for awscrt

### DIFF
--- a/botocore/session.py
+++ b/botocore/session.py
@@ -216,13 +216,9 @@ class Session(object):
 
     def _get_crt_version(self):
         try:
-            import pkg_resources
-            return pkg_resources.get_distribution("awscrt").version
-        except Exception:
-            # We're catching *everything* here to avoid failing
-            # on pkg_resources issues. This is unlikely in our
-            # supported versions but it avoids making a hard
-            # dependency on the package being present.
+            import awscrt
+            return awscrt.__version__
+        except AttributeError:
             return "Unknown"
 
     @property


### PR DESCRIPTION
When CRT was first integrated into botocore, it didn't provide a way to easily access its version infromation. This resulted in using pkg_resources to introspect the information which is non-trivially expensive performing during client creation (it accounts for ~6% of the client creation time 😬).

I had introduced a patch to fix the issue in awslabs/aws-crt-python#268 which finally made it into CRT 0.11.14. We never revisited the issue though, so let's start using the `__version__` now.