### PR TITLE
Update awscrt to 0.13.7

### DIFF
--- a/.changes/next-release/enhancement-AWSCRT-43547.json
+++ b/.changes/next-release/enhancement-AWSCRT-43547.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "AWSCRT",
+  "description": "Upgrade awscrt version to 0.13.7"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ requires_dist =
     urllib3>=1.25.4,<1.27
 
 [options.extras_require]
-crt = awscrt==0.13.5
+crt = awscrt==0.13.7
 
 [flake8]
 ignore = E203,E226,E501,E731,W503,W504


### PR DESCRIPTION
Update to the latest version of `awscrt`. This should resolve rare occurrences of `SignatureMismatchError` for SigV4a requests on Windows.