### PR TITLE
Pin version of alabaster

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,14 @@
 # Botocore Documentation
 
 Documentation for botocore can be found [here](https://botocore.amazonaws.com/v1/documentation/api/latest/index.html)
+
+## Generating Documentation
+
+Sphinx is used for documentation. You can generate HTML locally with the
+following:
+
+```
+$ pip install -r requirements-docs.txt
+$ cd docs
+$ make html
+```

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,7 +3,17 @@
 # removed python 3.5 support we need to add our own pins.
 markupsafe>=1.1,<2.0
 jinja2>=2.3,<3.0
+
 # docutils needs a pin until we update to Sphinx > 3.0
 docutils>=0.10,<0.17
 Sphinx>=1.1.3,<=1.3.2
 guzzle_sphinx_theme>=0.7.10,<0.8
+
+# Recent release of alabaster requires Sphinx >=1.6, which requires a pin.
+alabaster>0.7,<0.7.13
+
+# Dependencies for Sphinx==1.3.2 (TODO: Remove with Sphinx upgrade)
+babel<=2.11.0 # via sphinx
+pygments<=2.14.0 # via sphinx
+pytz<=2022.7 # via babel
+snowballstemmer<=2.2.0 # via sphinx


### PR DESCRIPTION
Recent version of alabaster (0.7.13) requires `sphinx>=1.6`.