### PR TITLE
Support doc page redirects for ALL services

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -15,9 +15,10 @@ limitations under the License.
 */
 
 // Checks if an html doc name matches a service class name.
-function isValidServiceName(docName, serviceClassName) {
-	const new_docName = docName.replaceAll('-', '').toLowerCase();
-	return new_docName === serviceClassName;
+function isValidServiceName(serviceClassName) {
+	const pageTitle = document.getElementsByTagName('h1')[0];
+	const newDocName = pageTitle.getElementsByTagName('a')[0].innerHTML;
+	return newDocName.toLowerCase() === serviceClassName;
 }
 // Checks if all elements of the split fragment are valid.
 // Fragment items should only contain alphanumerics, hyphens, & underscores.
@@ -44,7 +45,7 @@ function isValidFragment(splitFragment) {
 		const serviceDocName = currentPath[currentPath.length - 1].replace('.html', '');
 		const splitFragment = fragment.split('.');
 		splitFragment[0] = splitFragment[0].toLowerCase();
-		if (isValidFragment(splitFragment) && isValidServiceName(serviceDocName, splitFragment[0])) {
+		if (isValidFragment(splitFragment) && isValidServiceName(splitFragment[0])) {
 			// Replace class name with doc name
 			splitFragment[0] = serviceDocName;
 			splitFragment[1] = splitFragment[1].toLowerCase();


### PR DESCRIPTION
The current process for redirecting includes a validation that compares part of the fragment that represents the client's class name with the service's doc page name (also the`serviceId`). This works for most services but there are also cases where these don't actually map to each other directly (`elb` --> `ElasticLoadBalancing`). We will instead compare the client's class name to the title of the current doc page.