### PR TITLE
Replace out of date credref URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,10 +107,10 @@ Maintenance and Support for SDK Major Versions
 
 Botocore was made generally available on 06/22/2015 and is currently in the full support phase of the availability life cycle.
 
-For information about maintenance and support for SDK major versions and their underlying dependencies, see the following in the AWS SDKs and Tools Shared Configuration and Credentials Reference Guide:
+For information about maintenance and support for SDK major versions and their underlying dependencies, see the following in the AWS SDKs and Tools Reference Guide:
 
-* `AWS SDKs and Tools Maintenance Policy <https://docs.aws.amazon.com/credref/latest/refdocs/maint-policy.html>`__
-* `AWS SDKs and Tools Version Support Matrix <https://docs.aws.amazon.com/credref/latest/refdocs/version-support-matrix.html>`__
+* `AWS SDKs and Tools Maintenance Policy <https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html>`__
+* `AWS SDKs and Tools Version Support Matrix <https://docs.aws.amazon.com/sdkref/latest/guide/version-support-matrix.html>`__
 
 
 More Resources


### PR DESCRIPTION
Updates the README.rst file to replace obsolete links to the old credentials and
shared settings guide to the new SDKs and Tools Reference Guide.