### PR TITLE
Ignore response/request sections in docs if they're too large.

### DIFF
--- a/botocore/docs/bcdoc/restdoc.py
+++ b/botocore/docs/bcdoc/restdoc.py
@@ -234,7 +234,6 @@ class DocumentStructure(ReSTDocument):
         line_count = len(value.splitlines())
         line_limit = SECTION_LINE_LIMITS.get(self.name)
         if line_limit and line_count > line_limit:
-            print(f'Lines:{line_count}, Section:{self.name}')
             value = (
                 f'\n\n    **{SECTION_NAME_MAPPING.get(self.name)}**'
                 f'\n{LARGE_SECTION_MESSAGE}'

--- a/botocore/docs/bcdoc/restdoc.py
+++ b/botocore/docs/bcdoc/restdoc.py
@@ -17,6 +17,11 @@ from botocore.docs.bcdoc.docstringparser import DocStringParser
 from botocore.docs.bcdoc.style import ReSTStyle
 
 LOG = logging.getLogger('bcdocs')
+SECTION_LINE_LIMITS = {
+    'example': 1500,
+    'description': 10000,
+    'request-params': 10000,
+}
 
 
 class ReSTDocument:
@@ -206,7 +211,10 @@ class DocumentStructure(ReSTDocument):
         value = self.getvalue()
         for name, section in self._structure.items():
             value += section.flush_structure()
-        return value
+        # Ignores response/request sections if the line number exceeds our limit.
+        line_count = value.decode('utf-8').count('\n')
+        line_limit = SECTION_LINE_LIMITS.get(self.name)
+        return b'' if line_limit and line_count > line_limit else value
 
     def getvalue(self):
         return ''.join(self._writes).encode('utf-8')

--- a/botocore/docs/bcdoc/restdoc.py
+++ b/botocore/docs/bcdoc/restdoc.py
@@ -18,7 +18,7 @@ from botocore.docs.bcdoc.docstringparser import DocStringParser
 from botocore.docs.bcdoc.style import ReSTStyle
 
 DEFAULT_AWS_DOCS_LINK = 'https://docs.aws.amazon.com/index.html'
-DOCUMENTATION_LINK_REGEX = (
+DOCUMENTATION_LINK_REGEX = re.compile(
     r'`AWS API Documentation '
     r'<https://docs.aws.amazon.com/goto/WebAPI/[a-z0-9-.]*/[a-zA-Z]*>`_'
 )
@@ -238,9 +238,9 @@ class DocumentStructure(ReSTDocument):
         for name, section in self._structure.items():
             # Checks is the AWS API Documentation link has been generated.
             # If it has been generated, it gets passed as a the doc_link parameter.
-            match = re.search(DOCUMENTATION_LINK_REGEX, value.decode())
+            match = DOCUMENTATION_LINK_REGEX.search(value.decode())
             docs_link = (
-                (match.group(0) + '\n\n').encode() if match else docs_link
+                f'{match.group(0)}\n\n'.encode() if match else docs_link
             )
             value += section.flush_structure(docs_link)
 

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -217,7 +217,7 @@ def document_model_driven_method(
         method_intro_section.writeln('')
 
     # Add the example section.
-    example_section = section.add_new_section('example')
+    example_section = section.add_new_section('request-example')
     example_section.style.new_paragraph()
     example_section.style.bold('Request Syntax')
 
@@ -287,7 +287,9 @@ def document_model_driven_method(
             event_section.style.new_line()
 
         # Add an example return value
-        return_example_section = return_section.add_new_section('example')
+        return_example_section = return_section.add_new_section(
+            'response-example'
+        )
         return_example_section.style.new_line()
         return_example_section.style.bold('Response Syntax')
         return_example_section.style.new_paragraph()


### PR DESCRIPTION
## Summary
Services such as `quicksight` have recently become very large and contain several layers of nested shapes that result in doc pages which are basically unusable in some cases such as [this one](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/quicksight.html).

## Solution
The temporary solution to get these pages usable again is to ignore response/request sections that are too large, specifically here are the limits:
* **`Request/Response Syntax Examples:`** Limited to 1500 lines. If larger, the section will be replaced with a "too large" message and be provided a link to AWS API Documentation for the corresponding service/section.
* **`Descriptions/Params:`** Limited to 5000 lines. If larger, the section will be replaced with a "too large" message and be provided a link to AWS API Documentation for the corresponding service/section.

**Affected Service Pages:** # sections  (min_lines - max_lines)
* `ec2.html` - 3 sections (5,974 - 5,989)
* `lexv2-models.html` - 20 sections (1,778 - 18,487)
* `quicksight.html` - 18 sections (29,481 - 160,523)  # This was the worst one
* `sagemaker.html` - 4 sections (2,133 - 14,376)
*  `securityhub.html` - 13 sections (3979 -  23,728)
*  `wafv2.html` - 10 sections (2,036 - 17,672)
