### PR TITLE
Make Baseclient constructor signature backwards compatible with <1.28.0

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -823,7 +823,7 @@ class BaseClient:
         client_config,
         partition,
         exceptions_factory,
-        endpoint_ruleset_resolver,
+        endpoint_ruleset_resolver=None,
     ):
         self._serializer = serializer
         self._endpoint = endpoint


### PR DESCRIPTION
#2785 (released in version 1.28.0) introduced a backwards-incompatible change to the signature of the constructor of `botocore.client.BaseClient`. This change modifies the signature to be backwards-compatible.