### PR TITLE
Upgrade to awcrt 0.12.5

### DIFF
--- a/.changes/next-release/enchancement-AWSCRT-92804.json
+++ b/.changes/next-release/enchancement-AWSCRT-92804.json
@@ -1,0 +1,5 @@
+{
+  "type": "enchancement",
+  "category": "AWSCRT",
+  "description": "Upgrade awscrt extra to 0.12.5"
+}

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ requires_dist =
     urllib3>=1.25.4,<1.27
 
 [options.extras_require]
-crt = awscrt==0.11.24
+crt = awscrt==0.12.5
 
 [flake8]
 ignore = E203,E226,E501,E731,W503,W504


### PR DESCRIPTION
This patch will move us to use awscrt 0.12.5 which provides wheel support for Python 3.10.