### PR TITLE
suppress pyopenssl deprecation warning with catch_warnings

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import socket
 import sys
+import warnings
 from base64 import b64encode
 
 from urllib3 import PoolManager, Timeout, proxy_from_url
@@ -37,8 +38,14 @@ except ImportError:
     from ssl import OP_NO_TICKET, PROTOCOL_TLS_CLIENT
 
 try:
-    # Always import the original SSLContext, even if it has been patched
-    from urllib3.contrib.pyopenssl import orig_util_SSLContext as SSLContext
+    # pyopenssl will be removed in urllib3 2.0, we'll fall back to ssl_ at that point.
+    # This can be removed once our urllib3 floor is raised to >= 2.0.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        # Always import the original SSLContext, even if it has been patched
+        from urllib3.contrib.pyopenssl import (
+            orig_util_SSLContext as SSLContext,
+        )
 except ImportError:
     from urllib3.util.ssl_ import SSLContext
 


### PR DESCRIPTION
This addresses https://github.com/boto/botocore/issues/2744. It does so by suppressing all warnings of type `DeprecationWarning` when attempting to import from `pyOpenSSL`