### PR TITLE
Avoid BytesWarning on logging responses

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -237,8 +237,8 @@ class ResponseParser:
             always be present.
 
         """
-        LOG.debug('Response headers: %s', response['headers'])
-        LOG.debug('Response body:\n%s', response['body'])
+        LOG.debug('Response headers: %r', response['headers'])
+        LOG.debug('Response body:\n%r', response['body'])
         if response['status_code'] >= 301:
             if self._is_generic_error_response(response):
                 parsed = self._do_generic_error_parse(response)


### PR DESCRIPTION
`type(response['body'])` is `bytes`. Formatting it as `%s` results in a `BytesWarning` on Python 3.