### PR TITLE
allow StreamingBody class to be used as a context manager

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -124,6 +124,12 @@ class StreamingBody(IOBase):
             return current_chunk
         raise StopIteration()
 
+    def __enter__(self):
+        return self._raw_stream
+
+    def __exit__(self, type, value, traceback):
+        self._raw_stream.close()
+
     next = __next__
 
     def iter_lines(self, chunk_size=_DEFAULT_CHUNK_SIZE, keepends=False):

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -230,6 +230,13 @@ class TestStreamWrapper(unittest.TestCase):
         )
         self.assert_lines(stream.iter_lines(), [])
 
+    def test_streaming_body_as_context_manager(self):
+        body = BytesIO(b'1234567890')
+        with response.StreamingBody(body, content_length=10) as stream:
+            self.assertEqual(stream.read(), b'1234567890')
+            self.assertFalse(body.closed)
+        self.assertTrue(body.closed)
+
 
 class FakeRawResponse(BytesIO):
     def stream(self, amt=1024, decode_content=None):


### PR DESCRIPTION
This is addressing a feature request originally made in https://github.com/boto/botocore/issues/1197. It allows the `StreamingBody` class to be instantiated as a context manager (i.e. able to use in a `with` statement). It's implemented in the standard way by adding `__enter__` and `__exit__` magic methods.