### PR TITLE
Add fallback for PROTOCOL_TLS when using older urllib3 version

### DIFF
--- a/.changes/next-release/bugfix-urllib3-2580.json
+++ b/.changes/next-release/bugfix-urllib3-2580.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "urllib3",
+  "description": "Fix PROTOCOL_TLS import bug in older versions of urllib3"
+}

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -9,7 +9,7 @@ from urllib3 import PoolManager, proxy_from_url, Timeout
 from urllib3.util.retry import Retry
 from urllib3.util.ssl_ import (
     ssl, OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_COMPRESSION,
-    PROTOCOL_TLS, DEFAULT_CIPHERS,
+    DEFAULT_CIPHERS,
 )
 from urllib3.exceptions import SSLError as URLLib3SSLError
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
@@ -17,11 +17,11 @@ from urllib3.exceptions import ConnectTimeoutError as URLLib3ConnectTimeoutError
 from urllib3.exceptions import NewConnectionError, ProtocolError, ProxyError
 
 try:
-    from urllib3.util.ssl_ import PROTOCOL_TLS_CLIENT, OP_NO_TICKET
+    from urllib3.util.ssl_ import PROTOCOL_TLS, PROTOCOL_TLS_CLIENT, OP_NO_TICKET
 except ImportError:
     # Fallback directly to ssl for version of urllib3 before 1.26.
     # They are available in the standard library starting in Python 3.6.
-    from ssl import PROTOCOL_TLS_CLIENT, OP_NO_TICKET
+    from ssl import PROTOCOL_TLS, PROTOCOL_TLS_CLIENT, OP_NO_TICKET
 
 try:
     # Always import the original SSLContext, even if it has been patched


### PR DESCRIPTION
This PR is a follow-up to https://github.com/boto/botocore/pull/2563 and it resolves https://github.com/boto/botocore/issues/2580