### PR TITLE
Move IP regexes into compat to avoid circular imports

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -19,6 +19,7 @@ import warnings
 import hashlib
 import logging
 import shlex
+import re
 import os
 from math import floor
 
@@ -359,3 +360,44 @@ try:
     HAS_CRT = not disabled.lower() == 'true'
 except ImportError:
     HAS_CRT = False
+
+
+########################################################
+#              urllib3 compat backports                #
+########################################################
+
+# Vendoring IPv6 validation regex patterns from urllib3
+# https://github.com/urllib3/urllib3/blob/7e856c0/src/urllib3/util/url.py
+IPV4_PAT = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
+HEX_PAT = "[0-9A-Fa-f]{1,4}"
+LS32_PAT = "(?:{hex}:{hex}|{ipv4})".format(hex=HEX_PAT, ipv4=IPV4_PAT)
+_subs = {"hex": HEX_PAT, "ls32": LS32_PAT}
+_variations = [
+    #                            6( h16 ":" ) ls32
+    "(?:%(hex)s:){6}%(ls32)s",
+    #                       "::" 5( h16 ":" ) ls32
+    "::(?:%(hex)s:){5}%(ls32)s",
+    # [               h16 ] "::" 4( h16 ":" ) ls32
+    "(?:%(hex)s)?::(?:%(hex)s:){4}%(ls32)s",
+    # [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+    "(?:(?:%(hex)s:)?%(hex)s)?::(?:%(hex)s:){3}%(ls32)s",
+    # [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+    "(?:(?:%(hex)s:){0,2}%(hex)s)?::(?:%(hex)s:){2}%(ls32)s",
+    # [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+    "(?:(?:%(hex)s:){0,3}%(hex)s)?::%(hex)s:%(ls32)s",
+    # [ *4( h16 ":" ) h16 ] "::"              ls32
+    "(?:(?:%(hex)s:){0,4}%(hex)s)?::%(ls32)s",
+    # [ *5( h16 ":" ) h16 ] "::"              h16
+    "(?:(?:%(hex)s:){0,5}%(hex)s)?::%(hex)s",
+    # [ *6( h16 ":" ) h16 ] "::"
+    "(?:(?:%(hex)s:){0,6}%(hex)s)?::",
+]
+
+UNRESERVED_PAT = r"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._!\-~"
+IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
+ZONE_ID_PAT = "(?:%25|%)(?:[" + UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"
+IPV6_ADDRZ_PAT = r"\[" + IPV6_PAT + r"(?:" + ZONE_ID_PAT + r")?\]"
+IPV6_ADDRZ_RE = re.compile("^" + IPV6_ADDRZ_PAT + "$")
+
+# These are the characters that are stripped by post-bpo-43882 urlparse().
+UNSAFE_URL_CHARS = frozenset('\t\r\n')

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -32,6 +32,17 @@ from urllib3.exceptions import LocationParseError
 import botocore
 import botocore.awsrequest
 import botocore.httpsession
+
+# IP Regexes retained for backwards compatibility
+from botocore.compat import HEX_PAT  # noqa: F401
+from botocore.compat import IPV4_PAT  # noqa: F401
+from botocore.compat import IPV6_ADDRZ_PAT  # noqa: F401
+from botocore.compat import IPV6_ADDRZ_RE  # noqa: F401
+from botocore.compat import IPV6_PAT  # noqa: F401
+from botocore.compat import LS32_PAT  # noqa: F401
+from botocore.compat import UNRESERVED_PAT  # noqa: F401
+from botocore.compat import UNSAFE_URL_CHARS  # noqa: F401
+from botocore.compat import ZONE_ID_PAT  # noqa: F401
 from botocore.compat import (
     HAS_CRT,
     MD5_AVAILABLE,
@@ -166,41 +177,6 @@ EVENT_ALIASES = {
     "tagging": "resource-groups-tagging-api"
 }
 
-# Vendoring IPv6 validation regex patterns from urllib3
-# https://github.com/urllib3/urllib3/blob/7e856c0/src/urllib3/util/url.py
-IPV4_PAT = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
-HEX_PAT = "[0-9A-Fa-f]{1,4}"
-LS32_PAT = "(?:{hex}:{hex}|{ipv4})".format(hex=HEX_PAT, ipv4=IPV4_PAT)
-_subs = {"hex": HEX_PAT, "ls32": LS32_PAT}
-_variations = [
-    #                            6( h16 ":" ) ls32
-    "(?:%(hex)s:){6}%(ls32)s",
-    #                       "::" 5( h16 ":" ) ls32
-    "::(?:%(hex)s:){5}%(ls32)s",
-    # [               h16 ] "::" 4( h16 ":" ) ls32
-    "(?:%(hex)s)?::(?:%(hex)s:){4}%(ls32)s",
-    # [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
-    "(?:(?:%(hex)s:)?%(hex)s)?::(?:%(hex)s:){3}%(ls32)s",
-    # [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
-    "(?:(?:%(hex)s:){0,2}%(hex)s)?::(?:%(hex)s:){2}%(ls32)s",
-    # [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
-    "(?:(?:%(hex)s:){0,3}%(hex)s)?::%(hex)s:%(ls32)s",
-    # [ *4( h16 ":" ) h16 ] "::"              ls32
-    "(?:(?:%(hex)s:){0,4}%(hex)s)?::%(ls32)s",
-    # [ *5( h16 ":" ) h16 ] "::"              h16
-    "(?:(?:%(hex)s:){0,5}%(hex)s)?::%(hex)s",
-    # [ *6( h16 ":" ) h16 ] "::"
-    "(?:(?:%(hex)s:){0,6}%(hex)s)?::",
-]
-
-UNRESERVED_PAT = r"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._!\-~"
-IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
-ZONE_ID_PAT = "(?:%25|%)(?:[" + UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"
-IPV6_ADDRZ_PAT = r"\[" + IPV6_PAT + r"(?:" + ZONE_ID_PAT + r")?\]"
-IPV6_ADDRZ_RE = re.compile("^" + IPV6_ADDRZ_PAT + "$")
-
-# These are the characters that are stripped by post-bpo-43882 urlparse().
-UNSAFE_URL_CHARS = frozenset('\t\r\n')
 
 # This pattern can be used to detect if a header is a flexible checksum header
 CHECKSUM_HEADER_PATTERN = re.compile(


### PR DESCRIPTION
When working with urllib3's vendored regexes for IP parsing, they're impossible to import directly into httpsession due to a circular reference between modules. The purpose of vendoring is to support older versions of urllib3 prior to their release. This falls more under compatibility and storing them in compat avoids the unnecessary import conflicts.

This should address the issue seen in #2652.