### PR TITLE
Skip serializing empty lists in headers

### DIFF
--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -588,6 +588,9 @@ class BaseRestSerializer(Serializer):
                 partitioned['query_string_kwargs'][key_name] = param_value
         elif location == 'header':
             shape = shape_members[param_name]
+            if not param_value and shape.type_name == 'list':
+                # Empty lists should not be set on the headers
+                return
             value = self._convert_header_value(shape, param_value)
             partitioned['headers'][key_name] = str(value)
         elif location == 'headers':

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -2165,6 +2165,29 @@
             "x-amz-list-param": "one,two,three"
           }
         }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/example"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "OperationRequest"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ListParam": []
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/2014-01-01/example",
+          "headers": {},
+          "forbidHeaders": ["x-amz-list-param"]
+        }
       }
     ]
   }

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -1946,6 +1946,30 @@
             "x-amz-list-param": "one,two,three"
           }
         }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/example"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "OperationRequest",
+            "xmlNamespace": {"uri": "https://foo/"}
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ListParam": []
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/2014-01-01/example",
+          "headers": {},
+          "forbidHeaders": ["x-amz-list-param"]
+        }
       }
     ]
   }


### PR DESCRIPTION
Right now we end up serializing a list parameter into the headers as an empty string when we shouldn't be adding the header at all.