### PR TITLE
Fix for S3 pre-signed URLs with bucket names that contain dots

### DIFF
--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -3395,6 +3395,16 @@ def _addressing_for_presigned_url_test_cases():
         signature_version="s3v4",
         expected_url=("https://bucket.s3.us-east-1.amazonaws.com/key"),
     )
+    # Bucket names that contain dots or are otherwise not virtual host style
+    # compatible should always resolve to a regional endpoint.
+    # https://github.com/boto/botocore/issues/2798
+    yield dict(
+        region="us-west-1",
+        bucket="foo.bar.biz",
+        key="key",
+        signature_version="s3",
+        expected_url="https://s3.us-west-1.amazonaws.com/foo.bar.biz/key",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Addresses https://github.com/boto/botocore/issues/2798.

Version 1.28.0 erroneously introduced a change in behavior for S3 pre-signed URLs with bucket names that aren't valid host labels as defined in [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123#section-2). After the change, the resulting URLs no longer used the regional endpoint. 

This PR fixes the specific issue reported in https://github.com/boto/botocore/issues/2798 and adds test coverage for it. In addition, it reverts to pre-1.28.0 logic for whether to use a regional or global endpoint for certain S3 requests where either option is valid.