### PR TITLE
Use alternative credential provider if shared credential has been expired

### DIFF
--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1390,6 +1390,23 @@ class TestSharedCredentialsProvider(BaseEnvVar):
         creds = provider.load()
         self.assertIsNone(creds)
 
+    def test_expired_credential_file_returns_none(self):
+        self.ini_parser.return_value = {
+            'default': {
+                'aws_access_key_id': 'a',
+                'aws_secret_access_key': 'b',
+                'aws_session_token': 'c',
+                'x_security_token_expires': '2022-07-03T16:24:39+09:00'
+            }
+        }
+        provider = credentials.SharedCredentialProvider(
+            creds_filename='~/.aws/creds',
+            profile_name='default',
+            ini_parser=self.ini_parser
+        )
+        creds = provider.load()
+        self.assertIsNone(creds)
+
 
 class TestConfigFileProvider(BaseEnvVar):
     def setUp(self):


### PR DESCRIPTION
I am using `saml2aws` which returns expirable access token for `credential_process`.

When token is expired, botocore does not re-run `credential_process`.

I revised `SharedCredentialProvider` class so it can check the expiration of access token and make alternative providers to load credential.

ref. https://github.com/aws/aws-toolkit-vscode/issues/2664