### PR TITLE
Dox fix: default role used.

### DIFF
--- a/docs/source/topics/paginators.rst
+++ b/docs/source/topics/paginators.rst
@@ -112,5 +112,5 @@ expression returns a single value that is not an array, that value is yielded
 directly. If the result of applying the JMESPath expression to a page of
 results is a list, then each value of the list is yielded individually
 (essentially implementing a flat map). For example, in the above expression,
-each key that has a ``Size`` greater than `100` is yielded by the
+each key that has a ``Size`` greater than ``100`` is yielded by the
 ``filtered_iterator``.


### PR DESCRIPTION
Don't mind me, I spotted while working on an Sphinx linter.

For context, simple backticks in Sphinx are [default roles](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html), the Sphinx doc explicitly allows using default role for whatever you want, so I'm fixing nothing here.

But as it's the only default role in botocore whole doc it feels a small inconsistency that can be fixed.
