### PR TITLE
Readme virtualenv

### DIFF
--- a/.changes/next-release/enhancement-docs-63042.json
+++ b/.changes/next-release/enhancement-docs-63042.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "docs",
+  "description": "Minor update Getting Started in Readme"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pip-log.txt
 env
 env2
 env3
+venv
 
 docs/source/reference/services
 tests/coverage.xml

--- a/README.rst
+++ b/README.rst
@@ -36,13 +36,13 @@ For more information, see this `blog post <https://aws.amazon.com/blogs/develope
 
 Getting Started
 ---------------
-Assuming that you have Python and ``virtualenv`` installed, set up your environment and install the required dependencies like this or you can install the library using ``pip``:
+Assuming that you have Python installed, set up your environment and install the required dependencies like this or you can install the library using ``pip``:
 
 .. code-block:: sh
 
     $ git clone https://github.com/boto/botocore.git
     $ cd botocore
-    $ virtualenv venv
+    $ python -m venv venv
     ...
     $ . venv/bin/activate
     $ pip install -r requirements.txt


### PR DESCRIPTION
This PR updates the README to use `venv` over `virtualenv`.