### PR TITLE
Bump docutils and sphinx pin to match AWS CLI

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,6 +4,6 @@
 markupsafe>=1.1,<2.0
 jinja2>=2.3,<3.0
 # docutils needs a pin until we update to Sphinx > 3.0
-docutils>=0.10,<0.16
-Sphinx>=1.1.3,<1.3
+docutils>=0.10,<0.17
+Sphinx>=1.1.3,<=1.3.2
 guzzle_sphinx_theme>=0.7.10,<0.8


### PR DESCRIPTION
Matches the updates here: https://github.com/aws/aws-cli/pull/6977