### PR TITLE
Add initialization hook to customize botocore sessions

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -28,6 +28,7 @@ class NullHandler(logging.Handler):
 log = logging.getLogger('botocore')
 log.addHandler(NullHandler())
 
+_INITIALIZERS = []
 
 _first_cap_regex = re.compile('(.)([A-Z][a-z]+)')
 _end_cap_regex = re.compile('([a-z0-9])([A-Z])')
@@ -97,3 +98,42 @@ def xform_name(name, sep='_', _xform_cache=_xform_cache):
         transformed = _end_cap_regex.sub(r'\1' + sep + r'\2', s1).lower()
         _xform_cache[key] = transformed
     return _xform_cache[key]
+
+
+def register_initializer(callback):
+    """Register an initializer function for session creation.
+
+    This initializer function will be invoked whenever a new
+    `botocore.session.Session` is instantiated.
+
+    :type callback: callable
+    :param callback: A callable that accepts a single argument
+        of type `botocore.session.Session`.
+
+    """
+    _INITIALIZERS.append(callback)
+
+
+def unregister_initializer(callback):
+    """Unregister an initializer function.
+
+    :type callback: callable
+    :param callback: A callable that was previously registered
+        with `botocore.register_initializer`.
+
+    :raises ValueError: If a callback is provided that is not currently
+        registered as an initializer.
+
+    """
+    _INITIALIZERS.remove(callback)
+
+
+def invoke_initializers(session):
+    """Invoke all initializers for a session.
+
+    :type session: botocore.session.Session
+    :param session: The session to initialize.
+
+    """
+    for initializer in _INITIALIZERS:
+        initializer(session)

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -30,6 +30,7 @@ from botocore import (
     UNSIGNED,
     __version__,
     handlers,
+    invoke_initializers,
     monitoring,
     paginate,
     retryhandler,
@@ -148,6 +149,7 @@ class Session:
         self.session_var_map = SessionVarDict(self, self.SESSION_VARIABLES)
         if session_vars is not None:
             self.session_var_map.update(session_vars)
+        invoke_initializers(self)
 
     def _register_components(self):
         self._register_credential_provider()


### PR DESCRIPTION
This adds an initialization hook to customize any botocore sessions.

Botocore sessions provide context for creating one or more clients.
It allows you to provide configuration, components, hooks, etc. that
can be shared across all clients created within that session.

There is no similar concept for sessions.  Specifically, there is no way
to provide a common set of configuration, components, hooks, etc. that
can shared across all sessions created within botocore.

This PR adds this initialization hook.  You can now register an initialization
callback that's invoked whenever a session is created:


```python
import botocore

def my_initializer(session: botocore.session.Session) -> None:
    session.register_component('data_loader', MyNewCrazyLoader())

botocore.register_initializer(my_initializer)
```

Now every session will automatically use this new loader:


```python

some_session = botocore.session.get_session()
assert isinstance(
    some_session.get_component('data_loader'), MyNewCrazyLoader
)
```

## Rationale

Botocore's extensibility points allows customers to customize the behavior of
botocore.  However, in order to leverage these extensibility points, customers
must write explicit code to register these hooks that requires a reference to a
specific session (e.g `session.register`, `session.register_component`,
`session.set_default_client_config`).  There is no way to provide "plugin" like
behavior where customers can declaratively specify functionality without having
to modify all their existing code.

Here's one concrete use case.  Botocore has a data loader component that's
responsible for loading the service model based on various parameters
(`service_name`, `type_name`, `api_version`).  The current implementation uses
JSON, which is not efficient in terms of disk space nor load time.  There have
been initiatives to improve this (#2628), but in order to make this default
behavior, the existing `JSONFileLoader` class had to be modified.
There are also crazier use case specific ideas to further optimize both the
load time and disk size of our service models.  However, in order to use
a new loader, users must add this line of code to every session they create:

```
s = botocore.session.get_session()
new_fancy_loader = MyNewCrazyLoader()
s.register_component(new_fancy_loader)
```

This is fine if you are able to obtain a reference to every single
session you create, but this isn't always the case, especially if
you're not directly using a session (e.g. some high level library
that wraps sessions/clients for you).

I maintain a framework, [Chalice](https://github.com/aws/chalice/), where I would like to allow users
to opt-in to more optimized data loaders through a framework-specific
config file, without having to change any of their existing code.
