### PR TITLE
Add a settimeout() method to FakeSocket

### DIFF
--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -58,6 +58,9 @@ class FakeSocket:
     def close(self):
         pass
 
+    def settimeout(self, value):
+        pass
+
 
 class BytesIOWithLen(six.BytesIO):
     def __len__(self):


### PR DESCRIPTION
As a [part of urllib3 v2.0](https://github.com/urllib3/urllib3/pull/2768) we changed how `HTTPConnectionPools` interact with inner `HTTPConnection` objects, mostly to remove manipulation of inner state like the socket. Instead now the `HTTPConnection` calls `settimeout()` on it's own socket.

We also run botocore in our integration tests, and this change caused a failure where `FakeSocket` didn't have the `settimeout` method. This PR is upstreaming the [patch we have committed to our repository](https://github.com/urllib3/urllib3/blob/main/ci/0005-botocore-fakesocket-settimeout.patch).