### PR TITLE
Add Windows support in CI

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -1,30 +1,27 @@
-
 name: Run CRT tests
-
+ 
 on:
   push:
   pull_request:
-    branches-ignore: [ master ]
+    branches-ignore: [master]
 
 jobs:
   build:
-
-    runs-on: ${{ matrix.os }}
+    runs-on: '${{ matrix.os }}'
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
-        os: [ubuntu-latest, macOS-latest]
-
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies and CRT
-      run: |
-        python scripts/ci/install --extras crt
-    - name: Run tests
-      run: |
-        python scripts/ci/run-crt-tests
+      - uses: actions/checkout@v2
+      - name: 'Set up Python ${{ matrix.python-version }}'
+        uses: actions/setup-python@v2
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - name: Install dependencies and CRT
+        run: |
+          python scripts/ci/install --extras crt
+      - name: Run tests
+        run: |
+          python scripts/ci/run-crt-tests --with-cov --with-xdist

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,33 +3,31 @@ name: Run tests
 on:
   push:
   pull_request:
-    branches-ignore: [ master ]
+    branches-ignore: [master]
 
 jobs:
   build:
-
-    runs-on: ${{ matrix.os }}
+    runs-on: '${{ matrix.os }}'
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
-        os: [ubuntu-latest, macOS-latest ]
-
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install codecov
-        python scripts/ci/install
-    - name: Run tests
-      run: |
-        python scripts/ci/run-tests --with-cov
-    - name: codecov
-      run: |
-        rm tests/coverage.xml
-        mv tests/.coverage ./
-        codecov
+      - uses: actions/checkout@v2
+      - name: 'Set up Python ${{ matrix.python-version }}'
+        uses: actions/setup-python@v2
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - name: Install dependencies
+        run: |
+          pip install codecov
+          python scripts/ci/install
+      - name: Run tests
+        run: |
+          python scripts/ci/run-tests --with-cov --with-xdist
+      - name: Run codecov
+        run: |
+          rm tests/coverage.xml
+          mv tests/.coverage ./
+          codecov

--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -78,6 +78,10 @@ coverage==5.5 \
     # via
     #   -r requirements-dev.txt
     #   pytest-cov
+execnet==1.9.0 \
+    --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
+    --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
+    # via pytest-xdist
 importlib-metadata==4.8.1 \
     --hash=sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15 \
     --hash=sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1
@@ -118,7 +122,9 @@ pluggy==1.0.0 \
 py==1.10.0 \
     --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
     --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-forked
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
@@ -127,12 +133,22 @@ pytest-cov==2.12.1 \
     --hash=sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a \
     --hash=sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7
     # via -r requirements-dev.txt
+pytest-forked==1.3.0 \
+    --hash=sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca \
+    --hash=sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815
+    # via pytest-xdist
+pytest-xdist==2.4.0 \
+    --hash=sha256:7b61ebb46997a0820a263553179d6d1e25a8c50d8a8620cd1aa1e20e3be99168 \
+    --hash=sha256:89b330316f7fc475f999c81b577c2b926c9569f3d397ae432c0c2e2496d61ff9
+    # via -r requirements-dev.txt
 pytest==6.2.5 \
     --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89 \
     --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134
     # via
     #   -r requirements-dev.txt
     #   pytest-cov
+    #   pytest-forked
+    #   pytest-xdist
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ coverage==5.5
 # Pytest specific deps
 pytest==6.2.5
 pytest-cov==2.12.1
+pytest-xdist==2.4.0
 atomicwrites>=1.0 # Windows requirement
 colorama>0.3.0 # Windows requirement

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -40,5 +40,5 @@ if __name__ == "__main__":
         wheel_dist = os.listdir("dist")[0]
         package = os.path.join('dist', wheel_dist)
         if args.extras:
-            package = "'%s[%s]'" % (package, args.extras)
+            package = "\"%s[%s]\"" % (package, args.extras)
         run('pip install %s' % package)

--- a/scripts/ci/run-crt-tests
+++ b/scripts/ci/run-crt-tests
@@ -36,4 +36,5 @@ except ImportError:
 
 if __name__ == "__main__":
     with cd(os.path.join(REPO_ROOT, "tests")):
-        run(f"{REPO_ROOT}/scripts/ci/run-tests unit/ functional/")
+        test_script = os.sep.join([REPO_ROOT, 'scripts', 'ci', 'run-tests'])
+        run(f"python {test_script} unit functional")

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -32,6 +32,8 @@ def run(command):
 def process_args(args):
     runner = args.test_runner
     test_args = ""
+    if args.with_xdist:
+        test_args += "-n auto --dist=loadfile --maxprocesses=4 "
     if args.with_cov:
         test_args += f"--cov={PACKAGE} --cov-report xml "
     dirs = " ".join(args.test_dirs)
@@ -59,6 +61,13 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
         help="Run default test-runner with code coverage enabled.",
+    )
+    parser.add_argument(
+        "-x",
+        "--with-xdist",
+        default=False,
+        action="store_true",
+        help="Run default test-runner with parallelization.",
     )
     raw_args = parser.parse_args()
     test_runner, test_args, test_dirs = process_args(raw_args)

--- a/tests/functional/retries/test_bucket.py
+++ b/tests/functional/retries/test_bucket.py
@@ -98,12 +98,5 @@ class TestTokenBucketThreading(unittest.TestCase):
             self.shutdown_threads = True
             for thread in all_threads:
                 thread.join()
+        # Verify all threads complete sucessfully
         self.assertEqual(self.caught_exceptions, [])
-        distribution = self.acquisitions_by_thread.values()
-        mean = sum(distribution) / float(len(distribution))
-        # We can't really rely on any guarantees about evenly distributing
-        # thread acquisition(), e.g. must be with a 2 stddev range, but we
-        # can sanity check that our implementation isn't drastically
-        # starving a thread.  So we'll arbitrarily say that a thread
-        # can't have less than 20% of the mean allocations per thread.
-        self.assertTrue(not any(x < (0.2 * mean) for x in distribution))

--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -100,19 +100,20 @@ NOT_SUPPORTED_IN_SDK = [
 ]
 
 
-@pytest.fixture(scope="module")
-def known_endpoint_prefixes():
+SESSION = get_session()
+LOADER = SESSION.get_component('data_loader')
+AVAILABLE_SERVICES = LOADER.list_available_services('service-2')
+
+
+def _known_endpoint_prefixes():
     # The entries in endpoints.json are keyed off of the endpoint
     # prefix.  We don't directly have that data, so we have to load
     # every service model and look up its endpoint prefix in its
     # ``metadata`` section.
-    session = get_session()
-    loader = session.get_component('data_loader')
-    known_services = loader.list_available_services('service-2')
-    return [
-        session.get_service_model(service_name).endpoint_prefix
-        for service_name in known_services
-    ]
+    return set([
+        SESSION.get_service_model(service_name).endpoint_prefix
+        for service_name in AVAILABLE_SERVICES
+    ])
 
 
 def _computed_endpoint_prefixes():
@@ -122,9 +123,7 @@ def _computed_endpoint_prefixes():
     # session.create_client(...).
     # So first we get a list of all the service names in the endpoints
     # file.
-    session = get_session()
-    loader = session.get_component('data_loader')
-    endpoints = loader.load_data('endpoints')
+    endpoints = LOADER.load_data('endpoints')
     # A service can be in multiple partitions so we're using
     # a set here to remove dupes.
     services_in_endpoints_file = set([])
@@ -139,40 +138,37 @@ def _computed_endpoint_prefixes():
     # Now we go through every known endpoint prefix in the endpoints.json
     # file and ensure it maps to an endpoint prefix we've seen
     # in a service model.
+    endpoint_prefixes = []
     for endpoint_prefix in services_in_endpoints_file:
         # Check for an override where we know that an entry
         # in the endpoints.json actually maps to a different endpoint
         # prefix.
         endpoint_prefix = ENDPOINT_PREFIX_OVERRIDE.get(endpoint_prefix,
                                                        endpoint_prefix)
-        yield endpoint_prefix
+        endpoint_prefixes.append(endpoint_prefix)
+    return sorted(endpoint_prefixes)
 
 
-@pytest.mark.parametrize("endpoint_prefix", _computed_endpoint_prefixes())
-def test_endpoint_matches_service(known_endpoint_prefixes, endpoint_prefix):
+KNOWN_ENDPOINT_PREFIXES = _known_endpoint_prefixes()
+COMPUTED_ENDPOINT_PREFIXES = _computed_endpoint_prefixes()
+
+
+@pytest.mark.parametrize("endpoint_prefix", COMPUTED_ENDPOINT_PREFIXES)
+def test_endpoint_matches_service(endpoint_prefix):
     # We need to cross check all computed endpoints against our
     # known values in endpoints.json, to ensure everything lines
     # up correctly.
-    assert endpoint_prefix in known_endpoint_prefixes
+    assert endpoint_prefix in KNOWN_ENDPOINT_PREFIXES
 
 
-def _available_services():
-    # Load the list of available services. The names here represent what
-    # will become the client names.
-    session = get_session()
-    loader = session.get_component('data_loader')
-    return loader.list_available_services('service-2')
-
-
-@pytest.mark.parametrize("service_name", _available_services())
+@pytest.mark.parametrize("service_name", AVAILABLE_SERVICES)
 def test_service_name_matches_endpoint_prefix(service_name):
     """Generates tests for each service to verify that the computed service
     named based on the service id matches the service name used to
     create a client (i.e the directory name in botocore/data)
     unless there is an explicit exception.
     """
-    session = get_session()
-    service_model = session.get_service_model(service_name)
+    service_model = SESSION.get_service_model(service_name)
     computed_name = service_model.service_id.replace(' ', '-').lower()
 
     # Handle known exceptions where we have renamed the service directory
@@ -199,9 +195,7 @@ _S3_ALLOWED_PSEUDO_FIPS_REGIONS = [
 
 
 def _s3_region_names():
-    session = get_session()
-    loader = session.get_component('data_loader')
-    endpoints = loader.load_data('endpoints')
+    endpoints = LOADER.load_data('endpoints')
 
     for partition in endpoints['partitions']:
         s3_service = partition['services'].get('s3', {})

--- a/tests/functional/test_mturk.py
+++ b/tests/functional/test_mturk.py
@@ -24,6 +24,7 @@ class TestMturk(BaseSessionTest):
         self.stubber.activate()
 
     def tearDown(self):
+        super().setUp()
         self.stubber.deactivate()
 
     def test_list_hits_aliased(self):

--- a/tests/functional/test_rds.py
+++ b/tests/functional/test_rds.py
@@ -10,10 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import botocore.session
 from tests import BaseSessionTest, ClientHTTPStubber
 from botocore.stub import Stubber
-from tests import unittest
 
 
 class TestRDSPresignUrlInjection(BaseSessionTest):
@@ -80,9 +78,9 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
             self.assert_presigned_url_injected_in_request(sent_request.body)
 
 
-class TestRDS(unittest.TestCase):
+class TestRDS(BaseSessionTest):
     def setUp(self):
-        self.session = botocore.session.get_session()
+        super().setUp()
         self.client = self.session.create_client('rds', 'us-west-2')
         self.stubber = Stubber(self.client)
         self.stubber.activate()

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -87,7 +87,9 @@ def generate_test_cases():
         if not any(f.endswith('.req') for f in filenames):
             continue
 
-        test_case = os.path.relpath(dirpath, TESTSUITE_DIR)
+        test_case = os.path.relpath(dirpath, TESTSUITE_DIR).replace(
+            os.sep, '/'
+        )
         if test_case in TESTS_TO_IGNORE:
             log.debug("Skipping test: %s", test_case)
             continue

--- a/tests/unit/response_parsing/test_response_parsing.py
+++ b/tests/unit/response_parsing/test_response_parsing.py
@@ -38,7 +38,37 @@ SPECIAL_CASES = [
 ]
 
 
-def _test_parsed_response(xmlfile, response_body, operation_model, expected):
+def _get_expected_parsed_result(filename):
+    dirname, filename = os.path.split(filename)
+    basename = os.path.splitext(filename)[0]
+    jsonfile = os.path.join(dirname, basename + '.json')
+    with open(jsonfile) as f:
+        return json.load(f)
+
+
+def _get_raw_response_body(xmlfile):
+    with open(xmlfile, 'rb') as f:
+        return f.read()
+
+
+def _get_operation_model(service_model, filename):
+    dirname, filename = os.path.split(filename)
+    basename = os.path.splitext(filename)[0]
+    sn, opname = basename.split('-', 1)
+    # In order to have multiple tests for the same
+    # operation a '#' char is used to separate
+    # operation names from some other suffix so that
+    # the tests have a different filename, e.g
+    # my-operation#1.xml, my-operation#2.xml.
+    opname = opname.split('#')[0]
+    operation_names = service_model.operation_names
+    for operation_name in operation_names:
+        if xform_name(operation_name) == opname.replace('-', '_'):
+            return service_model.operation_model(operation_name)
+
+
+def _test_parsed_response(xmlfile, operation_model, expected):
+    response_body = _get_raw_response_body(xmlfile)
     response = {
         'body': response_body,
         'status_code': 200,
@@ -106,10 +136,11 @@ def _convert_bytes_to_str(parsed):
 
 
 def _xml_test_cases():
+    session = create_session()
+    test_cases = []
     for dp in ['responses', 'errors']:
         data_path = os.path.join(os.path.dirname(__file__), 'xml')
         data_path = os.path.join(data_path, dp)
-        session = create_session()
         xml_files = glob.glob('%s/*.xml' % data_path)
         service_names = set()
         for fn in xml_files:
@@ -121,47 +152,20 @@ def _xml_test_cases():
             for xmlfile in service_xml_files:
                 expected = _get_expected_parsed_result(xmlfile)
                 operation_model = _get_operation_model(service_model, xmlfile)
-                raw_response_body = _get_raw_response_body(xmlfile)
-                yield xmlfile, raw_response_body, operation_model, expected
+                test_cases.append(
+                    (xmlfile, operation_model, expected)
+                )
+    return sorted(test_cases)
 
 
 @pytest.mark.parametrize(
-    "xmlfile, raw_response_body, operation_model, expected",
+    "xmlfile, operation_model, expected",
     _xml_test_cases()
 )
-def test_xml_parsing(xmlfile, raw_response_body, operation_model, expected):
+def test_xml_parsing(xmlfile, operation_model, expected):
     _test_parsed_response(
-        xmlfile, raw_response_body, operation_model, expected
+        xmlfile, operation_model, expected
     )
-
-
-def _get_raw_response_body(xmlfile):
-    with open(xmlfile, 'rb') as f:
-        return f.read()
-
-
-def _get_operation_model(service_model, filename):
-    dirname, filename = os.path.split(filename)
-    basename = os.path.splitext(filename)[0]
-    sn, opname = basename.split('-', 1)
-    # In order to have multiple tests for the same
-    # operation a '#' char is used to separate
-    # operation names from some other suffix so that
-    # the tests have a different filename, e.g
-    # my-operation#1.xml, my-operation#2.xml.
-    opname = opname.split('#')[0]
-    operation_names = service_model.operation_names
-    for operation_name in operation_names:
-        if xform_name(operation_name) == opname.replace('-', '_'):
-            return service_model.operation_model(operation_name)
-
-
-def _get_expected_parsed_result(filename):
-    dirname, filename = os.path.split(filename)
-    basename = os.path.splitext(filename)[0]
-    jsonfile = os.path.join(dirname, basename + '.json')
-    with open(jsonfile) as f:
-        return json.load(f)
 
 
 def _json_test_cases():
@@ -172,6 +176,7 @@ def _json_test_cases():
     json_responses_dir = os.path.join(base_dir, 'errors')
     expected_parsed_dir = os.path.join(base_dir, 'expected')
     session = botocore.session.get_session()
+    json_test_cases = []
     for json_response_file in os.listdir(json_responses_dir):
         # Files look like: 'datapipeline-create-pipeline.json'
         service_name, operation_name = os.path.splitext(
@@ -188,18 +193,19 @@ def _json_test_cases():
         for op_name in operation_names:
             if xform_name(op_name) == operation_name.replace('-', '_'):
                 operation_model = service_model.operation_model(op_name)
-        with open(raw_response_file, 'rb') as f:
-            raw_response_body = f.read()
-        yield raw_response_file, raw_response_body, operation_model, expected
+        json_test_cases.append(
+            (raw_response_file, operation_model, expected)
+        )
+    return sorted(json_test_cases)
 
 
 @pytest.mark.parametrize(
-    "raw_response_file, raw_response_body, operation_model, expected",
+    "raw_response_file, operation_model, expected",
     _json_test_cases()
 )
 def test_json_errors_parsing(
-    raw_response_file, raw_response_body, operation_model, expected
+    raw_response_file, operation_model, expected
 ):
     _test_parsed_response(
-        raw_response_file, raw_response_body, operation_model, expected
+        raw_response_file, operation_model, expected
     )

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3336,7 +3336,7 @@ class TestSSOProvider(unittest.TestCase):
             'sso_role_name': self.role_name,
             'sso_account_id': self.account_id,
         }
-        self.expires_at = datetime.now(tzlocal()) + timedelta(hours=24)
+        self.expires_at = datetime.now(tzutc()) + timedelta(hours=24)
         self.cached_creds_key = '048db75bbe50955c16af7aba6ff9c41a3131bb7e'
         self.cached_token_key = '13f9d35043871d073ab260e020f0ffde092cb14b'
         self.cache = {

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -308,7 +308,7 @@ class TestBuiltinEventHandlers(BaseSessionTest):
         self.foo_called = True
 
     def tearDown(self):
-        super(TestBuiltinEventHandlers, self).setUp()
+        super(TestBuiltinEventHandlers, self).tearDown()
         self.handler_patch.stop()
 
     def test_registered_builtin_handlers(self):

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -291,7 +291,7 @@ class TestBuiltinEventHandlers(BaseSessionTest):
         self.foo_called = True
 
     def tearDown(self):
-        super(TestBuiltinEventHandlers, self).setUp()
+        super(TestBuiltinEventHandlers, self).tearDown()
         self.handler_patch.stop()
 
     def test_registered_builtin_handlers(self):


### PR DESCRIPTION
This patch will fix some broken tests that were previously preventing running Windows in our CI tests for new PRs. This also adds support for parallelization with pytest-xdist to help compensate for the added time with new testing platforms.