### PR TITLE
Address Github Actions warning by updating actions versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Run pre-commit
-      uses: pre-commit/action@v2.0.0
+      uses: pre-commit/action@v3.0.0

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -15,9 +15,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Install dependencies and CRT

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,9 +15,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Install dependencies


### PR DESCRIPTION
Github Actions has been displaying instances of these warnings under each workflow run:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/setup-python, actions/checkout

and

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: pre-commit/action

This PR does exactly what the warnings suggests: Update the version of the `action/checkout`, `actions/setup-python`, and `pre-commit/action` actions away from the one that only works with node12 to the latest version.

### Changelogs

actions/checkout from v2 to v3
Changelog: https://github.com/actions/checkout/blob/main/CHANGELOG.md

actions/setup-python from v2 to v4
Changelog: https://github.com/actions/setup-python/releases

pre-commit/action from v2.0.0 to v3.0.0
Changelog: https://github.com/pre-commit/action/releases

### Testing

Workflow runs with the new versions and _without_ the warnings:
* https://github.com/jonemo/botocore/actions/runs/3301464179
* https://github.com/jonemo/botocore/actions/runs/3301464178
* https://github.com/jonemo/botocore/actions/runs/3301464177