### PR TITLE
add `tcp_keepalive` to Config object

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -183,6 +183,12 @@ class Config:
         endpoint resolution.
 
         Defaults to None.
+
+    :type tcp_keepalive: bool
+    :param tcp_keepalive: Enables the TCP Keep-Alive socket option used when
+        creating new connections if set to True.
+
+        Defaults to False.
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -205,6 +211,7 @@ class Config:
             ('use_dualstack_endpoint', None),
             ('use_fips_endpoint', None),
             ('defaults_mode', None),
+            ('tcp_keepalive', None),
         ]
     )
 


### PR DESCRIPTION
This PR partially addresses https://github.com/boto/botocore/issues/2249. We have chosen not to incorporate `duration_seconds` as it is a pretty niche, rarely used argument that also relies on others to be set in the same config object.  Because `tcp_keepalive` is a setting that originates from an operating system, it can only ever be enabled not disabled. This means if set in a scoped config, but not the client config object, it will still be enabled.