### PR TITLE
Resolve endpoint with default partition when no region is set

### DIFF
--- a/.changes/next-release/bugfix-Endpoints-16572.json
+++ b/.changes/next-release/bugfix-Endpoints-16572.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoints",
+  "description": "Resolve endpoint with default partition when no region is set"
+}

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -202,13 +202,12 @@ class RuleSetStandardLibary:
         :type value: str
         :rtype: dict
         """
-        if value is None:
-            return None
-
         partitions = self.partitions_data['partitions']
-        for partition in partitions:
-            if self.is_partition_match(value, partition):
-                return self.format_partition_output(partition)
+
+        if value is not None:
+            for partition in partitions:
+                if self.is_partition_match(value, partition):
+                    return self.format_partition_output(partition)
 
         # return the default partition if no matches were found
         aws_partition = partitions[0]

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -22,5 +22,6 @@ def patched_session(monkeypatch):
     monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'secret_key')
     monkeypatch.setenv('AWS_CONFIG_FILE', 'no-exist-foo')
     monkeypatch.delenv('AWS_PROFILE', raising=False)
+    monkeypatch.delenv('AWS_DEFAULT_REGION', raising=False)
     session = create_session()
     return session

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -288,3 +288,29 @@ class TestSTSEndpoints(BaseSessionTest):
             expected_url='https://sts.not-real.amazonaws.com/',
             expected_signing_region='not-real',
         )
+
+
+def test_assume_role_with_saml_no_region_custom_endpoint(patched_session):
+    # When an endpoint_url and no region are given, AssumeRoleWithSAML should
+    # resolve to the endpoint_url and succeed, not fail in endpoint resolution:
+    # https://github.com/aws/aws-cli/issues/7455
+
+    client = patched_session.create_client(
+        'sts', region_name=None, endpoint_url="https://custom.endpoint.aws"
+    )
+    assert client.meta.region_name is None
+
+    mock_response_body = b"""\
+<AssumeRoleWithSAMLResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+    <AssumeRoleWithSAMLResult></AssumeRoleWithSAMLResult>
+</AssumeRoleWithSAMLResponse>
+"""
+    with ClientHTTPStubber(client) as http_stubber:
+        http_stubber.add_response(body=mock_response_body)
+        client.assume_role_with_saml(
+            RoleArn='arn:aws:iam::123456789:role/RoleA',
+            PrincipalArn='arn:aws:iam::123456789:role/RoleB',
+            SAMLAssertion='xxxx',
+        )
+    captured_request = http_stubber.requests[0]
+    assert captured_request.url == "https://custom.endpoint.aws/"

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -205,8 +205,9 @@ def test_endpoint_resolution(
     assert endpoint.headers == expected_endpoint.get("headers", {})
 
 
-def test_none_doesnt_use_default_partition(rule_lib):
-    assert rule_lib.aws_partition(None) is None
+def test_none_returns_default_partition(rule_lib):
+    partition_dict = rule_lib.aws_partition(None)
+    assert partition_dict['name'] == "aws"
 
 
 def test_no_match_region_returns_default_partition(rule_lib):


### PR DESCRIPTION
Addresses https://github.com/aws/aws-cli/issues/7455.

Changes endpoint resolution to resolve the endpoint for the default AWS partition when no region is given.