### PR TITLE
One-liner: Eliminate Magic Number as Default Argument to iter_lines method of StreamingBody

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -124,7 +124,7 @@ class StreamingBody(IOBase):
 
     next = __next__
 
-    def iter_lines(self, chunk_size=1024, keepends=False):
+    def iter_lines(self, chunk_size=_DEFAULT_CHUNK_SIZE, keepends=False):
         """Return an iterator to yield lines from the raw stream.
 
         This is achieved by reading chunk of bytes (of size chunk_size) at a


### PR DESCRIPTION
Hello,

I was rummaging through botocore to investigate how `StreamingBody`'s `iter_lines` worked, and noticed that this took `1024` as a default instead of the provided constant, so I thought I would make a PR. This is my first time making a PR here; I'm glad it's small.

Anyway, I ran the pre-commit and it worked out nicely:

```
pre-commit run --all-files
Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
flake8...................................................................Passed
```

What do you think?

Regards,
SamV