### PR TITLE
Fix deprecated warn usage

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -136,7 +136,7 @@ class ClientCreator(object):
                         config_use_fips_endpoint)
                 else:
                     client_config = config_use_fips_endpoint
-                logger.warn(
+                logger.warning(
                     'transforming region from %s to %s and setting '
                     'use_fips_endpoint to true. client should not '
                     'be configured with a fips psuedo region.' % (

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -142,6 +142,10 @@ class ProxyConnectionError(ConnectionError, requests.exceptions.ProxyError):
     fmt = 'Failed to connect to proxy URL: "{proxy_url}"'
 
 
+class ResponseStreamingError(HTTPClientError):
+    fmt = 'An error occurred while reading from response stream: {error}'
+
+
 class NoCredentialsError(BotoCoreError):
     """
     No credentials could be found.

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -15,8 +15,11 @@
 import logging
 
 from botocore.compat import set_socket_timeout
-from botocore.exceptions import IncompleteReadError, ReadTimeoutError
+from botocore.exceptions import (
+    IncompleteReadError, ReadTimeoutError, ResponseStreamingError
+)
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
+from urllib3.exceptions import ProtocolError as URLLib3ProtocolError
 from botocore import parsers
 
 # Keep these imported.  There's pre-existing code that uses them.
@@ -80,6 +83,8 @@ class StreamingBody(object):
         except URLLib3ReadTimeoutError as e:
             # TODO: the url will be None as urllib3 isn't setting it yet
             raise ReadTimeoutError(endpoint_url=e.url, error=e)
+        except URLLib3ProtocolError as e:
+            raise ResponseStreamingError(error=e)
         self._amount_read += len(chunk)
         if amt is None or (not chunk and amt > 0):
             # If the server sends empty contents or


### PR DESCRIPTION
Fixing use of deprecated `warn` function on logger. This should clean up some of the warning clutter logged when running pytest.