### PR TITLE
Endpoint resolution v2: builtin parameter values

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -468,7 +468,7 @@ class ClientArgsCreator:
         else:
             return val.lower() == 'true'
 
-    def _compute_endpoint_resolver_v2_builtin_defaults(
+    def compute_endpoint_resolver_builtin_defaults(
         self,
         region_name,
         service_name,

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -496,9 +496,11 @@ class ClientArgsCreator:
                 endpoint_bridge._resolve_endpoint_variant_config_var(
                     'use_fips_endpoint'
                 )
+                or False
             ),
             EPRBuiltins.AWS_USE_DUALSTACK: (
                 endpoint_bridge._resolve_use_dualstack_endpoint(service_name)
+                or False
             ),
             EPRBuiltins.AWS_STS_USE_GLOBAL_ENDPOINT: (
                 self._should_set_global_sts_endpoint(

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -26,6 +26,7 @@ import botocore.serialize
 import botocore.utils
 from botocore.config import Config
 from botocore.endpoint import EndpointCreator
+from botocore.regions import EndpointResolverBuiltins as EPRBuiltins
 from botocore.signers import RequestSigner
 
 logger = logging.getLogger(__name__)
@@ -344,8 +345,9 @@ class ClientArgsCreator:
     def _should_set_global_sts_endpoint(
         self, region_name, endpoint_url, endpoint_config
     ):
-        endpoint_variant_tags = endpoint_config['metadata'].get('tags')
-        if endpoint_url or endpoint_variant_tags:
+        if endpoint_url:
+            return False
+        if endpoint_config and endpoint_config.get('metadata', {}).get('tags'):
             return False
         return (
             self._get_sts_regional_endpoints_config() == 'legacy'
@@ -464,3 +466,63 @@ class ClientArgsCreator:
             return val
         else:
             return val.lower() == 'true'
+
+    def _compute_endpoint_resolver_v2_builtin_defaults(
+        self,
+        region_name,
+        service_name,
+        s3_config,
+        endpoint_bridge,
+        client_endpoint_url,
+        legacy_endpoint_url,
+    ):
+        # EndpointResolverv2 rulesets may accept an "SDK::Endpoint" as input.
+        # If the endpoint_url argument of create_client() is set, it always
+        # takes priority.
+        if client_endpoint_url:
+            given_endpoint = client_endpoint_url
+        # If an endpoints.json data file other than the one bundled within
+        # the botocore/data directory is used, the output of legacy
+        # endpoint resolution is provided to EndpointResolverv2.
+        elif not endpoint_bridge.endpoint_resolver.uses_builtin_data:
+            given_endpoint = legacy_endpoint_url
+        else:
+            given_endpoint = None
+
+        return {
+            EPRBuiltins.AWS_REGION: region_name,
+            EPRBuiltins.AWS_USE_FIPS: (
+                endpoint_bridge._resolve_endpoint_variant_config_var(
+                    'use_fips_endpoint'
+                )
+            ),
+            EPRBuiltins.AWS_USE_DUALSTACK: (
+                endpoint_bridge._resolve_use_dualstack_endpoint(service_name)
+            ),
+            EPRBuiltins.AWS_STS_USE_GLOBAL_ENDPOINT: (
+                self._should_set_global_sts_endpoint(
+                    region_name=region_name,
+                    endpoint_url=None,
+                    endpoint_config=None,
+                )
+            ),
+            EPRBuiltins.AWS_S3_USE_GLOBAL_ENDPOINT: (
+                self._should_force_s3_global(region_name, s3_config)
+            ),
+            EPRBuiltins.AWS_S3_ACCELERATE: s3_config.get(
+                'use_accelerate_endpoint', False
+            ),
+            EPRBuiltins.AWS_S3_FORCE_PATH_STYLE: (
+                s3_config.get('addressing_style') == 'path'
+            ),
+            EPRBuiltins.AWS_S3_USE_ARN_REGION: s3_config.get(
+                'use_arn_region', True
+            ),
+            EPRBuiltins.AWS_S3CONTROL_USE_ARN_REGION: s3_config.get(
+                'use_arn_region', False
+            ),
+            EPRBuiltins.AWS_S3_DISABLE_MRAP: s3_config.get(
+                's3_disable_multiregion_access_points', False
+            ),
+            EPRBuiltins.SDK_ENDPOINT: given_endpoint,
+        }

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -497,10 +497,12 @@ class ClientArgsCreator:
                     'use_fips_endpoint'
                 )
                 or False
+                and not given_endpoint
             ),
             EPRBuiltins.AWS_USE_DUALSTACK: (
                 endpoint_bridge._resolve_use_dualstack_endpoint(service_name)
                 or False
+                and not given_endpoint
             ),
             EPRBuiltins.AWS_STS_USE_GLOBAL_ENDPOINT: (
                 self._should_set_global_sts_endpoint(

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -345,9 +345,10 @@ class ClientArgsCreator:
     def _should_set_global_sts_endpoint(
         self, region_name, endpoint_url, endpoint_config
     ):
-        if endpoint_url:
-            return False
-        if endpoint_config and endpoint_config.get('metadata', {}).get('tags'):
+        has_variant_tags = endpoint_config and endpoint_config.get(
+            'metadata', {}
+        ).get('tags')
+        if endpoint_url or has_variant_tags:
             return False
         return (
             self._get_sts_regional_endpoints_config() == 'legacy'

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -18,6 +18,7 @@ in a specific AWS partition.
 """
 import logging
 import re
+from enum import Enum
 
 from botocore.exceptions import (
     EndpointVariantError,
@@ -401,3 +402,34 @@ class EndpointResolver(BaseEndpointResolver):
         return template.format(
             service=service_name, region=endpoint_name, dnsSuffix=dnsSuffix
         )
+
+
+class EndpointResolverBuiltins(str, Enum):
+    # The AWS Region configured for the SDK client (str)
+    AWS_REGION = "AWS::Region"
+    # Whether the UseFIPSEndpoint configuration option has been enabled for the
+    # SDK client (bool)
+    AWS_USE_FIPS = "AWS::UseFIPS"
+    # Whether the UseDualStackEndpoint configuration option has been enabled for
+    # the SDK client (bool)
+    AWS_USE_DUALSTACK = "AWS::UseDualStack"
+    # Whether the global endpoint should be used, rather the the regional
+    # endpoint for us-east-1 (bool)
+    AWS_STS_USE_GLOBAL_ENDPOINT = "AWS::STS::UseGlobalEndpoint"
+    # Whether the global endpoint should be used, rather then the regional
+    # endpoint for us-east-1 (bool)
+    AWS_S3_USE_GLOBAL_ENDPOINT = "AWS::S3::UseGlobalEndpoint"
+    # Whether S3 Transfer Acceleration has been requested (bool)
+    AWS_S3_ACCELERATE = "AWS::S3::Accelerate"
+    # Whether S3 Force Path Style has been enabled  (bool)
+    AWS_S3_FORCE_PATH_STYLE = "AWS::S3::ForcePathStyle"
+    # Whether to use the ARN region or raise an error when ARN and client
+    # region differ (for s3 service only)
+    AWS_S3_USE_ARN_REGION = "AWS::S3::UseArnRegion"
+    # Whether to use the ARN region or raise an error when ARN and client
+    # region differ (for s3-control service only).
+    AWS_S3CONTROL_USE_ARN_REGION = 'AWS::S3Control::UseArnRegion'
+    # Whether multi-region access points (MRAP) should be disabled.
+    AWS_S3_DISABLE_MRAP = "AWS::S3::DisableMultiRegionAccessPoints"
+    # Whether a custom endpoint has been configured (string)
+    SDK_ENDPOINT = "SDK::Endpoint"

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -405,31 +405,31 @@ class EndpointResolver(BaseEndpointResolver):
 
 
 class EndpointResolverBuiltins(str, Enum):
-    # The AWS Region configured for the SDK client
-    AWS_REGION: str = "AWS::Region"
+    # The AWS Region configured for the SDK client (str)
+    AWS_REGION = "AWS::Region"
     # Whether the UseFIPSEndpoint configuration option has been enabled for
-    # the SDK client
-    AWS_USE_FIPS: bool = "AWS::UseFIPS"
+    # the SDK client (bool)
+    AWS_USE_FIPS = "AWS::UseFIPS"
     # Whether the UseDualStackEndpoint configuration option has been enabled
-    # for the SDK client
-    AWS_USE_DUALSTACK: bool = "AWS::UseDualStack"
+    # for the SDK client (bool)
+    AWS_USE_DUALSTACK = "AWS::UseDualStack"
     # Whether the global endpoint should be used with STS, rather the the
-    # regional endpoint for us-east-1
-    AWS_STS_USE_GLOBAL_ENDPOINT: bool = "AWS::STS::UseGlobalEndpoint"
+    # regional endpoint for us-east-1 (bool)
+    AWS_STS_USE_GLOBAL_ENDPOINT = "AWS::STS::UseGlobalEndpoint"
     # Whether the global endpoint should be used with S3, rather then the
-    # regional endpoint for us-east-1
-    AWS_S3_USE_GLOBAL_ENDPOINT: bool = "AWS::S3::UseGlobalEndpoint"
-    # Whether S3 Transfer Acceleration has been requested
-    AWS_S3_ACCELERATE: bool = "AWS::S3::Accelerate"
-    # Whether S3 Force Path Style has been enabled
-    AWS_S3_FORCE_PATH_STYLE: bool = "AWS::S3::ForcePathStyle"
+    # regional endpoint for us-east-1 (bool)
+    AWS_S3_USE_GLOBAL_ENDPOINT = "AWS::S3::UseGlobalEndpoint"
+    # Whether S3 Transfer Acceleration has been requested (bool)
+    AWS_S3_ACCELERATE = "AWS::S3::Accelerate"
+    # Whether S3 Force Path Style has been enabled (bool)
+    AWS_S3_FORCE_PATH_STYLE = "AWS::S3::ForcePathStyle"
     # Whether to use the ARN region or raise an error when ARN and client
-    # region differ (for s3 service only)
-    AWS_S3_USE_ARN_REGION: bool = "AWS::S3::UseArnRegion"
+    # region differ (for s3 service only, bool)
+    AWS_S3_USE_ARN_REGION = "AWS::S3::UseArnRegion"
     # Whether to use the ARN region or raise an error when ARN and client
-    # region differ (for s3-control service only)
-    AWS_S3CONTROL_USE_ARN_REGION: bool = 'AWS::S3Control::UseArnRegion'
-    # Whether multi-region access points (MRAP) should be disabled.
-    AWS_S3_DISABLE_MRAP: bool = "AWS::S3::DisableMultiRegionAccessPoints"
-    # Whether a custom endpoint has been configured
-    SDK_ENDPOINT: str = "SDK::Endpoint"
+    # region differ (for s3-control service only, bool)
+    AWS_S3CONTROL_USE_ARN_REGION = 'AWS::S3Control::UseArnRegion'
+    # Whether multi-region access points (MRAP) should be disabled (bool)
+    AWS_S3_DISABLE_MRAP = "AWS::S3::DisableMultiRegionAccessPoints"
+    # Whether a custom endpoint has been configured (str)
+    SDK_ENDPOINT = "SDK::Endpoint"

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -405,31 +405,31 @@ class EndpointResolver(BaseEndpointResolver):
 
 
 class EndpointResolverBuiltins(str, Enum):
-    # The AWS Region configured for the SDK client (str)
-    AWS_REGION = "AWS::Region"
-    # Whether the UseFIPSEndpoint configuration option has been enabled for the
-    # SDK client (bool)
-    AWS_USE_FIPS = "AWS::UseFIPS"
-    # Whether the UseDualStackEndpoint configuration option has been enabled for
-    # the SDK client (bool)
-    AWS_USE_DUALSTACK = "AWS::UseDualStack"
-    # Whether the global endpoint should be used, rather the the regional
-    # endpoint for us-east-1 (bool)
-    AWS_STS_USE_GLOBAL_ENDPOINT = "AWS::STS::UseGlobalEndpoint"
-    # Whether the global endpoint should be used, rather then the regional
-    # endpoint for us-east-1 (bool)
-    AWS_S3_USE_GLOBAL_ENDPOINT = "AWS::S3::UseGlobalEndpoint"
-    # Whether S3 Transfer Acceleration has been requested (bool)
-    AWS_S3_ACCELERATE = "AWS::S3::Accelerate"
-    # Whether S3 Force Path Style has been enabled  (bool)
-    AWS_S3_FORCE_PATH_STYLE = "AWS::S3::ForcePathStyle"
+    # The AWS Region configured for the SDK client
+    AWS_REGION: str = "AWS::Region"
+    # Whether the UseFIPSEndpoint configuration option has been enabled for
+    # the SDK client
+    AWS_USE_FIPS: bool = "AWS::UseFIPS"
+    # Whether the UseDualStackEndpoint configuration option has been enabled
+    # for the SDK client
+    AWS_USE_DUALSTACK: bool = "AWS::UseDualStack"
+    # Whether the global endpoint should be used with STS, rather the the
+    # regional endpoint for us-east-1
+    AWS_STS_USE_GLOBAL_ENDPOINT: bool = "AWS::STS::UseGlobalEndpoint"
+    # Whether the global endpoint should be used with S3, rather then the
+    # regional endpoint for us-east-1
+    AWS_S3_USE_GLOBAL_ENDPOINT: bool = "AWS::S3::UseGlobalEndpoint"
+    # Whether S3 Transfer Acceleration has been requested
+    AWS_S3_ACCELERATE: bool = "AWS::S3::Accelerate"
+    # Whether S3 Force Path Style has been enabled
+    AWS_S3_FORCE_PATH_STYLE: bool = "AWS::S3::ForcePathStyle"
     # Whether to use the ARN region or raise an error when ARN and client
     # region differ (for s3 service only)
-    AWS_S3_USE_ARN_REGION = "AWS::S3::UseArnRegion"
+    AWS_S3_USE_ARN_REGION: bool = "AWS::S3::UseArnRegion"
     # Whether to use the ARN region or raise an error when ARN and client
-    # region differ (for s3-control service only).
-    AWS_S3CONTROL_USE_ARN_REGION = 'AWS::S3Control::UseArnRegion'
+    # region differ (for s3-control service only)
+    AWS_S3CONTROL_USE_ARN_REGION: bool = 'AWS::S3Control::UseArnRegion'
     # Whether multi-region access points (MRAP) should be disabled.
-    AWS_S3_DISABLE_MRAP = "AWS::S3::DisableMultiRegionAccessPoints"
-    # Whether a custom endpoint has been configured (string)
-    SDK_ENDPOINT = "SDK::Endpoint"
+    AWS_S3_DISABLE_MRAP: bool = "AWS::S3::DisableMultiRegionAccessPoints"
+    # Whether a custom endpoint has been configured
+    SDK_ENDPOINT: str = "SDK::Endpoint"

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -498,7 +498,7 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             'legacy_endpoint_url': 'https://my.legacy.endpoint.com',
         }
         kwargs = {**defaults, **overrides}
-        return self.args_create._compute_endpoint_resolver_v2_builtin_defaults(
+        return self.args_create.compute_endpoint_resolver_builtin_defaults(
             **kwargs
         )
 

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -13,7 +13,6 @@
 # language governing permissions and limitations under the License.
 import socket
 
-import botocore.config
 from botocore import args, exceptions
 from botocore.client import ClientEndpointBridge
 from botocore.config import Config
@@ -131,7 +130,7 @@ class TestCreateClientArgs(unittest.TestCase):
         )
 
     def test_max_pool_from_client_config_forwarded_to_endpoint_creator(self):
-        config = botocore.config.Config(max_pool_connections=20)
+        config = Config(max_pool_connections=20)
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(client_config=config)
             self.assert_create_endpoint_call(m, max_pool_connections=20)
@@ -141,7 +140,7 @@ class TestCreateClientArgs(unittest.TestCase):
             'http': 'http://foo.bar:1234',
             'https': 'https://foo.bar:4321',
         }
-        config = botocore.config.Config(proxies=proxies)
+        config = Config(proxies=proxies)
         with mock.patch('botocore.args.EndpointCreator') as m:
             self.call_get_client_args(client_config=config)
             self.assert_create_endpoint_call(m, proxies=proxies)
@@ -370,16 +369,14 @@ class TestCreateClientArgs(unittest.TestCase):
             )
 
     def test_provides_total_max_attempts(self):
-        config = botocore.config.Config(retries={'total_max_attempts': 10})
+        config = Config(retries={'total_max_attempts': 10})
         client_args = self.call_get_client_args(client_config=config)
         self.assertEqual(
             client_args['client_config'].retries['total_max_attempts'], 10
         )
 
     def test_provides_total_max_attempts_has_precedence(self):
-        config = botocore.config.Config(
-            retries={'total_max_attempts': 10, 'max_attempts': 5}
-        )
+        config = Config(retries={'total_max_attempts': 10, 'max_attempts': 5})
         client_args = self.call_get_client_args(client_config=config)
         self.assertEqual(
             client_args['client_config'].retries['total_max_attempts'], 10
@@ -387,7 +384,7 @@ class TestCreateClientArgs(unittest.TestCase):
         self.assertNotIn('max_attempts', client_args['client_config'].retries)
 
     def test_provide_retry_config_maps_total_max_attempts(self):
-        config = botocore.config.Config(retries={'max_attempts': 10})
+        config = Config(retries={'max_attempts': 10})
         client_args = self.call_get_client_args(client_config=config)
         self.assertEqual(
             client_args['client_config'].retries['total_max_attempts'], 11

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -460,35 +460,6 @@ class TestCreateClientArgs(unittest.TestCase):
         )['client_config']
         self.assertEqual(config.retries['mode'], 'standard')
 
-    def test_does_set_global_sts_endpoint_if_in_legacy_region(self):
-        should = self.args_create._should_set_global_sts_endpoint(
-            region_name='us-west-1', endpoint_url=None, endpoint_config=None
-        )
-        self.assertTrue(should)
-
-    def test_doesnt_set_global_sts_endpoint_if_not_in_legacy_region(self):
-        should = self.args_create._should_set_global_sts_endpoint(
-            region_name='eu-south-1', endpoint_url=None, endpoint_config=None
-        )
-        self.assertFalse(should)
-
-    def test_doesnt_set_global_sts_endpoint_if_endpoint_url_is_given(self):
-        should = self.args_create._should_set_global_sts_endpoint(
-            region_name='us-west-1',
-            endpoint_url="https://my.endpoint.url.com",
-            endpoint_config=None,
-        )
-        self.assertFalse(should)
-
-    def test_doesnt_set_global_sts_endpoint_if_configured(self):
-        self.args_create._config_store.set_config_variable(
-            'sts_regional_endpoints', 'regional'
-        )
-        should = self.args_create._should_set_global_sts_endpoint(
-            region_name='us-west-1', endpoint_url=None, endpoint_config=None
-        )
-        self.assertFalse(should)
-
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):
@@ -596,11 +567,6 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             region_name='my-region-2',
         )
         self.assertEqual(bins['AWS::STS::UseGlobalEndpoint'], False)
-        self.args_create._should_set_global_sts_endpoint.assert_called_once_with(
-            region_name='my-region-2',
-            endpoint_url=None,
-            endpoint_config=None,
-        )
 
     def test_s3_global_endpoint(self):
         # The only reason for this builtin to not have the default value

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -459,3 +459,32 @@ class TestCreateClientArgs(unittest.TestCase):
             client_config=Config(retries={'mode': 'standard'})
         )['client_config']
         self.assertEqual(config.retries['mode'], 'standard')
+
+    def test_does_set_global_sts_endpoint_if_in_legacy_region(self):
+        should = self.args_create._should_set_global_sts_endpoint(
+            region_name='us-west-1', endpoint_url=None, endpoint_config=None
+        )
+        self.assertTrue(should)
+
+    def test_doesnt_set_global_sts_endpoint_if_not_in_legacy_region(self):
+        should = self.args_create._should_set_global_sts_endpoint(
+            region_name='eu-south-1', endpoint_url=None, endpoint_config=None
+        )
+        self.assertFalse(should)
+
+    def test_doesnt_set_global_sts_endpoint_if_endpoint_url_is_given(self):
+        should = self.args_create._should_set_global_sts_endpoint(
+            region_name='us-west-1',
+            endpoint_url="https://my.endpoint.url.com",
+            endpoint_config=None,
+        )
+        self.assertFalse(should)
+
+    def test_doesnt_set_global_sts_endpoint_if_configured(self):
+        self.args_create._config_store.set_config_variable(
+            'sts_regional_endpoints', 'regional'
+        )
+        should = self.args_create._should_set_global_sts_endpoint(
+            region_name='us-west-1', endpoint_url=None, endpoint_config=None
+        )
+        self.assertFalse(should)


### PR DESCRIPTION
This PR is part of the ongoing endpoint resolution v2 work, together with #2737, #2740, #2751, #2747. It contains the code that assigns values to a list of "builtin parameters" that may be referenced by endpoint rulesets. It's glue code between the existing `ClientCreator` and `ClientArgsCreator` and the future `EndpointProvider` (see #2737).

Q: By itself, this PR adds only unused code. Why is it a separate PR? — A: I decided to break this out of a larger PR with all the middleware for calling `EndpointProvider` to keep this a separate review/discussion. Even though the code is pretty simple, there could be a complex discussion hiding behind each parameter assignment and how it is tested. Let's get these debates out of the way first :) 