### PR TITLE
Fixed doc issues around links and nested formatting

### DIFF
--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -12,6 +12,10 @@
 # language governing permissions and limitations under the License.
 from html.parser import HTMLParser
 
+PRIORITY_PARENT_TAGS = ('code', 'a')
+OMIT_NESTED_TAGS = ('span', 'i', 'code', 'a')
+OMIT_SELF_TAGS = ('i', 'b')
+
 
 class DocStringParser(HTMLParser):
     """
@@ -134,7 +138,26 @@ class TagNode(StemNode):
         self.attrs = attrs
         self.tag = tag
 
+    def _has_nested_tags(self):
+        # Returns True if any children are TagNodes and False otherwise.
+        for child in self.children:
+            if isinstance(child, TagNode):
+                return True
+        return False
+
     def write(self, doc, next_child=None):
+        prioritize_nested_tags = (
+            self.tag in OMIT_SELF_TAGS and self._has_nested_tags()
+        )
+        prioritize_parent_tag = (
+            isinstance(self.parent, TagNode)
+            and self.parent.tag in PRIORITY_PARENT_TAGS
+            and self.tag in OMIT_NESTED_TAGS
+        )
+        if prioritize_nested_tags or prioritize_parent_tag:
+            self._write_children(doc)
+            return
+
         self._write_start(doc)
         self._write_children(doc)
         self._write_end(doc, next_child)
@@ -201,6 +224,10 @@ class DataNode(Node):
 
         if self.data.isspace():
             str_data = ' '
+            if isinstance(self.parent, TagNode) and self.parent.tag == 'code':
+                # Prevents adding whitespace to code tags that would cause
+                # issues. We want to generate ``Test`` instead of `` Test ``.
+                str_data = ''
         else:
             end_space = self.data[-1].isspace()
             words = self.data.split()

--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -140,10 +140,7 @@ class TagNode(StemNode):
 
     def _has_nested_tags(self):
         # Returns True if any children are TagNodes and False otherwise.
-        for child in self.children:
-            if isinstance(child, TagNode):
-                return True
-        return False
+        return any(isinstance(child, TagNode) for child in self.children)
 
     def write(self, doc, next_child=None):
         prioritize_nested_tags = (
@@ -225,8 +222,9 @@ class DataNode(Node):
         if self.data.isspace():
             str_data = ' '
             if isinstance(self.parent, TagNode) and self.parent.tag == 'code':
-                # Prevents adding whitespace to code tags that would cause
-                # issues. We want to generate ``Test`` instead of `` Test ``.
+                # Inline markup content may not start or end with whitespace.
+                # When provided <code> Test </code>, we want to
+                # generate ``Test`` instead of `` Test ``.
                 str_data = ''
         else:
             end_space = self.data[-1].isspace()

--- a/botocore/docs/bcdoc/restdoc.py
+++ b/botocore/docs/bcdoc/restdoc.py
@@ -58,7 +58,7 @@ class ReSTDocument:
         """
         Removes and returns the last content written to the stack.
         """
-        return self._writes.pop()
+        return self._writes.pop() if len(self._writes) > 0 else None
 
     def push_write(self, s):
         """

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -67,7 +67,7 @@ class BaseStyle:
     def add_leading_space(self):
         # Adds a leading white space if none exists.
         last_write = self.doc.pop_write()
-        if last_write == None:
+        if last_write is None:
             last_write = ''
         if last_write != '' and last_write[-1] != ' ':
             last_write += ' '
@@ -249,7 +249,9 @@ class ReSTStyle(BaseStyle):
         # Pop till we reach the link start character to retrieve link text.
         last_write = doc.pop_write()[::-1]
         while last_write[-1] != '`':
-            last_write += doc.pop_write()[::-1]  # Reverse text to preserve order
+            last_write += doc.pop_write()[
+                ::-1
+            ]  # Reverse text to preserve order
         doc.push_write('`')
         last_write = last_write[:-1]
 

--- a/tests/unit/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/docs/bcdoc/test_docstringparser.py
@@ -91,18 +91,14 @@ class TestDocStringParser(unittest.TestCase):
         )
 
     def test_bold_with_nested_formatting(self):
-        html = (
-            "<b><code>Test</code>test<a href=\" https://testing.com\">Link</a></b>"
-        )
+        html = "<b><code>Test</code>test<a href=\" https://testing.com\">Link</a></b>"
         result = self.parse(html)
         self.assert_contains_exact_lines_in_order(
             result, [b'``Test`` test `Link <https://testing.com>`__ ']
         )
 
     def test_link_with_nested_formatting(self):
-        html = (
-            "<a href=\"https://testing.com\"><code>Test</code></a>"
-        )
+        html = "<a href=\"https://testing.com\"><code>Test</code></a>"
         result = self.parse(html)
         self.assert_contains_exact_lines_in_order(
             result, [b'`Test <https://testing.com>`__ ']

--- a/tests/unit/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/docs/bcdoc/test_docstringparser.py
@@ -68,6 +68,46 @@ class TestDocStringParser(unittest.TestCase):
             result, [b'This is a test `Link <https://testing.com>`__.']
         )
 
+    def test_code_with_empty_link(self):
+        html = "<code> <a>Link</a> </code>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [b'``Link`` '])
+
+    def test_code_with_link_spaces(self):
+        html = "<code> <a href=\"https://testing.com\">Link</a> </code>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [b'``Link`` '])
+
+    def test_code_with_link_no_spaces(self):
+        html = "<code><a href=\"https://testing.com\">Link</a></code>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [b'``Link`` '])
+
+    def test_href_with_spaces(self):
+        html = "<p><a href=\" https://testing.com\">Link</a></p>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b' `Link <https://testing.com>`__ ']
+        )
+
+    def test_bold_with_nested_formatting(self):
+        html = (
+            "<b><code>Test</code>test<a href=\" https://testing.com\">Link</a></b>"
+        )
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'``Test`` test `Link <https://testing.com>`__ ']
+        )
+
+    def test_link_with_nested_formatting(self):
+        html = (
+            "<a href=\"https://testing.com\"><code>Test</code></a>"
+        )
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'`Test <https://testing.com>`__ ']
+        )
+
 
 class TestHTMLTree(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR addresses issues with botocore docs which include:
* Missing or necessary white space which causes links to render incorrectly
* [Nested formatting](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#:~:text=No%20nested%20inline%20markup%3A%20Something%20like%20*see%20%3Afunc%3A%60foo%60*%20is%20not%20possible.) not being supported by Sphinx.

Examples:
* https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/kms.html#:~:text=https%3A//docs.aws.amazon.com/kms/latest/developerguide/%60.
* https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#:~:text=parameter%20in%20the-,%60%60%20GetOrganizationsAccessReport%20%60%60,-operation%20to%20check
 