### PR TITLE
Support IPv6 endpoint urls

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -22,7 +22,9 @@ from botocore.vendored import six
 from botocore.awsrequest import create_request_object
 from botocore.exceptions import HTTPClientError
 from botocore.httpsession import URLLib3Session
-from botocore.utils import is_valid_endpoint_url, get_environ_proxies
+from botocore.utils import (
+    is_valid_endpoint_url, is_valid_ipv6_endpoint_url, get_environ_proxies
+)
 from botocore.hooks import first_non_none_response
 from botocore.history import get_global_history_recorder
 from botocore.response import StreamingBody
@@ -272,18 +274,19 @@ class EndpointCreator(object):
     def __init__(self, event_emitter):
         self._event_emitter = event_emitter
 
-    def create_endpoint(self, service_model, region_name, endpoint_url,
-                        verify=None, response_parser_factory=None,
-                        timeout=DEFAULT_TIMEOUT,
-                        max_pool_connections=MAX_POOL_CONNECTIONS,
-                        http_session_cls=URLLib3Session,
-                        proxies=None,
-                        socket_options=None,
-                        client_cert=None,
-                        proxies_config=None):
-        if not is_valid_endpoint_url(endpoint_url):
-
+    def create_endpoint(
+        self, service_model, region_name, endpoint_url,
+        verify=None, response_parser_factory=None,
+        timeout=DEFAULT_TIMEOUT, max_pool_connections=MAX_POOL_CONNECTIONS,
+        http_session_cls=URLLib3Session, proxies=None, socket_options=None,
+        client_cert=None, proxies_config=None
+    ):
+        if (
+            not is_valid_endpoint_url(endpoint_url)
+            and not is_valid_ipv6_endpoint_url(endpoint_url)
+        ):
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
+
         if proxies is None:
             proxies = self._get_proxies(endpoint_url)
         endpoint_prefix = service_model.endpoint_prefix

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1032,8 +1032,8 @@ class ArgumentGenerator(object):
 def is_valid_ipv6_endpoint_url(endpoint_url):
     if UNSAFE_URL_CHARS.intersection(endpoint_url):
         return False
-    netloc = urlparse(endpoint_url).netloc
-    return IPV6_ADDRZ_RE.match(netloc) is not None
+    hostname = '[{}]'.format(urlparse(endpoint_url).hostname)
+    return IPV6_ADDRZ_RE.match(hostname) is not None
 
 
 def is_valid_endpoint_url(endpoint_url):

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 import socket
 
+import pytest
+
 from tests import mock
 from tests import unittest
 
@@ -292,6 +294,25 @@ class TestEndpointCreator(unittest.TestCase):
             self.service_model, region_name='us-east-1',
             endpoint_url='https://endpoint.url')
         self.assertEqual(endpoint.host, 'https://endpoint.url')
+
+    def test_creates_endpoint_with_ipv4_url(self):
+        endpoint = self.creator.create_endpoint(
+            self.service_model, region_name='us-east-1',
+            endpoint_url='https://192.168.0.0')
+        self.assertEqual(endpoint.host, 'https://192.168.0.0')
+
+    def test_creates_endpoint_with_ipv6_url(self):
+        endpoint = self.creator.create_endpoint(
+            self.service_model, region_name='us-east-1',
+            endpoint_url='https://[100:0:2::61]:7480')
+        self.assertEqual(endpoint.host, 'https://[100:0:2::61]:7480')
+
+    def test_raises_error_with_invalid_url(self):
+        with pytest.raises(ValueError):
+            self.creator.create_endpoint(
+                self.service_model, region_name='us-east-1',
+                endpoint_url='https://*.aws.amazon.com/'
+            )
 
     def test_create_endpoint_with_default_timeout(self):
         self.creator.create_endpoint(


### PR DESCRIPTION
This patch should expand our support for endpoint URLs to include both ipv4 and ipv6 addresses. This should address boto/boto3#3086.