### PR TITLE
Implemented nested doc pages.

### DIFF
--- a/botocore/docs/__init__.py
+++ b/botocore/docs/__init__.py
@@ -25,15 +25,21 @@ def generate_docs(root_dir, session):
         service's reference documentation is loacated at
         root_dir/reference/services/service-name.rst
     """
-    services_doc_path = os.path.join(root_dir, 'reference', 'services')
-    if not os.path.exists(services_doc_path):
-        os.makedirs(services_doc_path)
+    # Create the root directory where all service docs live.
+    services_dir_path = os.path.join(root_dir, 'reference', 'services')
+    if not os.path.exists(services_dir_path):
+        os.makedirs(services_dir_path)
 
     # Generate reference docs and write them out.
     for service_name in session.get_available_services():
-        docs = ServiceDocumenter(service_name, session).document_service()
-        service_doc_path = os.path.join(
-            services_doc_path, f"{service_name}.rst"
+        docs = ServiceDocumenter(
+            service_name, session, services_dir_path
+        ).document_service()
+
+        # Write the main service documentation page.
+        # Path: <root>/reference/services/<service>/index.rst
+        service_file_path = os.path.join(
+            services_dir_path, service_name, 'index.rst'
         )
-        with open(service_doc_path, 'wb') as f:
+        with open(service_file_path, 'wb') as f:
             f.write(docs)

--- a/botocore/docs/__init__.py
+++ b/botocore/docs/__init__.py
@@ -39,7 +39,7 @@ def generate_docs(root_dir, session):
         # Write the main service documentation page.
         # Path: <root>/reference/services/<service>/index.rst
         service_file_path = os.path.join(
-            services_dir_path, service_name, 'index.rst'
+            services_dir_path, f'{service_name}.rst'
         )
         with open(service_file_path, 'wb') as f:
             f.write(docs)

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -102,10 +102,10 @@ class ClientDocumenter:
         self._add_client_creation_example(section)
 
         # List out all of the possible client methods.
-        section.style.new_line()
+        section.style.dedent()
+        section.style.new_paragraph()
         section.writeln('These are the available methods:')
         section.style.toctree()
-        section.style.dedent()
         for method_name in sorted(client_methods):
             section.style.tocitem(f'client/{method_name}')
 
@@ -277,7 +277,6 @@ class ClientExceptionsDocumenter:
         section.style.new_line()
         section.writeln('The available client exceptions are:')
         section.style.toctree()
-        section.style.dedent()
         for shape in error_shapes:
             section.style.tocitem(f'exceptions/{shape.name}')
 

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -107,7 +107,7 @@ class ClientDocumenter:
         section.writeln('These are the available methods:')
         section.style.toctree()
         for method_name in sorted(client_methods):
-            section.style.tocitem(f'client/{method_name}')
+            section.style.tocitem(f'{self._service_name}/client/{method_name}')
 
     def _add_class_signature(self, section):
         section.style.start_sphinx_py_class(
@@ -278,7 +278,9 @@ class ClientExceptionsDocumenter:
         section.writeln('The available client exceptions are:')
         section.style.toctree()
         for shape in error_shapes:
-            section.style.tocitem(f'exceptions/{shape.name}')
+            section.style.tocitem(
+                f'{self._service_name}/exceptions/{shape.name}'
+            )
 
     def _add_exception_classes(self):
         for shape in self._client.meta.service_model.error_shapes:

--- a/botocore/docs/paginator.py
+++ b/botocore/docs/paginator.py
@@ -36,7 +36,6 @@ class PaginatorDocumenter:
         section.style.new_line()
         section.writeln('The available paginators are:')
         section.style.toctree()
-        section.style.dedent()
 
         paginator_names = sorted(
             self._service_paginator_model._paginator_config

--- a/botocore/docs/paginator.py
+++ b/botocore/docs/paginator.py
@@ -43,7 +43,9 @@ class PaginatorDocumenter:
 
         # List the available paginators and then document each paginator.
         for paginator_name in paginator_names:
-            section.style.tocitem(f'paginators/{paginator_name}')
+            section.style.tocitem(
+                f'{self._service_name}/paginators/{paginator_name}'
+            )
             # Create a new DocumentStructure for each paginator and add contents.
             waiter_doc_structure = DocumentStructure(
                 self._service_name, target='html'

--- a/botocore/docs/service.py
+++ b/botocore/docs/service.py
@@ -18,9 +18,10 @@ from botocore.exceptions import DataNotFoundError
 
 
 class ServiceDocumenter:
-    def __init__(self, service_name, session):
+    def __init__(self, service_name, session, root_docs_path):
         self._session = session
         self._service_name = service_name
+        self._root_docs_path = root_docs_path
 
         self._client = self._session.create_client(
             service_name,
@@ -71,10 +72,14 @@ class ServiceDocumenter:
         except DataNotFoundError:
             pass
 
-        ClientDocumenter(self._client, examples).document_client(section)
+        ClientDocumenter(
+            self._client, self._root_docs_path, examples
+        ).document_client(section)
 
     def client_exceptions(self, section):
-        ClientExceptionsDocumenter(self._client).document_exceptions(section)
+        ClientExceptionsDocumenter(
+            self._client, self._root_docs_path
+        ).document_exceptions(section)
 
     def paginator_api(self, section):
         try:
@@ -84,7 +89,7 @@ class ServiceDocumenter:
         except DataNotFoundError:
             return
         paginator_documenter = PaginatorDocumenter(
-            self._client, service_paginator_model
+            self._client, service_paginator_model, self._root_docs_path
         )
         paginator_documenter.document_paginators(section)
 
@@ -94,7 +99,7 @@ class ServiceDocumenter:
                 self._service_name
             )
             waiter_documenter = WaiterDocumenter(
-                self._client, service_waiter_model
+                self._client, service_waiter_model, self._root_docs_path
             )
             waiter_documenter.document_waiters(section)
 

--- a/botocore/docs/waiter.py
+++ b/botocore/docs/waiter.py
@@ -37,7 +37,9 @@ class WaiterDocumenter:
         section.writeln('The available waiters are:')
         section.style.toctree()
         for waiter_name in self._service_waiter_model.waiter_names:
-            section.style.tocitem(f'waiters/{waiter_name}')
+            section.style.tocitem(
+                f'{self._service_name}/waiters/{waiter_name}'
+            )
             # Create a new DocumentStructure for each waiter and add contents.
             waiter_doc_structure = DocumentStructure(
                 self._service_name, target='html'

--- a/botocore/docs/waiter.py
+++ b/botocore/docs/waiter.py
@@ -10,18 +10,22 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
+
 from botocore import xform_name
 from botocore.compat import OrderedDict
+from botocore.docs.bcdoc.restdoc import DocumentStructure
 from botocore.docs.method import document_model_driven_method
 from botocore.docs.utils import DocumentedShape
 from botocore.utils import get_service_module_name
 
 
 class WaiterDocumenter:
-    def __init__(self, client, service_waiter_model):
+    def __init__(self, client, service_waiter_model, root_docs_path):
         self._client = client
         self._service_name = self._client.meta.service_model.service_name
         self._service_waiter_model = service_waiter_model
+        self._root_docs_path = root_docs_path
 
     def document_waiters(self, section):
         """Documents the various waiters for a service.
@@ -31,35 +35,52 @@ class WaiterDocumenter:
         section.style.h2('Waiters')
         section.style.new_line()
         section.writeln('The available waiters are:')
+        section.style.toctree()
+        section.style.dedent()
         for waiter_name in self._service_waiter_model.waiter_names:
-            section.style.li(
-                f":py:class:`{self._client.__class__.__name__}.Waiter.{waiter_name}`"
+            section.style.tocitem(f'waiters/{waiter_name}')
+            # Create a new DocumentStructure for each waiter and add contents.
+            waiter_doc_structure = DocumentStructure(
+                self._service_name, target='html'
             )
-            self._add_single_waiter(section, waiter_name)
+            self._add_single_waiter(waiter_doc_structure, waiter_name)
 
     def _add_single_waiter(self, section, waiter_name):
-        section = section.add_new_section(waiter_name)
-        section.style.start_sphinx_py_class(
+        title_section = section.add_new_section('title')
+        title_section.style.h1(waiter_name)
+        waiter_section = section.add_new_section(waiter_name)
+        waiter_section.style.start_sphinx_py_class(
             class_name=f"{self._client.__class__.__name__}.Waiter.{waiter_name}"
         )
 
         # Add example on how to instantiate waiter.
-        section.style.start_codeblock()
-        section.style.new_line()
-        section.write(
+        waiter_section.style.start_codeblock()
+        waiter_section.style.new_line()
+        waiter_section.write(
             'waiter = client.get_waiter(\'%s\')' % xform_name(waiter_name)
         )
-        section.style.end_codeblock()
+        waiter_section.style.end_codeblock()
 
         # Add information on the wait() method
-        section.style.new_line()
+        waiter_section.style.new_line()
         document_wait_method(
-            section=section,
+            section=waiter_section,
             waiter_name=waiter_name,
             event_emitter=self._client.meta.events,
             service_model=self._client.meta.service_model,
             service_waiter_model=self._service_waiter_model,
         )
+
+        # Write waiters in individual/nested files.
+        # Path: <root>/reference/services/<service>/waiters/<waiter_name>.rst
+        waiter_dir_path = os.path.join(
+            self._root_docs_path, f"{self._service_name}", 'waiters'
+        )
+        if not os.path.exists(waiter_dir_path):
+            os.makedirs(waiter_dir_path)
+        waiter_file_path = os.path.join(waiter_dir_path, f'{waiter_name}.rst')
+        with open(waiter_file_path, 'wb') as f:
+            f.write(section.flush_structure())
 
 
 def document_wait_method(

--- a/botocore/docs/waiter.py
+++ b/botocore/docs/waiter.py
@@ -36,7 +36,6 @@ class WaiterDocumenter:
         section.style.new_line()
         section.writeln('The available waiters are:')
         section.style.toctree()
-        section.style.dedent()
         for waiter_name in self._service_waiter_model.waiter_names:
             section.style.tocitem(f'waiters/{waiter_name}')
             # Create a new DocumentStructure for each waiter and add contents.

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -6,4 +6,4 @@ Available Services
   :titlesonly:
   :glob:
 
-  services/*
+  services/*/index

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -6,4 +6,4 @@ Available Services
   :titlesonly:
   :glob:
 
-  services/*/index
+  services/*

--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -10,6 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
+import shutil
+import tempfile
+
 from botocore.docs.service import ServiceDocumenter
 from botocore.session import get_session
 from tests import unittest
@@ -18,6 +22,13 @@ from tests import unittest
 class BaseDocsFunctionalTest(unittest.TestCase):
     def setUp(self):
         self._session = get_session()
+        self.docs_root_dir = tempfile.mkdtemp()
+        self.root_services_path = os.path.join(
+            self.docs_root_dir, 'reference', 'services'
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.docs_root_dir)
 
     def assert_contains_line(self, line, contents):
         contents = contents.decode('utf-8')
@@ -39,9 +50,21 @@ class BaseDocsFunctionalTest(unittest.TestCase):
         for line in lines:
             self.assertNotIn(line, contents)
 
+    def get_client_method_contents(self, service_name, method_name):
+        service_file_path = os.path.join(
+            self.root_services_path,
+            service_name,
+            'client',
+            f'{method_name}.rst',
+        )
+        with open(service_file_path, 'rb') as f:
+            return f.read()
+
     def get_title_section_for(self, service_name):
         contents = (
-            ServiceDocumenter(service_name, self._session)
+            ServiceDocumenter(
+                service_name, self._session, self.root_services_path
+            )
             .document_service()
             .decode('utf-8')
         )
@@ -53,48 +76,49 @@ class BaseDocsFunctionalTest(unittest.TestCase):
 
     def get_method_document_block(self, operation_name, contents):
         contents = contents.decode('utf-8')
-        start_method_document = '  .. py:method:: %s(' % operation_name
+        start_method_document = '.. py:method:: %s(' % operation_name
         start_index = contents.find(start_method_document)
         self.assertNotEqual(start_index, -1, 'Method is not found in contents')
         contents = contents[start_index:]
-        end_index = contents.find(
-            '  .. py:method::', len(start_method_document)
-        )
+        end_index = contents.find('.. py:method::', len(start_method_document))
         contents = contents[:end_index]
         return contents.encode('utf-8')
 
     def get_parameter_document_block(self, param_name, contents):
         contents = contents.decode('utf-8')
-        start_param_document = '    :type %s:' % param_name
+        start_param_document = '  :type %s:' % param_name
         start_index = contents.find(start_param_document)
         self.assertNotEqual(start_index, -1, 'Param is not found in contents')
         contents = contents[start_index:]
-        end_index = contents.find('    :type', len(start_param_document))
+        end_index = contents.find('  :type', len(start_param_document))
         contents = contents[:end_index]
         return contents.encode('utf-8')
 
     def get_parameter_documentation_from_service(
         self, service_name, method_name, param_name
     ):
-        contents = ServiceDocumenter(
-            service_name, self._session
+        ServiceDocumenter(
+            service_name, self._session, self.root_services_path
         ).document_service()
+        contents = self.get_client_method_contents(service_name, method_name)
         method_contents = self.get_method_document_block(method_name, contents)
         return self.get_parameter_document_block(param_name, method_contents)
 
     def get_docstring_for_method(self, service_name, method_name):
-        contents = ServiceDocumenter(
-            service_name, self._session
+        ServiceDocumenter(
+            service_name, self._session, self.root_services_path
         ).document_service()
+        contents = self.get_client_method_contents(service_name, method_name)
         method_contents = self.get_method_document_block(method_name, contents)
         return method_contents
 
     def assert_is_documented_as_autopopulated_param(
         self, service_name, method_name, param_name, doc_string=None
     ):
-        contents = ServiceDocumenter(
-            service_name, self._session
+        ServiceDocumenter(
+            service_name, self._session, self.root_services_path
         ).document_service()
+        contents = self.get_client_method_contents(service_name, method_name)
         method_contents = self.get_method_document_block(method_name, contents)
 
         # Ensure it is not in the example.

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -45,12 +45,13 @@ class TestS3Docs(BaseDocsFunctionalTest):
             'put_object_acl',
             'put_bucket_versioning',
         ]
-        service_contents = ServiceDocumenter(
-            's3', self._session
+        ServiceDocumenter(
+            's3', self._session, self.root_services_path
         ).document_service()
         for method_name in modified_methods:
+            contents = self.get_client_method_contents('s3', method_name)
             method_contents = self.get_method_document_block(
-                method_name, service_contents
+                method_name, contents
             )
             self.assertNotIn(
                 'ContentMD5=\'string\'', method_contents.decode('utf-8')

--- a/tests/functional/docs/test_secretsmanager.py
+++ b/tests/functional/docs/test_secretsmanager.py
@@ -16,6 +16,8 @@ from tests.functional.docs import BaseDocsFunctionalTest
 
 class TestSecretsManagerDocs(BaseDocsFunctionalTest):
     def test_generate_presigned_url_is_not_documented(self):
-        documenter = ServiceDocumenter('secretsmanager', self._session)
+        documenter = ServiceDocumenter(
+            'secretsmanager', self._session, self.root_services_path
+        )
         docs = documenter.document_service()
         self.assert_not_contains_line('generate_presigned_url', docs)

--- a/tests/functional/docs/test_streaming_body.py
+++ b/tests/functional/docs/test_streaming_body.py
@@ -33,8 +33,9 @@ class TestStreamingBodyDocumentation(BaseDocsFunctionalTest):
                     )
 
     def assert_streaming_body_is_properly_documented(self, service, operation):
-        service_docs = ServiceDocumenter(
-            service, self._session
+        ServiceDocumenter(
+            service, self._session, self.root_services_path
         ).document_service()
-        method_docs = self.get_method_document_block(operation, service_docs)
+        contents = self.get_client_method_contents(service, operation)
+        method_docs = self.get_method_document_block(operation, contents)
         self.assert_contains_line('StreamingBody', method_docs)

--- a/tests/unit/docs/__init__.py
+++ b/tests/unit/docs/__init__.py
@@ -42,6 +42,10 @@ class BaseDocsTest(unittest.TestCase):
         self.example_model_file = os.path.join(
             self.version_dirs, 'examples-1.json'
         )
+        self.docs_root_dir = tempfile.mkdtemp()
+        self.root_services_path = os.path.join(
+            self.docs_root_dir, 'reference', 'services'
+        )
 
         self.json_model = {}
         self.nested_json_model = {}
@@ -54,6 +58,7 @@ class BaseDocsTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.root_dir)
+        shutil.rmtree(self.docs_root_dir)
 
     def setup_client(self):
         with open(self.example_model_file, 'w') as f:
@@ -202,6 +207,13 @@ class BaseDocsTest(unittest.TestCase):
             },
         }
 
+    def get_nested_service_contents(self, service, type, name):
+        service_file_path = os.path.join(
+            self.root_services_path, service, type, f'{name}.rst'
+        )
+        with open(service_file_path, 'rb') as f:
+            return f.read().decode('utf-8')
+
     def build_models(self):
         self.service_model = ServiceModel(self.json_model)
         self.operation_model = OperationModel(
@@ -237,8 +249,9 @@ class BaseDocsTest(unittest.TestCase):
         contents = self.doc_structure.flush_structure().decode('utf-8')
         self.assertIn(line, contents)
 
-    def assert_contains_lines_in_order(self, lines):
-        contents = self.doc_structure.flush_structure().decode('utf-8')
+    def assert_contains_lines_in_order(self, lines, contents=None):
+        if contents is None:
+            contents = self.doc_structure.flush_structure().decode('utf-8')
         for line in lines:
             self.assertIn(line, contents)
             beginning = contents.find(line)

--- a/tests/unit/docs/test_client.py
+++ b/tests/unit/docs/test_client.py
@@ -28,7 +28,9 @@ class TestClientDocumenter(BaseDocsTest):
         self.add_shape_to_params('Biz', 'String')
         self.add_shape_to_errors('SomeException')
         self.setup_client()
-        self.client_documenter = ClientDocumenter(self.client)
+        self.client_documenter = ClientDocumenter(
+            self.client, self.root_services_path
+        )
 
     def test_document_client(self):
         self.client_documenter.document_client(self.doc_structure)
@@ -42,41 +44,65 @@ class TestClientDocumenter(BaseDocsTest):
                 '  AWS MyService Description',
                 '    client = session.create_client(\'myservice\')',
                 '  These are the available methods:',
-                '  *   :py:meth:`~MyService.Client.can_paginate`',
-                '  *   :py:meth:`~MyService.Client.get_paginator`',
-                '  *   :py:meth:`~MyService.Client.get_waiter`',
-                '  *   :py:meth:`~MyService.Client.sample_operation`',
-                '  .. py:method:: can_paginate(operation_name)',
-                '  .. py:method:: get_paginator(operation_name)',
-                '  .. py:method:: get_waiter(waiter_name)',
-                '  .. py:method:: sample_operation(**kwargs)',
-                '    **Request Syntax**',
-                '    ::',
-                '      response = client.sample_operation(',
-                '          Biz=\'string\'',
-                '      )',
-                '    :type Biz: string',
-                '    :param Biz:',
-                '    :rtype: dict',
-                '    :returns:',
-                '      **Response Syntax**',
-                '      ::',
-                '        {',
-                '            \'Biz\': \'string\'',
-                '        }',
-                '      **Response Structure**',
-                '      - *(dict) --*',
-                '        - **Biz** *(string) --*',
-                '**Exceptions**',
-                '*     :py:class:`MyService.Client.exceptions.SomeException`',
+                '  client/can_paginate',
+                '  client/get_paginator',
+                '  client/get_waiter',
+                '  client/sample_operation',
             ]
+        )
+        self.assert_contains_lines_in_order(
+            ['.. py:method:: can_paginate(operation_name)'],
+            self.get_nested_service_contents(
+                'myservice', 'client', 'can_paginate'
+            ),
+        )
+        self.assert_contains_lines_in_order(
+            ['.. py:method:: get_paginator(operation_name)'],
+            self.get_nested_service_contents(
+                'myservice', 'client', 'get_paginator'
+            ),
+        )
+        self.assert_contains_lines_in_order(
+            ['.. py:method:: get_waiter(waiter_name)'],
+            self.get_nested_service_contents(
+                'myservice', 'client', 'get_waiter'
+            ),
+        )
+        self.assert_contains_lines_in_order(
+            [
+                '.. py:method:: sample_operation(**kwargs)',
+                '  **Request Syntax**',
+                '  ::',
+                '    response = client.sample_operation(',
+                '        Biz=\'string\'',
+                '    )',
+                '  :type Biz: string',
+                '  :param Biz:',
+                '  :rtype: dict',
+                '  :returns:',
+                '    **Response Syntax**',
+                '    ::',
+                '      {',
+                '          \'Biz\': \'string\'',
+                '      }',
+                '    **Response Structure**',
+                '    - *(dict) --*',
+                '      - **Biz** *(string) --*',
+                '**Exceptions**',
+                '*   :py:class:`MyService.Client.exceptions.SomeException`',
+            ],
+            self.get_nested_service_contents(
+                'myservice', 'client', 'sample_operation'
+            ),
         )
 
 
 class TestClientExceptionsDocumenter(BaseDocsTest):
     def setup_documenter(self):
         self.setup_client()
-        self.exceptions_documenter = ClientExceptionsDocumenter(self.client)
+        self.exceptions_documenter = ClientExceptionsDocumenter(
+            self.client, self.root_services_path
+        )
 
     def test_no_modeled_exceptions(self):
         self.setup_documenter()
@@ -109,7 +135,14 @@ class TestClientExceptionsDocumenter(BaseDocsTest):
                 '=================',
                 'Client exceptions are available',
                 'The available client exceptions are:',
-                '* :py:class:`MyService.Client.exceptions.SomeException`',
+                '.. toctree::',
+                ':maxdepth: 1',
+                ':titlesonly:',
+                '  exceptions/SomeException',
+            ]
+        )
+        self.assert_contains_lines_in_order(
+            [
                 '.. py:class:: MyService.Client.exceptions.SomeException',
                 '**Example** ::',
                 'except client.exceptions.SomeException as e:',
@@ -128,5 +161,8 @@ class TestClientExceptionsDocumenter(BaseDocsTest):
                 '- **Error** *(dict) --* ',
                 '- **Code** *(string) --* ',
                 '- **Message** *(string) --* ',
-            ]
+            ],
+            self.get_nested_service_contents(
+                'myservice', 'exceptions', 'SomeException'
+            ),
         )

--- a/tests/unit/docs/test_client.py
+++ b/tests/unit/docs/test_client.py
@@ -43,11 +43,11 @@ class TestClientDocumenter(BaseDocsTest):
                 '  A low-level client representing AWS MyService',
                 '  AWS MyService Description',
                 '    client = session.create_client(\'myservice\')',
-                '  These are the available methods:',
-                '  client/can_paginate',
-                '  client/get_paginator',
-                '  client/get_waiter',
-                '  client/sample_operation',
+                'These are the available methods:',
+                '  myservice/client/can_paginate',
+                '  myservice/client/get_paginator',
+                '  myservice/client/get_waiter',
+                '  myservice/client/sample_operation',
             ]
         )
         self.assert_contains_lines_in_order(
@@ -138,7 +138,7 @@ class TestClientExceptionsDocumenter(BaseDocsTest):
                 '.. toctree::',
                 ':maxdepth: 1',
                 ':titlesonly:',
-                '  exceptions/SomeException',
+                '  myservice/exceptions/SomeException',
             ]
         )
         self.assert_contains_lines_in_order(

--- a/tests/unit/docs/test_docs.py
+++ b/tests/unit/docs/test_docs.py
@@ -11,8 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import shutil
-import tempfile
 
 from botocore.docs import generate_docs
 from botocore.session import get_session
@@ -23,7 +21,6 @@ from tests.unit.docs import BaseDocsTest
 class TestGenerateDocs(BaseDocsTest):
     def setUp(self):
         super().setUp()
-        self.docs_root = tempfile.mkdtemp()
         self.loader_patch = mock.patch(
             'botocore.session.create_loader', return_value=self.loader
         )
@@ -36,20 +33,16 @@ class TestGenerateDocs(BaseDocsTest):
 
     def tearDown(self):
         super().tearDown()
-        shutil.rmtree(self.docs_root)
         self.loader_patch.stop()
         self.available_service_patch.stop()
 
     def test_generate_docs(self):
         session = get_session()
         # Have the rst files get written to the temporary directory
-        generate_docs(self.docs_root, session)
+        generate_docs(self.docs_root_dir, session)
 
-        reference_services_path = os.path.join(
-            self.docs_root, 'reference', 'services'
-        )
         reference_service_path = os.path.join(
-            reference_services_path, 'myservice.rst'
+            self.root_services_path, 'myservice', 'index.rst'
         )
         self.assertTrue(os.path.exists(reference_service_path))
 

--- a/tests/unit/docs/test_docs.py
+++ b/tests/unit/docs/test_docs.py
@@ -42,7 +42,7 @@ class TestGenerateDocs(BaseDocsTest):
         generate_docs(self.docs_root_dir, session)
 
         reference_service_path = os.path.join(
-            self.root_services_path, 'myservice', 'index.rst'
+            self.root_services_path, 'myservice.rst'
         )
         self.assertTrue(os.path.exists(reference_service_path))
 

--- a/tests/unit/docs/test_paginator.py
+++ b/tests/unit/docs/test_paginator.py
@@ -25,7 +25,9 @@ class TestPaginatorDocumenter(BaseDocsTest):
         self.setup_client()
         paginator_model = PaginatorModel(self.paginator_json_model)
         self.paginator_documenter = PaginatorDocumenter(
-            client=self.client, service_paginator_model=paginator_model
+            client=self.client,
+            service_paginator_model=paginator_model,
+            root_docs_path=self.root_services_path,
         )
 
     def test_document_paginators(self):
@@ -36,7 +38,11 @@ class TestPaginatorDocumenter(BaseDocsTest):
                 'Paginators',
                 '==========',
                 'The available paginators are:',
-                '* :py:class:`MyService.Paginator.SampleOperation`',
+                'paginators/SampleOperation',
+            ]
+        )
+        self.assert_contains_lines_in_order(
+            [
                 '.. py:class:: MyService.Paginator.SampleOperation',
                 '  ::',
                 '    paginator = client.get_paginator(\'sample_operation\')',
@@ -78,7 +84,10 @@ class TestPaginatorDocumenter(BaseDocsTest):
                 '      - *(dict) --*',
                 '        - **Biz** *(string) --*',
                 '        - **NextToken** *(string) --*',
-            ]
+            ],
+            self.get_nested_service_contents(
+                'myservice', 'paginators', 'SampleOperation'
+            ),
         )
 
     def test_no_page_size_if_no_limit_key(self):

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -27,7 +27,9 @@ class TestServiceDocumenter(BaseDocsTest):
             'botocore.session.create_loader', return_value=self.loader
         ):
             session = get_session()
-            self.service_documenter = ServiceDocumenter('myservice', session)
+            self.service_documenter = ServiceDocumenter(
+                'myservice', session, self.root_services_path
+            )
 
     def test_document_service(self):
         # Note that not everything will be included as it is just
@@ -47,12 +49,7 @@ class TestServiceDocumenter(BaseDocsTest):
             '  AWS MyService Description',
             '    client = session.create_client(\'myservice\')',
             '  These are the available methods:',
-            '  *   :py:meth:`~MyService.Client.sample_operation`',
-            '  .. py:method:: sample_operation(**kwargs)',
-            '    **Examples** ',
-            '    Sample Description.',
-            '    ::',
-            '      response = client.sample_operation(',
+            '  client/sample_operation',
             '=================',
             'Client Exceptions',
             '=================',
@@ -60,16 +57,27 @@ class TestServiceDocumenter(BaseDocsTest):
             '==========',
             'Paginators',
             '==========',
-            '.. py:class:: MyService.Paginator.SampleOperation',
-            '  .. py:method:: paginate(**kwargs)',
+            '  paginators/SampleOperation',
             '=======',
             'Waiters',
             '=======',
-            '.. py:class:: MyService.Waiter.SampleOperationComplete',
-            '  .. py:method:: wait(**kwargs)',
+            '  waiters/SampleOperationComplete',
         ]
         for line in lines:
             self.assertIn(line, contents)
+
+        self.assert_contains_lines_in_order(
+            [
+                '.. py:method:: sample_operation(**kwargs)',
+                '  **Examples** ',
+                '  Sample Description.',
+                '  ::',
+                '    response = client.sample_operation(',
+            ],
+            self.get_nested_service_contents(
+                'myservice', 'client', 'sample_operation'
+            ),
+        )
 
     def test_document_service_no_paginator(self):
         os.remove(self.paginator_model_file)

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -48,8 +48,8 @@ class TestServiceDocumenter(BaseDocsTest):
             '  A low-level client representing AWS MyService',
             '  AWS MyService Description',
             '    client = session.create_client(\'myservice\')',
-            '  These are the available methods:',
-            '  client/sample_operation',
+            'These are the available methods:',
+            '  myservice/client/sample_operation',
             '=================',
             'Client Exceptions',
             '=================',
@@ -57,11 +57,11 @@ class TestServiceDocumenter(BaseDocsTest):
             '==========',
             'Paginators',
             '==========',
-            '  paginators/SampleOperation',
+            '  myservice/paginators/SampleOperation',
             '=======',
             'Waiters',
             '=======',
-            '  waiters/SampleOperationComplete',
+            '  myservice/waiters/SampleOperationComplete',
         ]
         for line in lines:
             self.assertIn(line, contents)

--- a/tests/unit/docs/test_waiter.py
+++ b/tests/unit/docs/test_waiter.py
@@ -22,7 +22,9 @@ class TestWaiterDocumenter(BaseDocsTest):
         self.setup_client()
         waiter_model = WaiterModel(self.waiter_json_model)
         self.waiter_documenter = WaiterDocumenter(
-            client=self.client, service_waiter_model=waiter_model
+            client=self.client,
+            service_waiter_model=waiter_model,
+            root_docs_path=self.root_services_path,
         )
 
     def test_document_waiters(self):
@@ -33,7 +35,11 @@ class TestWaiterDocumenter(BaseDocsTest):
                 'Waiters',
                 '=======',
                 'The available waiters are:',
-                '* :py:class:`MyService.Waiter.SampleOperationComplete`',
+                'waiters/SampleOperationComplete',
+            ]
+        )
+        self.assert_contains_lines_in_order(
+            [
                 '.. py:class:: MyService.Waiter.SampleOperationComplete',
                 '  ::',
                 '    waiter = client.get_waiter(\'sample_operation_complete\')',
@@ -64,5 +70,8 @@ class TestWaiterDocumenter(BaseDocsTest):
                 '      - **MaxAttempts** *(integer) --*',
                 '        The maximum number of attempts to be made. Default: 40',
                 '    :returns: None',
-            ]
+            ],
+            self.get_nested_service_contents(
+                'myservice', 'waiters', 'SampleOperationComplete'
+            ),
         )


### PR DESCRIPTION
# Summary
This PR implements the changes needed to migrate our docs website from using single documentation pages for each service to having nested pages for each client method, exception, paginator, and waiter. The main page for each service (`<service_name>.html`) has client information along with sub-sections for each of the 4 categories (if applicable e.g. no waiters), each which contain a list of links to the corresponding sub-pages. A zip file is attached which contains example documentation html files that can be viewed locally for reference.
[Example Documentation Zip](https://github.com/boto/botocore/files/10407088/html.zip)

Note: `<service_name>.html` files remain in their original location to preserve pre-existing URL's. There will also be new folders for each service containing the corresponding sub-pages as shown below.

Old Structure:
```
reference
├── services
│   ├── ec2.html
│   ├── s3.html
│   ├── ...
```

New Structure:
```
reference
├── services
│   ├── ec2.html
│   ├── s3.html
│   ├── ...
│   ├── s3
│   │   ├── client
│   │   │   ├── get_object.html
│   │   │   ├── ...
│   │   ├── exceptions
│   │   │   ├── BucketAlreadyExists.html
│   │   │   ├── ...
│   │   ├── paginators
│   │   │   ├── ListObjectsV2.html
│   │   │   ├── ...
│   │   ├── waiters
│   │   │   ├── ObjectNotExists.html
│   │   │   ├── ...
│   ├── ...
```