### PR TITLE
sse for SelectObjectCount s3 op

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1109,6 +1109,7 @@ BUILTIN_HANDLERS = [
     ('before-parameter-build.s3.UploadPart', sse_md5),
     ('before-parameter-build.s3.UploadPartCopy', sse_md5),
     ('before-parameter-build.s3.UploadPartCopy', copy_source_sse_md5),
+    ('before-parameter-build.s3.SelectObjectContent', sse_md5),
     ('before-parameter-build.ec2.RunInstances', base64_encode_user_data),
     (
         'before-parameter-build.autoscaling.CreateLaunchConfiguration',

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1166,6 +1166,7 @@ class TestSSEMD5(BaseMD5Test):
             'CreateMultipartUpload',
             'UploadPart',
             'UploadPartCopy',
+            'SelectObjectContent',
         ):
             event = 'before-parameter-build.s3.%s' % op
             params = {


### PR DESCRIPTION
This PR addresses https://github.com/boto/boto3/discussions/3268. Discussion about supporting SSE for all s3 ops was discussed, but the service only supports it for 11 out of its 97 APIs/ops.

A manual integration test was performed before and after registering the handler for `SelectObjectContent`. Before the same exception `botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the SelectObjectContent operation: Access Denied` was raised that the user in the original issue highlighted. After, the call succeeded.