### PR TITLE
Fix linting error from unnecessary import

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -11,7 +11,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import io
 import logging
 import functools
 


### PR DESCRIPTION
Fixing unnecessary import from a previously merged PR that's causing CI to fail.