### PR TITLE
Endpoint Provider for botocore

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -307,6 +307,7 @@ except ImportError:
 # Vendoring IPv6 validation regex patterns from urllib3
 # https://github.com/urllib3/urllib3/blob/7e856c0/src/urllib3/util/url.py
 IPV4_PAT = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
+IPV4_RE = re.compile("^" + IPV4_PAT + "$")
 HEX_PAT = "[0-9A-Fa-f]{1,4}"
 LS32_PAT = "(?:{hex}:{hex}|{ipv4})".format(hex=HEX_PAT, ipv4=IPV4_PAT)
 _subs = {"hex": HEX_PAT, "ls32": LS32_PAT}

--- a/botocore/endpoints_v2.py
+++ b/botocore/endpoints_v2.py
@@ -1,0 +1,727 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# NOTE: All classes and functions in this module are considered private and not
+# subject to backwards compatibility guarantees. Please do not use them directly.
+
+
+# NOTE: To view the raw JSON that the objects in this module represent, please
+# go to any `endpoint-rule-set.json` file in /botocore/data/<service>/<api version>/
+# or you can look at the test files in /tests/unit/data/endpoints/valid-rules/
+
+
+import logging
+import re
+from enum import Enum
+from functools import lru_cache
+from string import Formatter
+from typing import NamedTuple
+
+from botocore import xform_name
+from botocore.compat import quote, urlparse
+from botocore.exceptions import EndpointResolutionError
+from botocore.utils import (
+    ArnParser,
+    InvalidArnException,
+    is_valid_ipv4_endpoint_url,
+    is_valid_ipv6_endpoint_url,
+    normalize_url_path,
+    percent_encode,
+)
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_STRING_RE = re.compile(r"\{[a-zA-Z#]+\}")
+GET_ATTR_RE = re.compile(r"(\w+)\[(\d+)\]")
+VALID_HOST_LABEL_RE = re.compile(
+    r"^(?!-)[a-zA-Z\d-]{1,63}(?<!-)$",
+)
+CACHE_SIZE = 100
+ARN_PARSER = ArnParser()
+STRING_FORMATTER = Formatter()
+
+
+class RuleSetStandardLibary:
+    """A set of functions supported in rule sets and helpers."""
+
+    def __init__(self, partitions_data):
+        self.partitions_data = partitions_data
+
+    def _is_func(self, argument):
+        """Determine if an object is a function object.
+
+        :type argument: Any
+        :rtype: bool
+        """
+        return isinstance(argument, dict) and "fn" in argument
+
+    def _is_ref(self, argument):
+        """Determine if an object is a reference object.
+
+        :type argument: Any
+        :rtype: bool
+        """
+        return isinstance(argument, dict) and "ref" in argument
+
+    def _is_template(self, argument):
+        """Determine if an object contains a template string.
+
+        :type argument: Any
+        :rtpe: bool
+        """
+        return (
+            isinstance(argument, str)
+            and TEMPLATE_STRING_RE.search(argument) is not None
+        )
+
+    def _resolve_template_string(self, value, scope_vars):
+        """Resolve and inject values into a template string.
+
+        :type value: str
+        :type scope_vars: dict
+        :rtype: str
+        """
+        result = ""
+        for literal, reference, _, _ in STRING_FORMATTER.parse(value):
+            if reference is not None:
+                template_value = scope_vars
+                template_params = reference.split("#")
+                for param in template_params:
+                    template_value = template_value[param]
+                result += f"{literal}{template_value}"
+            else:
+                result += literal
+        return result
+
+    def _resolve_value(self, value, scope_vars):
+        """Return evaluated value based on type.
+
+        :type value: Any
+        :type scope_vars: dict
+        :rtype: Any
+        """
+        if self._is_func(value):
+            return self._call_function(value, scope_vars)
+        elif self._is_ref(value):
+            return scope_vars.get(value["ref"])
+        elif self._is_template(value):
+            return self._resolve_template_string(value, scope_vars)
+
+        return value
+
+    def _convert_func_name(self, value):
+        """Normalize function names.
+
+        :type value: str
+        :rtype: str
+        """
+        change_case = f"_{xform_name(value)}"
+        return change_case.replace(".", "_")
+
+    def _call_function(self, func_signature, scope_vars):
+        """Call the function with the resolved arguments and assign to `scope_vars`
+        when applicable.
+
+        :type func_signature: dict
+        :type scope_vars: dict
+        :rtype: Any
+        """
+        func_args = [
+            self._resolve_value(arg, scope_vars)
+            for arg in func_signature["argv"]
+        ]
+        func_name = self._convert_func_name(func_signature["fn"])
+        func = getattr(self, func_name)
+        result = func(*func_args)
+        if "assign" in func_signature:
+            assign = func_signature["assign"]
+            if assign in scope_vars:
+                raise EndpointResolutionError(
+                    msg=f"Assignment {assign} already exists in "
+                    "scoped variables and cannot be overwritten"
+                )
+            scope_vars[assign] = result
+        return result
+
+    def _is_set(self, value):
+        """Evaluates whether a value (such as an endpoint parameter) is set
+        (aka not None).
+
+        :type value: Any
+        :rytpe: bool
+        """
+        return value is not None
+
+    def _get_attr(self, value, path):
+        """Find an attribute within a value given a path string. The path can contain
+        the name of the attribute and an index in brackets. A period separating attribute
+        names indicates the one to the right is nested. The index will always occur at
+        the end of the path.
+
+        :type value: dict or list
+        :type path: str
+        :rtype: Any
+        """
+        for part in path.split("."):
+            match = GET_ATTR_RE.search(part)
+            if match is not None:
+                name, index = match.groups()
+                index = int(index)
+                value = value.get(name)
+                if value is None or index >= len(value):
+                    return None
+                return value[index]
+            else:
+                value = value[part]
+        return value
+
+    def _format_partition_output(self, partition):
+        output = partition["outputs"]
+        output["name"] = partition["id"]
+        return output
+
+    def _is_partition_match(self, region, partition):
+        return (
+            region in partition["regions"]
+            or re.match(partition["regionRegex"], region) is not None
+        )
+
+    def _aws_partition(self, value):
+        """Match a region string to an AWS partition.
+
+        :type value: str
+        :rtype: dict
+        """
+        if value is None:
+            return None
+
+        partitions = self.partitions_data['partitions']
+        for partition in partitions:
+            if self._is_partition_match(value, partition):
+                return self._format_partition_output(partition)
+
+        # return the default partition if no matches were found
+        aws_partition = partitions[0]
+        return self._format_partition_output(aws_partition)
+
+    def _aws_parse_arn(self, value):
+        """Parse and validate string for ARN components.
+
+        :type value: str
+        :rtype: dict
+        """
+        if value is None or not value.startswith("arn:"):
+            return None
+
+        try:
+            arn_dict = ARN_PARSER.parse_arn(value)
+        except InvalidArnException:
+            return None
+
+        # these three components are the only ones that cannot be empty
+        if not all(
+            (arn_dict["partition"], arn_dict["service"], arn_dict["resource"])
+        ):
+            return None
+
+        arn_dict["accountId"] = arn_dict.pop("account")
+
+        resource = arn_dict.pop("resource")
+        delimiter = ":" if ":" in resource else "/"
+        arn_dict["resourceId"] = resource.split(delimiter)
+
+        return arn_dict
+
+    def _is_valid_host_label(self, value, allow_subdomains):
+        """Evaluates whether one or more string values are valid host labels per
+        RFC 1123. If allow_subdomains is True, split on `.` and recurse with
+        it set to False.
+
+        :type value: str
+        :type allow_subdomains: bool
+        :rtype: bool
+        """
+        if value is None or allow_subdomains is False and value.count(".") > 0:
+            return False
+
+        if allow_subdomains is True:
+            return all(
+                self._is_valid_host_label(label, False)
+                for label in value.split(".")
+            )
+
+        return VALID_HOST_LABEL_RE.match(value) is not None
+
+    def _string_equals(self, value1, value2):
+        """Evaluates two string values for equality and returns a boolean indicating
+        if they match or not.
+
+        :type value1: str
+        :type value2: str
+        :rtype: bool
+        """
+        if not all(isinstance(val, str) for val in (value1, value2)):
+            raise EndpointResolutionError(
+                msg=(
+                    f"Both values must be strings.\n"
+                    f"value1: {value1}\n"
+                    f"value2: {value2}"
+                )
+            )
+        return value1 == value2
+
+    def _uri_encode(self, value):
+        """Perform percent-encoding on an input string.
+
+        :type value: str
+        :rytpe: str
+        """
+        if value is None:
+            return None
+
+        return percent_encode(value)
+
+    def _parse_url(self, value):
+        """Parse a URL string into components.
+
+        :type value: str
+        :rtype: dict
+        """
+        if value is None:
+            return None
+
+        url_components = urlparse(value)
+        # urlparse will silently include a port in the authority (netloc) even if
+        # the value is not a base-10 integer.
+        try:
+            url_components.port
+        except ValueError:
+            return None
+
+        scheme = url_components.scheme
+        query = url_components.query
+        # URLs with queries are not supported
+        if scheme not in ["https", "http"] or len(query) > 0:
+            return None
+
+        path = url_components.path
+        normalized_path = quote(normalize_url_path(path))
+        if not normalized_path.endswith("/"):
+            normalized_path = f"{normalized_path}/"
+
+        return {
+            "scheme": scheme,
+            "authority": url_components.netloc,
+            "path": path,
+            "normalizedPath": normalized_path,
+            "isIp": is_valid_ipv4_endpoint_url(value)
+            or is_valid_ipv6_endpoint_url(value),
+        }
+
+    def _boolean_equals(self, value1, value2):
+        """Evaluates two boolean values for equality.
+
+        :type value1: bool
+        :type value2: bool
+        :rtype: bool
+        """
+        if not all(isinstance(val, bool) for val in (value1, value2)):
+            raise EndpointResolutionError(
+                msg=(
+                    f"Both arguments must be booleans.\n"
+                    f"value1: {value1}\n"
+                    f"value2: {value2}"
+                )
+            )
+        return value1 is value2
+
+    def _is_ascii(self, string):
+        """Evaluates if a string only contains ASCII characters.
+
+        :type string: str
+        :rtype: bool
+        """
+        try:
+            string.encode("ascii")
+            return True
+        except UnicodeEncodeError:
+            return False
+
+    def _substring(self, string_input, start, stop, reverse):
+        """Computes a substring given the start index and end index. If `reverse` is
+        True, slice the string from the end instead.
+
+        :type string_input: str
+        :type start: int
+        :type end: int
+        :type reverse: bool
+        :rtype: str
+        """
+        if not isinstance(string_input, str):
+            raise EndpointResolutionError(
+                msg=(
+                    f"Input must be a string.\n"
+                    f"string_input: {string_input}"
+                )
+            )
+        if (
+            start >= stop
+            or len(string_input) < stop
+            or not self._is_ascii(string_input)
+        ):
+            return None
+
+        if reverse is True:
+            r_start = len(string_input) - stop
+            r_stop = len(string_input) - start
+            return string_input[r_start:r_stop]
+
+        return string_input[start:stop]
+
+    def _not(self, value):
+        """A function implementation of the logical operator `not`.
+
+        :type value: Any
+        :rtype: bool
+        """
+        return not value
+
+
+class BaseRule:
+    """A rule within a rule set. All rules contain a conditions property,
+    which can be empty, and documentation about the rule.
+    """
+
+    def __init__(self, conditions, documentation=None):
+        self.conditions = conditions
+        self.documentation = documentation
+
+    def evaluate(self, scope_vars, standard_library):
+        raise NotImplementedError()
+
+    def evaluate_conditions(self, scope_vars, standard_library):
+        """Determine if all conditions in a rule are met.
+
+        :type scope_vars: dict
+        :type standard_library: RuleSetStandardLibrary
+        :rtype: bool
+        """
+        for func_signature in self.conditions:
+            result = standard_library._call_function(
+                func_signature, scope_vars
+            )
+            if result is False or result is None:
+                return False
+        return True
+
+
+class RuleSetEndpoint(NamedTuple):
+    """A fully resolved endpoint object returned by a rule."""
+
+    url: str
+    properties: dict
+    headers: dict
+
+
+class EndpointRule(BaseRule):
+    def __init__(self, endpoint, **kwargs):
+        super().__init__(**kwargs)
+        self.endpoint = endpoint
+
+    def evaluate(self, scope_vars, standard_library):
+        """If an endpoint rule's conditions are met, return the fully resolved
+        endpoint object.
+
+        :type scope_vars: dict
+        :rtype: RuleSetEndpoint
+        """
+        if self.evaluate_conditions(scope_vars, standard_library) is True:
+            url = standard_library._resolve_value(
+                self.endpoint["url"], scope_vars
+            )
+            properties = self.resolve_properties(
+                self.endpoint.get("properties", {}),
+                scope_vars,
+                standard_library,
+            )
+            headers = self.resolve_headers(scope_vars, standard_library)
+            return RuleSetEndpoint(
+                url=url, properties=properties, headers=headers
+            )
+
+        return None
+
+    def resolve_properties(self, properties, scope_vars, standard_library):
+        """Recurse through an endpoint's `properties` attribute, resolving template
+        strings when found. Return the fully resolved attribute.
+
+        :type properties: dict/list/str
+        :type scope_vars: dict
+        :type standard_library: RuleSetStandardLibrary
+        :rtype: dict
+        """
+        if isinstance(properties, list):
+            return [
+                self.resolve_properties(prop, scope_vars, standard_library)
+                for prop in properties
+            ]
+        elif isinstance(properties, dict):
+            return {
+                key: self.resolve_properties(
+                    value, scope_vars, standard_library
+                )
+                for key, value in properties.items()
+            }
+        elif standard_library._is_template(properties):
+            return standard_library._resolve_template_string(
+                properties, scope_vars
+            )
+        return properties
+
+    def resolve_headers(self, scope_vars, standard_library):
+        """Iterate through an endpoint's headers attribute resolving values along
+        the way. Return the fully resolved attribute.
+
+        :type scope_vars: dict
+        :type standard_library: RuleSetStandardLibrary
+        :rtype: dict
+        """
+        resolved_headers = {}
+        headers = self.endpoint.get("headers", {})
+
+        for header, values in headers.items():
+            resolved_headers[header] = [
+                standard_library._resolve_value(item, scope_vars)
+                for item in values
+            ]
+        return resolved_headers
+
+
+class ErrorRule(BaseRule):
+    def __init__(self, error, **kwargs):
+        super().__init__(**kwargs)
+        self.error = error
+
+    def evaluate(self, scope_vars, standard_library):
+        """If an error rule's conditions are met, raise the fully resolved error rule
+
+        :type scope_vars: dict
+        :type standard_library: RuleSetStandardLibrary
+        :rtype: EndpointResolutionError
+        """
+        if self.evaluate_conditions(scope_vars, standard_library) is True:
+            error = standard_library._resolve_value(self.error, scope_vars)
+            raise EndpointResolutionError(msg=error)
+        return None
+
+
+class TreeRule(BaseRule):
+    """A tree rule is non-terminal meaning it will never be returned to a provider.
+    Additionally this means it has no attributes that need to be resolved.
+    """
+
+    def __init__(self, rules, **kwargs):
+        super().__init__(**kwargs)
+        self.rules = [RuleCreator.create(**rule) for rule in rules]
+
+    def evaluate(self, scope_vars, standard_library):
+        """If a tree rule's conditions evaluate successfully, iterate over its
+        subordinate rules and return a result if there is one. If any of the
+        subsequent rules are trees, the function will recurse until it reaches
+        an error or an endpoint rule.
+
+        :type scope_vars: dict
+        :type standard_library: RuleSetStandardLibrary
+        :rtype: RuleSetEndpoint/EndpointResolutionError
+        """
+        if self.evaluate_conditions(scope_vars, standard_library) is True:
+            for rule in self.rules:
+                # newly set parameters via "assign" cannot be shared between
+                # adjacent rules
+                rule_result = rule.evaluate(
+                    scope_vars.copy(), standard_library
+                )
+                if rule_result:
+                    return rule_result
+        return None
+
+
+class RuleCreator:
+
+    endpoint = EndpointRule
+    error = ErrorRule
+    tree = TreeRule
+
+    @classmethod
+    def create(cls, **kwargs):
+        """Create a class instance from rule metadata.
+
+        :rtype: TreeRule/EndpointRule/ErrorRule
+        """
+        rule_type = kwargs.pop("type")
+        try:
+            rule_class = getattr(cls, rule_type)
+        except AttributeError:
+            raise EndpointResolutionError(
+                msg=f"Unknown rule type: {rule_type}. A rule must "
+                "be of type tree, endpoint or error."
+            )
+        else:
+            return rule_class(**kwargs)
+
+
+class ParameterDefinition:
+    """The spec of an individual parameter defined in a rule set object."""
+
+    def __init__(
+        self,
+        name,
+        parameter_type,
+        documentation=None,
+        builtIn=None,
+        default=None,
+        required=None,
+        deprecated=None,
+    ):
+        self.name = name
+        try:
+            self.parameter_type = getattr(
+                self.ParameterType, parameter_type.lower()
+            ).value
+        except AttributeError:
+            raise EndpointResolutionError(
+                msg=f"Unknown parameter type: {parameter_type}. "
+                "A parameter must be of type string or boolean"
+            )
+        self.documentation = documentation
+        self.built_in = builtIn
+        self.default = default
+        self.required = required
+        self.deprecated = deprecated
+
+    class ParameterType(Enum):
+        """An enum that translates a parameter definition's `type` attribute to
+        its corresponding python native type.
+        """
+
+        string = str
+        boolean = bool
+
+    def validate_input(self, input_param):
+        """Validate that an input parameter matches the type provided in its spec.
+
+        :type input_param: Any
+        :raises: EndpointParametersError
+        """
+
+        if not isinstance(input_param, self.parameter_type):
+            raise EndpointResolutionError(
+                msg=f"Input parameter {self.name} is the wrong "
+                f"type. Must be {self.parameter_type}"
+            )
+        if self.deprecated is not None:
+            depr_string = f"{self.name} has been deprecated."
+            msg = self.deprecated["message"]
+            if msg:
+                depr_string += f"\n{msg}"
+            since = self.deprecated.get("since")
+            if since:
+                depr_string += f"\nDeprecated since {since}."
+            logger.info(depr_string)
+        return None
+
+
+class RuleSet:
+    """An entire rule set object. Every rule set contains a version, parameters
+    (specification of parameters not values) and rules. Additionally, it is provided
+    with input parameters from a client to validate against its defined parameter
+    traits and an instance of an endpoint provider.
+    """
+
+    def __init__(
+        self, version, parameters, rules, partitions, documentation=None
+    ):
+        self.version = version
+        self.parameters = {
+            name: ParameterDefinition(
+                name,
+                spec["type"],
+                spec.get("documentation"),
+                spec.get("builtIn"),
+                spec.get("default"),
+                spec.get("required"),
+                spec.get("deprecated"),
+            )
+            for name, spec in parameters.items()
+        }
+        self.rules = [RuleCreator.create(**rule) for rule in rules]
+        self.standard_library = RuleSetStandardLibary(partitions)
+        self.documentation = documentation
+
+    def validate_input_parameters(self, input_parameters):
+        """Validate each input parameter against its spec. If not provided, add
+        the default value to the `input_parameters` dictionary.
+
+        :type input_parameters: dict
+        """
+        for param_name, param_spec in self.parameters.items():
+            input_param = input_parameters.get(param_name)
+            if input_param is None and param_spec.default is not None:
+                input_parameters[param_name] = param_spec.default
+            elif input_param is not None:
+                param_spec.validate_input(input_param)
+        return None
+
+    def evaluate(self, input_parameters):
+        """Evaluate the rule set against the input parameters. Return the first rule
+        the parameters match against.
+
+        :type input_parameters: dict
+        """
+        self.validate_input_parameters(input_parameters)
+        for rule in self.rules:
+            # newly set parameters via "assign" cannot be shared between
+            # adjacent rules
+            evaluation = rule.evaluate(
+                input_parameters.copy(), self.standard_library
+            )
+            if evaluation is not None:
+                return evaluation
+        return None
+
+
+class EndpointProvider:
+    """Provides a resolved endpoint for a set of input parameters after evaluating
+    them against a service rule set.
+    """
+
+    def __init__(self, ruleset_data, partition_data):
+        self.ruleset = RuleSet(**ruleset_data, partitions=partition_data)
+
+    @lru_cache(maxsize=CACHE_SIZE)
+    def resolve_endpoint(self, **input_parameters):
+        """Match input parameters to a rule.
+
+        :type input_parameters: dict
+        :rtype: RuleSetEndpoint
+        """
+        params_for_error = input_parameters.copy()
+        endpoint = self.ruleset.evaluate(input_parameters)
+        if endpoint is None:
+            param_string = "\n".join(
+                [f"{key}: {value}" for key, value in params_for_error.items()]
+            )
+            raise EndpointResolutionError(
+                msg=f"No endpoint found for parameters:\n{param_string}"
+            )
+        return endpoint

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -798,3 +798,15 @@ class FlexibleChecksumError(BotoCoreError):
 
 class InvalidEndpointConfigurationError(BotoCoreError):
     fmt = 'Invalid endpoint configuration: {msg}'
+
+
+class EndpointProviderError(BotoCoreError):
+    """Base error for the EndpointProvider class"""
+
+    fmt = '{msg}'
+
+
+class EndpointResolutionError(EndpointProviderError):
+    """Error when input parameters resolve to an error rule"""
+
+    fmt = '{msg}'

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -37,15 +37,16 @@ import botocore.httpsession
 from botocore.compat import HEX_PAT  # noqa: F401
 from botocore.compat import IPV4_PAT  # noqa: F401
 from botocore.compat import IPV6_ADDRZ_PAT  # noqa: F401
-from botocore.compat import IPV6_ADDRZ_RE  # noqa: F401
 from botocore.compat import IPV6_PAT  # noqa: F401
 from botocore.compat import LS32_PAT  # noqa: F401
 from botocore.compat import UNRESERVED_PAT  # noqa: F401
-from botocore.compat import UNSAFE_URL_CHARS  # noqa: F401
 from botocore.compat import ZONE_ID_PAT  # noqa: F401
 from botocore.compat import (
     HAS_CRT,
+    IPV4_RE,
+    IPV6_ADDRZ_RE,
     MD5_AVAILABLE,
+    UNSAFE_URL_CHARS,
     OrderedDict,
     get_md5,
     get_tzinfo_options,
@@ -1217,6 +1218,11 @@ def is_valid_ipv6_endpoint_url(endpoint_url):
         return False
     hostname = f'[{urlparse(endpoint_url).hostname}]'
     return IPV6_ADDRZ_RE.match(hostname) is not None
+
+
+def is_valid_ipv4_endpoint_url(endpoint_url):
+    hostname = urlparse(endpoint_url).hostname
+    return IPV4_RE.match(hostname) is not None
 
 
 def is_valid_endpoint_url(endpoint_url):

--- a/tests/unit/data/endpoints/test-cases/aws-region.json
+++ b/tests/unit/data/endpoints/test-cases/aws-region.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "basic region templating",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-1.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingRegion": "us-east-1",
+                "signingName": "serviceName"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "documentation": "test case where region is unset",
+      "params": {},
+      "expect": {
+        "error": "Region must be set to resolve a valid endpoint"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/default-values.json
+++ b/tests/unit/data/endpoints/test-cases/default-values.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "default endpoint",
+      "params": {},
+      "expect": {
+        "endpoint": {
+          "url": "https://fips.us-west-5.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "test case where FIPS is disabled",
+      "params": {
+        "UseFips": false
+      },
+      "expect": {
+        "error": "UseFips = false"
+      }
+    },
+    {
+      "documentation": "test case where FIPS is enabled explicitly",
+      "params": {
+        "UseFips": true
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://fips.us-west-5.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "defaults can be overridden",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://fips.us-east-1.amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/eventbridge.json
+++ b/tests/unit/data/endpoints/test-cases/eventbridge.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "simple region endpoint",
+      "params": {
+        "region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://events.us-east-1.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "basic case of endpointId",
+      "params": {
+        "region": "us-east-1",
+        "endpointId": "myendpoint"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://myendpoint.endpoint.events.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4a",
+                "signingName": "events",
+                "signingRegionSet": ["*"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "documentation": "endpointId & FIPS",
+      "params": {
+        "region": "us-east-1",
+        "endpointId": "myendpoint",
+        "useFIPSEndpoint": true
+      },
+      "expect": {
+        "error": "FIPS endpoints not supported with multi-region endpoints"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/fns.json
+++ b/tests/unit/data/endpoints/test-cases/fns.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "test where URI is set and flows to URI and header",
+      "params": {
+        "Uri": "https://www.example.com",
+        "Arn": "arn:aws:s3:us-east-2:012345678:outpost:op-1234"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://www.example.com",
+          "headers": {
+            "x-uri": [
+              "https://www.example.com"
+            ],
+            "x-arn-region": [
+              "us-east-2"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "documentation": "test where explicit error is set",
+      "params": {
+        "CustomError": "This is an error!"
+      },
+      "expect": {
+        "error": "This is an error!"
+      }
+    },
+    {
+      "documentation": "test where an ARN field is used in the error directly",
+      "params": {
+        "Arn": "arn:This is an error!:s3:us-east-2:012345678:outpost:op-1234"
+      },
+      "expect": {
+        "error": "This is an error!"
+      }
+    },
+    {
+      "documentation": "test case where no fields are set",
+      "params": {},
+      "expect": {
+        "error": "No fields were set"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/headers.json
+++ b/tests/unit/data/endpoints/test-cases/headers.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "header set to region",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-1.amazonaws.com",
+          "headers": {
+            "x-amz-region": [
+              "us-east-1"
+            ],
+            "x-amz-multi": [
+              "*",
+              "us-east-1"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/local-region-override.json
+++ b/tests/unit/data/endpoints/test-cases/local-region-override.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "local region override",
+      "params": {
+        "Region": "local"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://localhost:8080"
+        }
+      }
+    },
+    {
+      "documentation": "standard region templated",
+      "params": {
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-2.someservice.amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/parse-arn.json
+++ b/tests/unit/data/endpoints/test-cases/parse-arn.json
@@ -1,0 +1,152 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "arn + region resolution",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost:op-1234",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://op-1234-012345678.us-east-2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "arn, unset outpost id",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "error": "Invalid ARN: outpostId was not set"
+      }
+    },
+    {
+      "documentation": "arn, empty outpost id (tests that empty strings are handled properly during matching)",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost::",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "error": "OutpostId was empty"
+      }
+    },
+    {
+      "documentation": "arn, empty outpost id (tests that ARN parsing considers a trailing colon)",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost:",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "error": "OutpostId was empty"
+      }
+    },
+    {
+      "documentation": "valid hostlabel + region resolution",
+      "params": {
+        "Bucket": "mybucket",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://mybucket.us-east-2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "not a valid hostlabel + region resolution",
+      "params": {
+        "Bucket": "99_a",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-2.amazonaws.com/99_a"
+        }
+      }
+    },
+    {
+      "documentation": "no bucket",
+      "params": {
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "a string that is not a 6-part ARN",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "asdf"
+      },
+      "expect": {
+        "error": "Test case passed: `asdf` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "resource id MUST not be null",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "arn:aws:s3:us-west-2:123456789012:"
+      },
+      "expect": {
+        "error": "Test case passed: `arn:aws:s3:us-west-2:123456789012:` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "service MUST not be null",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "arn:aws::us-west-2:123456789012:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: `arn:aws::us-west-2:123456789012:resource-id` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "partition MUST not be null",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "arn::s3:us-west-2:123456789012:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: `arn::s3:us-west-2:123456789012:resource-id` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "region MAY be null",
+      "params": {
+        "TestCaseId": "valid-arn",
+        "Bucket": "arn:aws:s3::123456789012:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: A valid ARN was parsed: service: `s3`, partition: `aws, region: ``, accountId: `123456789012`, resource: `resource-id`"
+      }
+    },
+    {
+      "documentation": "accountId MAY be null",
+      "params": {
+        "TestCaseId": "valid-arn",
+        "Bucket": "arn:aws:s3:us-east-1::resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: A valid ARN was parsed: service: `s3`, partition: `aws, region: `us-east-1`, accountId: ``, resource: `resource-id`"
+      }
+    },
+    {
+      "documentation": "accountId MAY be non-numeric",
+      "params": {
+        "TestCaseId": "valid-arn",
+        "Bucket": "arn:aws:s3:us-east-1:abcd:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: A valid ARN was parsed: service: `s3`, partition: `aws, region: `us-east-1`, accountId: `abcd`, resource: `resource-id`"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/parse-url.json
+++ b/tests/unit/data/endpoints/test-cases/parse-url.json
@@ -1,0 +1,153 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "simple URL parsing",
+      "params": {
+        "Endpoint": "https://authority.com/custom-path"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-authority.com.example.com/path-is/custom-path"
+        }
+      }
+    },
+    {
+      "documentation": "empty path no slash",
+      "params": {
+        "Endpoint": "https://authority.com"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-authority.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "empty path with slash",
+      "params": {
+        "Endpoint": "https://authority.com/"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-authority.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "authority with port",
+      "params": {
+        "Endpoint": "https://authority.com:8000/port"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://authority.com:8000/uri-with-port"
+        }
+      }
+    },
+    {
+      "documentation": "http schemes",
+      "params": {
+        "Endpoint": "http://authority.com:8000/port"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://authority.com:8000/uri-with-port"
+        }
+      }
+    },
+    {
+      "documentation": "arbitrary schemes are not supported",
+      "params": {
+        "Endpoint": "acbd://example.com"
+      },
+      "expect": {
+        "error": "endpoint was invalid"
+      }
+    },
+    {
+      "documentation": "host labels are not validated",
+      "params": {
+        "Endpoint": "http://99_ab.com"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://http-99_ab.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "host labels are not validated",
+      "params": {
+        "Endpoint": "http://99_ab-.com"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://http-99_ab-.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "invalid URL",
+      "params": {
+        "Endpoint": "http://abc.com:a/foo"
+      },
+      "expect": {
+        "error": "endpoint was invalid"
+      }
+    },
+    {
+      "documentation": "IP Address",
+      "params": {
+        "Endpoint": "http://192.168.1.1/foo/"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://192.168.1.1/foo/is-ip-addr"
+        }
+      }
+    },
+    {
+      "documentation": "IP Address with port",
+      "params": {
+        "Endpoint": "http://192.168.1.1:1234/foo/"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://192.168.1.1:1234/foo/is-ip-addr"
+        }
+      }
+    },
+    {
+      "documentation": "IPv6 Address",
+      "params": {
+        "Endpoint": "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/is-ip-addr"
+        }
+      }
+    },
+    {
+      "documentation": "weird DNS name",
+      "params": {
+        "Endpoint": "https://999.999.abc.blah"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-999.999.abc.blah-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "query in resolved endpoint is not supported",
+      "params": {
+        "Endpoint": "https://example.com/path?query1=foo"
+      },
+      "expect": {
+        "error": "endpoint was invalid"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/partition-fn.json
+++ b/tests/unit/data/endpoints/test-cases/partition-fn.json
@@ -1,0 +1,125 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "standard AWS region",
+      "params": {
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-partition.us-east-2.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "us-east-2"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com",
+              "dualStackSuffix": "api.aws"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "AWS region that doesn't match any regexes",
+      "params": {
+        "Region": "mars-global"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-partition.mars-global.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "mars-global"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com",
+              "dualStackSuffix": "api.aws"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "AWS region that matches the AWS regex",
+      "params": {
+        "Region": "us-east-10"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-partition.us-east-10.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "us-east-10"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com",
+              "dualStackSuffix": "api.aws"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "CN region that matches the AWS regex",
+      "params": {
+        "Region": "cn-north-5"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-cn.cn-north-5.amazonaws.com.cn",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "cn-north-5"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com.cn",
+              "dualStackSuffix": "api.amazonwebservices.com.cn"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "CN region that is in the explicit list",
+      "params": {
+        "Region": "aws-cn-global"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-cn.aws-cn-global.amazonaws.com.cn",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "aws-cn-global"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com.cn",
+              "dualStackSuffix": "api.amazonwebservices.com.cn"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/substring.json
+++ b/tests/unit/data/endpoints/test-cases/substring.json
@@ -1,0 +1,185 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "substring when string is long enough",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcdefg"
+      },
+      "expect": {
+        "error": "The value is: `abcd`"
+      }
+    },
+    {
+      "documentation": "substring when string is exactly the right length",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcd"
+      },
+      "expect": {
+        "error": "The value is: `abcd`"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abc"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "1",
+        "Input": ""
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring on wide characters (ensure that unicode code points are properly counted)",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "\ufdfd"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "unicode characters always return `None`",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcdef\uD83D\uDC31"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "non-ascii cause substring to always return `None`",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcdef\u0080"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "the full set of ascii is supported, including non-printable characters",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "\u007Fabcdef"
+      },
+      "expect": {
+        "error": "The value is: `\u007Fabc`"
+      }
+    },
+    {
+      "documentation": "substring when string is long enough",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "abcdefg"
+      },
+      "expect": {
+        "error": "The value is: `defg`"
+      }
+    },
+    {
+      "documentation": "substring when string is exactly the right length",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "defg"
+      },
+      "expect": {
+        "error": "The value is: `defg`"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "abc"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "2",
+        "Input": ""
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring on wide characters (ensure that unicode code points are properly counted)",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "\ufdfd"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is longer",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "defg"
+      },
+      "expect": {
+        "error": "The value is: `ef`"
+      }
+    },
+    {
+      "documentation": "substring when string is exact length",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "def"
+      },
+      "expect": {
+        "error": "The value is: `ef`"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "ab"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "3",
+        "Input": ""
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring on wide characters (ensure that unicode code points are properly counted)",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "\ufdfd"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/uri-encode.json
+++ b/tests/unit/data/endpoints/test-cases/uri-encode.json
@@ -1,0 +1,75 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "uriEncode when the string has nothing to encode returns the input",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcdefg"
+      },
+      "expect": {
+        "error": "The value is: `abcdefg`"
+      }
+    },
+    {
+      "documentation": "uriEncode with single character to encode encodes only that character",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abc:defg"
+      },
+      "expect": {
+        "error": "The value is: `abc%3Adefg`"
+      }
+    },
+    {
+      "documentation": "uriEncode with all ASCII characters to encode encodes all characters",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "/:,?#[]{}|@! $&'()*+;=%<>\"^`\\"
+      },
+      "expect": {
+        "error": "The value is: `%2F%3A%2C%3F%23%5B%5D%7B%7D%7C%40%21%20%24%26%27%28%29%2A%2B%3B%3D%25%3C%3E%22%5E%60%5C`"
+      }
+    },
+    {
+      "documentation": "uriEncode with ASCII characters that should not be encoded returns the input",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "0123456789.underscore_dash-Tilda~"
+      },
+      "expect": {
+        "error": "The value is: `0123456789.underscore_dash-Tilda~`"
+      }
+    },
+    {
+      "documentation": "uriEncode encodes unicode characters",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "\ud83d\ude39"
+      },
+      "expect": {
+        "error": "The value is: `%F0%9F%98%B9`"
+      }
+    },
+    {
+      "documentation": "uriEncode on all printable ASCII characters",
+      "params": {
+        "TestCaseId": "1",
+        "Input": " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+      },
+      "expect": {
+        "error": "The value is: `%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~`"
+      }
+    },
+    {
+      "documentation": "uriEncode on an empty string",
+      "params": {
+        "TestCaseId": "1",
+        "Input": ""
+      },
+      "expect": {
+        "error": "The value is: ``"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/test-cases/valid-hostlabel.json
+++ b/tests/unit/data/endpoints/test-cases/valid-hostlabel.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "standard region is a valid hostlabel",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-1.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "starting with a number is a valid hostlabel",
+      "params": {
+        "Region": "3aws4"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://3aws4.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "when there are dots, only match if subdomains are allowed",
+      "params": {
+        "Region": "part1.part2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://part1.part2-subdomains.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "a space is never a valid hostlabel",
+      "params": {
+        "Region": "part1 part2"
+      },
+      "expect": {
+        "error": "Invalid hostlabel"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/aws-region.json
+++ b/tests/unit/data/endpoints/valid-rules/aws-region.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/default-values.json
+++ b/tests/unit/data/endpoints/valid-rules/default-values.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`.",
+      "default": "us-west-5",
+      "required": true
+    },
+    "UseFips": {
+      "type": "boolean",
+      "builtIn": "AWS::UseFIPS",
+      "default": true,
+      "required": true
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when FIPS is enabled",
+      "conditions": [
+        {
+          "fn": "booleanEquals",
+          "argv": [
+            {
+              "ref": "UseFips"
+            },
+            true
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://fips.{Region}.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "error when fips is disabled",
+      "conditions": [],
+      "error": "UseFips = false",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/deprecated-param.json
+++ b/tests/unit/data/endpoints/valid-rules/deprecated-param.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": false,
+      "deprecated": {
+        "message": "use blahdeblah region instead"
+      }
+    }
+  },
+  "rules": [
+    {
+      "documentation": "base rule",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/eventbridge.json
+++ b/tests/unit/data/endpoints/valid-rules/eventbridge.json
@@ -1,0 +1,323 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true
+    },
+    "useDualStackEndpoint": {
+      "type": "boolean",
+      "builtIn": "AWS::UseDualStack"
+    },
+    "useFIPSEndpoint": {
+      "type": "boolean",
+      "builtIn": "AWS::UseFIPS"
+    },
+    "endpointId": {
+      "type": "string"
+    }
+  },
+  "rules": [
+    {
+      "conditions": [
+        {
+          "fn": "aws.partition",
+          "argv": [
+            {
+              "ref": "region"
+            }
+          ],
+          "assign": "partitionResult"
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "endpointId"
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "error": "FIPS endpoints not supported with multi-region endpoints",
+              "type": "error"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "not",
+                  "argv": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "useFIPSEndpoint"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://{endpointId}.endpoint.events.{partitionResult#dualStackDnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": [
+                        "*"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://{endpointId}.endpoint.events.{partitionResult#dnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": [
+                        "*"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            }
+          ],
+          "type": "tree"
+        },
+        {
+          "conditions": [
+            {
+              "fn": "isValidHostLabel",
+              "argv": [
+                {
+                  "ref": "region"
+                },
+                false
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    },
+                    true
+                  ]
+                },
+                {
+                  "fn": "not",
+                  "argv": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "useDualStackEndpoint"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://events-fips.{region}.{partitionResult#dnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": [
+                        "*"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    },
+                    true
+                  ]
+                },
+                {
+                  "fn": "not",
+                  "argv": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "useFIPSEndpoint"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://events.{region}.{partitionResult#dualStackDnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": [
+                        "*"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    },
+                    true
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://events-fips.{region}.{partitionResult#dualStackDnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": [
+                        "*"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://events.{region}.{partitionResult#dnsSuffix}"
+              },
+              "type": "endpoint"
+            }
+          ],
+          "type": "tree"
+        },
+        {
+          "conditions": [],
+          "error": "{region} is not a valid HTTP host-label",
+          "type": "error"
+        }
+      ],
+      "type": "tree"
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/fns.json
+++ b/tests/unit/data/endpoints/valid-rules/fns.json
@@ -1,0 +1,128 @@
+{
+  "documentation": "functions in more places",
+  "parameters": {
+    "Uri": {
+      "type": "string",
+      "documentation": "A URI to use"
+    },
+    "Arn": {
+      "type": "string",
+      "documentation": "an ARN to extract fields from"
+    },
+    "CustomError": {
+      "type": "string",
+      "documentation": "when set, a custom error message"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "when URI is set, use it directly",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Uri"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ]
+        },
+        {
+          "fn": "aws.parseArn",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ],
+          "assign": "parsedArn"
+        }
+      ],
+      "endpoint": {
+        "url": {
+          "ref": "Uri"
+        },
+        "headers": {
+          "x-uri": [
+            {
+              "ref": "Uri"
+            }
+          ],
+          "x-arn-region": [
+            {
+              "fn": "getAttr",
+              "argv": [
+                {
+                  "ref": "parsedArn"
+                },
+                "region"
+              ]
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "A custom error",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "CustomError"
+            }
+          ]
+        }
+      ],
+      "type": "error",
+      "error": {
+        "ref": "CustomError"
+      }
+    },
+    {
+      "type": "error",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ]
+        },
+        {
+          "fn": "aws.parseArn",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ],
+          "assign": "parsedArn"
+        }
+      ],
+      "error": {
+        "fn": "getAttr",
+        "argv": [
+          {
+            "ref": "parsedArn"
+          },
+          "partition"
+        ]
+      }
+    },
+    {
+      "documentation": "fallback when nothing is set",
+      "conditions": [],
+      "error": "No fields were set",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/get-attr-type-inference.json
+++ b/tests/unit/data/endpoints/valid-rules/get-attr-type-inference.json
@@ -1,0 +1,46 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "Bucket": {
+      "type": "string"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "bucket is set, handle bucket specific endpoints",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Bucket"
+            }
+          ]
+        },
+        {
+          "fn": "aws.parseArn",
+          "argv": [
+            {
+              "ref": "Bucket"
+            }
+          ],
+          "assign": "bucketArn"
+        },
+        {
+          "fn": "getAttr",
+          "argv": [
+            {
+              "ref": "bucketArn"
+            },
+            "resourceId[2]"
+          ],
+          "assign": "outpostId"
+        }
+      ],
+      "endpoint": {
+        "url": "https://{bucketArn#accountId}.{outpostId}.{bucketArn#region}"
+      },
+      "type": "endpoint"
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/headers.json
+++ b/tests/unit/data/endpoints/valid-rules/headers.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "headers": {
+          "x-amz-region": [
+            "{Region}"
+          ],
+          "x-amz-multi": [
+            "*",
+            "{Region}"
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/local-region-override.json
+++ b/tests/unit/data/endpoints/valid-rules/local-region-override.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true
+    }
+  },
+  "rules": [
+    {
+      "documentation": "override rule for the local pseduo region",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": [
+            "local",
+            "{Region}"
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "http://localhost:8080"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "base rule",
+      "conditions": [],
+      "endpoint": {
+        "url": "https://{Region}.someservice.amazonaws.com"
+      },
+      "type": "endpoint"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/minimal-ruleset.json
+++ b/tests/unit/data/endpoints/valid-rules/minimal-ruleset.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true
+    }
+  },
+  "rules": [
+    {
+      "documentation": "base rule",
+      "conditions": [],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/parse-arn.json
+++ b/tests/unit/data/endpoints/valid-rules/parse-arn.json
@@ -1,0 +1,251 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region"
+    },
+    "Bucket": {
+      "type": "string"
+    },
+    "TestCaseId": {
+      "type": "string"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "tests of invalid arns",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "TestCaseId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Bucket"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            "{TestCaseId}",
+            "invalid-arn"
+          ]
+        }
+      ],
+      "type": "tree",
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "aws.parseArn",
+              "argv": ["{Bucket}"]
+            }
+          ],
+          "type": "error",
+          "error": "A valid ARN was parsed but `{Bucket}` is not a valid ARN"
+        },
+        {
+          "conditions": [],
+          "type": "error",
+          "error": "Test case passed: `{Bucket}` is not a valid ARN."
+        }
+      ]
+    },
+    {
+      "documentation": "tests of valid arns",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "TestCaseId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Bucket"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            "{TestCaseId}",
+            "valid-arn"
+          ]
+        }
+      ],
+      "type": "tree",
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "aws.parseArn",
+              "argv": ["{Bucket}"],
+              "assign": "arn"
+            },
+            {
+              "fn": "getAttr",
+              "argv": [{"ref": "arn"}, "resourceId[0]"],
+              "assign": "resource"
+            }
+          ],
+          "type": "error",
+          "error": "Test case passed: A valid ARN was parsed: service: `{arn#service}`, partition: `{arn#partition}, region: `{arn#region}`, accountId: `{arn#accountId}`, resource: `{resource}`"
+        },
+        {
+          "conditions": [],
+          "type": "error",
+          "error": "Test case failed: `{Bucket}` is a valid ARN but parseArn failed to parse it."
+        }
+      ]
+    },
+    {
+      "documentation": "region is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        },
+        {
+          "fn": "aws.partition",
+          "argv": [
+            "{Region}"
+          ],
+          "assign": "partitionResult"
+        }
+      ],
+      "rules": [
+        {
+          "documentation": "bucket is set, handle bucket specific endpoints",
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Bucket"
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "documentation": "bucket is set and is an arn",
+              "conditions": [
+                {
+                  "fn": "aws.parseArn",
+                  "argv": [
+                    {
+                      "ref": "Bucket"
+                    }
+                  ],
+                  "assign": "bucketArn"
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "getAttr",
+                      "argv": [
+                        {
+                          "ref": "bucketArn"
+                        },
+                        "resourceId[1]"
+                      ],
+                      "assign": "outpostId"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            "{outpostId}",
+                            ""
+                          ]
+                        }
+                      ],
+                      "error": "OutpostId was empty",
+                      "type": "error"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://{outpostId}-{bucketArn#accountId}.{bucketArn#region}.{partitionResult#dnsSuffix}"
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "Invalid ARN: outpostId was not set",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "documentation": "bucket can be used as a host label",
+              "conditions": [
+                {
+                  "fn": "isValidHostLabel",
+                  "argv": [
+                    "{Bucket}",
+                    false
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://{Bucket}.{Region}.amazonaws.com"
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "documentation": "fallback: use bucket in the path",
+              "endpoint": {
+                "url": "https://{Region}.amazonaws.com/{Bucket}"
+              },
+              "type": "endpoint"
+            }
+          ],
+          "type": "tree"
+        },
+        {
+          "documentation": "region is set, bucket is not",
+          "conditions": [],
+          "endpoint": {
+            "url": "https://{Region}.{partitionResult#dnsSuffix}"
+          },
+          "type": "endpoint"
+        }
+      ],
+      "type": "tree"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/parse-url.json
+++ b/tests/unit/data/endpoints/valid-rules/parse-url.json
@@ -1,0 +1,102 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region"
+    },
+    "Endpoint": {
+      "type": "string"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "endpoint is set and is a valid URL",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Endpoint"
+            }
+          ]
+        },
+        {
+          "fn": "parseURL",
+          "argv": [
+            "{Endpoint}"
+          ],
+          "assign": "url"
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "url"
+                    },
+                    "isIp"
+                  ]
+                },
+                true
+              ]
+            }
+          ],
+          "endpoint": {
+            "url": "{url#scheme}://{url#authority}{url#normalizedPath}is-ip-addr"
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [
+            {
+              "fn": "stringEquals",
+              "argv": [
+                "{url#path}",
+                "/port"
+              ]
+            }
+          ],
+          "endpoint": {
+            "url": "{url#scheme}://{url#authority}/uri-with-port"
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [
+            {
+              "fn": "stringEquals",
+              "argv": [
+                "{url#normalizedPath}",
+                "/"
+              ]
+            }
+          ],
+          "endpoint": {
+            "url": "https://{url#scheme}-{url#authority}-nopath.example.com"
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [],
+          "endpoint": {
+            "url": "https://{url#scheme}-{url#authority}.example.com/path-is{url#path}"
+          },
+          "type": "endpoint"
+        }
+      ],
+      "type": "tree"
+    },
+    {
+      "error": "endpoint was invalid",
+      "conditions": [],
+      "type": "error"
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/partition-fn.json
+++ b/tests/unit/data/endpoints/valid-rules/partition-fn.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true
+    },
+    "PropertyOne": {
+      "type": "boolean"
+    },
+    "PropertyTwo": {
+      "type": "string"
+    },
+    "PropertyThree": {
+      "type": "boolean"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "base rule",
+      "conditions": [
+        {
+          "fn": "aws.partition",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ],
+          "assign": "PartResult"
+        }
+      ],
+      "rules": [
+        {
+          "documentation": "the AWS partition",
+          "conditions": [
+            {
+              "fn": "stringEquals",
+              "argv": [
+                "aws",
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartResult"
+                    },
+                    "name"
+                  ]
+                }
+              ]
+            }
+          ],
+          "endpoint": {
+            "url": "https://aws-partition.{Region}.{PartResult#dnsSuffix}",
+            "properties": {
+              "authSchemes": [
+                {
+                  "name": "sigv4",
+                  "signingName": "serviceName",
+                  "signingRegion": "{Region}"
+                }
+              ],
+              "meta": {
+                "baseSuffix": "{PartResult#dnsSuffix}",
+                "dualStackSuffix": "{PartResult#dualStackDnsSuffix}"
+              }
+            }
+          },
+          "type": "endpoint"
+        },
+        {
+          "documentation": "the other partitions",
+          "conditions": [],
+          "endpoint": {
+            "url": "https://{PartResult#name}.{Region}.{PartResult#dnsSuffix}",
+            "properties": {
+              "authSchemes": [
+                {
+                  "name": "sigv4",
+                  "signingName": "serviceName",
+                  "signingRegion": "{Region}"
+                }
+              ],
+              "meta": {
+                "baseSuffix": "{PartResult#dnsSuffix}",
+                "dualStackSuffix": "{PartResult#dualStackDnsSuffix}"
+              }
+            }
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [],
+          "error": "no rules matched",
+          "type": "error"
+        }
+      ],
+      "type": "tree"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/substring.json
+++ b/tests/unit/data/endpoints/valid-rules/substring.json
@@ -1,0 +1,95 @@
+{
+  "parameters": {
+    "TestCaseId": {
+      "type": "string",
+      "required": true,
+      "documentation": "Test case id used to select the test case to use"
+    },
+    "Input": {
+      "type": "string",
+      "required": true,
+      "documentation": "the input used to test substring"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Substring from beginning of input",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": [
+            "{TestCaseId}",
+            "1"
+          ]
+        },
+        {
+          "fn": "substring",
+          "argv": [
+            "{Input}",
+            0,
+            4,
+            false
+          ],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "Substring from end of input",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": [
+            "{TestCaseId}",
+            "2"
+          ]
+        },
+        {
+          "fn": "substring",
+          "argv": [
+            "{Input}",
+            0,
+            4,
+            true
+          ],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "Substring the middle of the string",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": [
+            "{TestCaseId}",
+            "3"
+          ]
+        },
+        {
+          "fn": "substring",
+          "argv": [
+            "{Input}",
+            1,
+            3,
+            false
+          ],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "fallback when no tests match",
+      "conditions": [],
+      "error": "No tests matched",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/data/endpoints/valid-rules/uri-encode.json
+++ b/tests/unit/data/endpoints/valid-rules/uri-encode.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "TestCaseId": {
+      "type": "string",
+      "required": true,
+      "documentation": "Test case id used to select the test case to use"
+    },
+    "Input": {
+      "type": "string",
+      "required": true,
+      "documentation": "the input used to test uriEncode"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "uriEncode on input",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": [
+            "{TestCaseId}",
+            "1"
+          ]
+        },
+        {
+          "fn": "uriEncode",
+          "argv": [
+            "{Input}"
+          ],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "fallback when no tests match",
+      "conditions": [],
+      "error": "No tests matched",
+      "type": "error"
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/valid-hostlabel.json
+++ b/tests/unit/data/endpoints/valid-rules/valid-hostlabel.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true,
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isValidHostLabel",
+          "argv": [
+            {
+              "ref": "Region"
+            },
+            false
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isValidHostLabel",
+          "argv": [
+            {
+              "ref": "Region"
+            },
+            true
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}-subdomains.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Region was not a valid host label",
+      "conditions": [],
+      "error": "Invalid hostlabel",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/test_endpoints_v2.py
+++ b/tests/unit/test_endpoints_v2.py
@@ -1,0 +1,347 @@
+# Copyright 2012-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import logging
+import os
+
+import pytest
+
+from botocore.endpoints_v2 import (
+    EndpointProvider,
+    EndpointRule,
+    ErrorRule,
+    RuleCreator,
+    RuleSet,
+    RuleSetStandardLibary,
+    TreeRule,
+)
+from botocore.exceptions import EndpointResolutionError
+from botocore.loaders import Loader
+
+REGION_TEMPLATE = "{Region}"
+REGION_REF = {"ref": "Region"}
+BUCKET_ARN_REF = {"ref": "bucketArn"}
+PARSE_ARN_FUNC = {
+    "fn": "aws.parseArn",
+    "argv": [{"ref": "Bucket"}],
+    "assign": "bucketArn",
+}
+STRING_EQUALS_FUNC = {
+    "fn": "stringEquals",
+    "argv": [
+        {
+            "fn": "getAttr",
+            "argv": [BUCKET_ARN_REF, "region"],
+            "assign": "bucketRegion",
+        },
+        "",
+    ],
+}
+DNS_SUFFIX_TEMPLATE = "{PartitionResults#dnsSuffix}"
+URL_TEMPLATE = (
+    f"https://{REGION_TEMPLATE}.myGreatService.{DNS_SUFFIX_TEMPLATE}"
+)
+ENDPOINT_DICT = {
+    "url": URL_TEMPLATE,
+    "properties": {
+        "authSchemes": [
+            {
+                "signingName": "s3",
+                "signingScope": REGION_TEMPLATE,
+                "name": "s3v4",
+            }
+        ],
+    },
+    "headers": {
+        "x-amz-region-set": [
+            REGION_REF,
+            {
+                "fn": "getAttr",
+                "argv": [BUCKET_ARN_REF, "region"],
+            },
+            "us-east-2",
+        ],
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def loader():
+    return Loader()
+
+
+@pytest.fixture(scope="module")
+def partitions(loader):
+    return loader.load_data("partitions")
+
+
+@pytest.fixture(scope="module")
+def standard_library(partitions):
+    return RuleSetStandardLibary(partitions)
+
+
+@pytest.fixture(scope="module")
+def ruleset_dict():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "data",
+        "endpoints",
+        "valid-rules",
+        "deprecated-param.json",
+    )
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def endpoint_provider(ruleset_dict, partitions):
+    return EndpointProvider(ruleset_dict, partitions)
+
+
+@pytest.fixture(scope="module")
+def endpoint_rule():
+    return EndpointRule(
+        endpoint=ENDPOINT_DICT,
+        conditions=[
+            PARSE_ARN_FUNC,
+            {
+                "fn": "not",
+                "argv": [STRING_EQUALS_FUNC],
+            },
+            {
+                "fn": "aws.partition",
+                "argv": [REGION_REF],
+                "assign": "PartitionResults",
+            },
+        ],
+    )
+
+
+def ruleset_testcases():
+    filenames = [
+        "aws-region",
+        "default-values",
+        "eventbridge",
+        "fns",
+        "headers",
+        "local-region-override",
+        "parse-arn",
+        "parse-url",
+        "substring",
+        "uri-encode",
+        "valid-hostlabel",
+    ]
+    error_cases = []
+    endpoint_cases = []
+    base_path = os.path.join(os.path.dirname(__file__), "data", "endpoints")
+    for name in filenames:
+
+        with open(os.path.join(base_path, "valid-rules", f"{name}.json")) as f:
+            ruleset = json.load(f)
+        with open(os.path.join(base_path, "test-cases", f"{name}.json")) as f:
+            tests = json.load(f)
+
+        for test in tests["testCases"]:
+            input_params = test["params"]
+            expected_object = test["expect"]
+            if "error" in expected_object:
+                error_cases.append(
+                    (ruleset, input_params, expected_object["error"])
+                )
+            elif "endpoint" in expected_object:
+                endpoint_cases.append(
+                    (ruleset, input_params, expected_object["endpoint"])
+                )
+            else:
+                raise ValueError("Expected `error` or `endpoint` in test case")
+    return error_cases, endpoint_cases
+
+
+ERROR_TEST_CASES, ENDPOINT_TEST_CASES = ruleset_testcases()
+
+
+@pytest.mark.parametrize(
+    "ruleset,input_params,expected_error",
+    ERROR_TEST_CASES,
+)
+def test_endpoint_resolution_raises(
+    partitions, ruleset, input_params, expected_error
+):
+    endpoint_provider = EndpointProvider(ruleset, partitions)
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        endpoint_provider.resolve_endpoint(**input_params)
+    assert str(exc_info.value) == expected_error
+
+
+@pytest.mark.parametrize(
+    "ruleset,input_params,expected_endpoint",
+    ENDPOINT_TEST_CASES,
+)
+def test_endpoint_resolution(
+    partitions, ruleset, input_params, expected_endpoint
+):
+    endpoint_provider = EndpointProvider(ruleset, partitions)
+    endpoint = endpoint_provider.resolve_endpoint(**input_params)
+    assert endpoint.url == expected_endpoint["url"]
+    assert endpoint.properties == expected_endpoint.get("properties", {})
+    assert endpoint.headers == expected_endpoint.get("headers", {})
+
+
+def test_none_doesnt_use_default_partition(standard_library):
+    assert standard_library._aws_partition(None) is None
+
+
+def test_no_match_region_returns_default_partition(standard_library):
+    partition_dict = standard_library._aws_partition("invalid-region-42")
+    assert partition_dict['name'] == "aws"
+
+
+def test_invalid_arn_returns_none(standard_library):
+    assert (
+        standard_library._aws_parse_arn("arn:aws:this-is-not-an-arn:foo")
+        is None
+    )
+
+
+def test_uri_encode_none_returns_none(standard_library):
+    assert standard_library._uri_encode(None) is None
+
+
+def test_parse_url_none_return_none(standard_library):
+    assert standard_library._parse_url(None) is None
+
+
+def test_string_equals_wrong_type_raises(standard_library):
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        standard_library._string_equals(1, 2)
+    assert "Both values must be strings" in str(exc_info.value)
+
+
+def test_boolean_equals_wrong_type_raises(standard_library):
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        standard_library._boolean_equals(1, 2)
+    assert "Both arguments must be booleans." in str(exc_info.value)
+
+
+def test_substring_wrong_type_raises(standard_library):
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        standard_library._substring(["h", "e", "l", "l", "o"], 0, 5, False)
+    assert "Input must be a string." in str(exc_info.value)
+
+
+def test_creator_unknown_type_raises():
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        RuleCreator.create(type="foo")
+    assert "Unknown rule type: foo." in str(exc_info.value)
+
+
+def test_parameter_wrong_type_raises(endpoint_provider):
+    param = endpoint_provider.ruleset.parameters["Region"]
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        param.validate_input(1)
+    assert "Input parameter Region is the wrong type" in str(exc_info.value)
+
+
+def test_deprecated_parameter_logs(endpoint_provider, caplog):
+    caplog.set_level(logging.INFO)
+    param = endpoint_provider.ruleset.parameters["Region"]
+    param.validate_input("foo")
+    assert "Region has been deprecated." in caplog.text
+
+
+def test_no_endpoint_found_error(endpoint_provider):
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        endpoint_provider.resolve_endpoint(
+            **{"Endpoint": "mygreatendpoint.com", "Bucket": "mybucket"}
+        )
+    assert "No endpoint found for parameters" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "rule_dict,expected_rule_type",
+    [
+        (
+            {
+                "type": "endpoint",
+                "conditions": [],
+                "endpoint": {
+                    "url": (
+                        "https://{Region}.myGreatService."
+                        "{PartitionResult#dualStackDnsSuffix}"
+                    ),
+                    "properties": {},
+                    "headers": {},
+                },
+            },
+            EndpointRule,
+        ),
+        (
+            {
+                "type": "error",
+                "conditions": [],
+                "error": (
+                    "Dualstack is enabled but this partition "
+                    "does not support DualStack"
+                ),
+            },
+            ErrorRule,
+        ),
+        ({"type": "tree", "conditions": [], "rules": []}, TreeRule),
+    ],
+)
+def test_rule_creation(rule_dict, expected_rule_type):
+    rule = RuleCreator.create(**rule_dict)
+    assert isinstance(rule, expected_rule_type)
+
+
+def test_assign_existing_scope_var_raises(standard_library):
+    rule = EndpointRule(
+        conditions=[
+            {
+                'fn': 'aws.parseArn',
+                'argv': ['{Bucket}'],
+                'assign': 'bucketArn',
+            },
+            {
+                'fn': 'aws.parseArn',
+                'argv': ['{Bucket}'],
+                'assign': 'bucketArn',
+            },
+        ],
+        endpoint={'url': 'foo.bar'},
+    )
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        rule.evaluate_conditions(
+            scope_vars={
+                'Bucket': 'arn:aws:s3:us-east-1:123456789012:mybucket'
+            },
+            standard_library=standard_library,
+        )
+    assert str(exc_info.value) == (
+        "Assignment bucketArn already exists in "
+        "scoped variables and cannot be overwritten"
+    )
+
+
+def test_ruleset_unknown_parameter_type_raises(partitions):
+    with pytest.raises(EndpointResolutionError) as exc_info:
+        RuleSet(
+            version='1.0',
+            parameters={
+                'Bucket': {"type": "list"},
+            },
+            rules=[],
+            partitions=partitions,
+        )
+    assert "Unknown parameter type: list." in str(exc_info.value)


### PR DESCRIPTION
This pull request implements a new interface for botocore `EndpointProvider`. As part of the Endpoints 2.0 initiative across the AWS SDK organization, it is responsible for reading a given service's endpoint ruleset and "resolving" aka determining an endpoint to return based on a set of parameters (i.e. region, bucket name etc.). 

This is done through the main API `resolve_endpoint`. It expects input parameters in the form of a dictionary and uses that to create a `Ruleset` object. This object houses the specification for each expected input parameter and rules that the provider will evaluate given those parameters. These rule objects come in three distinct types: `EndpointRule`, `TreeRule` and `ErrorRule`.

These three types of rules share a lot of common behavior. They all have a `conditions` property, which are a list of functions (can be empty but always present). These functions will evaluate to a truthy or falsy value depending on the input parameters given to the provider. All conditions in a rule must be truthy for it to be considered a match. Endpoint and error rules are terminal in that if their conditions are met, the evaluation will immediately be complete and return/raise. A tree rule is different in that it also contains a set of rules which have their own conditions that need to evaluate to a truthy value for it to be a match. However, only one of a tree rule's subordinate rules need to be a match for it itself to still be considered one as well. A tree rule is never terminal and therefore will never be returned to a provider.  If a rule's conditions are not met, the evaluation immediately terminates and proceeds to the next rule if there are any. An error is raised if no match is found.

The `test_endpoint_resolution` test functions run tests for all of the automatically generated test cases. The rest of the tests are handwritten to fill out any code that wasn't covered by the generated ones.