### PR TITLE
Add Type field for query errors from JSON protocol

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -706,6 +706,7 @@ class BaseJSONParser(ResponseParser):
         code = None
         if len(query_error_components) == 2 and query_error_components[0]:
             code = query_error_components[0]
+            error['Error']['Type'] = query_error_components[1]
         if code is None:
             code = body.get('__type', response_code and str(response_code))
         if code is not None:

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1104,6 +1104,7 @@ class TestParseErrorResponses(unittest.TestCase):
         self.assertEqual(
             parsed['Error']['Code'], 'AWS.SimpleQueueService.NonExistentQueue'
         )
+        self.assertEqual(parsed['Error']['Type'], 'Sender')
 
     def test_response_with_invalid_query_error_for_json_protocol(self):
         parser = parsers.JSONParser()
@@ -1125,6 +1126,7 @@ class TestParseErrorResponses(unittest.TestCase):
         self.assertIn('Error', parsed)
         self.assertEqual(parsed['Error']['Message'], 'this is a message')
         self.assertEqual(parsed['Error']['Code'], 'ValidationException')
+        self.assertNotIn('Type', parsed['Error'])
 
     def test_response_with_incomplete_query_error_for_json_protocol(self):
         parser = parsers.JSONParser()
@@ -1146,6 +1148,7 @@ class TestParseErrorResponses(unittest.TestCase):
         self.assertIn('Error', parsed)
         self.assertEqual(parsed['Error']['Message'], 'this is a message')
         self.assertEqual(parsed['Error']['Code'], 'ValidationException')
+        self.assertNotIn('Type', parsed['Error'])
 
     def test_response_with_empty_query_errors_for_json_protocol(self):
         parser = parsers.JSONParser()
@@ -1167,6 +1170,7 @@ class TestParseErrorResponses(unittest.TestCase):
         self.assertIn('Error', parsed)
         self.assertEqual(parsed['Error']['Message'], 'this is a message')
         self.assertEqual(parsed['Error']['Code'], 'ValidationException')
+        self.assertNotIn('Type', parsed['Error'])
 
     def test_parse_error_response_for_query_protocol(self):
         body = (


### PR DESCRIPTION
By default, the query parser parses all fields from the error response and includes them in the parsed error dictionary. This included a `Type` key. However, JSON protocol based services never return a `Type` as part of the parsed error response. So for backwards compatibility purposes, the SDK needs to parse the `Type` key from the `x-amz-query-error` header and include it as part of the parsed error response when the header is found for JSON protocol based services.