### PR TITLE
Append `aws-chunked` to `Content-Encoding` header if present

### DIFF
--- a/.changes/next-release/bugfix-s3-10151.json
+++ b/.changes/next-release/bugfix-s3-10151.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "boto3 no longer overwrites user supplied `Content-Encoding` with `aws-chunked` when user also supplies `ChecksumAlgorithm`."
+}

--- a/.changes/next-release/bugfix-s3contentencoding-88564.json
+++ b/.changes/next-release/bugfix-s3contentencoding-88564.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3 content encoding",
+  "description": "Appends `aws-chunked` to `Content-Encoding` header."
+}

--- a/.changes/next-release/bugfix-s3contentencoding-88564.json
+++ b/.changes/next-release/bugfix-s3contentencoding-88564.json
@@ -1,5 +1,0 @@
-{
-  "type": "bugfix",
-  "category": "s3 content encoding",
-  "description": "Appends `aws-chunked` to `Content-Encoding` header."
-}

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -331,7 +331,12 @@ def _apply_request_trailer_checksum(request):
         return
 
     headers["Transfer-Encoding"] = "chunked"
-    headers["Content-Encoding"] = "aws-chunked"
+    if "Content-Encoding" in headers:
+        # We need to preserve the existing content encoding and add
+        # aws-chunked as a new content encoding.
+        headers["Content-Encoding"] += ",aws-chunked"
+    else:
+        headers["Content-Encoding"] = "aws-chunked"
     headers["X-Amz-Trailer"] = location_name
 
     content_length = determine_content_length(body)

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -2141,6 +2141,36 @@ def test_checksums_included_in_expected_operations(
         assert "Content-MD5" in stub.requests[-1].headers
 
 
+@pytest.mark.parametrize(
+    "input_param, expected_header",
+    [("foo", "foo,aws-chunked"), (None, "aws-chunked")],
+)
+def test_checksum_content_encoding(input_param, expected_header):
+    environ = {}
+    op_kwargs = {
+        "Bucket": "mybucket",
+        "Key": "mykey",
+        "Body": b"foo",
+        "ChecksumAlgorithm": "sha256",
+    }
+    if input_param is not None:
+        op_kwargs["ContentEncoding"] = input_param
+    with mock.patch("os.environ", environ):
+        environ["AWS_ACCESS_KEY_ID"] = "access_key"
+        environ["AWS_SECRET_ACCESS_KEY"] = "secret_key"
+        environ["AWS_CONFIG_FILE"] = "no-exist-foo"
+        session = create_session()
+        session.config_filename = "no-exist-foo"
+        s3 = session.create_client("s3")
+        with ClientHTTPStubber(s3) as http_stubber:
+            http_stubber.add_response()
+            s3.put_object(**op_kwargs)
+            assert (
+                http_stubber.requests[-1].headers["Content-Encoding"].decode()
+                == expected_header
+            )
+
+
 def _s3_addressing_test_cases():
     # The default behavior for sigv2. DNS compatible buckets
     yield dict(

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -2154,13 +2154,7 @@ def test_checksum_content_encoding(content_encoding, expected_header):
     }
     if content_encoding is not None:
         op_kwargs["ContentEncoding"] = content_encoding
-    s3 = _create_s3_client(
-        region="us-west-2",
-        is_secure=True,
-        s3_config={},
-        signature_version="s3v4",
-        endpoint_url=None,
-    )
+    s3 = _create_s3_client()
     with ClientHTTPStubber(s3) as http_stubber:
         http_stubber.add_response()
         s3.put_object(**op_kwargs)

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -2143,7 +2143,7 @@ def test_checksums_included_in_expected_operations(
 
 @pytest.mark.parametrize(
     "content_encoding, expected_header",
-    [("foo", "foo,aws-chunked"), (None, "aws-chunked")],
+    [("foo", b"foo,aws-chunked"), (None, b"aws-chunked")],
 )
 def test_checksum_content_encoding(content_encoding, expected_header):
     op_kwargs = {
@@ -2158,10 +2158,8 @@ def test_checksum_content_encoding(content_encoding, expected_header):
     with ClientHTTPStubber(s3) as http_stubber:
         http_stubber.add_response()
         s3.put_object(**op_kwargs)
-        assert (
-            http_stubber.requests[-1].headers["Content-Encoding"].decode()
-            == expected_header
-        )
+        request_headers = http_stubber.requests[-1].headers
+        assert request_headers["Content-Encoding"] == expected_header
 
 
 def _s3_addressing_test_cases():

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -301,6 +301,34 @@ class TestHttpChecksumHandlers(unittest.TestCase):
         # The body should not have been wrapped
         self.assertIsInstance(request["body"], bytes)
 
+    def test_apply_request_checksum_content_encoding_preset(self):
+        request = self._build_request(b"")
+        request["context"]["checksum"] = {
+            "request_algorithm": {
+                "in": "trailer",
+                "algorithm": "crc32",
+                "name": "x-amz-checksum-crc32",
+            }
+        }
+        request["headers"]["Content-Encoding"] = "foo"
+        apply_request_checksum(request)
+        # The content encoding should not have been modified
+        self.assertEqual(request["headers"]["Content-Encoding"], "foo,aws-chunked")
+
+    def test_apply_request_checksum_content_encoding_default(self):
+        request = self._build_request(b"")
+        request["context"]["checksum"] = {
+            "request_algorithm": {
+                "in": "trailer",
+                "algorithm": "crc32",
+                "name": "x-amz-checksum-crc32",
+            }
+        }
+        apply_request_checksum(request)
+        self.assertEqual(
+            request["headers"]["Content-Encoding"], "aws-chunked"
+        )
+
     def test_response_checksum_algorithm_no_model(self):
         request = self._build_request(b"")
         operation_model = self._make_operation_model()

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -313,7 +313,9 @@ class TestHttpChecksumHandlers(unittest.TestCase):
         request["headers"]["Content-Encoding"] = "foo"
         apply_request_checksum(request)
         # The content encoding should not have been modified
-        self.assertEqual(request["headers"]["Content-Encoding"], "foo,aws-chunked")
+        self.assertEqual(
+            request["headers"]["Content-Encoding"], "foo,aws-chunked"
+        )
 
     def test_apply_request_checksum_content_encoding_default(self):
         request = self._build_request(b"")
@@ -325,9 +327,7 @@ class TestHttpChecksumHandlers(unittest.TestCase):
             }
         }
         apply_request_checksum(request)
-        self.assertEqual(
-            request["headers"]["Content-Encoding"], "aws-chunked"
-        )
+        self.assertEqual(request["headers"]["Content-Encoding"], "aws-chunked")
 
     def test_response_checksum_algorithm_no_model(self):
         request = self._build_request(b"")

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -312,7 +312,7 @@ class TestHttpChecksumHandlers(unittest.TestCase):
         }
         request["headers"]["Content-Encoding"] = "foo"
         apply_request_checksum(request)
-        # The content encoding should not have been modified
+        # The content encoding should only have been appended
         self.assertEqual(
             request["headers"]["Content-Encoding"], "foo,aws-chunked"
         )


### PR DESCRIPTION
Primarily in various S3 operations, users may provide a `ContentEncoding` parameter. This tells the service how the content that is being sent/requested is encoded. An example of this would be `gzip`. However, for streaming AWS operations (i.e. ones that have trailers) where a `ChecksumAlgorithm` parameter is provided, the SDK is currently overriding any user input to `aws-chunked`. Instead this special content encoding should be appended to the user input.