### PR TITLE
Fix: S3 on Outpost requests miss x-amz-content-sha256 headers

### DIFF
--- a/.changes/next-release/bugfix-s3-62528.json
+++ b/.changes/next-release/bugfix-s3-62528.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "fixes missing x-amz-content-sha256 header for s3 on outpost"
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -219,7 +219,7 @@ def set_operation_specific_signer(context, signing_name, **kwargs):
             context['payload_signing_enabled'] = False
 
         # s3 and s3-control have customized signers "s3v4" and "s3v4a".
-        if signing_name == 's3':
+        if signing_name in ('s3', 's3-outposts'):
             signature_version = f's3{signature_version}'
 
         return signature_version

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -716,6 +716,9 @@ class TestAccesspointArn(BaseS3ClientConfigurationTest):
             "s3-outposts.us-west-2.amazonaws.com"
         )
         self.assert_endpoint(request, expected_endpoint)
+        sha_header = request.headers.get("x-amz-content-sha256")
+        self.assertIsNotNone(sha_header)
+        self.assertNotEqual(sha_header, b"UNSIGNED-PAYLOAD")
 
     def test_basic_outpost_arn_custom_endpoint(self):
         outpost_arn = (

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -1405,6 +1405,10 @@ class TestS3SigV4(BaseS3OperationTest):
         self.assertIn("content-md5", self.get_sent_headers())
 
     def test_content_sha256_set_if_config_value_is_true(self):
+        # By default, put_object() does not include an x-amz-content-sha256
+        # header because it also includes a `Content-MD5`` header. The
+        # `payload_signing_enabled` config overrides this logic and forces the
+        # header.
         config = Config(
             signature_version="s3v4", s3={"payload_signing_enabled": True}
         )
@@ -1433,6 +1437,55 @@ class TestS3SigV4(BaseS3OperationTest):
         sent_headers = self.get_sent_headers()
         sha_header = sent_headers.get("x-amz-content-sha256")
         self.assertEqual(sha_header, b"UNSIGNED-PAYLOAD")
+
+    def test_content_sha256_set_if_config_value_not_set_put_object(self):
+        # The default behavior matches payload_signing_enabled=False. For
+        # operations where the `Content-MD5` is present this means that
+        # `x-amz-content-sha256` is present but not set.
+        config = Config(signature_version="s3v4")
+        self.client = self.session.create_client(
+            "s3", self.region, config=config
+        )
+        self.http_stubber = ClientHTTPStubber(self.client)
+        self.http_stubber.add_response()
+        with self.http_stubber:
+            self.client.put_object(Bucket="foo", Key="bar", Body="baz")
+        sent_headers = self.get_sent_headers()
+        sha_header = sent_headers.get("x-amz-content-sha256")
+        self.assertEqual(sha_header, b"UNSIGNED-PAYLOAD")
+
+    def test_content_sha256_set_if_config_value_not_set_list_objects(self):
+        # The default behavior matches payload_signing_enabled=False. For
+        # operations where the `Content-MD5` is not present, this means that
+        # `x-amz-content-sha256` is present and set.
+        config = Config(signature_version="s3v4")
+        self.client = self.session.create_client(
+            "s3", self.region, config=config
+        )
+        self.http_stubber = ClientHTTPStubber(self.client)
+        self.http_stubber.add_response()
+        with self.http_stubber:
+            self.client.list_objects(Bucket="foo")
+        sent_headers = self.get_sent_headers()
+        sha_header = sent_headers.get("x-amz-content-sha256")
+        self.assertNotEqual(sha_header, b"UNSIGNED-PAYLOAD")
+
+    def test_content_sha256_set_s3_on_outpost(self):
+        # S3 on Outpost bucket names should behave the same way.
+        config = Config(signature_version="s3v4")
+        bucket = (
+            'test-accessp-e0000075431d83bebde8xz5w8ijx1qzlbp3i3kuse10--op-s3'
+        )
+        self.client = self.session.create_client(
+            "s3", self.region, config=config
+        )
+        self.http_stubber = ClientHTTPStubber(self.client)
+        self.http_stubber.add_response()
+        with self.http_stubber:
+            self.client.list_objects(Bucket=bucket)
+        sent_headers = self.get_sent_headers()
+        sha_header = sent_headers.get("x-amz-content-sha256")
+        self.assertNotEqual(sha_header, b"UNSIGNED-PAYLOAD")
 
     def test_content_sha256_set_if_md5_is_unavailable(self):
         with mock.patch("botocore.compat.MD5_AVAILABLE", False):

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -1406,7 +1406,7 @@ class TestS3SigV4(BaseS3OperationTest):
 
     def test_content_sha256_set_if_config_value_is_true(self):
         # By default, put_object() does not include an x-amz-content-sha256
-        # header because it also includes a `Content-MD5`` header. The
+        # header because it also includes a `Content-MD5` header. The
         # `payload_signing_enabled` config overrides this logic and forces the
         # header.
         config = Config(
@@ -1468,6 +1468,7 @@ class TestS3SigV4(BaseS3OperationTest):
             self.client.list_objects(Bucket="foo")
         sent_headers = self.get_sent_headers()
         sha_header = sent_headers.get("x-amz-content-sha256")
+        self.assertIsNotNone(sha_header)
         self.assertNotEqual(sha_header, b"UNSIGNED-PAYLOAD")
 
     def test_content_sha256_set_s3_on_outpost(self):


### PR DESCRIPTION
Addresses an issue where requests for some S3 API operations that should include the `x-amz-content-sha256` header do not have this header for S3 on Outpost. This issue was introduced in version 1.28.0 of botocore.