### PR TITLE
Endpoint resolver 2.0: Use legacy resolver as source of default region name

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -527,7 +527,7 @@ class ClientArgsCreator:
         service_name_raw = service_model.endpoint_prefix
         # Maintain complex logic for s3 and sts endpoints for backwards
         # compatibility.
-        if service_name_raw in ['s3', 'sts']:
+        if service_name_raw in ['s3', 'sts'] or region_name is None:
             eprv2_region_name = endpoint_region_name
         else:
             eprv2_region_name = region_name


### PR DESCRIPTION
Fall back to the legacy resolver as source of a default region name when a region name cannot be sourced from elsewhere.