### PR TITLE
Support for context params in service models

### DIFF
--- a/botocore/model.py
+++ b/botocore/model.py
@@ -454,7 +454,7 @@ class ServiceModel:
             )
 
     # Signature version is one of the rare properties
-    # than can be modified so a CachedProperty is not used here.
+    # that can be modified so a CachedProperty is not used here.
 
     @property
     def signature_version(self):

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -85,6 +85,7 @@ class Shape:
         'document',
         'union',
         'contextParam',
+        'clientContextParams',
     ]
     MAP_TYPE = OrderedDict
 
@@ -275,6 +276,10 @@ StaticContextParameter = namedtuple(
 
 ContextParameter = namedtuple('ContextParameter', ['name', 'member_name'])
 
+ClientContextParameter = namedtuple(
+    'ClientContextParameter', ['name', 'type', 'documentation']
+)
+
 
 class ServiceModel:
     """
@@ -427,6 +432,18 @@ class ServiceModel:
             ):
                 return True
         return False
+
+    @CachedProperty
+    def client_context_parameters(self):
+        params = self._service_description.get('clientContextParams', {})
+        return [
+            ClientContextParameter(
+                name=param_name,
+                type=param_val['type'],
+                documentation=param_val['documentation'],
+            )
+            for param_name, param_val in params.items()
+        ]
 
     def _get_metadata_property(self, name):
         try:

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -11,7 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Abstractions to interact with service models."""
-from collections import defaultdict, namedtuple
+from collections import defaultdict
+from typing import NamedTuple, Union
 
 from botocore.compat import OrderedDict
 from botocore.exceptions import (
@@ -269,16 +270,20 @@ class StringShape(Shape):
         return self.metadata.get('enum', [])
 
 
-StaticContextParameter = namedtuple(
-    'StaticContextParameter', ['name', 'value']
-)
+class StaticContextParameter(NamedTuple):
+    name: str
+    value: Union[bool, str]
 
 
-ContextParameter = namedtuple('ContextParameter', ['name', 'member_name'])
+class ContextParameter(NamedTuple):
+    name: str
+    member_name: str
 
-ClientContextParameter = namedtuple(
-    'ClientContextParameter', ['name', 'type', 'documentation']
-)
+
+class ClientContextParameter(NamedTuple):
+    name: str
+    type: str
+    documentation: str
 
 
 class ServiceModel:

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -125,6 +125,43 @@ class TestServiceModel(unittest.TestCase):
         self.assertIn('ExceptionOne', error_shape_names)
         self.assertIn('ExceptionTwo', error_shape_names)
 
+    def test_client_context_params(self):
+        service_model = model.ServiceModel(
+            {
+                'metadata': {
+                    'protocol': 'query',
+                    'endpointPrefix': 'endpoint-prefix',
+                    'serviceId': 'MyServiceWithClientContextParams',
+                },
+                'documentation': 'Documentation value',
+                'operations': {},
+                'shapes': {},
+                'clientContextParams': {
+                    'stringClientContextParam': {
+                        'type': 'string',
+                        'documentation': 'str-valued',
+                    },
+                    'booleanClientContextParam': {
+                        'type': 'boolean',
+                        'documentation': 'bool-valued',
+                    },
+                },
+            }
+        )
+        self.assertEqual(len(service_model.client_context_parameters), 2)
+        client_ctx_param1 = service_model.client_context_parameters[0]
+        client_ctx_param2 = service_model.client_context_parameters[1]
+        self.assertEqual(client_ctx_param1.name, 'stringClientContextParam')
+        self.assertEqual(client_ctx_param1.type, 'string')
+        self.assertEqual(client_ctx_param1.documentation, 'str-valued')
+        self.assertEqual(client_ctx_param2.name, 'booleanClientContextParam')
+
+    def test_client_context_params_absent(self):
+        self.assertIsInstance(
+            self.service_model.client_context_parameters, list
+        )
+        self.assertEqual(len(self.service_model.client_context_parameters), 0)
+
 
 class TestOperationModelFromService(unittest.TestCase):
     def setUp(self):
@@ -185,6 +222,25 @@ class TestOperationModelFromService(unittest.TestCase):
                     'errors': [{'shape': 'NoSuchResourceException'}],
                     'documentation': 'Docs for NoBodyOperation',
                 },
+                'ContextParamOperation': {
+                    'http': {
+                        'method': 'POST',
+                        'requestUri': '/',
+                    },
+                    'name': 'ContextParamOperation',
+                    'input': {'shape': 'ContextParamOperationRequest'},
+                    'output': {'shape': 'OperationNameResponse'},
+                    'errors': [{'shape': 'NoSuchResourceException'}],
+                    'documentation': 'Docs for ContextParamOperation',
+                    'staticContextParams': {
+                        'stringStaticContextParam': {
+                            'value': 'Static Context Param Value',
+                        },
+                        'booleanStaticContextParam': {
+                            'value': True,
+                        },
+                    },
+                },
             },
             'shapes': {
                 'OperationNameRequest': {
@@ -228,6 +284,18 @@ class TestOperationModelFromService(unittest.TestCase):
                             'shape': 'stringType',
                         }
                     },
+                },
+                'ContextParamOperationRequest': {
+                    'type': 'structure',
+                    'members': {
+                        'ContextParamArg': {
+                            'shape': 'stringType',
+                            'contextParam': {
+                                'name': 'contextParamName',
+                            },
+                        }
+                    },
+                    'payload': 'ContextParamArg',
                 },
                 'NoSuchResourceException': {
                     'type': 'structure',
@@ -427,6 +495,37 @@ class TestOperationModelFromService(unittest.TestCase):
             http_checksum["responseAlgorithms"],
             ["crc32", "crc32c", "sha256", "sha1"],
         )
+
+    def test_context_parameter_present(self):
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('ContextParamOperation')
+        self.assertEqual(len(operation.context_parameters), 1)
+        context_param = operation.context_parameters[0]
+        self.assertEqual(context_param.name, 'contextParamName')
+        self.assertEqual(context_param.member_name, 'ContextParamArg')
+
+    def test_context_parameter_absent(self):
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('OperationTwo')
+        self.assertIsInstance(operation.context_parameters, list)
+        self.assertEqual(len(operation.context_parameters), 0)
+
+    def test_static_context_parameter_present(self):
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('ContextParamOperation')
+        self.assertEqual(len(operation.static_context_parameters), 2)
+        static_ctx_param1 = operation.static_context_parameters[0]
+        static_ctx_param2 = operation.static_context_parameters[1]
+        self.assertEqual(static_ctx_param1.name, 'stringStaticContextParam')
+        self.assertEqual(static_ctx_param1.value, 'Static Context Param Value')
+        self.assertEqual(static_ctx_param2.name, 'booleanStaticContextParam')
+        self.assertEqual(static_ctx_param2.value, True)
+
+    def test_static_context_parameter_abent(self):
+        service_model = model.ServiceModel(self.model)
+        operation = service_model.operation_model('OperationTwo')
+        self.assertIsInstance(operation.static_context_parameters, list)
+        self.assertEqual(len(operation.static_context_parameters), 0)
 
 
 class TestOperationModelEventStreamTypes(unittest.TestCase):


### PR DESCRIPTION
Service model files (`/botocore/data/*/*/service-2.json`) will soon contain information about three types of "context params": 

1. static context parameters, optional for each operation
2. (dynamic) context parameters, optional for each operation
3. client context parameters, optional for each service

This PR adds properties for accessing context parameters information in the `ServiceModel` class.