### PR TITLE
Address virtual host style addressing bugs for short subdomains provided in ``endpoint_url``

### DIFF
--- a/.changes/next-release/bugfix-EndpointProvider-38157.json
+++ b/.changes/next-release/bugfix-EndpointProvider-38157.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "EndpointProvider",
-  "description": "Addresses issue `#2938 <https://github.com/boto/botocore/issues/2938>`__"
+  "description": "Fixed bug in virtual addressing for S3 Buckets `#2938 <https://github.com/boto/botocore/issues/2938>`__"
 }

--- a/.changes/next-release/bugfix-EndpointProvider-38157.json
+++ b/.changes/next-release/bugfix-EndpointProvider-38157.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "EndpointProvider",
+  "description": "Addresses issue `#2938 <https://github.com/boto/botocore/issues/2938>`__"
+}

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -398,13 +398,9 @@ class RuleSetStandardLibrary:
         ):
             return False
 
-        if allow_subdomains is True:
-            return all(
-                self.aws_is_virtual_hostable_s3_bucket(label, False)
-                for label in value.split(".")
-            )
-
-        return self.is_valid_host_label(value, allow_subdomains=False)
+        return self.is_valid_host_label(
+            value, allow_subdomains=allow_subdomains
+        )
 
 
 # maintains backwards compatibility as `Library` was misspelled

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -3502,22 +3502,8 @@ def _addressing_for_presigned_url_test_cases():
         bucket="foo.b.biz",
         key="key",
         s3_config={"addressing_style": "virtual"},
-        is_secure=False,
-        expected_url="http://s3.amazonaws.com/foo.b.biz/key",
-    )
-    yield dict(
-        bucket="foo.b.biz",
-        key="key",
-        s3_config={"addressing_style": "virtual"},
         customer_provided_endpoint="https://s3.us-west-2.amazonaws.com",
         expected_url="https://s3.us-west-2.amazonaws.com/foo.b.biz/key",
-    )
-    yield dict(
-        region="us-west-1",
-        bucket="foo.b.biz",
-        key="key",
-        s3_config={"addressing_style": "virtual"},
-        expected_url="https://s3.us-west-1.amazonaws.com/foo.b.biz/key",
     )
 
 

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -3487,6 +3487,38 @@ def _addressing_for_presigned_url_test_cases():
         signature_version="s3",
         expected_url="https://s3.us-west-1.amazonaws.com/foo.bar.biz/key",
     )
+    # Bucket names that contain dots and subcomponents that are less than
+    # 3 characters should still use virtual host style addressing if
+    # configured by the customer and they provide their own ``endpoint_url``
+    # that is insecure. https://github.com/boto/botocore/issues/2938
+    yield dict(
+        bucket="foo.b.biz",
+        key="key",
+        s3_config={"addressing_style": "virtual"},
+        customer_provided_endpoint="http://s3.us-west-2.amazonaws.com",
+        expected_url="http://foo.b.biz.s3.us-west-2.amazonaws.com/key",
+    )
+    yield dict(
+        bucket="foo.b.biz",
+        key="key",
+        s3_config={"addressing_style": "virtual"},
+        is_secure=False,
+        expected_url="http://s3.amazonaws.com/foo.b.biz/key",
+    )
+    yield dict(
+        bucket="foo.b.biz",
+        key="key",
+        s3_config={"addressing_style": "virtual"},
+        customer_provided_endpoint="https://s3.us-west-2.amazonaws.com",
+        expected_url="https://s3.us-west-2.amazonaws.com/foo.b.biz/key",
+    )
+    yield dict(
+        region="us-west-1",
+        bucket="foo.b.biz",
+        key="key",
+        s3_config={"addressing_style": "virtual"},
+        expected_url="https://s3.us-west-1.amazonaws.com/foo.b.biz/key",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -491,3 +491,23 @@ def test_endpoint_reevaluates_result(endpoint_provider, monkeypatch):
     for region in regions:
         endpoint_provider.resolve_endpoint(Region=region)
     assert mock_evaluate.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "bucket, expected_value",
+    [
+        ("mybucket", True),
+        ("ab", False),
+        ("a.b", True),
+        ("my.great.bucket.aws.com", True),
+        ("mY.GREAT.bucket.aws.com", False),
+        ("192.168.1.1", False),
+    ],
+)
+def test_aws_is_virtual_hostable_s3_bucket_allow_subdomains(
+    rule_lib, bucket, expected_value
+):
+    assert (
+        rule_lib.aws_is_virtual_hostable_s3_bucket(bucket, True)
+        == expected_value
+    )


### PR DESCRIPTION
This addresses https://github.com/boto/botocore/issues/2938. Currently `RuleSetStandardLibrary.aws_is_virtual_hostable_s3_bucket` is performing the exact same validations on the entire input value as it does with individual subdomains within the input value. This is incorrect because only the entire value needs to be at least 3 characters, not each individual component. As described in the issue, this caused a bug when enabling virtual style addressing and providing an `endpoint_url` to an S3 client that is insecure (http not https). For bucket names that look like URLs containing short subdomain fragments, path style is being used instead which is incorrect. 

Additionally, we only need to perform validation that the input value is not an IPV4 address, None and all lowercase at the top level so the recursive check has been removed.