### PR TITLE
Remove unused file output in test_paginator_config.py

### DIFF
--- a/tests/functional/test_paginator_config.py
+++ b/tests/functional/test_paginator_config.py
@@ -253,12 +253,6 @@ def _validate_output_keys_match(operation_name, page_config, service_model):
             output_members.remove(member)
 
     if output_members:
-        for member in output_members:
-            key = "{}.{}.{}".format(
-                service_model.service_name, operation_name, member
-            )
-            with open('/tmp/blah', 'a') as f:
-                f.write("'%s',\n" % key)
         raise AssertionError(
             "There are member names in the output shape of "
             "%s that are not accounted for in the pagination "


### PR DESCRIPTION
Minor cleanup: This output to a temporary file in a functional test seems vestigial. 