### PR TITLE
Including additional endpoint data for modeled variants

### DIFF
--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -298,6 +298,7 @@ class EndpointResolver(BaseEndpointResolver):
                     service_name, endpoint_name
                 ))
                 raise EndpointVariantError(tags=tags, error_msg=error_msg)
+            self._merge_keys(endpoint_data, result)
         else:
             result = endpoint_data
 

--- a/tests/unit/test_regions.py
+++ b/tests/unit/test_regions.py
@@ -1172,3 +1172,11 @@ def _verify_expected_endpoint(service, region, fips, dualstack,
             use_fips_endpoint=fips
         )
     assert resolved['hostname'] == endpoint
+
+
+def test_additional_endpoint_data_exists_with_variants():
+    resolver = regions.EndpointResolver(_modeled_variants_template())
+    resolved = resolver.construct_endpoint(
+        'global-service', 'aws-global', use_fips_endpoint=True,
+    )
+    assert resolved['credentialScope'] == {'region': 'us-east-1'}


### PR DESCRIPTION
Merging in additional endpoint data beyond `hostname`, `dnsSuffix` and `tags` for modeled endpoint variants