### PR TITLE
json file cache race condition bug fix unit test

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -342,7 +342,7 @@ class JSONFileCache:
                 f"JSON serializable: {value}"
             )
         if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir)
+            os.makedirs(self._working_dir, exist_ok=True)
         with os.fdopen(
             os.open(full_key, os.O_WRONLY | os.O_CREAT, 0o600), 'w'
         ) as f:


### PR DESCRIPTION
This PR adds a unit test based off the changes from https://github.com/boto/botocore/pull/2721

I wasn't sure where to put it so I threw it in the `TestCreadeCredentialResolver` test case class, but not sure that makes sense since this test is unrelated. This will be merged only after 2721 is.