### PR TITLE
Copy env vars when injecting fake creds for test

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -165,9 +165,10 @@ class BaseClientDriverTest(unittest.TestCase):
 
     def setUp(self):
         self.driver = ClientDriver()
-        env = None
+        env = os.environ.copy()
         if self.INJECT_DUMMY_CREDS:
-            env = {'AWS_ACCESS_KEY_ID': 'foo', 'AWS_SECRET_ACCESS_KEY': 'bar'}
+            env['AWS_ACCESS_KEY_ID'] = 'foo'
+            env['AWS_SECRET_ACCESS_KEY'] = 'bar'
         self.driver.start(env=env)
 
     def cmd(self, *args):


### PR DESCRIPTION
Without providing a copy of the current environment variables, the cmd-runner may not work as we are not proxying over environment variables that are needed to function correctly. For example, the environment can be setting the PYTHONPATH in order to find additional Python packages that are not installed in the default site packages.

The code is copied from https://github.com/aws/aws-cli/pull/6725

Fixes https://github.com/boto/botocore/issues/2676