### PR TITLE
Add fallback for OP_NO_TICKET import on older versions of urllib3

### DIFF
--- a/.changes/next-release/bugfix-urllib3-31882.json
+++ b/.changes/next-release/bugfix-urllib3-31882.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "urllib3",
+  "description": "Fix NO_OP_TICKET import bug in older versions of urllib3"
+}

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -8,13 +8,21 @@ import sys
 from urllib3 import PoolManager, proxy_from_url, Timeout
 from urllib3.util.retry import Retry
 from urllib3.util.ssl_ import (
-    ssl, OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_COMPRESSION, OP_NO_TICKET,
-    PROTOCOL_TLS, PROTOCOL_TLS_CLIENT, DEFAULT_CIPHERS,
+    ssl, OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_COMPRESSION,
+    PROTOCOL_TLS, DEFAULT_CIPHERS,
 )
 from urllib3.exceptions import SSLError as URLLib3SSLError
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 from urllib3.exceptions import ConnectTimeoutError as URLLib3ConnectTimeoutError
 from urllib3.exceptions import NewConnectionError, ProtocolError, ProxyError
+
+try:
+    from urllib3.util.ssl_ import PROTOCOL_TLS_CLIENT, OP_NO_TICKET
+except ImportError:
+    # Fallback directly to ssl for version of urllib3 before 1.26.
+    # They are available in the standard library starting in Python 3.6.
+    from ssl import PROTOCOL_TLS_CLIENT, OP_NO_TICKET
+
 try:
     # Always import the original SSLContext, even if it has been patched
     from urllib3.contrib.pyopenssl import orig_util_SSLContext as SSLContext


### PR DESCRIPTION
Fix for #2562, adding fallback for OP_NO_TICKET import for older versions of urllib3.