### PR TITLE
Optionally allow HTTP redirects

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -234,6 +234,7 @@ class ClientArgsCreator:
                 client_cert=client_config.client_cert,
                 inject_host_prefix=client_config.inject_host_prefix,
                 tcp_keepalive=client_config.tcp_keepalive,
+                allow_http_redirects=client_config.allow_http_redirects,
             )
         self._compute_retry_config(config_kwargs)
         self._compute_connect_timeout(config_kwargs)

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -189,6 +189,18 @@ class Config:
         creating new connections if set to True.
 
         Defaults to False.
+
+    :type allow_http_redirects: bool
+    :param allow_http_redirects: Whether to allow HTTP redirects using the
+        'location' header.
+
+        Setting this True will cause botocore to redirect requests to
+        the URL specified by the HTTP 'location' header, if any, on receiving
+        a HTTP 301, 302 or 307 from the upstream service.
+
+        HTTP redirections are limited to a maximum of three per request.
+
+        Defaults to False.
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -212,6 +224,7 @@ class Config:
             ('use_fips_endpoint', None),
             ('defaults_mode', None),
             ('tcp_keepalive', None),
+            ('allow_http_redirects', False),
         ]
     )
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1549,12 +1549,6 @@ class S3RegionRedirectorv2:
             )
             return
 
-        if redirect_ctx.get('redirected'):
-            logger.debug(
-                'S3 request was previously redirected, not redirecting.'
-            )
-            return
-
         error = response[1].get('Error', {})
         error_code = error.get('Code')
         response_metadata = response[1].get('ResponseMetadata', {})
@@ -1588,6 +1582,41 @@ class S3RegionRedirectorv2:
                 is_redirect_status,
             ]
         ):
+            return
+
+        # If the user has enabled the "allow_http_redirects" config option,
+        # set our URL to that provided by the "location" response header
+        # on receiving a HTTP 301, 302 or 307.
+        #
+        # This helps compatibility with some third-party storage
+        # systems.
+        #
+        # We dont treat the codes as semantically different, and we don't
+        # implement any sort of caching (ie, we don't respect the
+        # "Cache-Control" or "Expires" response headers).
+        #
+        # We also won't redirect more than three times.
+        location = response_metadata.get('HTTPHeaders', {}).get('location')
+        is_http_redirect = (
+            self._client._client_config.allow_http_redirects
+            and is_redirect_status
+            and location
+        )
+        if is_http_redirect:
+            redirect_count = redirect_ctx.get('redirect_count', 0)
+            if redirect_count >= 3:
+                logger.debug(
+                    'S3 request was previously redirected too many times, not redirecting.'
+                )
+                return
+            request_dict['url'] = location
+            redirect_ctx['redirect_count'] = redirect_count + 1
+            return 0
+
+        if redirect_ctx.get('redirected'):
+            logger.debug(
+                'S3 request was previously redirected, not redirecting.'
+            )
             return
 
         bucket = request_dict['context']['s3_redirect']['bucket']
@@ -1697,6 +1726,7 @@ class S3RegionRedirectorv2:
         bucket = params.get('Bucket')
         context['s3_redirect'] = {
             'redirected': False,
+            'redirect_count': 0,
             'bucket': bucket,
             'params': params,
         }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1714,6 +1714,89 @@ class TestS3RegionRedirector(unittest.TestCase):
         )
         self.assertIsNone(redirect_response)
 
+    def test_allow_http_redirects(self):
+        self.client._client_config.allow_http_redirects = True
+
+        request_dict = {
+            'url': 'https://us-west-2.amazonaws.com/foo',
+            'context': {
+                's3_redirect': {
+                    'bucket': 'foo',
+                    'redirected': False,
+                    'params': {'Bucket': 'foo'},
+                },
+                'signing': {},
+            },
+        }
+
+        raw_response = mock.Mock()
+        raw_response.status_code = 307
+        raw_response.content = 'Temporary Redirect'
+        raw_response.headers = {'location': 'https://foo.spam:1234/ham?eggs'}
+        response = (
+            raw_response,
+            {
+                'Error': {'Code': '307', 'Message': 'Temporary Redirect'},
+                'ResponseMetadata': {
+                    'HTTPHeaders': {
+                        'location': 'https://foo.spam:1234/ham?eggs',
+                    }
+                },
+            },
+        )
+
+        self.operation.name = 'HeadObject'
+        redirect_response = self.redirector.redirect_from_error(
+            request_dict, response, self.operation
+        )
+        self.assertEqual(redirect_response, 0)
+        self.assertEqual(request_dict['url'], 'https://foo.spam:1234/ham?eggs')
+
+        self.operation.name = 'ListObjects'
+        redirect_response = self.redirector.redirect_from_error(
+            request_dict, response, self.operation
+        )
+        self.assertEqual(redirect_response, 0)
+        self.assertEqual(request_dict['url'], 'https://foo.spam:1234/ham?eggs')
+
+    def test_allow_http_redirects_limit(self):
+        self.client._client_config.allow_http_redirects = True
+
+        request_dict = {
+            'context': {
+                'signing': {'bucket': 'foo', 'region': 'us-west-2'},
+                's3_redirected': False,
+                's3_redirect': {
+                    'bucket': 'foo',
+                    'redirected': False,
+                    'params': {'Bucket': 'foo'},
+                    'redirect_count': 4,
+                },
+            },
+            'url': 'https://us-west-2.amazonaws.com/foo',
+        }
+
+        raw_response = mock.Mock()
+        raw_response.status_code = 307
+        raw_response.content = 'Temporary Redirect'
+        raw_response.headers = {'location': 'https://foo.spam:1234/ham?eggs'}
+        response = (
+            raw_response,
+            {
+                'Error': {'Code': '307', 'Message': 'Temporary Redirect'},
+                'ResponseMetadata': {
+                    'HTTPHeaders': {
+                        'location': 'https://foo.spam:1234/ham?eggs',
+                    }
+                },
+            },
+        )
+
+        redirect_response = self.redirector.redirect_from_error(
+            request_dict, response, self.operation
+        )
+        self.assertIsNone(redirect_response)
+
     def test_redirects_400_head_bucket(self):
         request_dict = {
             'url': 'https://us-west-2.amazonaws.com/foo',


### PR DESCRIPTION
This adds (optional, client configured) support for the HTTP "location" header when processing HTTP redirects for S3 responses.

I'm a developer at NVIDIA; I wrote this on behalf of the [AIStore project](https://github.com/NVIDIA/aistore). We'd really like to use botocore (and boto3) for client access; AIStore (and some other systems - like Apache Ozone, [referenced by this issue](https://github.com/boto/botocore/issues/2571)) rely on standard HTTP redirects - using the "location" header - for load balancing. 

botocore [constructs redirection URLs using the region instead](https://github.com/boto/botocore/blob/a94d3dfaa74b20d4f1ea700e411224467e76c7da/botocore/utils.py#L1595-L1635), and won't allow redirections outside of known Amazon URIs. 

I've gated the change here behind a config setting; that said, other AWS SDKs (aws-sdk-go, for instance) do appear to support redirects as normal, so hopefully this behaviour is in line with other clients.

This change - 

 - Introduces `allow_http_redirects` config option (default: `False`).
 - If set to `True`, performs [HTTP redirection](https://www.rfc-editor.org/rfc/rfc7231#section-6.4) based on the `Location` header
 - Limits the number of redirections for a given request to three (I didn't feel adding another config option was worth it in this case).
 - Closes #2571.

```
import boto3
from botocore.config import Config as Config

config = Config(allow_http_redirects=True)
session = boto3.Session()
s3 = session.resource("s3", endpoint_url="http://127.0.0.1:8080/s3", config=config)
```

I've added unit and functional tests and tried to keep the style consistent with your existing work. If there's any demand for caching using the `Cache-Control` or `Expires` headers, I could certainly do it in the follow-up.

Thanks.