### PR TITLE
Add missing `super().tearDown()` for test classes with custom base classes

### DIFF
--- a/tests/functional/test_mturk.py
+++ b/tests/functional/test_mturk.py
@@ -23,7 +23,7 @@ class TestMturk(BaseSessionTest):
         self.stubber.activate()
 
     def tearDown(self):
-        super().setUp()
+        super().tearDown()
         self.stubber.deactivate()
 
     def test_list_hits_aliased(self):

--- a/tests/functional/test_sagemaker.py
+++ b/tests/functional/test_sagemaker.py
@@ -15,6 +15,7 @@ class TestSagemaker(BaseSessionTest):
         self.hook_calls.append(kwargs['event_name'])
 
     def tearDown(self):
+        super().tearDown()
         self.stubber.deactivate()
 
     def test_event_with_old_prefix(self):

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -716,6 +716,7 @@ class TestS3SigV2Presign(BasePresignTest):
 
     def tearDown(self):
         self.time_patch.stop()
+        super().tearDown()
 
     def test_presign_with_query_string(self):
         self.request.url = (
@@ -808,6 +809,7 @@ class TestSigV4Presign(BasePresignTest):
 
     def tearDown(self):
         self.datetime_patcher.stop()
+        super().tearDown()
 
     def test_presign_no_params(self):
         request = AWSRequest()
@@ -1044,6 +1046,7 @@ class TestS3SigV2Post(BaseS3PresignPostTest):
 
     def tearDown(self):
         self.time_patch.stop()
+        super().tearDown()
 
     def test_presign_post(self):
         self.auth.add_auth(self.request)
@@ -1110,6 +1113,7 @@ class TestS3SigV4Post(BaseS3PresignPostTest):
 
     def tearDown(self):
         self.datetime_patcher.stop()
+        super().tearDown()
 
     def test_presign_post(self):
         self.auth.add_auth(self.request)

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -23,7 +23,7 @@ from botocore.configloader import (
     multi_file_load_config,
     raw_config_parse,
 )
-from tests import BaseEnvVar, mock, unittest
+from tests import mock, unittest
 
 
 def path(filename):
@@ -33,13 +33,12 @@ def path(filename):
     return os.path.join(directory, filename)
 
 
-class TestConfigLoader(BaseEnvVar):
+class TestConfigLoader(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
-        super().tearDown()
 
     def create_config_file(self, filename):
         contents = (

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -39,6 +39,7 @@ class TestConfigLoader(BaseEnvVar):
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
+        super().tearDown()
 
     def create_config_file(self, filename):
         contents = (


### PR DESCRIPTION
Addresses https://github.com/boto/botocore/issues/2752

The reported issue is a test failure of the new test `tests.unit.test_client.TestAutoGeneratedClient testMethod=test_BOTO_DISABLE_COMMONNAME`. This test failure is reproducible on all platforms by running the tests in `tests/functional/` before the failing test. Root cause was a test class in `tests/functional/test_mturk.py` that called `super().setUp()` instead of `super().tearDown()`. All tests run later in the same session ended up with a modified `os.environ`. 

This PR fixes the problematic test mentioned above. In addition, it adds a call to `super().tearDown()` to all `tearDown()` methods of test classes that have base class other than `unittest.TestCase` where this is not already in place. 