### PR TITLE
Endpoint resolution v2 for Eventbridge

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -159,14 +159,6 @@ class ClientCreator:
         self._register_retries(service_client)
         self._register_s3_events(service_client, client_config, scoped_config)
         self._register_s3_control_events(service_client)
-
-        if client_args['endpoint_ruleset_resolver'] is None:
-            # When using the legacy endpoint resolver, several event handlers
-            # modify endpoint and request context.
-            self._register_eventbridge_events(
-                service_client, endpoint_bridge, endpoint_url
-            )
-
         self._register_endpoint_discovery(
             service_client, endpoint_url, client_config
         )

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 # List of services for which rule-based endpoint resolution is always enabled.
 # This list will change and eventually be removed during minor or patch version
 # changes as part of the rollout of rule-based endpoints resolution.
-ENDPOINT_RESOLUTION_V2_SERVICES = ['s3', 's3control']
+ENDPOINT_RESOLUTION_V2_SERVICES = ['s3', 's3control', 'events']
 # Feature flag to enable rule-based endpoint resolution for all services.
 # Only for testing use. Rulesets for services may be missing or incomplete
 # until the service is enabled for rule-based endpoint resolution by default.

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -28,6 +28,7 @@ from botocore.endpoint_provider import EndpointProvider
 from botocore.exceptions import (
     EndpointProviderError,
     EndpointVariantError,
+    InvalidEndpointConfigurationError,
     InvalidHostLabelError,
     MissingDependencyException,
     NoRegionError,
@@ -818,4 +819,12 @@ class EndpointRulesetResolver:
                 return UnsupportedS3ControlConfigurationError(msg=msg)
             if msg == "AccountId is required but not set":
                 return ParamValidationError(report=msg)
+        if service_name == 'events':
+            if msg.startswith(
+                'Invalid Configuration: FIPS is not supported with '
+                'EventBridge multi-region endpoints.'
+            ):
+                return InvalidEndpointConfigurationError(msg=msg)
+            if msg == 'EndpointId must be a valid host label.':
+                return InvalidEndpointConfigurationError(msg=msg)
         return None

--- a/tests/functional/test_eventbridge.py
+++ b/tests/functional/test_eventbridge.py
@@ -143,9 +143,8 @@ class TestClientEvents(BaseSessionTest):
         default_args = self._default_put_events_args()
         endpoint_id = "badactor.com?foo=bar"
 
-        with pytest.raises(InvalidEndpointConfigurationError) as e:
+        with pytest.raises(InvalidEndpointConfigurationError):
             client.put_events(EndpointId=endpoint_id, **default_args)
-        assert "EndpointId is not a valid hostname component" in str(e.value)
 
     @requires_crt()
     def test_put_event_bad_endpoint_id_explicit_config(self):
@@ -159,9 +158,8 @@ class TestClientEvents(BaseSessionTest):
         default_args = self._default_put_events_args()
         endpoint_id = "badactor.com?foo=bar"
 
-        with pytest.raises(InvalidEndpointConfigurationError) as e:
+        with pytest.raises(InvalidEndpointConfigurationError):
             client.put_events(EndpointId=endpoint_id, **default_args)
-        assert "EndpointId is not a valid hostname component" in str(e.value)
 
     @requires_crt()
     def test_put_event_empty_endpoint_id(self):
@@ -171,9 +169,8 @@ class TestClientEvents(BaseSessionTest):
         default_args = self._default_put_events_args()
         endpoint_id = ""
 
-        with pytest.raises(InvalidEndpointConfigurationError) as e:
+        with pytest.raises(InvalidEndpointConfigurationError):
             client.put_events(EndpointId=endpoint_id, **default_args)
-        assert "EndpointId must not be a zero length string" in str(e.value)
 
     @requires_crt()
     def test_put_event_empty_endpoint_id_explicit_config(self):
@@ -187,9 +184,8 @@ class TestClientEvents(BaseSessionTest):
         default_args = self._default_put_events_args()
         endpoint_id = ""
 
-        with pytest.raises(InvalidEndpointConfigurationError) as e:
+        with pytest.raises(InvalidEndpointConfigurationError):
             client.put_events(EndpointId=endpoint_id, **default_args)
-        assert "EndpointId must not be a zero length string" in str(e.value)
 
     def test_put_event_default_dualstack_endpoint(self):
         config = Config(use_dualstack_endpoint=True, use_fips_endpoint=False)
@@ -248,12 +244,8 @@ class TestClientEvents(BaseSessionTest):
         default_args = self._default_put_events_args()
         endpoint_id = "abc123.456def"
 
-        with pytest.raises(InvalidEndpointConfigurationError) as e:
+        with pytest.raises(InvalidEndpointConfigurationError):
             client.put_events(EndpointId=endpoint_id, **default_args)
-        assert (
-            "FIPS is not supported with EventBridge multi-region endpoints"
-            in str(e.value)
-        )
 
     def test_put_events_default_dualstack_fips_endpoint(self):
         config = Config(use_dualstack_endpoint=True, use_fips_endpoint=True)
@@ -348,5 +340,5 @@ class TestClientEvents(BaseSessionTest):
                 ("EndpointId", endpoint_id),
             ],
         )
-        assert stubber.requests[0].url == "https://example.org"
+        assert stubber.requests[0].url == "https://example.org/"
         self._assert_sigv4a_headers(stubber.requests[0])


### PR DESCRIPTION
This PR is a small change stacked on top of https://github.com/boto/botocore/pull/2785. To see the diff between those two branches [click here](https://github.com/jonemo/botocore/compare/endpointsresolverv2-squash...jonemo:botocore:endpointsresolverv2-events).

https://github.com/boto/botocore/pull/2785 enables Endpoint resolution v2 for the `s3` and `s3control` clients. This PR adds the `events` (Eventbridge) client to the list. The PR bundles the relevant endpoint ruleset and endpoint tests data files. It also removes the code path for registering Eventbridge customizations which are completely replaced by the new endpoint ruleset.

After the code changes described above, seven test failures in the file `tests/functional/test_eventbridge.py` happened. These could be addressed by:

1. Removing assertions about the verbiage of exception messages. This is in line with the decision made for https://github.com/boto/botocore/pull/2785 to strive for consistent exception types but accept changes in text.
2. Add a trailing `/` to the expected URL in one assertion. This is a change in behavior (change from empty path to `/` path) but without significant effect. The new behavior is closer to [the documented example](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html#API_PutEvents_Examples) where `/` is used.