### PR TITLE
Update ARN delimiter parsing in endpoint provider

### DIFF
--- a/.changes/next-release/bugfix-Endpointprovider-32427.json
+++ b/.changes/next-release/bugfix-Endpointprovider-32427.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoint provider",
+  "description": "Updates ARN parsing ``resourceId`` delimiters"
+}

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -47,6 +47,7 @@ GET_ATTR_RE = re.compile(r"(\w+)\[(\d+)\]")
 VALID_HOST_LABEL_RE = re.compile(
     r"^(?!-)[a-zA-Z\d-]{1,63}(?<!-)$",
 )
+ARN_DELIMITER_RE = re.compile(r"/|:")
 CACHE_SIZE = 100
 ARN_PARSER = ArnParser()
 STRING_FORMATTER = Formatter()
@@ -236,8 +237,7 @@ class RuleSetStandardLibrary:
         arn_dict["accountId"] = arn_dict.pop("account")
 
         resource = arn_dict.pop("resource")
-        delimiter = ":" if ":" in resource else "/"
-        arn_dict["resourceId"] = resource.split(delimiter)
+        arn_dict["resourceId"] = re.split(ARN_DELIMITER_RE, resource)
 
         return arn_dict
 

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -220,6 +220,47 @@ def test_invalid_arn_returns_none(rule_lib):
     assert rule_lib.aws_parse_arn("arn:aws:this-is-not-an-arn:foo") is None
 
 
+@pytest.mark.parametrize(
+    "arn, expected_resource_id",
+    [
+        (
+            "arn:aws:s3:::myBucket/key",
+            {
+                "partition": "aws",
+                "service": "s3",
+                "region": "",
+                "accountId": "",
+                "resourceId": ["myBucket", "key"],
+            },
+        ),
+        (
+            "arn:aws:kinesis:us-east-1:1234567890:stream/mystream:foo",
+            {
+                "partition": "aws",
+                "service": "kinesis",
+                "region": "us-east-1",
+                "accountId": "1234567890",
+                "resourceId": ["stream", "mystream", "foo"],
+            },
+        ),
+        (
+            "arn:aws:s3:::myBucket",
+            {
+                "partition": "aws",
+                "service": "s3",
+                "region": "",
+                "accountId": "",
+                "region": "",
+                "resourceId": ["myBucket"],
+            },
+        ),
+    ],
+)
+def test_parse_arn_delimiters(rule_lib, arn, expected_resource_id):
+    parsed_arn = rule_lib.aws_parse_arn(arn)
+    assert parsed_arn == expected_resource_id
+
+
 def test_uri_encode_none_returns_none(rule_lib):
     assert rule_lib.uri_encode(None) is None
 


### PR DESCRIPTION
This addresses a bug for `aws_parse_arn` in `endpoint_provider.RuleSetStandardLibrary`. Currently the `resourceId` portion of a parsed ARN was only thought to either have a `/` or `:` as a delimiter. However, in services such as `kinesis`, they can have both.

Current Behavior
`arn:aws:kinesis:1234567890:us-east-1:thing/foo:bar`  -> `{...'resourceId': ['thing/foo', 'bar']}`

New Behavior
`arn:aws:kinesis:1234567890:us-east-1:thing/foo:bar`  -> `{...'resourceId': ['thing', 'foo', 'bar']}`
