### PR TITLE
Fix Trace ID environment variable

### DIFF
--- a/.changes/next-release/bugfix-Config-29558.json
+++ b/.changes/next-release/bugfix-Config-29558.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Config",
+  "description": "Obey _X_AMZN_TRACE_ID environment variable instead of _X_AMZ_TRACE_ID"
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -102,7 +102,7 @@ def handle_service_name_alias(service_name, **kwargs):
 
 def add_recursion_detection_header(params, **kwargs):
     has_lambda_name = 'AWS_LAMBDA_FUNCTION_NAME' in os.environ
-    trace_id = os.environ.get('_X_AMZ_TRACE_ID')
+    trace_id = os.environ.get('_X_AMZN_TRACE_ID')
     if has_lambda_name and trace_id:
         headers = params['headers']
         if 'X-Amzn-Trace-Id' not in headers:

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1520,21 +1520,21 @@ class TestPrependToHost(unittest.TestCase):
     'environ, header_before, header_after',
     [
         ({'AWS_LAMBDA_FUNCTION_NAME': 'foo'}, {}, {}),
-        ({'_X_AMZ_TRACE_ID': 'bar'}, {}, {}),
+        ({'_X_AMZN_TRACE_ID': 'bar'}, {}, {}),
         (
-            {'AWS_LAMBDA_FUNCTION_NAME': 'foo', '_X_AMZ_TRACE_ID': 'bar'},
+            {'AWS_LAMBDA_FUNCTION_NAME': 'foo', '_X_AMZN_TRACE_ID': 'bar'},
             {},
             {'X-Amzn-Trace-Id': 'bar'},
         ),
         (
-            {'AWS_LAMBDA_FUNCTION_NAME': 'foo', '_X_AMZ_TRACE_ID': 'bar'},
+            {'AWS_LAMBDA_FUNCTION_NAME': 'foo', '_X_AMZN_TRACE_ID': 'bar'},
             {'X-Amzn-Trace-Id': 'fizz'},
             {'X-Amzn-Trace-Id': 'fizz'},
         ),
         (
             {
                 'AWS_LAMBDA_FUNCTION_NAME': 'foo',
-                '_X_AMZ_TRACE_ID': 'first\nsecond',
+                '_X_AMZN_TRACE_ID': 'first\nsecond',
             },
             {},
             {'X-Amzn-Trace-Id': 'first%0Asecond'},


### PR DESCRIPTION
There was a typo in expected env var. It should be `_X_AMZN_TRACE_ID` and not `_X_AMZ_TRACE_ID`.