### PR TITLE
Generalize set_operation_specific_signer to recognize "s3v4a" case

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -59,7 +59,6 @@ from botocore.signers import (
 from botocore.utils import (
     SAFE_CHARS,
     conditionally_calculate_md5,
-    is_global_accesspoint,
     percent_encode,
     switch_host_with_param,
 )
@@ -70,6 +69,7 @@ from botocore import translate  # noqa
 from botocore.compat import MD5_AVAILABLE  # noqa
 from botocore.exceptions import MissingServiceIdError  # noqa
 from botocore.utils import hyphenize_service_id  # noqa
+from botocore.utils import is_global_accesspoint  # noqa
 
 
 logger = logging.getLogger(__name__)
@@ -194,28 +194,27 @@ def set_operation_specific_signer(context, signing_name, **kwargs):
     if auth_type == 'none':
         return botocore.UNSIGNED
 
-    if auth_type == 'v4a':
-        # If sigv4a is chosen, we must add additional
-        # signing config for global signature.
-        signing = {'region': '*', 'signing_name': signing_name}
-        if 'signing' in context:
-            context['signing'].update(signing)
-        else:
-            context['signing'] = signing
-        return 'v4a'
-
     if auth_type.startswith('v4'):
-        signature_version = 'v4'
-        if signing_name == 's3':
-            if is_global_accesspoint(context):
-                signature_version = 's3v4a'
+        if auth_type == 'v4a':
+            # If sigv4a is chosen, we must add additional signing config for
+            # global signature.
+            signing = {'region': '*', 'signing_name': signing_name}
+            if 'signing' in context:
+                context['signing'].update(signing)
             else:
-                signature_version = 's3v4'
+                context['signing'] = signing
+            signature_version = 'v4a'
+        else:
+            signature_version = 'v4'
 
         # If the operation needs an unsigned body, we set additional context
         # allowing the signer to be aware of this.
         if auth_type == 'v4-unsigned-body':
             context['payload_signing_enabled'] = False
+
+        # S3 has customized signers "s3v4" and "s3v4a"
+        if signing_name == 's3':
+            signature_version = f's3{signature_version}'
 
         return signature_version
 

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1017,6 +1017,34 @@ class TestHandlers(BaseSessionTest):
         )
         self.assertEqual(response, 'v4')
 
+    def test_set_operation_specific_signer_v4a(self):
+        signing_name = 'myservice'
+        context = {'auth_type': 'v4a'}
+        response = handlers.set_operation_specific_signer(
+            context=context, signing_name=signing_name
+        )
+        self.assertEqual(response, 'v4a')
+        # for v4a, context gets updated in place
+        self.assertIsNotNone(context.get('signing'))
+        self.assertEqual(context['signing']['region'], '*')
+        self.assertEqual(context['signing']['signing_name'], signing_name)
+
+    def test_set_operation_specific_signer_v4a_existing_signing_context(self):
+        signing_name = 'myservice'
+        context = {
+            'auth_type': 'v4a',
+            'signing': {'foo': 'bar', 'region': 'abc'},
+        }
+        handlers.set_operation_specific_signer(
+            context=context, signing_name=signing_name
+        )
+        # region has been updated
+        self.assertEqual(context['signing']['region'], '*')
+        # signing_name has been added
+        self.assertEqual(context['signing']['signing_name'], signing_name)
+        # foo remained untouched
+        self.assertEqual(context['signing']['foo'], 'bar')
+
     def test_set_operation_specific_signer_v4_unsinged_payload(self):
         signing_name = 'myservice'
         context = {'auth_type': 'v4-unsigned-body'}

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1017,14 +1017,6 @@ class TestHandlers(BaseSessionTest):
         )
         self.assertEqual(response, 'v4')
 
-    def test_set_operation_specific_signer_s3v4(self):
-        signing_name = 's3'
-        context = {'auth_type': 'v4'}
-        response = handlers.set_operation_specific_signer(
-            context=context, signing_name=signing_name
-        )
-        self.assertEqual(response, 's3v4')
-
     def test_set_operation_specific_signer_v4_unsinged_payload(self):
         signing_name = 'myservice'
         context = {'auth_type': 'v4-unsigned-body'}
@@ -1042,6 +1034,18 @@ class TestHandlers(BaseSessionTest):
         )
         self.assertEqual(response, 's3v4')
         self.assertEqual(context.get('payload_signing_enabled'), False)
+
+
+@pytest.mark.parametrize(
+    'auth_type, expected_response', [('v4', 's3v4'), ('v4a', 's3v4a')]
+)
+def test_set_operation_specific_signer_s3v4(auth_type, expected_response):
+    signing_name = 's3'
+    context = {'auth_type': auth_type}
+    response = handlers.set_operation_specific_signer(
+        context=context, signing_name=signing_name
+    )
+    assert response == expected_response
 
 
 class TestConvertStringBodyToFileLikeObject(BaseSessionTest):


### PR DESCRIPTION
Refactors the `set_operation_specific_signer` event handler to work independently of other S3-specific event handlers. This is in preparation for future changes to S3-specific logic. 

After this change, when the function is called with `signing_name == 's3'` and `auth_type='v4a'`, it will now return `s3v4a` instead of previously `v4a`. This does not change any current behavior because the function is never called with this combination of values (see below for why).

Context: The function `set_operation_specific_signer` usually gets called when a `choose-signer.*` event is emitted. However, it currently does _not_ get called for the `choose-signer.s3.GetObjectAttributes` event when a global access point is used because the handler `S3EndpointSetter.set_signer` [is subscribed to the same event](https://github.com/boto/botocore/blob/2a672d6753af1c59b83f2d783a28c4c59b07dfd1/botocore/utils.py#L1802) and [returns a value first](https://github.com/boto/botocore/blob/f4ed130b78076fb5683e4384c7df007e82dda71d/botocore/utils.py#L1978). This is also the reason why the `if is_global_accesspoint` branch can be removed from the function.

Separately, a new unit test is added to add test coverage for the scenario where the `context['signing']` is already set. 
