### PR TITLE
add list of tuples functionality to AWSRequest params attribute

### DIFF
--- a/.changes/next-release/enhancement-AWSRequest-24612.json
+++ b/.changes/next-release/enhancement-AWSRequest-24612.json
@@ -1,5 +1,0 @@
-{
-  "type": "enhancement",
-  "category": "AWSRequest",
-  "description": "Allows AWSRequest to accept list of tuples in params attribute"
-}

--- a/.changes/next-release/enhancement-AWSRequest-24612.json
+++ b/.changes/next-release/enhancement-AWSRequest-24612.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "AWSRequest",
+  "description": "Allows AWSRequest to accept list of tuples in params attribute"
+}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -19,6 +19,7 @@ import hmac
 import json
 import logging
 import time
+from collections.abc import Mapping
 from email.utils import formatdate
 from hashlib import sha1, sha256
 from operator import itemgetter
@@ -245,10 +246,11 @@ class SigV4Auth(BaseSigner):
     def _canonical_query_string_params(self, params):
         # [(key, value), (key2, value2)]
         key_val_pairs = []
-        for key in params:
-            value = str(params[key])
+        if isinstance(params, Mapping):
+            params = params.items()
+        for key, value in params:
             key_val_pairs.append(
-                (quote(key, safe='-_.~'), quote(value, safe='-_.~'))
+                (quote(key, safe='-_.~'), quote(str(value), safe='-_.~'))
             )
         sorted_key_vals = []
         # Sort by the URI-encoded key names, and in the case of

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -13,6 +13,7 @@
 # language governing permissions and limitations under the License.
 import functools
 import logging
+from collections.abc import Mapping
 
 import urllib3.util
 from urllib3.connection import HTTPConnection, VerifiedHTTPSConnection
@@ -367,7 +368,11 @@ class AWSRequestPreparer:
         if original.params:
             url_parts = urlparse(url)
             delim = '&' if url_parts.query else '?'
-            params = urlencode(list(original.params.items()), doseq=True)
+            if isinstance(original.params, Mapping):
+                params_to_encode = list(original.params.items())
+            else:
+                params_to_encode = original.params
+            params = urlencode(params_to_encode, doseq=True)
             url = delim.join((url, params))
         return url
 

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -134,6 +134,26 @@ class TestAWSRequest(unittest.TestCase):
             prepared_request.url, 'http://example.com/?bar=foo&foo=bar'
         )
 
+    def test_can_use_list_tuples_for_params(self):
+        request = AWSRequest(
+            url='http://example.com/', params=[('foo', 'bar')]
+        )
+        prepared_request = request.prepare()
+        self.assertEqual(
+            prepared_request.url, 'http://example.com/?foo=bar'
+        )
+
+    def test_can_use_list_duplicate_tuples_for_params(self):
+        request = AWSRequest(
+            url='http://example.com/', params=[
+                ('foo', 'bar'), ('foo', 'bar'), ('hello', 'world')
+            ]
+        )
+        prepared_request = request.prepare()
+        self.assertEqual(
+            prepared_request.url, 'http://example.com/?foo=bar&foo=bar&hello=world'
+        )
+
     def test_can_prepare_dict_body(self):
         body = {'dead': 'beef'}
         request = AWSRequest(url='http://example.com/', data=body)

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -18,6 +18,7 @@ import shutil
 import socket
 import tempfile
 
+import pytest
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from botocore.awsrequest import (
@@ -132,26 +133,6 @@ class TestAWSRequest(unittest.TestCase):
         prepared_request = request.prepare()
         self.assertEqual(
             prepared_request.url, 'http://example.com/?bar=foo&foo=bar'
-        )
-
-    def test_can_use_list_tuples_for_params(self):
-        request = AWSRequest(
-            url='http://example.com/', params=[('foo', 'bar')]
-        )
-        prepared_request = request.prepare()
-        self.assertEqual(
-            prepared_request.url, 'http://example.com/?foo=bar'
-        )
-
-    def test_can_use_list_duplicate_tuples_for_params(self):
-        request = AWSRequest(
-            url='http://example.com/', params=[
-                ('foo', 'bar'), ('foo', 'bar'), ('hello', 'world')
-            ]
-        )
-        prepared_request = request.prepare()
-        self.assertEqual(
-            prepared_request.url, 'http://example.com/?foo=bar&foo=bar&hello=world'
         )
 
     def test_can_prepare_dict_body(self):
@@ -286,6 +267,41 @@ class TestAWSRequest(unittest.TestCase):
         self.prepared_request.reset_stream()
         # The stream should now be reset.
         self.assertTrue(looks_like_file.seek_called)
+
+
+@pytest.mark.parametrize(
+    "test_input,expected_output",
+    [
+        ([('foo', None)], 'http://example.com/?foo=None'),
+        ([(None, None)], 'http://example.com/?None=None'),
+        (
+            [('foo', 'bar'), ('foo', 'baz'), ('fizz', 'buzz')],
+            'http://example.com/?foo=bar&foo=baz&fizz=buzz'
+        ),
+        ([('foo', 'bar'), ('foo', None)], 'http://example.com/?foo=bar&foo=None'),
+        ([('foo', 'bar')], 'http://example.com/?foo=bar'),
+        (
+            [('foo', 'bar'), ('foo', 'bar'), ('fizz', 'buzz')],
+            'http://example.com/?foo=bar&foo=bar&fizz=buzz'
+        ),
+        ([('', 'bar')], 'http://example.com/?=bar'),
+        ([(1, 'bar')], 'http://example.com/?1=bar'),
+    ]
+)
+def test_can_use_list_tuples_for_params(test_input, expected_output):
+    request = AWSRequest(
+        url='http://example.com/', params=test_input
+    )
+    prepared_request = request.prepare()
+    assert prepared_request.url == expected_output
+
+
+def test_empty_list_tuples_value_error_for_params():
+    request = AWSRequest(
+        url='http://example.com/', params=[()]
+    )
+    with pytest.raises(ValueError):
+        request.prepare()
 
 
 class TestAWSResponse(unittest.TestCase):


### PR DESCRIPTION
Addresses https://github.com/boto/botocore/issues/2667. Allows request parameters to be passed to the low level interface `AWSRequest` as a list of tuples (`params` attribute). Currently it can only accept dictionaries. This will also allow the user to send duplicate queries should they wish to do so.