### PR TITLE
add custom error message for using crc32c without crt

### DIFF
--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -250,7 +250,14 @@ def resolve_request_checksum_algorithm(
             supported_algorithms = _SUPPORTED_CHECKSUM_ALGORITHMS
 
         algorithm_name = params[algorithm_member].lower()
-        if algorithm_name not in supported_algorithms:
+        if algorithm_name == "crc32c" and not HAS_CRT:
+            raise FlexibleChecksumError(
+                error_msg=(
+                    "CRC32C is not supported without the CRT. To use "
+                    "CRC32C, please install the `awscrt` package."
+                )
+            )
+        elif algorithm_name not in supported_algorithms:
             raise FlexibleChecksumError(
                 error_msg="Unsupported checksum algorithm: %s" % algorithm_name
             )

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -253,8 +253,8 @@ def resolve_request_checksum_algorithm(
         if algorithm_name == "crc32c" and not HAS_CRT:
             raise FlexibleChecksumError(
                 error_msg=(
-                    "CRC32C is not supported without the CRT. To use "
-                    "CRC32C, please install the `awscrt` package."
+                    "Using CRC32C requires an additional dependency. You will "
+                    "need to pip install botocore[crt] before proceeding."
                 )
             )
         elif algorithm_name not in supported_algorithms:

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -185,7 +185,7 @@ class TestHttpChecksumHandlers(unittest.TestCase):
                 request, operation_model, params
             )
             self.assertIn(
-                "CRC32C is not supported without the CRT",
+                "Using CRC32C requires an additional dependency",
                 str(context.exception),
             )
 


### PR DESCRIPTION
Adds a custom error message for customers trying to use `CRC32C` checksum algorithm, but don't have `awscrt` installed.