### PR TITLE
Added retries to delete_objects; Removed redundant deletions

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -104,7 +104,7 @@ def clear_out_bucket(bucket, region, delete_bucket=False):
                     exists_waiter.wait(Bucket=bucket)
                 except WaiterError:
                     continue
-    
+
     if delete_bucket:
         for _ in range(5):
             try:


### PR DESCRIPTION
Removed redundant calls to `delete_object` which should be taken care of by the clean up provided by the `teardown_module` method. Added retries for `delete_objects` to handle rare cases of failure. 