### PR TITLE
Update awscrt version to 0.12.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ requires_dist =
     python-dateutil>=2.1,<3.0.0
     jmespath>=0.7.1,<1.0.0
     urllib3>=1.25.4,<1.27
-    awscrt==0.11.24
+    awscrt==0.12.4

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requires = [
     'jmespath>=0.7.1,<1.0.0',
     'python-dateutil>=2.1,<3.0.0',
     'urllib3>=1.25.4,<1.27',
-    'awscrt==0.11.24',
+    'awscrt==0.12.4',
 ]
 
 


### PR DESCRIPTION
This PR updates the botocore v2 branch to use awscrt 0.12.4, which supports the `HTTPS_PROXY` environment variable for S3 transfers when the `preferred_transfer_client` is set to `crt`