### PR TITLE
fix: resolve potential race condition in JSONFileCache

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -342,7 +342,8 @@ class JSONFileCache:
                 f"JSON serializable: {value}"
             )
         if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir)
+            # a racing parallel thread / process might just have created the working dir:
+            os.makedirs(self._working_dir, exist_ok=True)
         with os.fdopen(
             os.open(full_key, os.O_WRONLY | os.O_CREAT, 0o600), 'w'
         ) as f:


### PR DESCRIPTION
The `JSONFileCache.__setitems__` might raise a `FileExistsError` if it is
run in parallel by two threads / processes:
1. Both processes discover the working dir hasn't been created yet.
2. The first process creates the working dir.
3. The second process tries to create the working dir, too and fails
   as it already exists.

Accept this potential race — `exist_ok=True` will prevent `os.makedirs`
to raise an exception.

The `os.path.isdir` condition is technically no longer needed but kept
keeping the change small. Furthermore, it should be slightly faster
as the cache should exist most of the time.

The `exist_ok` parameter is supported since Python 3.2 / fixed in 3.4.1 
and therefore available in all needed python versions.