### PR TITLE
Sphinx domain fix

### DIFF
--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -148,26 +148,17 @@ class ClientDocumenter:
         if self._is_custom_method(method_name):
             self._add_custom_method(
                 method_section,
-                method_name,
+                full_method_name,
                 method,
-                full_method_name=full_method_name,
             )
         else:
-            self._add_model_driven_method(
-                method_section, method_name, full_method_name=full_method_name
-            )
+            self._add_model_driven_method(method_section, full_method_name)
 
     def _is_custom_method(self, method_name):
         return method_name not in self._client.meta.method_to_api_mapping
 
-    def _add_custom_method(
-        self, section, method_name, method, full_method_name=None
-    ):
-        if full_method_name is None:
-            full_method_name = method_name
-        document_custom_method(
-            section, full_method_name, method, full_method_name=None
-        )
+    def _add_custom_method(self, section, method_name, method):
+        document_custom_method(section, method_name, method)
 
     def _add_method_exceptions_list(self, section, operation_model):
         error_section = section.add_new_section('exceptions')
@@ -180,16 +171,14 @@ class ClientDocumenter:
             )
             error_section.style.li(':py:class:`%s`' % class_name)
 
-    def _add_model_driven_method(
-        self, section, method_name, full_method_name=None
-    ):
+    def _add_model_driven_method(self, section, method_name):
+        full_method_name = method_name
+        method_name = full_method_name.split('.')[-1]
         service_model = self._client.meta.service_model
         operation_name = self._client.meta.method_to_api_mapping[method_name]
         operation_model = service_model.operation_model(operation_name)
 
         example_prefix = 'response = client.%s' % method_name
-        if full_method_name is None:
-            full_method_name = method_name
         document_model_driven_method(
             section,
             full_method_name,

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -144,17 +144,30 @@ class ClientDocumenter:
     def _add_client_method(self, section, method_name, method):
         section.add_title_section(method_name)
         method_section = section.add_new_section(method_name)
+        full_method_name = f'{self._client_class_name}.Client.{method_name}'
         if self._is_custom_method(method_name):
-            self._add_custom_method(method_section, method_name, method)
+            self._add_custom_method(
+                method_section,
+                method_name,
+                method,
+                full_method_name=full_method_name,
+            )
         else:
-            self._add_model_driven_method(method_section, method_name)
+            self._add_model_driven_method(
+                method_section, method_name, full_method_name=full_method_name
+            )
 
     def _is_custom_method(self, method_name):
         return method_name not in self._client.meta.method_to_api_mapping
 
-    def _add_custom_method(self, section, method_name, method):
-        full_method_name = f'{self._client_class_name}.Client.{method_name}'
-        document_custom_method(section, full_method_name, method)
+    def _add_custom_method(
+        self, section, method_name, method, full_method_name=None
+    ):
+        if full_method_name is None:
+            full_method_name = method_name
+        document_custom_method(
+            section, full_method_name, method, full_method_name=None
+        )
 
     def _add_method_exceptions_list(self, section, operation_model):
         error_section = section.add_new_section('exceptions')
@@ -167,13 +180,16 @@ class ClientDocumenter:
             )
             error_section.style.li(':py:class:`%s`' % class_name)
 
-    def _add_model_driven_method(self, section, method_name):
+    def _add_model_driven_method(
+        self, section, method_name, full_method_name=None
+    ):
         service_model = self._client.meta.service_model
         operation_name = self._client.meta.method_to_api_mapping[method_name]
         operation_model = service_model.operation_model(operation_name)
 
         example_prefix = 'response = client.%s' % method_name
-        full_method_name = f'{self._client_class_name}.Client.{method_name}'
+        if full_method_name is None:
+            full_method_name = method_name
         document_model_driven_method(
             section,
             full_method_name,

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -143,8 +143,11 @@ class ClientDocumenter:
 
     def _add_client_method(self, section, method_name, method):
         section.add_title_section(method_name)
-        method_section = section.add_new_section(method_name)
         full_method_name = f'{self._client_class_name}.Client.{method_name}'
+        method_section = section.add_new_section(
+            method_name,
+            context={'full_method_name': full_method_name},
+        )
         if self._is_custom_method(method_name):
             self._add_custom_method(
                 method_section,
@@ -152,7 +155,7 @@ class ClientDocumenter:
                 method,
             )
         else:
-            self._add_model_driven_method(method_section, full_method_name)
+            self._add_model_driven_method(method_section, method_name)
 
     def _is_custom_method(self, method_name):
         return method_name not in self._client.meta.method_to_api_mapping
@@ -172,13 +175,12 @@ class ClientDocumenter:
             error_section.style.li(':py:class:`%s`' % class_name)
 
     def _add_model_driven_method(self, section, method_name):
-        full_method_name = method_name
-        method_name = full_method_name.split('.')[-1]
         service_model = self._client.meta.service_model
         operation_name = self._client.meta.method_to_api_mapping[method_name]
         operation_model = service_model.operation_model(operation_name)
 
         example_prefix = 'response = client.%s' % method_name
+        full_method_name = section.context.get('full_method_name', method_name)
         document_model_driven_method(
             section,
             full_method_name,

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -143,15 +143,14 @@ class ClientDocumenter:
 
     def _add_client_method(self, section, method_name, method):
         section.add_title_section(method_name)
-        full_method_name = f'{self._client_class_name}.Client.{method_name}'
         method_section = section.add_new_section(
             method_name,
-            context={'full_method_name': full_method_name},
+            context={'qualifier': f'{self._client_class_name}.Client.'},
         )
         if self._is_custom_method(method_name):
             self._add_custom_method(
                 method_section,
-                full_method_name,
+                method_name,
                 method,
             )
         else:
@@ -180,7 +179,9 @@ class ClientDocumenter:
         operation_model = service_model.operation_model(operation_name)
 
         example_prefix = 'response = client.%s' % method_name
-        full_method_name = section.context.get('full_method_name', method_name)
+        full_method_name = (
+            f"{section.context.get('qualifier', '')}{method_name}"
+        )
         document_model_driven_method(
             section,
             full_method_name,

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -153,7 +153,8 @@ class ClientDocumenter:
         return method_name not in self._client.meta.method_to_api_mapping
 
     def _add_custom_method(self, section, method_name, method):
-        document_custom_method(section, method_name, method)
+        full_method_name = f'{self._client_class_name}.Client.{method_name}'
+        document_custom_method(section, full_method_name, method)
 
     def _add_method_exceptions_list(self, section, operation_model):
         error_section = section.add_new_section('exceptions')
@@ -172,9 +173,10 @@ class ClientDocumenter:
         operation_model = service_model.operation_model(operation_name)
 
         example_prefix = 'response = client.%s' % method_name
+        full_method_name = f'{self._client_class_name}.Client.{method_name}'
         document_model_driven_method(
             section,
-            method_name,
+            full_method_name,
             operation_model,
             event_emitter=self._client.meta.events,
             method_description=operation_model.documentation,

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -127,7 +127,8 @@ def document_custom_method(section, method_name, method):
 
     :param method: The handle to the method being documented
     """
-    document_custom_signature(section, method_name, method)
+    full_method_name = f"{section.context.get('qualifier', '')}{method_name}"
+    document_custom_signature(section, full_method_name, method)
     method_intro_section = section.add_new_section('method-intro')
     method_intro_section.writeln('')
     doc_string = inspect.getdoc(method)

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -118,9 +118,7 @@ def document_custom_signature(
     section.style.start_sphinx_py_method(name, signature_params)
 
 
-def document_custom_method(
-    section, method_name, method, full_method_name=None
-):
+def document_custom_method(section, method_name, method):
     """Documents a non-data driven method
 
     :param section: The section to write the documentation to.
@@ -129,9 +127,7 @@ def document_custom_method(
 
     :param method: The handle to the method being documented
     """
-    if full_method_name is None:
-        full_method_name = method_name
-    document_custom_signature(section, full_method_name, method)
+    document_custom_signature(section, method_name, method)
     method_intro_section = section.add_new_section('method-intro')
     method_intro_section.writeln('')
     doc_string = inspect.getdoc(method)

--- a/botocore/docs/method.py
+++ b/botocore/docs/method.py
@@ -118,7 +118,9 @@ def document_custom_signature(
     section.style.start_sphinx_py_method(name, signature_params)
 
 
-def document_custom_method(section, method_name, method):
+def document_custom_method(
+    section, method_name, method, full_method_name=None
+):
     """Documents a non-data driven method
 
     :param section: The section to write the documentation to.
@@ -127,7 +129,9 @@ def document_custom_method(section, method_name, method):
 
     :param method: The handle to the method being documented
     """
-    document_custom_signature(section, method_name, method)
+    if full_method_name is None:
+        full_method_name = method_name
+    document_custom_signature(section, full_method_name, method)
     method_intro_section = section.add_new_section('method-intro')
     method_intro_section.writeln('')
     doc_string = inspect.getdoc(method)

--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -77,7 +77,7 @@ class BaseDocsFunctionalTest(unittest.TestCase):
 
     def get_method_document_block(self, operation_name, contents):
         contents = contents.decode('utf-8')
-        regex = rf'.. py:method:: [a-zA-Z0-9]*.Client.{operation_name}\('
+        regex = rf'.. py:method:: ([a-zA-Z0-9]*\.)*{operation_name}\('
         match = re.search(regex, contents)
         self.assertNotEqual(match, None, 'Method is not found in contents')
         start_method_document = match.group()

--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
+import re
 import shutil
 import tempfile
 
@@ -76,9 +77,11 @@ class BaseDocsFunctionalTest(unittest.TestCase):
 
     def get_method_document_block(self, operation_name, contents):
         contents = contents.decode('utf-8')
-        start_method_document = '.. py:method:: %s(' % operation_name
-        start_index = contents.find(start_method_document)
-        self.assertNotEqual(start_index, -1, 'Method is not found in contents')
+        regex = rf'.. py:method:: [a-zA-Z0-9]*.Client.{operation_name}\('
+        match = re.search(regex, contents)
+        self.assertNotEqual(match, None, 'Method is not found in contents')
+        start_method_document = match.group()
+        start_index = match.start()
         contents = contents[start_index:]
         end_index = contents.find('.. py:method::', len(start_method_document))
         contents = contents[:end_index]

--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -79,7 +79,7 @@ class BaseDocsFunctionalTest(unittest.TestCase):
         contents = contents.decode('utf-8')
         regex = rf'.. py:method:: ([a-zA-Z0-9]*\.)*{operation_name}\('
         match = re.search(regex, contents)
-        self.assertNotEqual(match, None, 'Method is not found in contents')
+        self.assertIsNotNone(match, 'Method is not found in contents')
         start_method_document = match.group()
         start_index = match.start()
         contents = contents[start_index:]

--- a/tests/unit/docs/test_client.py
+++ b/tests/unit/docs/test_client.py
@@ -51,26 +51,26 @@ class TestClientDocumenter(BaseDocsTest):
             ]
         )
         self.assert_contains_lines_in_order(
-            ['.. py:method:: can_paginate(operation_name)'],
+            ['.. py:method:: MyService.Client.can_paginate(operation_name)'],
             self.get_nested_service_contents(
                 'myservice', 'client', 'can_paginate'
             ),
         )
         self.assert_contains_lines_in_order(
-            ['.. py:method:: get_paginator(operation_name)'],
+            ['.. py:method:: MyService.Client.get_paginator(operation_name)'],
             self.get_nested_service_contents(
                 'myservice', 'client', 'get_paginator'
             ),
         )
         self.assert_contains_lines_in_order(
-            ['.. py:method:: get_waiter(waiter_name)'],
+            ['.. py:method:: MyService.Client.get_waiter(waiter_name)'],
             self.get_nested_service_contents(
                 'myservice', 'client', 'get_waiter'
             ),
         )
         self.assert_contains_lines_in_order(
             [
-                '.. py:method:: sample_operation(**kwargs)',
+                '.. py:method:: MyService.Client.sample_operation(**kwargs)',
                 '  **Request Syntax**',
                 '  ::',
                 '    response = client.sample_operation(',

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -79,7 +79,7 @@ class TestServiceDocumenter(BaseDocsTest):
 
         self.assert_contains_lines_in_order(
             [
-                '.. py:method:: sample_operation(**kwargs)',
+                '.. py:method:: MyService.Client.sample_operation(**kwargs)',
                 '  **Examples** ',
                 '  Sample Description.',
                 '  ::',


### PR DESCRIPTION
## Overview
We previously had all class and method documentation on the same service page, however, we implemented nested docs to decrease page size. In doing so, we broke the way sphinx handles cross-references since methods on individual pages (not in the `py:class` body) should have the full class name attached as explained [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#:~:text=Methods%20and%20attributes%20belonging%20to%20the%20class%20should%20be%20placed%20in%20this%20directive%E2%80%99s%20body.%20If%20they%20are%20placed%20outside%2C%20the%20supplied%20name%20should%20contain%20the%20class%20name%20so%20that%20cross%2Dreferences%20still%20work.).

## Examples
Before Nested Docs:
```
# Page: <service>.html
.. py:class:: Foo
   .. py:method:: bar()
```

Current:
```
# Page: <service>.html
.. py:class:: Foo.Client

# Page: <method>.html
.. py:method:: bar()
```

New:
```
# Page: <service>.html
.. py:class:: Foo.Client

# Page: <method>.html
.. py:method:: Foo.Client.bar()
```