### PR TITLE
Swallow underlying exception for config parsing

### DIFF
--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -147,9 +147,9 @@ def raw_config_parse(config_filename, parse_subsections=True):
         cp = six.moves.configparser.RawConfigParser()
         try:
             cp.read([path])
-        except (six.moves.configparser.Error, UnicodeDecodeError):
+        except (six.moves.configparser.Error, UnicodeDecodeError) as e:
             raise botocore.exceptions.ConfigParseError(
-                path=_unicode_path(path))
+                path=_unicode_path(path), error=e) from None
         else:
             for section in cp.sections():
                 config[section] = {}
@@ -161,9 +161,9 @@ def raw_config_parse(config_filename, parse_subsections=True):
                         # of nesting for now.
                         try:
                             config_value = _parse_nested(config_value)
-                        except ValueError:
+                        except ValueError as e:
                             raise botocore.exceptions.ConfigParseError(
-                                path=_unicode_path(path))
+                                path=_unicode_path(path), error=e) from None
                     config[section][option] = config_value
     return config
 


### PR DESCRIPTION
This will address the issue posed in aws/awscli#6696. Rather than modifying the existing exception flow, we'll use the `from None` syntax to swallow the underlying stacktrace for config parsing exceptions. This will prevent unnecessary information from being logged by default. Users who want this for debugging purposes will find it's still available under `.kwargs['error']`.