### PR TITLE
Add support for sso-session credentials

### DIFF
--- a/.changes/next-release/enhancement-sso-60997.json
+++ b/.changes/next-release/enhancement-sso-60997.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "sso",
+  "description": "Add support for loading sso-session profiles from the aws config"
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -22,7 +22,6 @@ import time
 from collections import namedtuple
 from copy import deepcopy
 from hashlib import sha1
-from pathlib import Path
 
 from dateutil.parser import parse
 from dateutil.tz import tzlocal, tzutc
@@ -43,10 +42,12 @@ from botocore.exceptions import (
     UnauthorizedSSOTokenError,
     UnknownCredentialError,
 )
+from botocore.tokens import SSOTokenProvider
 from botocore.utils import (
     ContainerMetadataFetcher,
     FileWebIdentityTokenLoader,
     InstanceMetadataFetcher,
+    JSONFileCache,
     SSOTokenLoader,
     parse_key_val_file,
     resolve_imds_endpoint_mode,
@@ -223,6 +224,7 @@ class ProfileProviderBuilder:
             profile_name=profile_name,
             cache=self._cache,
             token_cache=self._sso_token_cache,
+            token_provider=SSOTokenProvider(self._session),
         )
 
 
@@ -290,68 +292,6 @@ def create_mfa_serial_refresher(actual_refresh):
             return self._refresh()
 
     return _Refresher(actual_refresh)
-
-
-class JSONFileCache:
-    """JSON file cache.
-    This provides a dict like interface that stores JSON serializable
-    objects.
-    The objects are serialized to JSON and stored in a file.  These
-    values can be retrieved at a later time.
-    """
-
-    CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'boto', 'cache'))
-
-    def __init__(self, working_dir=CACHE_DIR, dumps_func=None):
-        self._working_dir = working_dir
-        if dumps_func is None:
-            dumps_func = self._default_dumps
-        self._dumps = dumps_func
-
-    def _default_dumps(self, obj):
-        return json.dumps(obj, default=_serialize_if_needed)
-
-    def __contains__(self, cache_key):
-        actual_key = self._convert_cache_key(cache_key)
-        return os.path.isfile(actual_key)
-
-    def __getitem__(self, cache_key):
-        """Retrieve value from a cache key."""
-        actual_key = self._convert_cache_key(cache_key)
-        try:
-            with open(actual_key) as f:
-                return json.load(f)
-        except (OSError, ValueError):
-            raise KeyError(cache_key)
-
-    def __delitem__(self, cache_key):
-        actual_key = self._convert_cache_key(cache_key)
-        try:
-            key_path = Path(actual_key)
-            key_path.unlink()
-        except FileNotFoundError:
-            raise KeyError(cache_key)
-
-    def __setitem__(self, cache_key, value):
-        full_key = self._convert_cache_key(cache_key)
-        try:
-            file_content = self._dumps(value)
-        except (TypeError, ValueError):
-            raise ValueError(
-                f"Value cannot be cached, must be "
-                f"JSON serializable: {value}"
-            )
-        if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir)
-        with os.fdopen(
-            os.open(full_key, os.O_WRONLY | os.O_CREAT, 0o600), 'w'
-        ) as f:
-            f.truncate()
-            f.write(file_content)
-
-    def _convert_cache_key(self, cache_key):
-        full_path = os.path.join(self._working_dir, cache_key + '.json')
-        return full_path
 
 
 class Credentials:
@@ -2118,6 +2058,8 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         token_loader=None,
         cache=None,
         expiry_window_seconds=None,
+        token_provider=None,
+        sso_session_name=None,
     ):
         self._client_creator = client_creator
         self._sso_region = sso_region
@@ -2125,6 +2067,8 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         self._account_id = account_id
         self._start_url = start_url
         self._token_loader = token_loader
+        self._token_provider = token_provider
+        self._sso_session_name = sso_session_name
         super().__init__(cache, expiry_window_seconds)
 
     def _create_cache_key(self):
@@ -2133,10 +2077,13 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         The cache key is intended to be compatible with file names.
         """
         args = {
-            'startUrl': self._start_url,
             'roleName': self._role_name,
             'accountId': self._account_id,
         }
+        if self._sso_session_name:
+            args['sessionName'] = self._sso_session_name
+        else:
+            args['startUrl'] = self._start_url
         # NOTE: It would be good to hoist this cache key construction logic
         # into the CachedCredentialFetcher class as we should be consistent.
         # Unfortunately, the current assume role fetchers that sub class don't
@@ -2159,12 +2106,16 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
             region_name=self._sso_region,
         )
         client = self._client_creator('sso', config=config)
+        if self._token_provider:
+            initial_token_data = self._token_provider.load_token()
+            token = initial_token_data.get_frozen_token().token
+        else:
+            token = self._token_loader(self._start_url)['accessToken']
 
-        token_dict = self._token_loader(self._start_url)
         kwargs = {
             'roleName': self._role_name,
             'accountId': self._account_id,
-            'accessToken': token_dict['accessToken'],
+            'accessToken': token,
         }
         try:
             response = client.get_role_credentials(**kwargs)
@@ -2190,12 +2141,17 @@ class SSOProvider(CredentialProvider):
     _SSO_TOKEN_CACHE_DIR = os.path.expanduser(
         os.path.join('~', '.aws', 'sso', 'cache')
     )
-    _SSO_CONFIG_VARS = [
-        'sso_start_url',
-        'sso_region',
+    _PROFILE_REQUIRED_CONFIG_VARS = (
         'sso_role_name',
         'sso_account_id',
-    ]
+    )
+    _SSO_REQUIRED_CONFIG_VARS = (
+        'sso_start_url',
+        'sso_region',
+    )
+    _ALL_REQUIRED_CONFIG_VARS = (
+        _PROFILE_REQUIRED_CONFIG_VARS + _SSO_REQUIRED_CONFIG_VARS
+    )
 
     def __init__(
         self,
@@ -2204,10 +2160,12 @@ class SSOProvider(CredentialProvider):
         profile_name,
         cache=None,
         token_cache=None,
+        token_provider=None,
     ):
         if token_cache is None:
             token_cache = JSONFileCache(self._SSO_TOKEN_CACHE_DIR)
         self._token_cache = token_cache
+        self._token_provider = token_provider
         if cache is None:
             cache = {}
         self.cache = cache
@@ -2220,17 +2178,24 @@ class SSOProvider(CredentialProvider):
         profiles = loaded_config.get('profiles', {})
         profile_name = self._profile_name
         profile_config = profiles.get(self._profile_name, {})
+        sso_sessions = loaded_config.get('sso_sessions', {})
 
         # Role name & Account ID indicate the cred provider should be used
-        sso_cred_vars = ('sso_role_name', 'sso_account_id')
-        if all(c not in profile_config for c in sso_cred_vars):
+        if all(
+            c not in profile_config for c in self._PROFILE_REQUIRED_CONFIG_VARS
+        ):
             return None
+
+        resolved_config, extra_reqs = self._resolve_sso_session_reference(
+            profile_config, sso_sessions
+        )
 
         config = {}
         missing_config_vars = []
-        for config_var in self._SSO_CONFIG_VARS:
-            if config_var in profile_config:
-                config[config_var] = profile_config[config_var]
+        all_required_configs = self._ALL_REQUIRED_CONFIG_VARS + extra_reqs
+        for config_var in all_required_configs:
+            if config_var in resolved_config:
+                config[config_var] = resolved_config[config_var]
             else:
                 missing_config_vars.append(config_var)
 
@@ -2242,23 +2207,50 @@ class SSOProvider(CredentialProvider):
                     'required configuration: %s' % (profile_name, missing)
                 )
             )
-
         return config
+
+    def _resolve_sso_session_reference(self, profile_config, sso_sessions):
+        sso_session_name = profile_config.get('sso_session')
+        if sso_session_name is None:
+            # No reference to resolve, proceed with legacy flow
+            return profile_config, ()
+
+        if sso_session_name not in sso_sessions:
+            error_msg = f'The specified sso-session does not exist: "{sso_session_name}"'
+            raise InvalidConfigError(error_msg=error_msg)
+
+        config = profile_config.copy()
+        session = sso_sessions[sso_session_name]
+        for config_var, val in session.items():
+            # Validate any keys referenced in both profile and sso_session match
+            if config.get(config_var, val) != val:
+                error_msg = (
+                    f"The value for {config_var} is inconsistent between "
+                    f"profile ({config[config_var]}) and sso-session ({val})."
+                )
+                raise InvalidConfigError(error_msg=error_msg)
+            config[config_var] = val
+        return config, ('sso_session',)
 
     def load(self):
         sso_config = self._load_sso_config()
         if not sso_config:
             return None
 
-        sso_fetcher = SSOCredentialFetcher(
-            sso_config['sso_start_url'],
-            sso_config['sso_region'],
-            sso_config['sso_role_name'],
-            sso_config['sso_account_id'],
-            self._client_creator,
-            token_loader=SSOTokenLoader(cache=self._token_cache),
-            cache=self.cache,
-        )
+        fetcher_kwargs = {
+            'start_url': sso_config['sso_start_url'],
+            'sso_region': sso_config['sso_region'],
+            'role_name': sso_config['sso_role_name'],
+            'account_id': sso_config['sso_account_id'],
+            'client_creator': self._client_creator,
+            'token_loader': SSOTokenLoader(cache=self._token_cache),
+            'cache': self.cache,
+        }
+        if 'sso_session' in sso_config:
+            fetcher_kwargs['sso_session_name'] = sso_config['sso_session']
+            fetcher_kwargs['token_provider'] = self._token_provider
+
+        sso_fetcher = SSOCredentialFetcher(**fetcher_kwargs)
 
         return DeferredRefreshableCredentials(
             method=self.METHOD,

--- a/botocore/tokens.py
+++ b/botocore/tokens.py
@@ -23,13 +23,12 @@ from dateutil.tz import tzutc
 from botocore import UNSIGNED
 from botocore.compat import total_seconds
 from botocore.config import Config
-from botocore.credentials import JSONFileCache
 from botocore.exceptions import (
     ClientError,
     InvalidConfigError,
     TokenRetrievalError,
 )
-from botocore.utils import CachedProperty, SSOTokenLoader
+from botocore.utils import CachedProperty, JSONFileCache, SSOTokenLoader
 
 logger = logging.getLogger(__name__)
 
@@ -182,11 +181,12 @@ class SSOTokenProvider:
         "sso_region",
     ]
     _GRANT_TYPE = "refresh_token"
+    DEFAULT_CACHE_CLS = JSONFileCache
 
     def __init__(self, session, cache=None, time_fetcher=_utc_now):
         self._session = session
         if cache is None:
-            cache = JSONFileCache(
+            cache = self.DEFAULT_CACHE_CLS(
                 self._SSO_TOKEN_CACHE_DIR,
                 dumps_func=_sso_json_dumps,
             )

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import json
 import math
 import os
 import shutil
@@ -20,6 +21,7 @@ import time
 import uuid
 from datetime import datetime, timedelta
 
+import pytest
 from dateutil.tz import tzlocal
 
 from botocore import UNSIGNED
@@ -44,6 +46,7 @@ from botocore.exceptions import (
 )
 from botocore.session import Session
 from botocore.stub import Stubber
+from botocore.tokens import SSOTokenProvider
 from botocore.utils import datetime2timestamp
 from tests import (
     BaseEnvVar,
@@ -55,6 +58,9 @@ from tests import (
     temporary_file,
     unittest,
 )
+
+TIME_IN_ONE_HOUR = datetime.utcnow() + timedelta(hours=1)
+TIME_IN_SIX_MONTHS = datetime.utcnow() + timedelta(hours=4320)
 
 
 class TestCredentialRefreshRaces(unittest.TestCase):
@@ -929,3 +935,148 @@ class TestSTSRegional(BaseAssumeRoleTest):
             self.assertEqual(
                 stubber.requests[0].url, 'https://sts.us-west-2.amazonaws.com/'
             )
+
+
+class MockCache:
+    """Mock for JSONFileCache to avoid touching files on disk"""
+
+    def __init__(self, working_dir=None, dumps_func=None):
+        self.working_dir = working_dir
+        self.dumps_func = dumps_func
+
+    def __contains__(self, cache_key):
+        return True
+
+    def __getitem__(self, cache_key):
+        return {
+            "startUrl": "https://test.awsapps.com/start",
+            "region": "us-east-1",
+            "accessToken": "access-token",
+            "expiresAt": TIME_IN_ONE_HOUR.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            "expiresIn": 3600,
+            "clientId": "client-12345",
+            "clientSecret": "client-secret",
+            "registrationExpiresAt": TIME_IN_SIX_MONTHS.strftime(
+                '%Y-%m-%dT%H:%M:%SZ'
+            ),
+            "refreshToken": "refresh-here",
+        }
+
+    def __delitem__(self, cache_key):
+        pass
+
+
+class SSOSessionTest(BaseEnvVar):
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.config_file = os.path.join(self.tempdir, 'config')
+        self.environ['AWS_CONFIG_FILE'] = self.config_file
+        self.access_key_id = 'ASIA123456ABCDEFG'
+        self.secret_access_key = 'secret-key'
+        self.session_token = 'session-token'
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+        super().tearDown()
+
+    def write_config(self, config):
+        with open(self.config_file, 'w') as f:
+            f.write(config)
+
+    def test_token_chosen_from_provider(self):
+        profile = (
+            '[profile sso-test]\n'
+            'region = us-east-1\n'
+            'sso_session = sso-test-session\n'
+            'sso_account_id = 12345678901234\n'
+            'sso_role_name = ViewOnlyAccess\n'
+            '\n'
+            '[sso-session sso-test-session]\n'
+            'sso_region = us-east-1\n'
+            'sso_start_url = https://test.awsapps.com/start\n'
+            'sso_registration_scopes = sso:account:access\n'
+        )
+        self.write_config(profile)
+
+        session = Session(profile='sso-test')
+        with SessionHTTPStubber(session) as stubber:
+            self.add_credential_response(stubber)
+            stubber.add_response()
+            with mock.patch.object(
+                SSOTokenProvider, 'DEFAULT_CACHE_CLS', MockCache
+            ):
+                c = session.create_client('s3')
+                c.list_buckets()
+
+        self.assert_valid_sso_call(
+            stubber.requests[0],
+            (
+                'https://portal.sso.us-east-1.amazonaws.com/federation/credentials'
+                '?role_name=ViewOnlyAccess&account_id=12345678901234'
+            ),
+            b'access-token',
+        )
+        self.assert_credentials_used(
+            stubber.requests[1],
+            self.access_key_id.encode('utf-8'),
+            self.session_token.encode('utf-8'),
+        )
+
+    def test_mismatched_session_values(self):
+        profile = (
+            '[profile sso-test]\n'
+            'region = us-east-1\n'
+            'sso_session = sso-test-session\n'
+            'sso_start_url = https://test2.awsapps.com/start\n'
+            'sso_account_id = 12345678901234\n'
+            'sso_role_name = ViewOnlyAccess\n'
+            '\n'
+            '[sso-session sso-test-session]\n'
+            'sso_region = us-east-1\n'
+            'sso_start_url = https://test.awsapps.com/start\n'
+            'sso_registration_scopes = sso:account:access\n'
+        )
+        self.write_config(profile)
+
+        session = Session(profile='sso-test')
+        with pytest.raises(InvalidConfigError):
+            c = session.create_client('s3')
+            c.list_buckets()
+
+    def test_missing_sso_session(self):
+        profile = (
+            '[profile sso-test]\n'
+            'region = us-east-1\n'
+            'sso_session = sso-test-session\n'
+            'sso_start_url = https://test2.awsapps.com/start\n'
+            'sso_account_id = 12345678901234\n'
+            'sso_role_name = ViewOnlyAccess\n'
+            '\n'
+        )
+        self.write_config(profile)
+
+        session = Session(profile='sso-test')
+        with pytest.raises(InvalidConfigError):
+            c = session.create_client('s3')
+            c.list_buckets()
+
+    def assert_valid_sso_call(self, request, url, access_token):
+        assert request.url == url
+        assert 'x-amz-sso_bearer_token' in request.headers
+        assert request.headers['x-amz-sso_bearer_token'] == access_token
+
+    def assert_credentials_used(self, request, access_key, session_token):
+        assert access_key in request.headers.get('Authorization')
+        assert request.headers.get('X-Amz-Security-Token') == session_token
+
+    def add_credential_response(self, stubber):
+        response = {
+            'roleCredentials': {
+                'accessKeyId': self.access_key_id,
+                'secretAccessKey': self.secret_access_key,
+                'sessionToken': self.session_token,
+                'expiration': TIME_IN_ONE_HOUR.timestamp() * 1000,
+            }
+        }
+        stubber.add_response(body=json.dumps(response).encode('utf-8'))


### PR DESCRIPTION
This PR will add support for loading credentials via a configured `sso-session` in your AWS config file.