### PR TITLE
Support socks proxy

### DIFF
--- a/.github/workflows/run-socks-test.yml
+++ b/.github/workflows/run-socks-test.yml
@@ -1,0 +1,30 @@
+
+name: Run SOCKS tests
+
+on:
+  push:
+  pull_request:
+    branches-ignore: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies and SOCKS
+      run: |
+        python scripts/ci/install --extras socks
+    - name: Run tests
+      run: |
+        python scripts/ci/run-socks-tests

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -25,7 +25,7 @@ import botocore.utils
 from botocore.compat import six
 from botocore.compat import (
     HTTPHeaders, HTTPResponse, urlunsplit, urlsplit,
-    urlencode, urlparse, MutableMapping
+    urlencode, urlparse, MutableMapping, HAS_SOCKS
 )
 from botocore.exceptions import UnseekableStreamError
 
@@ -227,6 +227,28 @@ class AWSHTTPConnectionPool(HTTPConnectionPool):
 
 class AWSHTTPSConnectionPool(HTTPSConnectionPool):
     ConnectionCls = AWSHTTPSConnection
+
+
+if HAS_SOCKS:
+    from urllib3.contrib.socks import SOCKSConnection
+    from urllib3.contrib.socks import SOCKSHTTPSConnection
+    from urllib3.contrib.socks import SOCKSHTTPConnectionPool
+    from urllib3.contrib.socks import SOCKSHTTPSConnectionPool
+
+    class AWSSOCKSHTTPConnection(AWSConnection, SOCKSConnection):
+        """ An HTTPConnection that supports 100 Continue behavior. """
+
+
+    class AWSSOCKSHTTPSConnection(AWSConnection, SOCKSHTTPSConnection):
+        """ An HTTPSConnection that supports 100 Continue behavior. """
+
+
+    class AWSSOCKSHTTPConnectionPool(SOCKSHTTPConnectionPool):
+        ConnectionCls = AWSSOCKSHTTPConnection
+
+
+    class AWSSOCKSHTTPSConnectionPool(SOCKSHTTPSConnectionPool):
+        ConnectionCls = AWSSOCKSHTTPSConnection
 
 
 def prepare_request_dict(request_dict, endpoint_url, context=None,

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -359,3 +359,9 @@ try:
     HAS_CRT = not disabled.lower() == 'true'
 except ImportError:
     HAS_CRT = False
+
+try:
+    import socks
+    HAS_SOCKS = True
+except ImportError:
+    HAS_SOCKS = False

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -22,11 +22,15 @@ except ImportError:
 
 import botocore.awsrequest
 from botocore.vendored.six.moves.urllib_parse import unquote
-from botocore.compat import filter_ssl_warnings, urlparse
+from botocore.compat import filter_ssl_warnings, urlparse, HAS_SOCKS
+
+if HAS_SOCKS:
+    from urllib3.contrib.socks import SOCKSProxyManager
+
 from botocore.exceptions import (
     ConnectionClosedError, EndpointConnectionError, HTTPClientError,
     ReadTimeoutError, ProxyConnectionError, ConnectTimeoutError, SSLError,
-    InvalidProxiesConfigError
+    InvalidProxiesConfigError, MissingDependencyException
 )
 
 filter_ssl_warnings()
@@ -127,9 +131,7 @@ class ProxyConfiguration(object):
     def proxy_url_for(self, url):
         """Retrieves the corresponding proxy url for a given url. """
         parsed_url = urlparse(url)
-        proxy = self._proxies.get(parsed_url.scheme)
-        if proxy:
-            proxy = self._fix_proxy_url(proxy)
+        proxy = self.proxy_url_for_scheme(parsed_url.scheme)
         return proxy
 
     def proxy_headers_for(self, proxy_url):
@@ -141,17 +143,30 @@ class ProxyConfiguration(object):
             headers['Proxy-Authorization'] = basic_auth
         return headers
 
+    def proxy_url_for_scheme(self, scheme):
+        proxy = self._proxies.get(scheme)
+        if proxy:
+            proxy = self._fix_proxy_url(proxy)
+        return proxy
+
     @property
     def settings(self):
         return self._proxies_settings
 
     def _fix_proxy_url(self, proxy_url):
-        if proxy_url.startswith('http:') or proxy_url.startswith('https:'):
+        if proxy_url.startswith('http:') or proxy_url.startswith('https:') or self.is_socks_proxy(proxy_url):
             return proxy_url
         elif proxy_url.startswith('//'):
             return 'http:' + proxy_url
         else:
             return 'http://' + proxy_url
+
+    @staticmethod
+    def is_socks_proxy(proxy_url):
+        if proxy_url:
+            parsed_proxy_url = urlparse(proxy_url)
+            return parsed_proxy_url.scheme in ['socks5', 'socks5h', 'socks4', 'socks4a']
+        return False
 
     def _construct_basic_auth(self, username, password):
         auth_str = '{0}:{1}'.format(username, password)
@@ -191,10 +206,8 @@ class URLLib3Session(object):
         self._proxy_config = ProxyConfiguration(
             proxies=proxies, proxies_settings=proxies_config
         )
-        self._pool_classes_by_scheme = {
-            'http': botocore.awsrequest.AWSHTTPConnectionPool,
-            'https': botocore.awsrequest.AWSHTTPSConnectionPool,
-        }
+        self._pool_classes_by_scheme = self._get_pool_classes_by_scheme()
+
         if timeout is None:
             timeout = DEFAULT_TIMEOUT
         if not isinstance(timeout, (int, float)):
@@ -243,13 +256,45 @@ class URLLib3Session(object):
     def _get_ssl_context(self):
         return create_urllib3_context()
 
+    def _get_pool_classes_by_scheme(self):
+        http_proxy = self._proxy_config.proxy_url_for_scheme('http')
+        https_proxy = self._proxy_config.proxy_url_for_scheme('https')
+
+        if self._proxy_config.is_socks_proxy(http_proxy):
+            http_proxy_class = botocore.awsrequest.AWSSOCKSHTTPConnectionPool
+        else:
+            http_proxy_class = botocore.awsrequest.AWSHTTPConnectionPool
+
+        if self._proxy_config.is_socks_proxy(https_proxy):
+            https_proxy_class = botocore.awsrequest.AWSSOCKSHTTPSConnectionPool
+        else:
+            https_proxy_class = botocore.awsrequest.AWSHTTPSConnectionPool
+
+        pool_classes_by_scheme = {
+            'http': http_proxy_class,
+            'https': https_proxy_class,
+        }
+
+        return pool_classes_by_scheme
+
     def _get_proxy_manager(self, proxy_url):
         if proxy_url not in self._proxy_managers:
             proxy_headers = self._proxy_config.proxy_headers_for(proxy_url)
             proxy_manager_kwargs = self._get_pool_manager_kwargs(
                 proxy_headers=proxy_headers)
             proxy_manager_kwargs.update(**self._proxies_kwargs)
-            proxy_manager = proxy_from_url(proxy_url, **proxy_manager_kwargs)
+            if self._proxy_config.is_socks_proxy(proxy_url):
+                if HAS_SOCKS:
+                    proxy_manager_kwargs['_proxy_headers'] = proxy_manager_kwargs.pop('proxy_headers')
+                    proxy_manager = SOCKSProxyManager(proxy_url, **proxy_manager_kwargs)
+                else:
+                    raise MissingDependencyException(
+                        msg="Using socks proxy requires an additional "
+                            "dependency. You will need to pip install "
+                            "botocore[socks] before proceeding."
+                    )
+            else:
+                proxy_manager = proxy_from_url(proxy_url, **proxy_manager_kwargs)
             proxy_manager.pool_classes_by_scheme = self._pool_classes_by_scheme
             self._proxy_managers[proxy_url] = proxy_manager
 

--- a/scripts/ci/run-socks-tests
+++ b/scripts/ci/run-socks-tests
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Don't run tests from the root repo dir.
+# We want to ensure we're importing from the installed
+# binary package not from the CWD.
+
+import os
+import sys
+from contextlib import contextmanager
+from subprocess import check_call
+
+_dname = os.path.dirname
+
+REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
+
+
+@contextmanager
+def cd(path):
+    """Change directory while inside context manager."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
+
+
+def run(command):
+    return check_call(command, shell=True)
+
+
+try:
+    import sock # noqa
+except ImportError:
+    print("MISSING DEPENDENCY: PySocks must be installed to run the socks tests.")
+    sys.exit(1)
+
+if __name__ == "__main__":
+    with cd(os.path.join(REPO_ROOT, "tests")):
+        run(f"{REPO_ROOT}/scripts/ci/run-tests unit/ functional/")

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ requires_dist =
 
 [options.extras_require]
 crt = awscrt==0.12.5
+socks = PySocks>=1.5.6,<2.0,!=1.5.7
 
 [flake8]
 ignore = E203,E226,E501,E731,W503,W504

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,7 +34,7 @@ import botocore.loaders
 import botocore.session
 from botocore.awsrequest import AWSResponse
 from botocore.compat import (
-    parse_qs, six, urlparse, HAS_CRT
+    parse_qs, six, urlparse, HAS_CRT, HAS_SOCKS
 )
 from botocore import utils
 from botocore import credentials
@@ -76,6 +76,15 @@ def requires_crt(reason=None):
 
     def decorator(func):
         return unittest.skipIf(not HAS_CRT, reason)(func)
+    return decorator
+
+
+def requires_socks(reason=None):
+    if reason is None:
+        reason = "Test requires PySocks to be installed"
+
+    def decorator(func):
+        return unittest.skipIf(not HAS_SOCKS, reason)(func)
     return decorator
 
 


### PR DESCRIPTION
Fix #2540  and #880
I got approval from the author of #2081 to continue.

Could you please review this PR and approve it?

Test code:

1. Set environment proxy

  ```bash
  export https_proxy=socks5://127.0.0.1:50010 http_proxy=socks5://127.0.0.1:50010
  ```
2. Run test code
  ```Python
  import botocore.session
  c = botocore.session.get_session().create_client('s3')
  print(c.list_buckets())
  ```

BTW, it works only if proxies are set in environment while it doesn't work if proxies are set in [Specifying proxy servers](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) as http proxy doesn't work in configuration either.