### PR TITLE
Remove urllib3 __version__ info

### DIFF
--- a/botocore/vendored/requests/packages/urllib3/__init__.py
+++ b/botocore/vendored/requests/packages/urllib3/__init__.py
@@ -4,7 +4,7 @@ urllib3 - Thread-safe connection pooling and re-using.
 
 __author__ = 'Andrey Petrov (andrey.petrov@shazow.net)'
 __license__ = 'MIT'
-__version__ = '1.10.4'
+__version__ = ''
 
 
 from . import exceptions


### PR DESCRIPTION
The vendored copy of urllib3 was removed a few years ago, but exceptions were retained for backwards compatibility. The `__version__` string for urllib3 was left for reference on which version they originated from. Certain security scanning tools appear to be doing naive checks to find this version number and assume vulnerabilities exist, despite us no longer including the code. We'll truncate `__version__` to an empty string to avoid the noise.