### PR TITLE
Add json test examples

### DIFF
--- a/tests/unit/response_parsing/json/errors/sqs-delete-queue.json
+++ b/tests/unit/response_parsing/json/errors/sqs-delete-queue.json
@@ -1,0 +1,11 @@
+{
+    "Error": {
+        "Code": "InvalidAddress",
+        "Detail": null,
+        "Message": "The address foobar is not valid for this endpoint.",
+        "Type": "Sender"
+    },
+    "ResponseMetadata": {
+        "RequestId": "9b06cd2c-b433-550f-bde2-8728ce9b1a93"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-add-permission.json
+++ b/tests/unit/response_parsing/json/expected/sqs-add-permission.json
@@ -1,0 +1,5 @@
+{
+    "ResponseMetadata": {
+        "RequestId": "9a285199-c8d6-47c2-bdb2-314cb47d599d"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-change-message-visibility-batch.json
+++ b/tests/unit/response_parsing/json/expected/sqs-change-message-visibility-batch.json
@@ -1,0 +1,13 @@
+{
+    "Successful": [
+        {
+            "Id": "change_visibility_msg_2"
+        }, 
+        {
+            "Id": "change_visibility_msg_3"
+        }
+    ], 
+    "ResponseMetadata": {
+        "RequestId": "ca9668f7-ab1b-4f7a-8859-f15747ab17a7"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-create-queue.json
+++ b/tests/unit/response_parsing/json/expected/sqs-create-queue.json
@@ -1,0 +1,6 @@
+{
+    "QueueUrl": "http://sqs.us-east-1.amazonaws.com/123456789012/testQueue", 
+    "ResponseMetadata": {
+        "RequestId": "7a62c49f-347e-4fc4-9331-6e8e7a96aa73"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-delete-message-batch.json
+++ b/tests/unit/response_parsing/json/expected/sqs-delete-message-batch.json
@@ -1,0 +1,13 @@
+{
+    "Successful": [
+        {
+            "Id": "msg1"
+        }, 
+        {
+            "Id": "msg2"
+        }
+    ], 
+    "ResponseMetadata": {
+        "RequestId": "d6f86b7a-74d1-4439-b43f-196a1e29cd85"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-delete-queue.json
+++ b/tests/unit/response_parsing/json/expected/sqs-delete-queue.json
@@ -1,0 +1,11 @@
+{
+    "Error": {
+        "Code": "InvalidAddress",
+        "Detail": null,
+        "Message": "The address foobar is not valid for this endpoint.",
+        "Type": "Sender"
+    },
+    "ResponseMetadata": {
+        "RequestId": "9b06cd2c-b433-550f-bde2-8728ce9b1a93"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-get-queue-attributes.json
+++ b/tests/unit/response_parsing/json/expected/sqs-get-queue-attributes.json
@@ -1,0 +1,17 @@
+{
+    "Attributes": {
+        "ApproximateNumberOfMessagesNotVisible": "0",
+        "CreatedTimestamp": "1351044153",
+        "QueueArn": "arn:aws:sqs:us-east-1:123456789012:test1351044153",
+        "ApproximateNumberOfMessages": "0",
+        "DelaySeconds": "0",
+        "VisibilityTimeout": "45",
+        "ApproximateNumberOfMessagesDelayed": "0",
+        "MessageRetentionPeriod": "345600",
+        "LastModifiedTimestamp": "1351044214",
+        "MaximumMessageSize": "65536"
+    },
+    "ResponseMetadata": {
+        "RequestId": "0c8d2786-b7b4-56e2-a823-6e80a404d6fd"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-get-queue-url.json
+++ b/tests/unit/response_parsing/json/expected/sqs-get-queue-url.json
@@ -1,0 +1,6 @@
+{
+    "QueueUrl": "http://sqs.us-east-1.amazonaws.com/123456789012/testQueue", 
+    "ResponseMetadata": {
+        "RequestId": "470a6f13-2ed9-4181-ad8a-2fdea142988e"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-list-queues.json
+++ b/tests/unit/response_parsing/json/expected/sqs-list-queues.json
@@ -1,0 +1,9 @@
+{
+    "QueueUrls": [
+        "https://us-west-2.queue.amazonaws.com/123456789012/foobar",
+        "https://us-west-2.queue.amazonaws.com/123456789012/fiebaz"
+    ],
+    "ResponseMetadata": {
+        "RequestId": "517c6371-751f-5711-9ebc-2ab2b1a92268"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-receive-message.json
+++ b/tests/unit/response_parsing/json/expected/sqs-receive-message.json
@@ -1,0 +1,19 @@
+{
+    "Messages": [
+        {
+            "Body": "This is a test message", 
+            "Attributes": {
+                "ApproximateFirstReceiveTimestamp": "1250700979248", 
+                "SenderId": "195004372649", 
+                "ApproximateReceiveCount": "5", 
+                "SentTimestamp": "1238099229000"
+            }, 
+            "ReceiptHandle": "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw\n        Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE\n        auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=", 
+            "MD5OfBody": "fafb00f5732ab283681e124bf8747ed1", 
+            "MessageId": "5fea7756-0ea4-451a-a703-a558b933e274"
+        }
+    ], 
+    "ResponseMetadata": {
+        "RequestId": "b6633655-283d-45b4-aee4-4e84e0ae6afa"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-send-message-batch.json
+++ b/tests/unit/response_parsing/json/expected/sqs-send-message-batch.json
@@ -1,0 +1,17 @@
+{
+    "Successful": [
+        {
+            "MD5OfMessageBody": "0e024d309850c78cba5eabbeff7cae71", 
+            "Id": "test_msg_001", 
+            "MessageId": "0a5231c7-8bff-4955-be2e-8dc7c50a25fa"
+        }, 
+        {
+            "MD5OfMessageBody": "7fb8146a82f95e0af155278f406862c2", 
+            "Id": "test_msg_002", 
+            "MessageId": "15ee1ed3-87e7-40c1-bdaa-2e49968ea7e9"
+        }
+    ], 
+    "ResponseMetadata": {
+        "RequestId": "ca1ad5d0-8271-408b-8d0f-1351bf547e74"
+    }
+}

--- a/tests/unit/response_parsing/json/expected/sqs-send-message.json
+++ b/tests/unit/response_parsing/json/expected/sqs-send-message.json
@@ -1,0 +1,7 @@
+{
+    "MD5OfMessageBody": "fafb00f5732ab283681e124bf8747ed1", 
+    "ResponseMetadata": {
+        "RequestId": "27daac76-34dd-47df-bd01-1f6e873584a0"
+    }, 
+    "MessageId": "5fea7756-0ea4-451a-a703-a558b933e274"
+}


### PR DESCRIPTION
In the previous PR: https://github.com/boto/botocore/pull/2917, we removed unnecessary XML SQS examples. 
In this commit, we will fill the gap by adding the same SQS examples in JSON format.