### PR TITLE
Fix links and code edge cases in docs generation

### DIFF
--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -296,15 +296,10 @@ class DataNode(Node):
             self.rstrip()
 
     def rstrip(self):
-        # If there is no content, consolidate all white-space on the right.
-        if self._stripped_data == '' and self._leading_whitespace != '':
-            self._trailing_whitespace = (
-                f"{self._leading_whitespace}{self._trailing_whitespace}"
-            )
-            self._leading_whitespace = ''
-        # Up to one trailing space is always preserved
         if self._trailing_whitespace != '':
-            self._trailing_whitespace = ' '
+            self._trailing_whitespace = ''
+        elif self._stripped_data == '':
+            self.lstrip()
 
     def collapse_whitespace(self):
         """Noop, ``DataNode.write`` always collapses whitespace"""

--- a/botocore/docs/bcdoc/docstringparser.py
+++ b/botocore/docs/bcdoc/docstringparser.py
@@ -207,11 +207,19 @@ class TagNode(StemNode):
         # Collapse whitespace in situations like ``</b> <i> foo</i>`` into
         # ``</b><i> foo</i>``.
         for prev, cur in zip(self.children[:-1], self.children[1:]):
-            if prev.endswith_whitespace() and cur.startswith_whitespace():
+            if (
+                isinstance(prev, DataNode)
+                and prev.endswith_whitespace()
+                and cur.startswith_whitespace()
+            ):
                 cur.lstrip()
         # Same logic, but for situations like ``<b>bar </b> <i>``:
         for cur, nxt in zip(self.children[:-1], self.children[1:]):
-            if cur.endswith_whitespace() and nxt.startswith_whitespace():
+            if (
+                isinstance(nxt, DataNode)
+                and cur.endswith_whitespace()
+                and nxt.startswith_whitespace()
+            ):
                 cur.rstrip()
         # Recurse into children
         for child in self.children:

--- a/botocore/docs/bcdoc/style.py
+++ b/botocore/docs/bcdoc/style.py
@@ -252,8 +252,10 @@ class ReSTStyle(BaseStyle):
         last_write = doc.pop_write()
         while not last_write.startswith('`'):
             last_write = doc.pop_write() + last_write
-
         if last_write != '':
+            # Remove whitespace from the start of link text.
+            if last_write.startswith('` '):
+                last_write = f'`{last_write[1:].lstrip(" ")}'
             doc.push_write(last_write)
 
     def end_a(self, next_child=None):

--- a/tests/unit/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/docs/bcdoc/test_docstringparser.py
@@ -45,7 +45,7 @@ class TestDocStringParser(unittest.TestCase):
     def test_tag_with_collapsible_spaces(self):
         html = "<p>  a       bcd efg </p>"
         result = self.parse(html)
-        self.assert_contains_exact_lines_in_order(result, [b'a bcd efg '])
+        self.assert_contains_exact_lines_in_order(result, [b'a bcd efg'])
 
     def test_nested_lists(self):
         html = "<ul><li>Wello</li><ul><li>Horld</li></ul></ul>"
@@ -248,19 +248,14 @@ class TestDataNode(unittest.TestCase):
 @pytest.mark.parametrize(
     'data, lstrip, rstrip, both',
     [
-        # Note for cases with trailing white-space: If any white-space exists
-        # at the end of the string, stripping will leave behind a single space.
         ('foo', 'foo', 'foo', 'foo'),
         (' foo', 'foo', ' foo', 'foo'),
         ('   foo', 'foo', '   foo', 'foo'),
         ('\tfoo', 'foo', '\tfoo', 'foo'),
         ('\t \t foo', 'foo', '\t \t foo', 'foo'),
-        ('foo ', 'foo ', 'foo ', 'foo '),
-        ('foo  ', 'foo  ', 'foo ', 'foo '),
-        ('foo\t\t', 'foo\t\t', 'foo ', 'foo '),
-        (' ', ' ', ' ', ' '),
-        ('  ', ' ', ' ', ' '),
-        ('\t', ' ', ' ', ' '),
+        ('foo ', 'foo ', 'foo', 'foo'),
+        ('foo  ', 'foo  ', 'foo', 'foo'),
+        ('foo\t\t', 'foo\t\t', 'foo', 'foo'),
     ],
 )
 def test_datanode_stripping(data, lstrip, rstrip, both):
@@ -288,26 +283,43 @@ def test_datanode_stripping(data, lstrip, rstrip, both):
 
 
 @pytest.mark.parametrize(
+    'data',
+    [
+        (' '),
+        ('  '),
+        ('\t'),
+        ('\t \t '),
+    ],
+)
+def test_datanode_stripping_empty_string(data):
+    doc = mock.Mock()
+    doc.style = mock.Mock()
+    doc.translate_words.side_effect = lambda words: words
+    node = parser.DataNode(data)
+    node.lstrip()
+    node.write(doc)
+    doc.handle_data.assert_not_called()
+
+
+@pytest.mark.parametrize(
     'html, expected_lines',
     [
         ('<p>  foo</p>', [b'foo']),
+        ('<p>\tfoo</p>', [b'foo']),
         ('<p>  <span>  </span> <span> <span> foo</span></span></p>', [b'foo']),
-        # if there are trailing white-spaces, right-stripping text always
-        # leaves one space character behind
-        ('<p>foo  </p>', [b'foo ']),
-        ('<p>foo\t</p>', [b'foo ']),
-        ('<p>  foo  </p>', [b'foo ']),
-        ('<p>  <span>foo  </span>  </p>', [b'foo ']),
-        # ... but right-stripping tag-nodes does not
+        ('<p>foo  </p>', [b'foo']),
+        ('<p>foo\t</p>', [b'foo']),
+        ('<p>  foo  </p>', [b'foo']),
         ('<p>  <span>foo</span>  </p>', [b'foo']),
+        ('<p>  <span>foo  </span>  </p>', [b'foo']),
         ('<p>  <span>  foo</span>  </p>', [b'foo']),
-        ('<p>  <span>  foo  </span>  </p>', [b'foo ']),
+        ('<p>  <span>  foo  </span>  </p>', [b'foo']),
         # various nested markup examples
         ('<i>italic</i>', [b'*italic*']),
         ('<p><i>italic</i></p>', [b'*italic*']),
         ('<p><i>italic</i> </p>', [b'*italic*']),
-        ('<p><i>italic </i></p>', [b'*italic *']),
-        ('<p>foo <i> italic </i> bar</p>', [b'*italic * foo']),
+        ('<p><i>italic </i></p>', [b'*italic*']),
+        ('<p>foo <i> italic </i> bar</p>', [b'foo *italic* bar']),
         ('<p>  <span> foo <i> bar</i> </span>  </p>', [b'foo *bar*']),
         ('<p>  <span> foo<i> bar</i> </span>  </p>', [b'foo* bar*']),
         ('<p>  <span> foo <i>bar</i> </span>  </p>', [b'foo *bar*']),
@@ -326,12 +338,12 @@ def test_datanode_stripping(data, lstrip, rstrip, both):
         ('<li><foo>  </foo><foo> foo</foo> <foo> bar</li>', [b'* foo bar']),
         ('<li><foo>  </foo><foo> foo</foo><foo> bar</li>', [b'* foo bar']),
         # multiple block tags in sequence are each left and right stripped
-        ('<p>  foo</p><p>  bar\t</p>', [b'foo', b'bar ']),
-        ('<p>  foo</p><li>  bar  </li>', [b'foo', b'* bar ']),
+        ('<p>  foo</p><p>  bar\t</p>', [b'foo', b'bar']),
+        ('<p>  foo</p><li>  bar  </li>', [b'foo', b'* bar']),
         # nested block tags also work
         (
             '<p> <p> foo </p> <p> <span> bar </span> </p> </p>',
-            [b'foo ', b'bar '],
+            [b'foo', b'bar'],
         ),
     ],
 )

--- a/tests/unit/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/docs/bcdoc/test_docstringparser.py
@@ -303,12 +303,21 @@ def test_datanode_stripping(data, lstrip, rstrip, both):
         ('<p>  <span>  foo</span>  </p>', [b'foo']),
         ('<p>  <span>  foo  </span>  </p>', [b'foo ']),
         # various nested markup examples
+        ('<i>italic</i>', [b'*italic*']),
         ('<p><i>italic</i></p>', [b'*italic*']),
         ('<p><i>italic</i> </p>', [b'*italic*']),
         ('<p><i>italic </i></p>', [b'*italic *']),
+        ('<p>foo <i> italic </i> bar</p>', [b'*italic * foo']),
         ('<p>  <span> foo <i> bar</i> </span>  </p>', [b'foo *bar*']),
         ('<p>  <span> foo<i> bar</i> </span>  </p>', [b'foo* bar*']),
         ('<p>  <span> foo <i>bar</i> </span>  </p>', [b'foo *bar*']),
+        # links
+        ('<a href="url">foo</a> <i>bar</i>', [b'`foo <url>`__ *bar*']),
+        # ReST does not support link text starting with whitespace
+        ('<p>abc<a href="url"> foo</a></p>', [b'abc `foo <url>`__']),
+        ('<p>abc<a href="url"> foo </a> bar</p>', [b'abc `foo <url>`__ bar']),
+        # code-in-a removed and whitespace removed
+        ('<a href="url"> <code>foo</code> </a> bar', [b'`foo <url>`__ bar']),
         # list items
         ('<li>  foo</li>', [b'* foo']),
         ('<li>  <foo>  </foo><foo> foo</foo></li>', [b'* foo']),
@@ -326,7 +335,7 @@ def test_datanode_stripping(data, lstrip, rstrip, both):
         ),
     ],
 )
-def test_whitespace_collapsing_foo(html, expected_lines):
+def test_whitespace_collapsing(html, expected_lines):
     docstring_parser = parser.DocStringParser(ReSTDocument())
     docstring_parser.feed(html)
     docstring_parser.close()


### PR DESCRIPTION
Fixes two classes of errors that were introduced in https://github.com/boto/botocore/pull/2855:

* When link text starts with a space, the link no longer gets rendered correctly. This one was discovered by @nateprewitt 
* Preformatted and code snippets that contain stylized quotation marks (`“`) instead of plain `"`.

As part of investigating this, I found that the special treatment for trailing whitespace in data nodes (where one whitespace is always left behind) is another special case whitespace treatment longer needed and removed it.

#### Examples

Before

![Screenshot 2023-03-27 at 10 02 19 AM](https://user-images.githubusercontent.com/97921/227998039-eb86c159-5467-4ca8-b0c0-6d23d7d319a7.png)

After

![Screenshot 2023-03-27 at 10 02 35 AM](https://user-images.githubusercontent.com/97921/227998003-5d3b7206-c6d9-433f-993d-f3153e365e88.png)

Before

![Screenshot 2023-03-27 at 9 04 57 AM](https://user-images.githubusercontent.com/97921/227997000-01387904-8505-495e-be03-e2f6d447bfea.png)

After

![Screenshot 2023-03-27 at 9 05 04 AM](https://user-images.githubusercontent.com/97921/227997038-c18e1d1f-1885-4ce4-8144-a2251d82879b.png)

Before

![Screenshot 2023-03-27 at 9 16 53 AM](https://user-images.githubusercontent.com/97921/227996769-79e29ca9-3fb1-4327-bc3f-ae4c4cbf5f9c.png)

After

![Screenshot 2023-03-27 at 9 16 57 AM](https://user-images.githubusercontent.com/97921/227996917-c9b212ae-2aa7-4dad-8cf1-b6f5011cd4ad.png)

#### Testing

Spot checked HTML of ~200 pages with diffs from the changes in this PR. All of them are either fixes of the issues described above, or further removals of unnecessary whitespace.
