### PR TITLE
Add doc string to `PageIterator`

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -187,7 +187,8 @@ class PaginatorModel:
 class PageIterator:
     """An iterable object to pagiante API results.
     Please note it is NOT a python iterator.
-    Use ``iter`` to wrap this as a generator"""
+    Use ``iter`` to wrap this as a generator.
+    """
 
     def __init__(
         self,

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -185,6 +185,9 @@ class PaginatorModel:
 
 
 class PageIterator:
+    """An iterable object to pagiante API results.
+    Please note it is NOT a python iterator"""
+
     def __init__(
         self,
         method,

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -186,7 +186,8 @@ class PaginatorModel:
 
 class PageIterator:
     """An iterable object to pagiante API results.
-    Please note it is NOT a python iterator"""
+    Please note it is NOT a python iterator.
+    Use ``iter`` to wrap this as a generator"""
 
     def __init__(
         self,


### PR DESCRIPTION
Addressing https://github.com/boto/botocore/issues/2396

While ideally we would add `next` functionality to `PageIterator` or simply update the name of the class to prevent confusion, both would cause breaking changes. As a result all we really can do is add a doc string with additional info. Perhaps using a warning here would be warranted, but decided against it.

Let me know if there's anything that should be added to the doc string.