### PR TITLE
Replace default shape enum behavior from random to first element

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1168,7 +1168,7 @@ class ArgumentGenerator:
                 if self._use_member_names:
                     return name
                 if shape.enum:
-                    return random.choice(shape.enum)
+                    return shape.enum[0]
                 return ''
             elif shape.type_name in ['integer', 'long']:
                 return 0


### PR DESCRIPTION
Related issue: https://github.com/aws/aws-cli/issues/6695

Currently, if a `shape` object has the `enum` attribute, then it'll return a randomly sampled element from the list. This is confusing users who expect consistent outputs from their inputs. This PR takes the first element of the list instead in order to provide consistent reproducibility.