### PR TITLE
Readd missing six import in compat

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -26,6 +26,7 @@ from collections import OrderedDict
 from collections.abc import MutableMapping
 from math import floor
 
+from botocore.vendored import six
 from botocore.exceptions import MD5UnavailableError
 from dateutil.tz import tzlocal
 from urllib3 import exceptions


### PR DESCRIPTION
This fixes a miss from #2806 where six was incorrectly removed from the compat module. This is required for external test frameworks and is needed for backwards compatibility.