### PR TITLE
Issue #3300: Adding variables for retry and modes options

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -276,11 +276,14 @@ class Config:
                 )
 
     def _validate_retry_configuration(self, retries):
+        valid_options = ('max_attempts', 'mode', 'total_max_attempts')
+        valid_modes = ('legacy', 'standard', 'adaptive')
         if retries is not None:
             for key, value in retries.items():
-                if key not in ['max_attempts', 'mode', 'total_max_attempts']:
+                if key not in valid_options:
                     raise InvalidRetryConfigurationError(
-                        retry_config_option=key
+                        retry_config_option=key,
+                        valid_options=valid_options,
                     )
                 if key == 'max_attempts' and value < 0:
                     raise InvalidMaxRetryAttemptsError(
@@ -292,12 +295,11 @@ class Config:
                         provided_max_attempts=value,
                         min_value=1,
                     )
-                if key == 'mode' and value not in (
-                    'legacy',
-                    'standard',
-                    'adaptive',
-                ):
-                    raise InvalidRetryModeError(provided_retry_mode=value)
+                if key == 'mode' and value not in valid_modes:
+                    raise InvalidRetryModeError(
+                        provided_retry_mode=value,
+                        valid_modes=valid_modes,
+                    )
 
     def merge(self, other_config):
         """Merges the config object with another config object

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -635,7 +635,7 @@ class InvalidRetryConfigurationError(BotoCoreError):
 
     fmt = (
         'Cannot provide retry configuration for "{retry_config_option}". '
-        'Valid retry configuration options are: \'max_attempts\''
+        'Valid retry configuration options are: {valid_options}'
     )
 
 
@@ -653,7 +653,7 @@ class InvalidRetryModeError(InvalidRetryConfigurationError):
 
     fmt = (
         'Invalid value provided to "mode": "{provided_retry_mode}" must '
-        'be one of: "legacy", "standard", "adaptive"'
+        'be one of: {valid_modes}'
     )
 
 


### PR DESCRIPTION
Adding the variables corresponding to the options in the Retry config and the modes options.
Issue: [https://github.com/boto/boto3/issues/3300](url)