### PR TITLE
Add support for ListJobs pagination

### DIFF
--- a/botocore/data/glue/2017-03-31/paginators-1.json
+++ b/botocore/data/glue/2017-03-31/paginators-1.json
@@ -112,6 +112,12 @@
       "limit_key": "MaxResults",
       "output_token": "NextToken",
       "result_key": "Schemas"
+    },
+    "ListJobs": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "JobNames"
     }
   }
 }


### PR DESCRIPTION
This PR adds support for https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/client/list_jobs.html to paginator