### PR TITLE
Don't raise warning if common name and hostname are the same

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -617,7 +617,11 @@ class ClientEndpointBridge:
             is_disabled = ensure_boolean(
                 os.environ.get('BOTO_DISABLE_COMMONNAME', False)
             )
-            if not is_disabled and sslCommonName is not None:
+            if (
+                not is_disabled
+                and sslCommonName is not None
+                and sslCommonName != hostname
+            ):
                 warnings.warn(
                     f'The {service_name} client is currently using a '
                     f'deprecated endpoint: {sslCommonName}. In the next '


### PR DESCRIPTION
There are some SSL common names that are identical to the hostname, which was raised in https://github.com/boto/botocore/issues/2705#issuecomment-1236390963. This will suppress warnings where this is true.