### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/fail-master-prs.yml
+++ b/.github/workflows/fail-master-prs.yml
@@ -4,8 +4,13 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   fail:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Fail PRs against master

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches-ignore: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: '${{ matrix.os }}'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches-ignore: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: '${{ matrix.os }}'


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
