### PR TITLE
Accessibility

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -69,14 +69,15 @@ function isValidFragment(splitFragment) {
 function makeServiceLinkCurrent(serviceName) {
 	const servicesSection = $("a:contains('Available Services')")[0].parentElement;
 	var linkElement = servicesSection.querySelectorAll(`a[href*="../${ serviceName }.html"]`);
-	if (linkElement.length === 0) {
-		linkElement = sideBarElement.querySelectorAll(`a[href*="#"]`)[0];
+	if (linkElement.length !== 0) {
+		linkElement = linkElement[0];
+		let linkParent = linkElement.parentElement;
+		linkParent.classList.add('current');
+		linkParent.classList.add('current-page');
+		// linkElement = sideBarElement.querySelectorAll(`a[href*="#"]`)[0];
 	} else {
 		linkElement = linkElement[0];
 	}
-	let linkParent = linkElement.parentElement;
-	linkParent.classList.add('current');
-	linkParent.classList.add('current-page');
 }
 // Expands the "Available Services" sub-menu in the side-bar when viewing
 // nested doc pages and highlights the corresponding service list item.
@@ -89,3 +90,20 @@ if (currentPagePath.includes('services')) {
 	const serviceName = currentPagePath[serviceNameIndex];
 	makeServiceLinkCurrent(serviceName);
 }
+
+$(document).ready(function() {
+    const codeBlockSelector = 'div.highlight pre';
+	const codeCells = document.querySelectorAll(codeBlockSelector);
+	codeCells.forEach((codeCell) => {
+		codeCell.tabIndex = 0;
+	})
+
+	const boldSelector = 'strong';
+	const boldCells = document.querySelectorAll(boldSelector);
+	const testing = ['Request Syntax', 'Response Syntax', 'Response Structure', 'Exceptions', 'Examples'];
+	boldCells.forEach((boldCell) => {
+		if (testing.includes(boldCell.innerHTML)){
+			boldCell.parentElement.outerHTML = '<h3>' + boldCell.innerHTML + '</h3>';
+		}
+	})
+});

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -69,41 +69,57 @@ function isValidFragment(splitFragment) {
 function makeServiceLinkCurrent(serviceName) {
 	const servicesSection = $("a:contains('Available Services')")[0].parentElement;
 	var linkElement = servicesSection.querySelectorAll(`a[href*="../${ serviceName }.html"]`);
-	if (linkElement.length !== 0) {
-		linkElement = linkElement[0];
-		let linkParent = linkElement.parentElement;
-		linkParent.classList.add('current');
-		linkParent.classList.add('current-page');
-		// linkElement = sideBarElement.querySelectorAll(`a[href*="#"]`)[0];
+	if (linkElement.length === 0) {
+		linkElement = servicesSection.querySelectorAll(`a[href*="#"]`)[0];
 	} else {
 		linkElement = linkElement[0];
 	}
+	let linkParent = linkElement.parentElement;
+	linkParent.classList.add('current');
+	linkParent.classList.add('current-page');
 }
-// Expands the "Available Services" sub-menu in the side-bar when viewing
-// nested doc pages and highlights the corresponding service list item.
-const currentPagePath = window.location.pathname.split('/');
-const currentPagePathLength = currentPagePath.length;
-if (currentPagePath.includes('services')) {
-	document.getElementById('toctree-checkbox-1').checked = true;
-	// Example Nested Path: /reference/services/<service_name>/client/<operation_name>.html
-	const serviceNameIndex = currentPagePath.indexOf('services') + 1;
-	const serviceName = currentPagePath[serviceNameIndex];
-	makeServiceLinkCurrent(serviceName);
-}
-
-$(document).ready(function() {
-    const codeBlockSelector = 'div.highlight pre';
-	const codeCells = document.querySelectorAll(codeBlockSelector);
-	codeCells.forEach((codeCell) => {
-		codeCell.tabIndex = 0;
-	})
-
-	const boldSelector = 'strong';
-	const boldCells = document.querySelectorAll(boldSelector);
-	const testing = ['Request Syntax', 'Response Syntax', 'Response Structure', 'Exceptions', 'Examples'];
-	boldCells.forEach((boldCell) => {
-		if (testing.includes(boldCell.innerHTML)){
-			boldCell.parentElement.outerHTML = '<h3>' + boldCell.innerHTML + '</h3>';
+$(document).ready(function () {
+	const currentPagePath = window.location.pathname.split('/');
+	const codeBlockSelector = 'div.highlight pre';
+	const boldTextSelector = 'strong';
+	const boldElements = document.querySelectorAll(boldTextSelector);
+	const headings = [
+		'Example',
+		'Examples',
+		'Exceptions',
+		'Request Syntax',
+		'Response Structure',
+		'Response Syntax',
+		'Structure',
+		'Syntax'
+	];
+	// Expands the "Available Services" sub-menu in the side-bar when viewing
+	// nested doc pages and highlights the corresponding service list item.
+	function expandSubMenu() {
+		if (currentPagePath.includes('services')) {
+			document.getElementById('toctree-checkbox-1').checked = true;
+			// Example Nested Path: /reference/services/<service_name>/client/<operation_name>.html
+			const serviceNameIndex = currentPagePath.indexOf('services') + 1;
+			const serviceName = currentPagePath[serviceNameIndex];
+			makeServiceLinkCurrent(serviceName);
 		}
-	})
+	}
+	// Allows code blocks to be scrollable by keyboard only users.
+	function makeCodeBlocksScrollable() {
+		const codeCells = document.querySelectorAll(codeBlockSelector);
+		codeCells.forEach(codeCell => {
+			codeCell.tabIndex = 0;
+		});
+	}
+	// Converts implicit bold headings into actual headings with h3 tags.
+	function convertImplicitHeadings() {
+		boldElements.forEach(boldElement => {
+			if (headings.includes(boldElement.innerHTML)) {
+				boldElement.parentElement.outerHTML = `<h3>${ boldElement.innerHTML }</h3>`;
+			}
+		});
+	}
+	expandSubMenu();
+	makeCodeBlocksScrollable();
+	convertImplicitHeadings();
 });


### PR DESCRIPTION
## Issues
These changes address two main accessibility issues.
1. Keyboard only users can't access code blocks using the `tab` key and therefore can't view all content when scrollable.
2. The presence of implicit headings will result in screen reader users will have difficulty efficiently navigating and gaining an accurate overview of the page.

## Solution
1. Add [`tabindex=0`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#:~:text=tabindex%3D%220%22%20means%20that%20the%20element%20should%20be%20focusable%20in%20sequential%20keyboard%20navigation%2C%20after%20any%20positive%20tabindex%20values.%20The%20focus%20navigation%20order%20of%20these%20elements%20is%20defined%20by%20their%20order%20in%20the%20document%20source.) to all code blocks on a page.
2. Convert bold headings from `<strong>` to `<h3>` tags.