### PR TITLE
Adding to list of allowed S3 FIPS regions

### DIFF
--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -195,6 +195,12 @@ _S3_ALLOWED_PSEUDO_FIPS_REGIONS = [
     'fips-accesspoint-us-gov-east-1',
     'fips-accesspoint-us-gov-west-1',
     'fips-us-gov-west-1',
+    'fips-us-gov-east-1',
+    'fips-ca-central-1',
+    'fips-us-east-1',
+    'fips-us-east-2',
+    'fips-us-west-1',
+    'fips-us-west-2',
 ]
 
 


### PR DESCRIPTION
Adding regions to the the [`_S3_ALLOWED_PSEUDO_FIPS_REGIONS`](https://github.com/boto/botocore/blob/develop/tests/functional/test_endpoints.py#L185) in order to support s3 fips regions without ARN customizations.