### PR TITLE
Defer to system defaults for cipher suites with urllib3 2.0+

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -20,7 +20,6 @@ from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 from urllib3.exceptions import SSLError as URLLib3SSLError
 from urllib3.util.retry import Retry
 from urllib3.util.ssl_ import (
-    DEFAULT_CIPHERS,
     OP_NO_COMPRESSION,
     PROTOCOL_TLS,
     OP_NO_SSLv2,
@@ -48,6 +47,14 @@ try:
         )
 except ImportError:
     from urllib3.util.ssl_ import SSLContext
+
+try:
+    from urllib3.util.ssl_ import DEFAULT_CIPHERS
+except ImportError:
+    # Defer to system configuration starting with
+    # urllib3 2.0. This will choose the ciphers provided by
+    # Openssl 1.1.1+ or secure system defaults.
+    DEFAULT_CIPHERS = None
 
 import botocore.awsrequest
 from botocore.compat import (


### PR DESCRIPTION
Starting in urllib3 2.0, the hardcoded `DEFAULT_CIPHERS` for the ssl_context have been removed. This is a migration in a safer direction to allow user systems to define preferred cipher suites and enable modification without new releases of urllib3. This will expedite any security patching and give users finer grained control over what is chosen.

Please note that botocore **does not** support urllib3 2.0 yet, but users are starting to see this interaction when testing for a future upgrade. To help enable that, we'll start deferring to urllib3 for this selection when an appropriate urllib3 version is installed ([ref](https://github.com/urllib3/urllib3/blob/6446fef0cf432ca035169602a1447a0d8ef53e80/src/urllib3/util/ssl_.py#L236-L238)).