### PR TITLE
Update links and notices in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,14 @@
 botocore
 ========
 
-.. image:: https://codecov.io/github/boto/botocore/coverage.svg?branch=develop
-    :target: https://codecov.io/github/boto/botocore?branch=develop
-
+|Version| |Python| |License|
 
 A low-level interface to a growing number of Amazon Web Services. The
 botocore package is the foundation for the
 `AWS CLI <https://github.com/aws/aws-cli>`__ as well as
 `boto3 <https://github.com/boto/boto3>`__.
 
-Botocore is maintained and published by Amazon Web Services.
+Botocore is maintained and published by `Amazon Web Services`_.
 
 Notices
 -------
@@ -19,6 +17,19 @@ On 01/15/2021 deprecation for Python 2.7 was announced and support was dropped
 on 07/15/2021. To avoid disruption, customers using Botocore on Python 2.7 may
 need to upgrade their version of Python or pin the version of Botocore. For
 more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.
+
+Starting in May 2022, we will be dropping support for Python 3.6. This follows the Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__ for the runtime which occurred on 2021-12-23.
+
+.. _`Amazon Web Services`: https://aws.amazon.com/what-is-aws/
+.. |Python| image:: https://img.shields.io/pypi/pyversions/botocore.svg?style=flat
+    :target: https://pypi.python.org/pypi/botocore/
+    :alt: Python Versions
+.. |Version| image:: http://img.shields.io/pypi/v/botocore.svg?style=flat
+    :target: https://pypi.python.org/pypi/botocore/
+    :alt: Package Version
+.. |License| image:: http://img.shields.io/pypi/l/botocore.svg?style=flat
+    :target: https://github.com/boto/botocore/blob/develop/LICENSE.txt
+    :alt: License
 
 Getting Started
 ---------------
@@ -78,7 +89,6 @@ help. Please note many of the same resources available for ``boto3`` are
 applicable for ``botocore``:
 
 * Ask a question on `Stack Overflow <https://stackoverflow.com/>`__ and tag it with `boto3 <https://stackoverflow.com/questions/tagged/boto3>`__
-* Come join the AWS Python community chat on `gitter <https://gitter.im/boto/boto3>`__
 * Open a support ticket with `AWS Support <https://console.aws.amazon.com/support/home#/>`__
 * If it turns out that you may have found a bug, please `open an issue <https://github.com/boto/botocore/issues/new>`__
 


### PR DESCRIPTION
This PR will update badges, links, and the notice section with the most recent information.

Notable changes:
* Removal of links to Gitter due to lack of engagement and more widely adopted platforms
* Updated badges with Python support and licensing information.
* Added notice on end of support for Python 3.6 in May 2022.