### PR TITLE
Move from 3.10-dev to 3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macOS-latest ]
 
     steps:


### PR DESCRIPTION
Move off the "3.10-dev" ci environment to the official "3.10" release.

Change requires quotes because YAML helpfully shortens 3.10 to 3.1 🙃