### PR TITLE
Plumb profile_name into SSOTokenProvider

### DIFF
--- a/.changes/next-release/bugfix-SSO-37144.json
+++ b/.changes/next-release/bugfix-SSO-37144.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SSO",
+  "description": "Fixes aws/aws-cli`#7496 <https://github.com/aws/aws-cli/issues/7496>`__ by using the correct profile name rather than the one set in the session."
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -224,7 +224,11 @@ class ProfileProviderBuilder:
             profile_name=profile_name,
             cache=self._cache,
             token_cache=self._sso_token_cache,
-            token_provider=SSOTokenProvider(self._session),
+            token_provider=SSOTokenProvider(
+                self._session,
+                cache=self._sso_token_cache,
+                profile_name=profile_name,
+            ),
         )
 
 

--- a/botocore/tokens.py
+++ b/botocore/tokens.py
@@ -183,7 +183,9 @@ class SSOTokenProvider:
     _GRANT_TYPE = "refresh_token"
     DEFAULT_CACHE_CLS = JSONFileCache
 
-    def __init__(self, session, cache=None, time_fetcher=_utc_now):
+    def __init__(
+        self, session, cache=None, time_fetcher=_utc_now, profile_name=None
+    ):
         self._session = session
         if cache is None:
             cache = self.DEFAULT_CACHE_CLS(
@@ -193,15 +195,17 @@ class SSOTokenProvider:
         self._now = time_fetcher
         self._cache = cache
         self._token_loader = SSOTokenLoader(cache=self._cache)
+        self._profile_name = (
+            profile_name
+            or self._session.get_config_variable("profile")
+            or 'default'
+        )
 
     def _load_sso_config(self):
         loaded_config = self._session.full_config
         profiles = loaded_config.get("profiles", {})
         sso_sessions = loaded_config.get("sso_sessions", {})
-        profile_name = self._session.get_config_variable("profile")
-        if not profile_name:
-            profile_name = "default"
-        profile_config = profiles.get(profile_name, {})
+        profile_config = profiles.get(self._profile_name, {})
 
         if "sso_session" not in profile_config:
             return
@@ -211,7 +215,7 @@ class SSOTokenProvider:
 
         if not sso_config:
             error_msg = (
-                f'The profile "{profile_name}" is configured to use the SSO '
+                f'The profile "{self._profile_name}" is configured to use the SSO '
                 f'token provider but the "{sso_session_name}" sso_session '
                 f"configuration does not exist."
             )
@@ -224,7 +228,7 @@ class SSOTokenProvider:
 
         if missing_configs:
             error_msg = (
-                f'The profile "{profile_name}" is configured to use the SSO '
+                f'The profile "{self._profile_name}" is configured to use the SSO '
                 f"token provider but is missing the following configuration: "
                 f"{missing_configs}."
             )

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -252,9 +252,10 @@ class TestAssumeRole(BaseAssumeRoleTest):
         mock_instance.CANONICAL_NAME = provider_cls.CANONICAL_NAME
         return mock_instance
 
-    def create_session(self, profile=None):
+    def create_session(self, profile=None, sso_token_cache=None):
         session = StubbedSession(profile=profile)
-
+        if not sso_token_cache:
+            sso_token_cache = JSONFileCache(self.tempdir)
         # We have to set bogus credentials here or otherwise we'll trigger
         # an early credential chain resolution.
         sts = session.create_client(
@@ -277,7 +278,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
             ),
             profile_provider_builder=ProfileProviderBuilder(
                 session,
-                sso_token_cache=JSONFileCache(self.tempdir),
+                sso_token_cache=sso_token_cache,
             ),
         )
         stubber = session.stub('sts')
@@ -571,7 +572,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
         with self.assertRaises(InvalidConfigError):
             session.get_credentials()
 
-    def test_sso_source_profile(self):
+    def test_sso_source_profile_legacy(self):
         token_cache_key = 'f395038c92f1828cbb3991d2d6152d326b895606'
         cached_token = {
             'accessToken': 'a.token',
@@ -593,6 +594,68 @@ class TestAssumeRole(BaseAssumeRoleTest):
         self.write_config(config)
 
         session, sts_stubber = self.create_session(profile='A')
+        client_config = Config(
+            region_name='us-east-1',
+            signature_version=UNSIGNED,
+        )
+        sso_stubber = session.stub('sso', config=client_config)
+        sso_stubber.activate()
+        # The expiration needs to be in milliseconds
+        expiration = datetime2timestamp(self.some_future_time()) * 1000
+        sso_role_creds = self.create_random_credentials()
+        sso_role_response = {
+            'roleCredentials': {
+                'accessKeyId': sso_role_creds.access_key,
+                'secretAccessKey': sso_role_creds.secret_key,
+                'sessionToken': sso_role_creds.token,
+                'expiration': int(expiration),
+            }
+        }
+        sso_stubber.add_response('get_role_credentials', sso_role_response)
+
+        expected_creds = self.create_random_credentials()
+        assume_role_response = self.create_assume_role_response(expected_creds)
+        sts_stubber.add_response('assume_role', assume_role_response)
+
+        actual_creds = session.get_credentials()
+        self.assert_creds_equal(actual_creds, expected_creds)
+        sts_stubber.assert_no_pending_responses()
+        # Assert that the client was created with the credentials from the
+        # SSO get role credentials response
+        self.assertEqual(self.mock_client_creator.call_count, 1)
+        _, kwargs = self.mock_client_creator.call_args_list[0]
+        expected_kwargs = {
+            'aws_access_key_id': sso_role_creds.access_key,
+            'aws_secret_access_key': sso_role_creds.secret_key,
+            'aws_session_token': sso_role_creds.token,
+        }
+        self.assertEqual(kwargs, expected_kwargs)
+
+    def test_sso_source_profile(self):
+        token_cache_key = '32096c2e0eff33d844ee6d675407ace18289357d'
+        cached_token = {
+            'accessToken': 'C',
+            'expiresAt': TIME_IN_ONE_HOUR.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        }
+        temp_cache = JSONFileCache(self.tempdir)
+        temp_cache[token_cache_key] = cached_token
+        config = (
+            '[profile A]\n'
+            'role_arn = arn:aws:iam::123456789:role/RoleA\n'
+            'source_profile = B\n'
+            '[profile B]\n'
+            'sso_session = C\n'
+            'sso_role_name = SSORole\n'
+            'sso_account_id = 1234567890\n'
+            '[sso-session C]\n'
+            'sso_region = us-east-1\n'
+            'sso_start_url = https://test.url/start\n'
+        )
+        self.write_config(config)
+
+        session, sts_stubber = self.create_session(
+            profile='A', sso_token_cache=temp_cache
+        )
         client_config = Config(
             region_name='us-east-1',
             signature_version=UNSIGNED,


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/7496

When resolving credentials, `profile_name` should be plumbed into `SSOTokenProvider` so that if they need to be resolved recursively, the newly set `profile_name` gets used to load the SSO config rather than using the profile name defined in the session.

Example of a valid config that is currently failing to resolve:
```
[profile test]
role_arn = arn:aws:iam:XXXXXXXXXXXX:role/testrole-1
source_profile = AdministratorAccess-XXXXXXXXXXXX
region = us-west-2

[profile AdministratorAccess-XXXXXXXXXXXX]
sso_session = dev
sso_account_id = XXXXXXXXXXXX
sso_role_name = AdministratorAccess
region = us-west-2
output = json

[sso-session dev]
sso_start_url = https://d-XXXXXXXXX.awsapps.com/start
sso_region = us-west-2
sso_registration_scopes = sso:account:access
```