### PR TITLE
Fix IPv6 endpoints with non-default port

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -27,7 +27,7 @@ from botocore.compat import (
     six, unquote, urlsplit, urlunsplit, HAS_CRT
 )
 from botocore.exceptions import NoCredentialsError
-from botocore.utils import normalize_url_path, percent_encode_sequence
+from botocore.utils import is_valid_ipv6_endpoint_url, normalize_url_path, percent_encode_sequence
 
 # Imports for backwards compatibility
 from botocore.compat import MD5_AVAILABLE # noqa
@@ -59,6 +59,8 @@ def _host_from_url(url):
     # 3) excludes userinfo
     url_parts = urlsplit(url)
     host = url_parts.hostname  # urlsplit's hostname is always lowercase
+    if is_valid_ipv6_endpoint_url(url):
+        host = '[%s]' % (host)
     default_ports = {
         'http': 80,
         'https': 443

--- a/tests/unit/test_auth_sigv4.py
+++ b/tests/unit/test_auth_sigv4.py
@@ -31,3 +31,24 @@ class TestSigV4Auth(unittest.TestCase):
         request = AWSRequest(method='GET', url=endpoint)
         headers_to_sign = self.sigv4.headers_to_sign(request)
         self.assertEqual(expected_host, headers_to_sign.get('host'))
+
+    def test_signed_host_is_ipv6_without_port(self):
+        endpoint = 'http://[::1]'
+        expected_host = '[::1]'
+        request = AWSRequest(method='GET', url=endpoint)
+        headers_to_sign = self.sigv4.headers_to_sign(request)
+        self.assertEqual(expected_host, headers_to_sign.get('host'))
+
+    def test_signed_host_is_ipv6_with_default_port(self):
+        endpoint = 'http://[::1]:80'
+        expected_host = '[::1]'
+        request = AWSRequest(method='GET', url=endpoint)
+        headers_to_sign = self.sigv4.headers_to_sign(request)
+        self.assertEqual(expected_host, headers_to_sign.get('host'))
+
+    def test_signed_host_is_ipv6_with_explicit_port(self):
+        endpoint = 'http://[::1]:6789'
+        expected_host = '[::1]:6789'
+        request = AWSRequest(method='GET', url=endpoint)
+        headers_to_sign = self.sigv4.headers_to_sign(request)
+        self.assertEqual(expected_host, headers_to_sign.get('host'))


### PR DESCRIPTION
This commit adds brackets to IPv6 addresses in auth.py. Otherwise the signature is not calculated properly.