### PR TITLE
Remove symlink resolution in Loader.is_builtin_path

### DIFF
--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -460,7 +460,7 @@ class Loader:
         only needed to load *non* model files (such as _endpoints and
         _retry).  If you need to load model files, you should prefer
         ``load_service_model``.  Use ``load_data_with_path`` to get the
-        file system path of the data file as second return value.
+        data path of the data file as second return value.
 
         :type name: str
         :param name: The data path, i.e ``ec2/2015-03-01/service-2``.
@@ -499,8 +499,7 @@ class Loader:
 
         :return: Whether the given path is within the package's data directory.
         """
-        # normalize the path and resolve symlinks
-        path = os.path.realpath(os.path.abspath(path))
+        path = os.path.expanduser(os.path.expandvars(path))
         return path.startswith(self.BUILTIN_DATA_PATH)
 
 

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -22,10 +22,6 @@
 import contextlib
 import copy
 import os
-import sys
-import tempfile
-
-import pytest
 
 from botocore.exceptions import DataNotFoundError, UnknownServiceError
 from botocore.loaders import (
@@ -246,24 +242,6 @@ class TestLoader(BaseEnvVar):
         path_elsewhere = __file__
         self.assertTrue(loader.is_builtin_path(path_in_builtins))
         self.assertFalse(loader.is_builtin_path(path_elsewhere))
-
-    @pytest.mark.skipif(
-        sys.platform == 'win32',
-        reason=(
-            'os.symlink() requires developer mode or elevated permissions'
-        ),
-    )
-    def test_is_builtin_path_with_symlink(self):
-        loader = Loader()
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            link_to_builtins = os.path.join(tmp_dir, 'builtins')
-            os.symlink(
-                loader.BUILTIN_DATA_PATH,
-                link_to_builtins,
-                target_is_directory=True,
-            )
-            path_in_builtins = os.path.join(link_to_builtins, "foo.txt")
-            assert loader.is_builtin_path(path_in_builtins)
 
 
 class TestMergeExtras(BaseEnvVar):


### PR DESCRIPTION
Followup to https://github.com/boto/botocore/pull/2751: This removes the call to `os.path.realpath()` and the corresponding test coverage related to symlinks.

Reasoning for this reversal at the last minute before releasing the #2751 PR:

Because the `Loader` class never sees the _filesystem_ path of the data file, only the _data_ path (which excludes the file extension), the call to `os.path.realpath()` in #2751 would have never resolved a symlink. Even if working correctly, this symlink resolution would only have taken effect for users who have a symlink in their data directory (`~/.aws/models`) pointing back to the botocore package's builtin file. After considering the benefit of covering this unlikely edge case and the effort involved in making the _filesystem_ path available to the `Loader` class, the decision is to remove symlink resolution from `is_builtin_path`.