### PR TITLE
Adding retry information headers

### DIFF
--- a/.changes/next-release/enhancement-Requestheaders-37145.json
+++ b/.changes/next-release/enhancement-Requestheaders-37145.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Request headers",
+  "description": "Adding request headers with retry information."
+}

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -12,10 +12,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import datetime
 import os
 import logging
 import time
 import threading
+import uuid
 
 from botocore.vendored import six
 
@@ -129,15 +131,60 @@ class Endpoint(object):
         self._encode_headers(request.headers)
         return request.prepare()
 
+    def _calculate_ttl(self, response_received_timestamp, date_header,
+                       read_timeout):
+        local_timestamp = datetime.datetime.utcnow()
+        date_conversion = datetime.datetime.strptime(
+            date_header,
+            "%a, %d %b %Y %H:%M:%S %Z"
+        )
+        estimated_skew = date_conversion - response_received_timestamp
+        ttl = local_timestamp + datetime.timedelta(
+            seconds=read_timeout) + estimated_skew
+        return ttl.strftime('%Y%m%dT%H%M%SZ')
+
+    def _set_ttl(self, retries_context, read_timeout, success_response):
+        response_date_header = success_response[0].headers.get('Date')
+        has_streaming_input = retries_context.get('has_streaming_input')
+        if response_date_header and not has_streaming_input:
+            try:
+                response_received_timestamp = datetime.datetime.utcnow()
+                retries_context['ttl'] = self._calculate_ttl(
+                    response_received_timestamp,
+                    response_date_header,
+                    read_timeout
+                )
+            except Exception:
+                logger.debug(
+                    "Exception received when updating retries context with TTL",
+                    exc_info=True
+                )
+
+    def _update_retries_context(
+            self, context, attempt, success_response=None
+    ):
+        retries_context = context.setdefault('retries', {})
+        retries_context['attempt'] = attempt
+        if 'invocation-id' not in retries_context:
+            retries_context['invocation-id'] = str(uuid.uuid4())
+
+        if success_response:
+            read_timeout = context['client_config'].read_timeout
+            self._set_ttl(retries_context, read_timeout, success_response)
+
     def _send_request(self, request_dict, operation_model):
         attempts = 1
-        request = self.create_request(request_dict, operation_model)
         context = request_dict['context']
+        self._update_retries_context(context, attempts)
+        request = self.create_request(request_dict, operation_model)
         success_response, exception = self._get_response(
             request, operation_model, context)
         while self._needs_retry(attempts, operation_model, request_dict,
                                 success_response, exception):
             attempts += 1
+            self._update_retries_context(
+                context, attempts, success_response
+            )
             # If there is a stream associated with the request, we need
             # to reset it before attempting to send the request again.
             # This will ensure that we resend the entire contents of the

--- a/botocore/retries/standard.py
+++ b/botocore/retries/standard.py
@@ -266,6 +266,11 @@ class MaxAttemptsChecker(BaseRetryableChecker):
 
     def is_retryable(self, context):
         under_max_attempts = context.attempt_number < self._max_attempts
+        retries_context = context.request_context['retries']
+        retries_max_attempts = retries_context.setdefault(
+            'max', self._max_attempts)
+        if self._max_attempts > retries_max_attempts:
+            retries_context['max'] = self._max_attempts
         if not under_max_attempts:
             logger.debug("Max attempts of %s reached.", self._max_attempts)
             context.add_retry_metadata(MaxAttemptsReached=True)

--- a/botocore/retryhandler.py
+++ b/botocore/retryhandler.py
@@ -180,7 +180,16 @@ class RetryHandler(object):
         this will process retries appropriately.
 
         """
-        if self._checker(attempts, response, caught_exception):
+        checker_kwargs = {
+            'attempt_number': attempts,
+            'response': response,
+            'caught_exception': caught_exception
+        }
+        if isinstance(self._checker, MaxAttemptsDecorator):
+            retries_context = kwargs['request_dict']['context']['retries']
+            checker_kwargs.update({'retries_context': retries_context})
+
+        if self._checker(**checker_kwargs):
             result = self._action(attempts=attempts)
             logger.debug("Retry needed, action of: %s", result)
             return result
@@ -246,7 +255,13 @@ class MaxAttemptsDecorator(BaseChecker):
         self._max_attempts = max_attempts
         self._retryable_exceptions = retryable_exceptions
 
-    def __call__(self, attempt_number, response, caught_exception):
+    def __call__(self, attempt_number, response, caught_exception,
+                 retries_context):
+        retries_max_attempts = retries_context.setdefault(
+            'max', self._max_attempts)
+        if self._max_attempts > retries_max_attempts:
+            retries_context['max'] = self._max_attempts
+
         should_retry = self._should_retry(attempt_number, response,
                                           caught_exception)
         if should_retry:

--- a/tests/unit/retries/test_standard.py
+++ b/tests/unit/retries/test_standard.py
@@ -217,6 +217,7 @@ def _verify_retryable(checker, operation_model,
         parsed_response=parsed_response,
         http_response=http_response,
         caught_exception=caught_exception,
+        request_context={'retries': {}}
     )
     assert checker.is_retryable(context) == is_retryable
 
@@ -231,6 +232,7 @@ def arbitrary_retry_context():
         http_response=AWSResponse(status_code=500,
                                   raw=None, headers={}, url='https://foo'),
         caught_exception=None,
+        request_context={'retries': {}}
     )
 
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1023,7 +1023,7 @@ class TestRetryHandlerOrder(BaseSessionTest):
         operation = service_model.operation_model('CopyObject')
         responses = client.meta.events.emit(
             'needs-retry.s3.CopyObject',
-            request_dict={},
+            request_dict={'context': {'retries': {}}},
             response=(mock.Mock(), mock.Mock()), endpoint=mock.Mock(),
             operation=operation, attempts=1, caught_exception=None)
         # This is implementation specific, but we're trying to verify that


### PR DESCRIPTION
Adding the following request headers:
 - `amz-invocation-id`: A uuid unique to each SDK request invocation.
 - `amz-sdk-request`: Includes the following retry information for each SDK request: TTL, request attempt number, max number of retry attempts