### PR TITLE
Remove CHANGELOG from linting check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,8 @@ exclude: "\
     botocore/compat.py|\
     docs/|\
     tests/unit/auth/aws4_testsuite|\
-    tests/unit/response_parsing/xml\
+    tests/unit/response_parsing/xml|\
+    CHANGELOG.rst\
     )"
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
We're automatically adding an extra newline at the end of CHANGELOG.rst during each release. This is causing failures in our linter, so we'll ignore the file for now until that can be fixed.