### PR TITLE
Include params set in provide-client-param event handlers in dynamic context params for endpoint resolution

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -819,7 +819,6 @@ class ClientEndpointBridge:
 
 
 class BaseClient:
-
     # This is actually reassigned with the py->op_name mapping
     # when the client creator creates the subclass.  This value is used
     # because calls such as client.get_paginator('list_objects') use the
@@ -913,6 +912,11 @@ class BaseClient:
             'has_streaming_input': operation_model.has_streaming_input,
             'auth_type': operation_model.auth_type,
         }
+        api_params = self._emit_api_params(
+            api_params=api_params,
+            operation_model=operation_model,
+            context=request_context,
+        )
         endpoint_url, additional_headers = self._resolve_endpoint_ruleset(
             operation_model, api_params, request_context
         )
@@ -984,9 +988,6 @@ class BaseClient:
         headers=None,
         set_user_agent_header=True,
     ):
-        api_params = self._emit_api_params(
-            api_params, operation_model, context
-        )
         request_dict = self._serializer.serialize_to_request(
             api_params, operation_model
         )

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -663,7 +663,11 @@ def generate_presigned_url(
         context,
         ignore_signing_region=(not bucket_is_arn),
     )
-
+    params = self._emit_api_params(
+        api_params=params,
+        operation_model=operation_model,
+        context=context,
+    )
     request_dict = self._convert_to_request_dict(
         api_params=params,
         operation_model=operation_model,
@@ -786,7 +790,11 @@ def generate_presigned_post(
         context,
         ignore_signing_region=(not bucket_is_arn),
     )
-
+    params = self._emit_api_params(
+        api_params=params,
+        operation_model=operation_model,
+        context=context,
+    )
     request_dict = self._convert_to_request_dict(
         api_params=params,
         operation_model=operation_model,

--- a/tests/functional/test_context_params.py
+++ b/tests/functional/test_context_params.py
@@ -343,7 +343,7 @@ def test_client_context_param_sent_to_endpoint_resolver(
         ),
     )
 
-    # Stub client to prevent a request from getting sent and asceertain that
+    # Stub client to prevent a request from getting sent and ascertain that
     # only a single request would get sent. Wrap the EndpointProvider's
     # resolve_endpoint method for inspecting the arguments it gets called with.
     with ClientHTTPStubber(client, strict=True) as http_stubber:
@@ -488,3 +488,42 @@ def test_dynamic_context_param_sent_to_endpoint_resolver(
         )
     else:
         mock_resolve_endpoint.assert_called_once_with(Region='us-east-1')
+
+
+def test_dynamic_context_param_from_event_handler_sent_to_endpoint_resolver(
+    monkeypatch,
+    patched_session,
+):
+    # patch loader to return fake service model and fake endpoint ruleset
+    patch_load_service_model(
+        patched_session,
+        monkeypatch,
+        FAKE_MODEL_WITH_DYNAMIC_CONTEXT_PARAM,
+        FAKE_RULESET_WITH_DYNAMIC_CONTEXT_PARAM,
+    )
+
+    # event handler for provide-client-params that modifies the value of the
+    # MockOpParam parameter
+    def change_param(params, **kwargs):
+        params['MockOpParam'] = 'mock-op-param-value-2'
+
+    client = patched_session.create_client(
+        'otherservice', region_name='us-east-1'
+    )
+    client.meta.events.register_last(
+        'provide-client-params.other-service.*', change_param
+    )
+
+    with ClientHTTPStubber(client, strict=True) as http_stubber:
+        http_stubber.add_response(status=200)
+        with mock.patch.object(
+            client._ruleset_resolver._provider,
+            'resolve_endpoint',
+            wraps=client._ruleset_resolver._provider.resolve_endpoint,
+        ) as mock_resolve_endpoint:
+            client.mock_operation(MockOpParam='mock-op-param-value-1')
+
+    mock_resolve_endpoint.assert_called_once_with(
+        Region='us-east-1',
+        FooDynamicContextParamName='mock-op-param-value-2',
+    )


### PR DESCRIPTION
This PR moves the `provide-client-params.*` and `before-parameter-build.*` from immediately after endpoint resolution to immediately before endpoint resolution.

This addresses the fact that for endpoint rulesets that accept dynamic context parameters (currently `s3`, `s3-control`, `kinesis`, and `events`) any parameters changed or updated in an event handler for the `provide-client-params.*` were not accounted for in endpoint resolution because the event was only emitted _after_ endpoint resolution.