### PR TITLE
Add timezone info to the datetime instances used in test_token_chosen_from_provider

### DIFF
--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -19,7 +19,7 @@ import tempfile
 import threading
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from dateutil.tz import tzlocal
@@ -59,8 +59,8 @@ from tests import (
     unittest,
 )
 
-TIME_IN_ONE_HOUR = datetime.utcnow() + timedelta(hours=1)
-TIME_IN_SIX_MONTHS = datetime.utcnow() + timedelta(hours=4320)
+TIME_IN_ONE_HOUR = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+TIME_IN_SIX_MONTHS = datetime.now(tz=timezone.utc) + timedelta(hours=4320)
 
 
 class TestCredentialRefreshRaces(unittest.TestCase):


### PR DESCRIPTION
This affects the test: `tests/functional/test_credentials.py::SSOSessionTest::test_token_chosen_from_provider` which was previously throwing a RuntimeError ("Credentials were refreshed, but the refreshed credentials are still expired.") due to incorrect interpretation of the TIME_IN_ONE_HOUR timestamp. The timestamp() call in `test_credentials.py::SSOSessionTest::add_credential_response` assumes that the datetime object is in local time, which may be different from UTC time depending on the system's local timezone. This was causing the test to fail as the token expiry time was set to an invalid time before the current time.

Specifying the timezone as UTC ensures that the timestamp stored is the correct Unix timestamp to be used as the token expiry.