### PR TITLE
Retrieve the original request inside endpoint response

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -234,6 +234,7 @@ class ClientArgsCreator:
                 client_cert=client_config.client_cert,
                 inject_host_prefix=client_config.inject_host_prefix,
                 tcp_keepalive=client_config.tcp_keepalive,
+                retrieve_original_header=client_config.retrieve_original_header,
             )
         self._compute_retry_config(config_kwargs)
         self._compute_connect_timeout(config_kwargs)

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -189,6 +189,12 @@ class Config:
         creating new connections if set to True.
 
         Defaults to False.
+
+    :type retrieve_original_header: bool
+    :param retrieve_original_header: Enables the option to return request
+        information made internally.
+
+        Defaults to False.
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -212,6 +218,7 @@ class Config:
             ('use_fips_endpoint', None),
             ('defaults_mode', None),
             ('tcp_keepalive', None),
+            ('retrieve_original_header', False),
         ]
     )
 

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -227,6 +227,8 @@ class Endpoint:
             success_response[1]['ResponseMetadata'][
                 'RetryAttempts'
             ] = total_retries
+            if context["client_config"].retrieve_original_header:
+                success_response[1]["OriginalRequest"] = request
         if exception is not None:
             raise exception
         else:

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -229,6 +229,8 @@ class Endpoint:
             ] = total_retries
             if context["client_config"].retrieve_original_header:
                 success_response[1]["OriginalRequest"] = request
+            else:
+                success_response[1]["OriginalRequest"] = None
         if exception is not None:
             raise exception
         else:


### PR DESCRIPTION
Hello folks.
I hope you're all right.

## Summary
In some cases, the original request could be transmitted to another agent so that latency does not occur for the end user, that is, the data received in a request could be made by another service.

So that this could happen, I added a flag in the `retrieve_original_header` Config class that allows the system to receive the original request and forward it to another agent.

I made this modification after opening an issue here [#3567](https://github.com/boto/boto3/issues/3567)

## Use case
For example the case of downloading video from the `kinesisvideo` endpoint. The server response is a `StreamBody` class. I would like my frontend to make this request so I don't have to pass this object via HTTP. In this case my front-end would receive the original signed request and execute it locally.

## Solution
For that, I added a flag in the `retrieve_original_header` Config class that inserts an `OriginalRequest` field in the endpoint response. This field contains the header, body and method of the original request made by botocore, previously signed.

The received field will be inserted in the `_send_request` function of the `endpoint.py` module. This will make it possible for the user to see the original request in the final response.