### PR TITLE
Add readinto to StreamingBody

### DIFF
--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -243,6 +243,17 @@ class StreamingChecksumBody(StreamingBody):
             self._validate_checksum()
         return chunk
 
+    def readinto(self, b):
+        amount_read = super().readinto(b)
+        if amount_read == len(b):
+            view = b
+        else:
+            view = memoryview(b)[:amount_read]
+        self._checksum.update(view)
+        if amount_read == 0 and len(b) > 0:
+            self._validate_checksum()
+        return amount_read
+
     def _validate_checksum(self):
         if self._checksum.digest() != base64.b64decode(self._expected):
             error_msg = (


### PR DESCRIPTION
This adds a readinto implementation to StreamingBody, following the
contract outlined in the Python io package.

The primary motivation for this is that it allows consumers to wrap the
StreamingBody in an io.BufferedReader. This provides a nice performance
boost for parsing streaming binary data formats, where you want to be
able to read small numbers of bytes in your parsing algorithm, but
benefit from reading large chunks of data from upstream.