### PR TITLE
Add RequestId to error message

### DIFF
--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -158,3 +158,28 @@ class TestPickleExceptions(unittest.TestCase):
             unpickled_exception.request, botocore.awsrequest.AWSRequest)
         self.assertIsInstance(
             unpickled_exception.response, botocore.awsrequest.AWSResponse)
+
+
+def test_request_id_info_added_when_present():
+    response = {
+        'Error': {},
+        'ResponseMetadata': {
+            'RequestId': 'F9724212F07F14A2'
+        }
+    }
+    error_msg = str(exceptions.ClientError(response, 'operation'))
+    if '(RequestId: F9724212F07F14A2)' not in error_msg:
+        raise AssertionError("request id information not injected into error "
+                             "message: %s" % error_msg)
+
+
+def test_request_id_not_added_if_request_id_not_present():
+    response = {
+        'Error': {},
+        'ResponseMetadata': {}
+    }
+    error_msg = str(exceptions.ClientError(response, 'operation'))
+    if 'RequestId' in error_msg:
+        raise AssertionError("RequestId information should not be in exception "
+                             "message when RequestId not in response "
+                             "metadata: %s" % error_msg)


### PR DESCRIPTION
This adds the RequestID to the error string. The RequestID is useful/required when raising tickets with AWS support. 

It's possible to catch these errors and explicitly log the RequestID but that means handling exceptions for every API call. I believe it is also possible with DEBUG logging but that logs much more than errors. 

My experience was that I went to report an error but did not have the foresight to log the request id. In addition, it was a difficult to reproduce error. This is why I like the idea of including the RequestID by default for errors.

I tried to keep to the style of the repo but let me know if you want me to clean anything up.