### PR TITLE
Removed additional whitespace after hyperlinks for special cases in our docs

### DIFF
--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -115,14 +115,13 @@ class StemNode(Node):
         self._write_children(doc)
 
     def _write_children(self, doc):
-        for index in range(len(self.children)):
-            if isinstance(self.children[index], TagNode):
-                next_child = None
-                if index + 1 < len(self.children):
-                    next_child = self.children[index + 1]
-                self.children[index].write(doc, next_child)
+        for index, child in enumerate(self.children):
+            next_child = None
+            if isinstance(child, TagNode) and index + 1 < len(self.children):
+                next_child = self.children[index + 1]
+                child.write(doc, next_child)
             else:
-                self.children[index].write(doc)
+                child.write(doc)
 
 
 class TagNode(StemNode):
@@ -135,21 +134,21 @@ class TagNode(StemNode):
         self.attrs = attrs
         self.tag = tag
 
-    def write(self, doc, next):
+    def write(self, doc, next_child=None):
         self._write_start(doc)
         self._write_children(doc)
-        self._write_end(doc, next)
+        self._write_end(doc, next_child)
 
     def _write_start(self, doc):
         handler_name = 'start_%s' % self.tag
         if hasattr(doc.style, handler_name):
             getattr(doc.style, handler_name)(self.attrs)
 
-    def _write_end(self, doc, next):
+    def _write_end(self, doc, next_child):
         handler_name = 'end_%s' % self.tag
         if hasattr(doc.style, handler_name):
             if handler_name == 'end_a':
-                getattr(doc.style, handler_name)(next)
+                getattr(doc.style, handler_name)(next_child)
             else:
                 getattr(doc.style, handler_name)()
 
@@ -158,9 +157,9 @@ class LineItemNode(TagNode):
     def __init__(self, attrs=None, parent=None):
         super().__init__('li', attrs, parent)
 
-    def write(self, doc, next):
+    def write(self, doc, next_child=None):
         self._lstrip(self)
-        super().write(doc, next)
+        super().write(doc, next_child)
 
     def _lstrip(self, node):
         """

--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -117,7 +117,7 @@ class StemNode(Node):
     def _write_children(self, doc):
         for index, child in enumerate(self.children):
             if isinstance(child, TagNode) and index + 1 < len(self.children):
-                # Provide a look ahead for TagNode's when one exists
+                # Provide a look ahead for TagNodes when one exists
                 next_child = self.children[index + 1]
                 child.write(doc, next_child)
             else:

--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -116,8 +116,8 @@ class StemNode(Node):
 
     def _write_children(self, doc):
         for index, child in enumerate(self.children):
-            next_child = None
             if isinstance(child, TagNode) and index + 1 < len(self.children):
+                # Provide a look ahead for TagNode's when one exists
                 next_child = self.children[index + 1]
                 child.write(doc, next_child)
             else:
@@ -148,6 +148,7 @@ class TagNode(StemNode):
         handler_name = 'end_%s' % self.tag
         if hasattr(doc.style, handler_name):
             if handler_name == 'end_a':
+                # We use lookahead to determine if a space is needed after a link node
                 getattr(doc.style, handler_name)(next_child)
             else:
                 getattr(doc.style, handler_name)()

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -14,7 +14,8 @@
 import logging
 
 logger = logging.getLogger('bcdocs')
-SPECIAL_CHARACTERS = ('.', ',', '?', '!', ':', ';')
+# Terminal punctuation where a space is not needed before.
+PUNCTUATION_CHARACTERS = ('.', ',', '?', '!', ':', ';')
 
 
 class BaseStyle:
@@ -251,7 +252,10 @@ class ReSTStyle(BaseStyle):
                 self.doc.write('`__')
             self.a_href = None
 
-        if next_child is None or next_child.data[0] not in SPECIAL_CHARACTERS:
+        if (
+            next_child is None
+            or next_child.data[0] not in PUNCTUATION_CHARACTERS
+        ):
             # We only want to add a trailing space if the link is
             # not followed by a period, comma, or other gramatically
             # correct special character.

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -227,7 +227,7 @@ class ReSTStyle(BaseStyle):
         else:
             self.doc.write(text)
 
-    def end_a(self):
+    def end_a(self, next):
         self.doc.do_translation = False
         if self.a_href:
             last_write = self.doc.pop_write()
@@ -249,7 +249,13 @@ class ReSTStyle(BaseStyle):
                 self.doc.hrefs[self.a_href] = self.a_href
                 self.doc.write('`__')
             self.a_href = None
-        self.doc.write(' ')
+
+        special_characters = ['.', ',', '?', '!', ':', ';']
+        if next is None or next.data[0] not in special_characters:
+            # We only want to add a trailing space if the link is
+            # not followed by a period, comma, or other gramatically
+            # correct special character.
+            self.doc.write(' ')
 
     def start_i(self, attrs=None):
         self.doc.do_translation = True

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -14,6 +14,7 @@
 import logging
 
 logger = logging.getLogger('bcdocs')
+SPECIAL_CHARACTERS = ('.', ',', '?', '!', ':', ';')
 
 
 class BaseStyle:
@@ -227,7 +228,7 @@ class ReSTStyle(BaseStyle):
         else:
             self.doc.write(text)
 
-    def end_a(self, next):
+    def end_a(self, next_child=None):
         self.doc.do_translation = False
         if self.a_href:
             last_write = self.doc.pop_write()
@@ -250,8 +251,7 @@ class ReSTStyle(BaseStyle):
                 self.doc.write('`__')
             self.a_href = None
 
-        special_characters = ['.', ',', '?', '!', ':', ';']
-        if next is None or next.data[0] not in special_characters:
+        if next_child is None or next_child.data[0] not in SPECIAL_CHARACTERS:
             # We only want to add a trailing space if the link is
             # not followed by a period, comma, or other gramatically
             # correct special character.

--- a/tests/unit/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/docs/bcdoc/test_docstringparser.py
@@ -54,6 +54,20 @@ class TestDocStringParser(unittest.TestCase):
             result, [b'* Wello', b'  * Horld']
         )
 
+    def test_link_with_no_period(self):
+        html = "<p>This is a test <a href='https://testing.com'>Link</a></p>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'This is a test `Link <https://testing.com>`__ ']
+        )
+
+    def test_link_with_period(self):
+        html = "<p>This is a test <a href='https://testing.com'>Link</a>.</p>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'This is a test `Link <https://testing.com>`__.']
+        )
+
 
 class TestHTMLTree(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### Problem
When auto-generating botocore documentation, an additional whitespace is hardcoded after every hyperlink is created. This may have been done under the assumption that a hyperlink would always be followed by a word but fails to consider cases where a space wouldn't be needed such as before the following characters `['.', ',', '?', '!', ':', ';']`.
**Examples:**
* https://docs.aws.amazon.com/cli/latest/reference/ec2/create-traffic-mirror-target.html
* https://docs.aws.amazon.com/cli/latest/reference/kms/generate-random.html

### Solution
This PR addresses this issue by providing a look-ahead (`next`) when possible, and if either of these characters is detected, a space is omitted. 

### Validation
These changes were validated by generating the documentation files before and after the change and comparing using 
```
diff -w <old_docs> <new_docs> | grep .rst
```
No changes other than the expected white space changes were detected.