### PR TITLE
change error for missing crt. use list of crt checksums instead

### DIFF
--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -476,6 +476,8 @@ if HAS_CRT:
     }
     _CHECKSUM_CLS.update(_CRT_CHECKSUM_CLS)
     # Validate this list isn't out of sync with _CRT_CHECKSUM_CLS keys
-    assert all(name in _CRT_CHECKSUM_ALGORITHMS for name in _CRT_CHECKSUM_CLS)
+    assert all(
+        name in _CRT_CHECKSUM_ALGORITHMS for name in _CRT_CHECKSUM_CLS.keys()
+    )
 _SUPPORTED_CHECKSUM_ALGORITHMS = list(_CHECKSUM_CLS.keys())
 _ALGORITHMS_PRIORITY_LIST = ['crc32c', 'crc32', 'sha1', 'sha256']

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -469,12 +469,15 @@ _CHECKSUM_CLS = {
     "sha1": Sha1Checksum,
     "sha256": Sha256Checksum,
 }
+_CRT_CHECKSUM_CLS = {}
 
 if HAS_CRT:
     # Use CRT checksum implementations if available
-    _CHECKSUM_CLS.update(
-        {"crc32": CrtCrc32Checksum, "crc32c": CrtCrc32cChecksum}
-    )
+    _CRT_CHECKSUM_CLS = {
+        "crc32": CrtCrc32Checksum,
+        "crc32c": CrtCrc32cChecksum,
+    }
+    _CHECKSUM_CLS.update(_CRT_CHECKSUM_CLS)
 
 _SUPPORTED_CHECKSUM_ALGORITHMS = list(_CHECKSUM_CLS.keys())
 _CRT_SUPPORTED_CHECKSUM_ALGORITHMS = ["crc32", "crc32c"]

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -170,7 +170,7 @@ class TestHttpChecksumHandlers(unittest.TestCase):
         operation_model = self._make_operation_model(
             http_checksum={"requestAlgorithmMember": "Algorithm"},
         )
-        params = {"Algorithm": "sh256"}
+        params = {"Algorithm": "sha256"}
 
         with self.assertRaises(FlexibleChecksumError):
             resolve_request_checksum_algorithm(

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -174,11 +174,7 @@ class TestHttpChecksumHandlers(unittest.TestCase):
 
         with self.assertRaises(FlexibleChecksumError):
             resolve_request_checksum_algorithm(
-                request,
-                operation_model,
-                params,
-                supported_algorithms=[],
-                crt_supported_algorithms=[],
+                request, operation_model, params, supported_algorithms=[]
             )
 
     @unittest.skipIf(HAS_CRT, "Error only expected when CRT is not available")

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -170,7 +170,7 @@ class TestHttpChecksumHandlers(unittest.TestCase):
         operation_model = self._make_operation_model(
             http_checksum={"requestAlgorithmMember": "Algorithm"},
         )
-        params = {"Algorithm": "crc32"}
+        params = {"Algorithm": "sh256"}
 
         with self.assertRaises(FlexibleChecksumError):
             resolve_request_checksum_algorithm(

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -22,8 +22,6 @@ from botocore.exceptions import (
 )
 from botocore.httpchecksum import (
     _CHECKSUM_CLS,
-    _CRT_CHECKSUM_CLS,
-    _CRT_SUPPORTED_CHECKSUM_ALGORITHMS,
     AwsChunkedWrapper,
     Crc32Checksum,
     CrtCrc32cChecksum,
@@ -545,13 +543,6 @@ class TestHttpChecksumHandlers(unittest.TestCase):
         )
         body = response_dict["body"]
         self.assertEqual(body.read(), b"hello world")
-
-    @requires_crt()
-    def test_checksum_cls_crt_supported_algorithms_in_sync(self):
-        self.assertEqual(
-            sorted(_CRT_SUPPORTED_CHECKSUM_ALGORITHMS),
-            sorted(list(_CRT_CHECKSUM_CLS.keys())),
-        )
 
 
 class TestAwsChunkedWrapper(unittest.TestCase):

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -22,6 +22,7 @@ from botocore.exceptions import (
 )
 from botocore.httpchecksum import (
     _CHECKSUM_CLS,
+    _CRT_CHECKSUM_CLS,
     _CRT_SUPPORTED_CHECKSUM_ALGORITHMS,
     AwsChunkedWrapper,
     Crc32Checksum,
@@ -548,10 +549,9 @@ class TestHttpChecksumHandlers(unittest.TestCase):
     @requires_crt()
     def test_checksum_cls_crt_supported_algorithms_in_sync(self):
         self.assertEqual(
-            _CRT_SUPPORTED_CHECKSUM_ALGORITHMS, ["crc32", "crc32c"]
+            sorted(_CRT_SUPPORTED_CHECKSUM_ALGORITHMS),
+            sorted(list(_CRT_CHECKSUM_CLS.keys())),
         )
-        for algorithm in _CRT_SUPPORTED_CHECKSUM_ALGORITHMS:
-            self.assertIn(algorithm, _CHECKSUM_CLS.keys())
 
 
 class TestAwsChunkedWrapper(unittest.TestCase):


### PR DESCRIPTION
Follow up to https://github.com/boto/botocore/pull/2905. Use `MissingDependencyException` and check against extendible list of CRT checksums rather than single strings. Added test to validate CRT checksum list is in sync with checksum class dictionary keys.