### PR TITLE
Fix .git-blame-ignore-revs commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,4 +2,4 @@
 # git config --global blame.ignoreRevsFile .git-blame-ignore-revs
 
 # Reformat using isort
-36be9e16173f254ab7861fe554379597efc6d16b
+e34b6a36ae0c1571bcb5fd7034e817d3b397e283


### PR DESCRIPTION
We merged #2642 with a squash commit which changed the hash rendering the file incorrect. This PR updates the relevant hash. 

Thanks to @hugovk who found the [GH feature request](https://github.com/github/feedback/discussions/5033#discussioncomment-2318478) is actually already deployed as a Beta. We should start seeing the blame corrections in the Github UI after this is merged.