### PR TITLE
Update to awscrt dependency from 0.14.0 0.15.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ requires_dist =
     urllib3>=1.25.4,<1.27
 
 [options.extras_require]
-crt = awscrt==0.14.0
+crt = awscrt==0.15.3
 
 [flake8]
 ignore = E203,E226,E501,E731,W503,W504


### PR DESCRIPTION
awscrt is a conditional dependency of botocore (used when installing with `pip install botocore[crt]`. 

awscrt added wheels for Python 3.11 in https://github.com/awslabs/aws-crt-python/tree/v0.15.1 (and dropped wheels for Python 3.6 at the same time). botocore formally added support for Python 3.11 in #2693. As of last weekend, Github Actions CI runs fail for Windows + Python 3.11 + with CRT variant at the step where awscrt gets built from source.

Updating the dependency version ensures that an awscrt wheel is used for all botocore installs, including under Python 3.11. This indirectly also fixes the failing CI builds.

awscrt changelog: https://github.com/awslabs/aws-crt-python/releases

The change in this PR is by @davidlm, I am only creating the PR. The most recent awscrt version bump PR in botocore was #2736.