### PR TITLE
Loader utilities for determining source of loaded data

### DIFF
--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -488,9 +488,9 @@ class Loader:
                         yield full_path
 
     def is_builtin_path(self, path):
-        """Whether a given path is within the package's data directory
+        """Whether a given path is within the package's data directory.
 
-        This method can be used together with load_data(name, include_path=True)
+        This method can be used together with load_data_with_path(name)
         to determine if data has been loaded from a file bundled with the
         package, as opposed to a file in a separate location.
 
@@ -498,7 +498,6 @@ class Loader:
         :param path: The file path to check.
 
         :return: Whether the given path is within the package's data directory.
-
         """
         # normalize the path and resolve symlinks
         path = os.path.realpath(os.path.abspath(path))

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -496,8 +496,8 @@ class Loader:
         :return: Whether the given path is within the package's data directory.
 
         """
-        # normalize and absolutize the path, self.BUILTIN_DATA_PATH already is
-        path = os.path.realpath(path)
+        # normalize the path and resolve symlinks
+        path = os.path.realpath(os.path.abspath(path))
         return path.startswith(self.BUILTIN_DATA_PATH)
 
 

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -98,7 +98,7 @@ class EndpointResolver(BaseEndpointResolver):
 
     def __init__(self, endpoint_data, uses_builtin_data=False):
         """
-        :type path: dict
+        :type endpoint_data: dict
         :param endpoint_data: A dict of partition data.
 
         :type uses_builtin_data: boolean

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -96,13 +96,19 @@ class EndpointResolver(BaseEndpointResolver):
 
     _UNSUPPORTED_DUALSTACK_PARTITIONS = ['aws-iso', 'aws-iso-b']
 
-    def __init__(self, endpoint_data):
+    def __init__(self, endpoint_data, uses_builtin_data=False):
         """
+        :type path: dict
         :param endpoint_data: A dict of partition data.
+
+        :type uses_builtin_data: boolean
+        :param uses_builtin_data: Whether the endpoint data originates in the
+            package's data directory.
         """
         if 'partitions' not in endpoint_data:
             raise ValueError('Missing "partitions" in endpoint data')
         self._endpoint_data = endpoint_data
+        self.uses_builtin_data = uses_builtin_data
 
     def get_service_endpoints_data(self, service_name, partition_name='aws'):
         for partition in self._endpoint_data['partitions']:

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -197,8 +197,8 @@ class Session:
         def create_default_resolver():
             loader = self.get_component('data_loader')
             endpoints, path = loader.load_data('endpoints', return_path=True)
-            builtin = loader.is_builtin_path(path)
-            return EndpointResolver(endpoints, uses_builtin_data=builtin)
+            uses_builtin = loader.is_builtin_path(path)
+            return EndpointResolver(endpoints, uses_builtin_data=uses_builtin)
 
         self._internal_components.lazy_register_component(
             'endpoint_resolver', create_default_resolver

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -196,8 +196,9 @@ class Session:
     def _register_endpoint_resolver(self):
         def create_default_resolver():
             loader = self.get_component('data_loader')
-            endpoints = loader.load_data('endpoints')
-            return EndpointResolver(endpoints)
+            endpoints, path = loader.load_data('endpoints', return_path=True)
+            builtin = loader.is_builtin_path(path)
+            return EndpointResolver(endpoints, uses_builtin_data=builtin)
 
         self._internal_components.lazy_register_component(
             'endpoint_resolver', create_default_resolver

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -196,7 +196,7 @@ class Session:
     def _register_endpoint_resolver(self):
         def create_default_resolver():
             loader = self.get_component('data_loader')
-            endpoints, path = loader.load_data('endpoints', return_path=True)
+            endpoints, path = loader.load_data_with_path('endpoints')
             uses_builtin = loader.is_builtin_path(path)
             return EndpointResolver(endpoints, uses_builtin_data=uses_builtin)
 

--- a/tests/functional/test_regions.py
+++ b/tests/functional/test_regions.py
@@ -546,3 +546,17 @@ class TestEndpointResolution(BaseSessionTest):
         self.assertTrue(
             stubber.requests[0].url.startswith('https://iam.amazonaws.com/')
         )
+
+
+@pytest.mark.parametrize("is_builtin", [(True,), (False,)])
+def test_endpoint_resolver_knows_its_datasource(is_builtin):
+    # The information whether or not the endpoints.json file was loaded from
+    # the builtin data directory or not should be passed from Loader to
+    # EndpointResolver.
+    session = _get_patched_session()
+    loader = session.get_component('data_loader')
+    with mock.patch.object(
+        loader, 'is_builtin_path', mock.Mock(return_value=is_builtin)
+    ):
+        resolver = session._get_internal_component('endpoint_resolver')
+        assert resolver.uses_builtin_data == is_builtin

--- a/tests/functional/test_regions.py
+++ b/tests/functional/test_regions.py
@@ -548,7 +548,7 @@ class TestEndpointResolution(BaseSessionTest):
         )
 
 
-@pytest.mark.parametrize("is_builtin", [(True,), (False,)])
+@pytest.mark.parametrize("is_builtin", [True, False])
 def test_endpoint_resolver_knows_its_datasource(is_builtin):
     # The information whether or not the endpoints.json file was loaded from
     # the builtin data directory or not should be passed from Loader to

--- a/tests/functional/test_regions.py
+++ b/tests/functional/test_regions.py
@@ -555,8 +555,6 @@ def test_endpoint_resolver_knows_its_datasource(is_builtin):
     # EndpointResolver.
     session = _get_patched_session()
     loader = session.get_component('data_loader')
-    with mock.patch.object(
-        loader, 'is_builtin_path', mock.Mock(return_value=is_builtin)
-    ):
+    with mock.patch.object(loader, 'is_builtin_path', return_value=is_builtin):
         resolver = session._get_internal_component('endpoint_resolver')
         assert resolver.uses_builtin_data == is_builtin

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -22,7 +22,10 @@
 import contextlib
 import copy
 import os
+import sys
 import tempfile
+
+import pytest
 
 from botocore.exceptions import DataNotFoundError, UnknownServiceError
 from botocore.loaders import (
@@ -244,6 +247,12 @@ class TestLoader(BaseEnvVar):
         self.assertTrue(loader.is_builtin_path(path_in_builtins))
         self.assertFalse(loader.is_builtin_path(path_elsewhere))
 
+    @pytest.mark.skipif(
+        sys.platform == 'win32',
+        reason=(
+            'os.symlink() requires developer mode or elevated permissions'
+        ),
+    )
     def test_is_builtin_path_with_symlink(self):
         loader = Loader()
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -254,7 +263,7 @@ class TestLoader(BaseEnvVar):
                 target_is_directory=True,
             )
             path_in_builtins = os.path.join(link_to_builtins, "foo.txt")
-            self.assertTrue(loader.is_builtin_path(path_in_builtins))
+            assert loader.is_builtin_path(path_in_builtins)
 
 
 class TestMergeExtras(BaseEnvVar):

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -22,6 +22,7 @@
 import contextlib
 import copy
 import os
+import tempfile
 
 from botocore.exceptions import DataNotFoundError, UnknownServiceError
 from botocore.loaders import (
@@ -128,6 +129,23 @@ class TestLoader(BaseEnvVar):
         loaded = loader.load_data('baz')
         self.assertEqual(loaded, ['loaded data'])
 
+    @mock.patch('os.path.isdir', mock.Mock(return_value=True))
+    def test_load_data_optionally_returns_path(self):
+        search_paths = ['foo', 'bar', 'baz']
+
+        class FakeLoader:
+            def load_file(self, name):
+                expected_ending = os.path.join('bar', 'abc')
+                if name.endswith(expected_ending):
+                    return ['loaded data']
+
+        loader = Loader(
+            extra_search_paths=search_paths, file_loader=FakeLoader()
+        )
+        loaded, path = loader.load_data('abc', return_path=True)
+        self.assertEqual(loaded, ['loaded data'])
+        self.assertEqual(path, os.path.join('bar', 'abc'))
+
     def test_data_not_found_raises_exception(self):
         class FakeLoader:
             def load_file(self, name):
@@ -138,6 +156,15 @@ class TestLoader(BaseEnvVar):
         loader = Loader(file_loader=FakeLoader())
         with self.assertRaises(DataNotFoundError):
             loader.load_data('baz')
+
+    def test_asking_for_path_doesnt_break_notfound_exception(self):
+        class FakeLoader:
+            def load_file(self, name):
+                return None
+
+        loader = Loader(file_loader=FakeLoader())
+        with self.assertRaises(DataNotFoundError):
+            loader.load_data('baz', return_path=True)
 
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
     def test_error_raised_if_service_does_not_exist(self):
@@ -209,6 +236,25 @@ class TestLoader(BaseEnvVar):
         self.assertIn('foo', loader.search_paths)
         self.assertIn('bar', loader.search_paths)
         self.assertIn('baz', loader.search_paths)
+
+    def test_is_builtin_path(self):
+        loader = Loader()
+        path_in_builtins = os.path.join(loader.BUILTIN_DATA_PATH, "foo.txt")
+        path_elsewhere = __file__
+        self.assertTrue(loader.is_builtin_path(path_in_builtins))
+        self.assertFalse(loader.is_builtin_path(path_elsewhere))
+
+    def test_is_builtin_path_with_symlink(self):
+        loader = Loader()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            link_to_builtins = os.path.join(tmp_dir, 'builtins')
+            os.symlink(
+                loader.BUILTIN_DATA_PATH,
+                link_to_builtins,
+                target_is_directory=True,
+            )
+            path_in_builtins = os.path.join(link_to_builtins, "foo.txt")
+            self.assertTrue(loader.is_builtin_path(path_in_builtins))
 
 
 class TestMergeExtras(BaseEnvVar):

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -133,7 +133,7 @@ class TestLoader(BaseEnvVar):
         self.assertEqual(loaded, ['loaded data'])
 
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
-    def test_load_data_optionally_returns_path(self):
+    def test_load_data_with_path(self):
         search_paths = ['foo', 'bar', 'baz']
 
         class FakeLoader:
@@ -145,7 +145,7 @@ class TestLoader(BaseEnvVar):
         loader = Loader(
             extra_search_paths=search_paths, file_loader=FakeLoader()
         )
-        loaded, path = loader.load_data('abc', return_path=True)
+        loaded, path = loader.load_data_with_path('abc')
         self.assertEqual(loaded, ['loaded data'])
         self.assertEqual(path, os.path.join('bar', 'abc'))
 
@@ -160,14 +160,14 @@ class TestLoader(BaseEnvVar):
         with self.assertRaises(DataNotFoundError):
             loader.load_data('baz')
 
-    def test_asking_for_path_doesnt_break_notfound_exception(self):
+    def test_data_not_found_raises_exception_load_data_with_path(self):
         class FakeLoader:
             def load_file(self, name):
                 return None
 
         loader = Loader(file_loader=FakeLoader())
         with self.assertRaises(DataNotFoundError):
-            loader.load_data('baz', return_path=True)
+            loader.load_data_with_path('baz')
 
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
     def test_error_raised_if_service_does_not_exist(self):


### PR DESCRIPTION
Adds utilities to the `Loader` class to determine whether a file originates from within botocore's builtin data directory or not:
 * `load_data()` now accepts an optional argument `return_path`. If set to true, the path where the data is loaded from is returned as second return value
 * a new `is_builtin_path()` method that checks whether a given path is within the builtin data directory or not

Adds a new property `uses_builtin_data` to the `EndpointResolver` class. This property is set during component initialization using the helper methods from the `Loader` described above.