### PR TITLE
aws_is_virtual_hostable_bucket endpoint provider standard library function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ exclude: "\
     botocore/compat.py|\
     docs/|\
     tests/unit/auth/aws4_testsuite|\
+    tests/unit/data/endpoints/|\
     tests/unit/response_parsing/xml|\
     CHANGELOG.rst\
     )"

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -394,9 +394,9 @@ class RuleSetStandardLibary:
         """
         if (
             value is None
+            or len(value) < 3
             or value.lower() != value
             or IPV4_RE.match(value) is not None
-            or (allow_subdomains is False and value.count(".") > 0)
         ):
             return False
 
@@ -406,9 +406,7 @@ class RuleSetStandardLibary:
                 for label in value.split(".")
             )
 
-        return 3 <= len(value) <= 63 and self.is_valid_host_label(
-            value, allow_subdomains=False
-        )
+        return self.is_valid_host_label(value, allow_subdomains=False)
 
 
 class BaseRule:

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -29,7 +29,7 @@ from string import Formatter
 from typing import NamedTuple
 
 from botocore import xform_name
-from botocore.compat import quote, urlparse
+from botocore.compat import IPV4_RE, quote, urlparse
 from botocore.exceptions import EndpointResolutionError
 from botocore.utils import (
     ArnParser,
@@ -376,6 +376,39 @@ class RuleSetStandardLibary:
         :rtype: bool
         """
         return not value
+
+    def aws_is_virtual_hostable_s3_bucket(self, value, allow_subdomains):
+        """Evaluates whether a value is a valid bucket name for virtual host
+        style bucket URLs. To pass, the value must meet the following criteria:
+        1. is_valid_host_label(value) is True
+        2. length between 3 and 63 characters (inclusive)
+        3. does not contain uppercase characters
+        4. is not formatted as an IP address
+
+        If allow_subdomains is True, split on `.` and validate
+        each component separately.
+
+        :type value: str
+        :type allow_subdomains: bool
+        :rtype: bool
+        """
+        if (
+            value is None
+            or value.lower() != value
+            or IPV4_RE.match(value) is not None
+            or (allow_subdomains is False and value.count(".") > 0)
+        ):
+            return False
+
+        if allow_subdomains is True:
+            return all(
+                self.aws_is_virtual_hostable_s3_bucket(label, False)
+                for label in value.split(".")
+            )
+
+        return 3 <= len(value) <= 63 and self.is_valid_host_label(
+            value, allow_subdomains=False
+        )
 
 
 class BaseRule:

--- a/tests/unit/data/endpoints/test-cases/is-virtual-hostable-s3-bucket.json
+++ b/tests/unit/data/endpoints/test-cases/is-virtual-hostable-s3-bucket.json
@@ -1,0 +1,121 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "bucket-name:  isVirtualHostable",
+      "params": {
+        "BucketName": "bucket-name"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://bucket-name.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "bucket-with-number-1: isVirtualHostable",
+      "params": {
+        "BucketName": "bucket-with-number-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://bucket-with-number-1.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "BucketName: not isVirtualHostable (uppercase characters)",
+      "params": {
+        "BucketName": "BucketName"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket_name: not isVirtualHostable (underscore)",
+      "params": {
+        "BucketName": "bucket_name"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket.name: isVirtualHostable (http only)",
+      "params": {
+        "BucketName": "bucket.name"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://bucket.name.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "bucket.name.multiple.dots1: isVirtualHostable (http only)",
+      "params": {
+        "BucketName": "bucket.name.multiple.dots1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://bucket.name.multiple.dots1.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "-bucket-name: not isVirtualHostable (leading dash)",
+      "params": {
+        "BucketName": "-bucket-name"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket-name-: not isVirtualHostable (trailing dash)",
+      "params": {
+        "BucketName": "bucket-name-"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "aa: not isVirtualHostable (< 3 characters)",
+      "params": {
+        "BucketName": "aa"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "'a'*64: not isVirtualHostable (> 63 characters)",
+      "params": {
+        "BucketName": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": ".bucket-name: not isVirtualHostable (leading dot)",
+      "params": {
+        "BucketName": ".bucket-name"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket-name.: not isVirtualHostable (trailing dot)",
+      "params": {
+        "BucketName": "bucket-name."
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/is-virtual-hostable-s3-bucket.json
+++ b/tests/unit/data/endpoints/valid-rules/is-virtual-hostable-s3-bucket.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "BucketName": {
+      "type": "string",
+      "required": true,
+      "documentation": "the input used to test isVirtualHostableS3Bucket"
+    }
+  },
+  "rules": [
+    {
+      "conditions": [
+        {
+          "fn": "aws.isVirtualHostableS3Bucket",
+          "argv": [
+            "{BucketName}",
+            false
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{BucketName}.s3.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "conditions": [
+        {
+          "fn": "aws.isVirtualHostableS3Bucket",
+          "argv": [
+            "{BucketName}",
+            true
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "http://{BucketName}.s3.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "conditions": [
+      ],
+      "error": "not isVirtualHostableS3Bucket",
+      "type": "error"
+    }
+  ]
+}

--- a/tests/unit/test_endpoints_v2.py
+++ b/tests/unit/test_endpoints_v2.py
@@ -135,6 +135,7 @@ def ruleset_testcases():
         "eventbridge",
         "fns",
         "headers",
+        "is-virtual-hostable-s3-bucket",
         "local-region-override",
         "parse-arn",
         "parse-url",


### PR DESCRIPTION
Implements the `aws.isVirtualHostableS3Bucket` standard library function for endpoint provider rulesets. This is a small addition to #2737.

The spec for the function is:

> Evaluates whether a string is a DNS compatible bucket name and can be used with virtual hosted style addressing. In addition to the restrictions defined in [RFC 1123](https://www.ietf.org/rfc/rfc1123.txt) and `isValidHostLabel`, the `isVirtualHostableS3Bucket` function must also validate that the bucket name is between [3,63] characters, does not contain upper case characters, and is not formatted as an IP address.