### PR TITLE
Fix encoding scheme for trace ids

### DIFF
--- a/.changes/next-release/enhancement-Lambda-61491.json
+++ b/.changes/next-release/enhancement-Lambda-61491.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Lambda",
+  "description": "Add support for Trace ID in Lambda environments"
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -102,11 +102,11 @@ def handle_service_name_alias(service_name, **kwargs):
 
 def add_recursion_detection_header(params, **kwargs):
     has_lambda_name = 'AWS_LAMBDA_FUNCTION_NAME' in os.environ
-    trace_id = os.environ.get('_X_AMZ_TRACE_ID')
+    trace_id = os.environ.get('_X_AMZN_TRACE_ID')
     if has_lambda_name and trace_id:
         headers = params['headers']
         if 'X-Amzn-Trace-Id' not in headers:
-            headers['X-Amzn-Trace-Id'] = quote(trace_id)
+            headers['X-Amzn-Trace-Id'] = quote(trace_id, safe='-=;:+&[]{}"\',')
 
 
 def escape_xml_payload(params, **kwargs):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1519,25 +1519,57 @@ class TestPrependToHost(unittest.TestCase):
 @pytest.mark.parametrize(
     'environ, header_before, header_after',
     [
-        ({'AWS_LAMBDA_FUNCTION_NAME': 'foo'}, {}, {}),
-        ({'_X_AMZ_TRACE_ID': 'bar'}, {}, {}),
+        ({}, {}, {}),
+        ({'AWS_LAMBDA_FUNCTION_NAME': 'some-function'}, {}, {}),
         (
-            {'AWS_LAMBDA_FUNCTION_NAME': 'foo', '_X_AMZ_TRACE_ID': 'bar'},
+            {
+                '_X_AMZN_TRACE_ID': (
+                    'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;'
+                    'Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2'
+                )
+            },
             {},
-            {'X-Amzn-Trace-Id': 'bar'},
+            {},
         ),
         (
-            {'AWS_LAMBDA_FUNCTION_NAME': 'foo', '_X_AMZ_TRACE_ID': 'bar'},
-            {'X-Amzn-Trace-Id': 'fizz'},
-            {'X-Amzn-Trace-Id': 'fizz'},
+            {
+                'AWS_LAMBDA_FUNCTION_NAME': 'some-function',
+                '_X_AMZN_TRACE_ID': (
+                    'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;'
+                    'Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2'
+                ),
+            },
+            {},
+            {
+                'X-Amzn-Trace-Id': (
+                    'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;'
+                    'Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2'
+                )
+            },
+        ),
+        (
+            {
+                'AWS_LAMBDA_FUNCTION_NAME': 'some-function',
+                '_X_AMZN_TRACE_ID': 'EnvValue',
+            },
+            {'X-Amzn-Trace-Id': 'OriginalValue'},
+            {'X-Amzn-Trace-Id': 'OriginalValue'},
         ),
         (
             {
                 'AWS_LAMBDA_FUNCTION_NAME': 'foo',
-                '_X_AMZ_TRACE_ID': 'first\nsecond',
+                '_X_AMZN_TRACE_ID': 'first\nsecond',
             },
             {},
             {'X-Amzn-Trace-Id': 'first%0Asecond'},
+        ),
+        (
+            {
+                'AWS_LAMBDA_FUNCTION_NAME': 'foo',
+                '_X_AMZN_TRACE_ID': 'test123-=;:+&[]{}\"\'',
+            },
+            {},
+            {'X-Amzn-Trace-Id': 'test123-=;:+&[]{}\"\''},
         ),
     ],
 )


### PR DESCRIPTION
This is a follow up to #2727 to fix the encoding scheme for our trace IDs. The change omits characters that cannot be encoded to preserve content semantics with services parsing the header.