### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.changes/next-release/feature-Python-85983.json
+++ b/.changes/next-release/feature-Python-85983.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Python",
+  "description": "Dropped support for Python 3.6"
+}

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ on 2021-07-15. To avoid disruption, customers using Botocore on Python 2.7 may
 need to upgrade their version of Python or pin the version of Botocore. For
 more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
-On 2022-05-30, we will be dropping support for Python 3.6. This follows the
+On 2022-05-30, support was dropped for Python 3.6. This follows the
 Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__
 for the runtime which occurred on 2021-12-23.
 For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@ Services.  Botocore serves as the foundation for the
 `AWS-CLI <https://github.com/aws/aws-cli/>`_ command line utilities.
 It will also play an important role in the boto3.x project.
 
-The botocore package is compatible with Python versions Python 3.6
+The botocore package is compatible with Python versions Python 3.7
 and higher.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,8 @@ universal = 0
 
 [metadata]
 requires_dist =
+    jmespath>=0.7.1,<2.0.0
     python-dateutil>=2.1,<3.0.0
-    jmespath>=0.7.1,<2.0.0; python_version>'3.6'
-    jmespath>=0.7.1,<1.0.0; python_version<='3.6'
     urllib3>=1.25.4,<1.27
 
 [options.extras_require]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import codecs
 import os.path
 import re
-import sys
 
 from setuptools import find_packages, setup
 
@@ -24,18 +23,10 @@ def find_version(*file_paths):
 
 
 requires = [
+    'jmespath>=0.7.1,<2.0.0',
     'python-dateutil>=2.1,<3.0.0',
     'urllib3>=1.25.4,<1.27',
 ]
-if sys.version_info[:2] == (3, 6):
-    # jmespath dropped support for python 3.6 in release 1.0.0
-    requires.append(
-        'jmespath>=0.7.1,<1.0.0',
-    )
-else:
-    requires.append(
-        'jmespath>=0.7.1,<2.0.0',
-    )
 
 setup(
     name='botocore',
@@ -53,7 +44,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     license="Apache License 2.0",
-    python_requires=">= 3.6",
+    python_requires=">= 3.7",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -62,7 +53,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 
 skipsdist = True
 


### PR DESCRIPTION
**DO NOT MERGE PRIOR TO 5/30**

This PR will end support for Python 3.6 in Botocore as [announced](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/#:~:text=Overview,deprecations%20which%20started%20in%202021) earlier this year. This PR will remove the testing scaffolding, update documentation, and remove any Python 3.6 specific code paths. This will need to be merged in conjunction with the other PRs in awscli, boto3, and s3transfer.