### PR TITLE
Fetch query compatible error from header to support service

### DIFF
--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1081,6 +1081,98 @@ class TestParseErrorResponses(unittest.TestCase):
         self.assertEqual(parsed['Error']['Message'], 'this is a message')
         self.assertEqual(parsed['Error']['Code'], 'ValidationException')
 
+    def test_response_with_query_error_for_json_protocol(self):
+        parser = parsers.JSONParser()
+        response = {
+            "body": b"""
+                {"__type":"amazon.foo.validate#ValidationException",
+                 "message":"this is a message"}
+                """,
+            "status_code": 400,
+            "headers": {
+                "x-amzn-requestid": "request-id",
+                "x-amzn-query-error": "AWS.SimpleQueueService.NonExistentQueue;Sender"
+            }
+        }
+        parsed = parser.parse(response, None)
+        # Even (especially) on an error condition, the
+        # ResponseMetadata should be populated.
+        self.assertIn('ResponseMetadata', parsed)
+        self.assertEqual(parsed['ResponseMetadata']['RequestId'], 'request-id')
+
+        self.assertIn('Error', parsed)
+        self.assertEqual(parsed['Error']['Message'], 'this is a message')
+        self.assertEqual(parsed['Error']['Code'], 'AWS.SimpleQueueService.NonExistentQueue')
+
+    def test_response_with_invalid_query_error_for_json_protocol(self):
+        parser = parsers.JSONParser()
+        response = {
+            "body": b"""
+                {"__type":"amazon.foo.validate#ValidationException",
+                 "message":"this is a message"}
+                """,
+            "status_code": 400,
+            "headers": {
+                "x-amzn-requestid": "request-id",
+                "x-amzn-query-error": "AWS.SimpleQueueService.NonExistentQueue;sender;400"
+            }
+        }
+        parsed = parser.parse(response, None)
+        # Even (especially) on an error condition, the
+        # ResponseMetadata should be populated.
+        self.assertIn('ResponseMetadata', parsed)
+        self.assertEqual(parsed['ResponseMetadata']['RequestId'], 'request-id')
+
+        self.assertIn('Error', parsed)
+        self.assertEqual(parsed['Error']['Message'], 'this is a message')
+        self.assertEqual(parsed['Error']['Code'], 'ValidationException')
+
+    def test_response_with_incomplete_query_error_for_json_protocol(self):
+        parser = parsers.JSONParser()
+        response = {
+            "body": b"""
+                {"__type":"amazon.foo.validate#ValidationException",
+                 "message":"this is a message"}
+                """,
+            "status_code": 400,
+            "headers": {
+                "x-amzn-requestid": "request-id",
+                "x-amzn-query-error": ";sender"
+            }
+        }
+        parsed = parser.parse(response, None)
+        # Even (especially) on an error condition, the
+        # ResponseMetadata should be populated.
+        self.assertIn('ResponseMetadata', parsed)
+        self.assertEqual(parsed['ResponseMetadata']['RequestId'], 'request-id')
+
+        self.assertIn('Error', parsed)
+        self.assertEqual(parsed['Error']['Message'], 'this is a message')
+        self.assertEqual(parsed['Error']['Code'], 'ValidationException')
+
+    def test_response_with_empty_query_errors_for_json_protocol(self):
+        parser = parsers.JSONParser()
+        response = {
+            "body": b"""
+                {"__type":"amazon.foo.validate#ValidationException",
+                 "message":"this is a message"}
+                """,
+            "status_code": 400,
+            "headers": {
+                "x-amzn-requestid": "request-id",
+                "x-amzn-query-error": ""
+            }
+        }
+        parsed = parser.parse(response, None)
+        # Even (especially) on an error condition, the
+        # ResponseMetadata should be populated.
+        self.assertIn('ResponseMetadata', parsed)
+        self.assertEqual(parsed['ResponseMetadata']['RequestId'], 'request-id')
+
+        self.assertIn('Error', parsed)
+        self.assertEqual(parsed['Error']['Message'], 'this is a message')
+        self.assertEqual(parsed['Error']['Code'], 'ValidationException')
+
     def test_parse_error_response_for_query_protocol(self):
         body = (
             b'<ErrorResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">'


### PR DESCRIPTION
### Motivation
As we decided to parse `AwsQuery` Compatible `Error` in the Http response header, the required changes need to take in place on both SDK client and Service. 
This will be a pre-requisite for migrating services from AWSQuery wire protocol to AWSJson.
### What changed
Error code can be fetched from response content (for example __type#fooException). This PR takes another scenario into consideration, of which when `x-amzn-query-error` header with valid value is found from the Http response. 
- The parsed error code remains unchanged if this header is missing, or contains null or invalid value.

