### PR TITLE
Fix: S3 Object Lambda requests miss x-amz-content-sha256 headers

### DIFF
--- a/.changes/next-release/bugfix-s3-26698.json
+++ b/.changes/next-release/bugfix-s3-26698.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "fixes missing x-amz-content-sha256 header for s3 object lambda"
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -94,6 +94,9 @@ _OUTPOST_ARN = (
     r'[a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$'
 )
 VALID_S3_ARN = re.compile('|'.join([_ACCESSPOINT_ARN, _OUTPOST_ARN]))
+# signing names used for the services s3 and s3-control, for example in
+# botocore/data/s3/2006-03-01/endpoints-rule-set-1.json
+S3_SIGNING_NAMES = ('s3', 's3-outposts', 's3-object-lambda')
 VERSION_ID_SUFFIX = re.compile(r'\?versionId=[^\s]+$')
 
 SERVICE_NAME_ALIASES = {'runtime.sagemaker': 'sagemaker-runtime'}
@@ -220,7 +223,7 @@ def set_operation_specific_signer(context, signing_name, **kwargs):
 
         # Signing names used by s3 and s3-control use customized signers "s3v4"
         # and "s3v4a".
-        if signing_name in ('s3', 's3-outposts', 's3-object-lambda'):
+        if signing_name in S3_SIGNING_NAMES:
             signature_version = f's3{signature_version}'
 
         return signature_version

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -218,8 +218,9 @@ def set_operation_specific_signer(context, signing_name, **kwargs):
         if auth_type == 'v4-unsigned-body':
             context['payload_signing_enabled'] = False
 
-        # s3 and s3-control have customized signers "s3v4" and "s3v4a".
-        if signing_name in ('s3', 's3-outposts'):
+        # Signing names used by s3 and s3-control use customized signers "s3v4"
+        # and "s3v4a".
+        if signing_name in ('s3', 's3-outposts', 's3-object-lambda'):
             signature_version = f's3{signature_version}'
 
         return signature_version

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -959,6 +959,9 @@ class TestAccesspointArn(BaseS3ClientConfigurationTest):
             "myBanner-123456789012.s3-object-lambda.us-west-2.amazonaws.com"
         )
         self.assert_endpoint(request, expected_endpoint)
+        sha_header = request.headers.get("x-amz-content-sha256")
+        self.assertIsNotNone(sha_header)
+        self.assertNotEqual(sha_header, b"UNSIGNED-PAYLOAD")
 
     def test_outposts_raise_exception_if_fips_region(self):
         outpost_arn = (


### PR DESCRIPTION
Addresses https://github.com/aws/aws-cli/issues/7456: Requests for some S3 API operations that should include the x-amz-content-sha256 header do not have this header for S3 Object Lambdas. This issue was introduced in version 1.28.0 of botocore.