### PR TITLE
Add support for IMDS credential extension

### DIFF
--- a/.changes/next-release/feature-IMDS-63815.json
+++ b/.changes/next-release/feature-IMDS-63815.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "IMDS",
+  "description": "Added resiliency mechanisms to IMDS Credential Fetcher"
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -56,6 +56,9 @@ logger = logging.getLogger(__name__)
 ReadOnlyCredentials = namedtuple('ReadOnlyCredentials',
                                  ['access_key', 'secret_key', 'token'])
 
+_DEFAULT_MANDATORY_REFRESH_TIMEOUT = 10 * 60  # 10 min
+_DEFAULT_ADVISORY_REFRESH_TIMEOUT = 15 * 60  # 15 min
+
 
 def create_credential_resolver(session, cache=None, region_name=None):
     """Create a default credential resolver.
@@ -74,7 +77,8 @@ def create_credential_resolver(session, cache=None, region_name=None):
         'ec2_metadata_service_endpoint': session.get_config_variable(
             'ec2_metadata_service_endpoint'),
         'ec2_metadata_service_endpoint_mode': resolve_imds_endpoint_mode(
-            session)
+            session),
+        'ec2_credential_refresh_window': _DEFAULT_ADVISORY_REFRESH_TIMEOUT,
     }
 
     if cache is None:
@@ -342,10 +346,10 @@ class Credentials(object):
     """
     Holds the credentials needed to authenticate requests.
 
-    :ivar access_key: The access key part of the credentials.
-    :ivar secret_key: The secret key part of the credentials.
-    :ivar token: The security token, valid only for session credentials.
-    :ivar method: A string which identifies where the credentials
+    :param str access_key: The access key part of the credentials.
+    :param str secret_key: The secret key part of the credentials.
+    :param str token: The security token, valid only for session credentials.
+    :param str method: A string which identifies where the credentials
         were found.
     """
 
@@ -382,18 +386,20 @@ class RefreshableCredentials(Credentials):
     Holds the credentials needed to authenticate requests. In addition, it
     knows how to refresh itself.
 
-    :ivar access_key: The access key part of the credentials.
-    :ivar secret_key: The secret key part of the credentials.
-    :ivar token: The security token, valid only for session credentials.
-    :ivar method: A string which identifies where the credentials
+    :param str access_key: The access key part of the credentials.
+    :param str secret_key: The secret key part of the credentials.
+    :param str token: The security token, valid only for session credentials.
+    :param function refresh_using: Callback function to refresh the credentials.
+    :param str method: A string which identifies where the credentials
         were found.
+    :param function time_fetcher: Callback function to retrieve current time.
     """
     # The time at which we'll attempt to refresh, but not
     # block if someone else is refreshing.
-    _advisory_refresh_timeout = 15 * 60
+    _advisory_refresh_timeout = _DEFAULT_ADVISORY_REFRESH_TIMEOUT
     # The time at which all threads will block waiting for
     # refreshed credentials.
-    _mandatory_refresh_timeout = 10 * 60
+    _mandatory_refresh_timeout = _DEFAULT_MANDATORY_REFRESH_TIMEOUT
 
     def __init__(self, access_key, secret_key, token,
                  expiry_time, refresh_using, method,

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -378,7 +378,10 @@ class IMDSFetcher(object):
                  env=None, user_agent=None, config=None):
         self._timeout = timeout
         self._num_attempts = num_attempts
+        if config is None:
+            config = {}
         self._base_url = self._select_base_url(base_url, config)
+        self._config = config
 
         if env is None:
             env = os.environ.copy()
@@ -394,9 +397,6 @@ class IMDSFetcher(object):
         return self._base_url
 
     def _select_base_url(self, base_url, config):
-        if config is None:
-            config = {}
-
         requires_ipv6 = config.get(
             'ec2_metadata_service_endpoint_mode') == 'ipv6'
         custom_metadata_endpoint = config.get('ec2_metadata_service_endpoint')
@@ -550,13 +550,15 @@ class InstanceMetadataFetcher(IMDSFetcher):
             role_name = self._get_iam_role(token)
             credentials = self._get_credentials(role_name, token)
             if self._contains_all_credential_fields(credentials):
-                return {
+                credentials = {
                     'role_name': role_name,
                     'access_key': credentials['AccessKeyId'],
                     'secret_key': credentials['SecretAccessKey'],
                     'token': credentials['Token'],
                     'expiry_time': credentials['Expiration'],
                 }
+                self._evaluate_expiration(credentials)
+                return credentials
             else:
                 # IMDS can return a 200 response that has a JSON formatted
                 # error message (i.e. if ec2 is not trusted entity for the
@@ -622,6 +624,35 @@ class InstanceMetadataFetcher(IMDSFetcher):
                     field)
                 return False
         return True
+
+    def _evaluate_expiration(self, credentials):
+        expiration = credentials.get("expiry_time")
+        if expiration is None:
+            return
+        try:
+            expiration = datetime.datetime.strptime(
+                expiration, "%Y-%m-%dT%H:%M:%SZ"
+            )
+            refresh_interval = self._config.get(
+                "ec2_credential_refresh_window", 60 * 10
+            )
+            refresh_interval_with_jitter = refresh_interval + random.randint(120, 600)
+            current_time = datetime.datetime.utcnow()
+            refresh_offset = datetime.timedelta(seconds=refresh_interval_with_jitter)
+            extension_time = expiration - refresh_offset
+            if current_time >= extension_time:
+                new_time = current_time + refresh_offset
+                credentials["expiry_time"] = new_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+                logger.info(
+                    f"Attempting credential expiration extension due to a "
+                    f"credential service availability issue. A refresh of "
+                    f"these credentials will be attempted again within "
+                    f"the next {refresh_interval_with_jitter/60:.0f} minutes."
+                )
+        except ValueError:
+            logger.debug(
+                f"Unable to parse expiry_time in {credentials['expiry_time']}"
+            )
 
 
 class IMDSRegionProvider(object):


### PR DESCRIPTION
Adding support for server side credential validation during IMDS outage scenarios. This patch will defer validation of credential expiry to the service for cases where IMDS may not be capable of receiving new metadata updates.