### PR TITLE
Tolerate custom IMDS endpoints without trailing slash

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -416,9 +416,15 @@ class IMDSFetcher(object):
 
         return chosen_base_url
 
+    def _construct_url(self, path):
+        sep = ''
+        if self._base_url and not self._base_url.endswith('/'):
+            sep = '/'
+        return f'{self._base_url}{sep}{path}'
+
     def _fetch_metadata_token(self):
         self._assert_enabled()
-        url = self._base_url + self._TOKEN_PATH
+        url = self._construct_url(self._TOKEN_PATH)
         headers = {
             'x-aws-ec2-metadata-token-ttl-seconds': self._TOKEN_TTL,
         }
@@ -466,7 +472,7 @@ class IMDSFetcher(object):
         self._assert_enabled()
         if retry_func is None:
             retry_func = self._default_retry
-        url = self._base_url + url_path
+        url = self._construct_url(url_path)
         headers = {}
         if token is not None:
             headers['x-aws-ec2-metadata-token'] = token

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2787,6 +2787,16 @@ class TestIMDSRegionProvider(unittest.TestCase):
         self.assertIn('http://myendpoint/', args[0].url)
 
     @mock.patch('botocore.httpsession.URLLib3Session.send')
+    def test_can_set_imds_service_endpoint_custom(self, send):
+        session = Session()
+        session.set_config_variable(
+            'ec2_metadata_service_endpoint', 'http://myendpoint')
+        provider = IMDSRegionProvider(session)
+        provider.provide()
+        args, _ = send.call_args
+        self.assertIn('http://myendpoint/latest/meta-data', args[0].url)
+
+    @mock.patch('botocore.httpsession.URLLib3Session.send')
     def test_imds_service_endpoint_overrides_ipv6_endpoint(self, send):
         session = Session()
         session.set_config_variable(


### PR DESCRIPTION
When using `AWS_EC2_METADATA_SERVICE_ENDPOINT` or `ec2_metadata_service_endpoint`, we use the url as-is without checking how it's formatted. This leads to issues with appending an IMDS path for URLs that don't end in a trailing slash. Most users aren't going to think to add that when using the override and this causes unnecessary failures.

This fix will maintain the backwards compatibility of `get_base_url` while ensuring paths are constructed correctly.