### PR TITLE
Support for sdk_ua_app_id config setting

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -28,6 +28,7 @@ from botocore.endpoint import EndpointCreator
 from botocore.regions import EndpointResolverBuiltins as EPRBuiltins
 from botocore.regions import EndpointRulesetResolver
 from botocore.signers import RequestSigner
+from botocore.useragent import sanitize_user_agent_string_component
 from botocore.utils import ensure_boolean, is_s3_accelerate_url
 
 logger = logging.getLogger(__name__)
@@ -202,7 +203,9 @@ class ClientArgsCreator:
             if client_config.user_agent is not None:
                 user_agent = client_config.user_agent
             if client_config.user_agent_appid is not None:
-                appid = client_config.user_agent_appid
+                appid = sanitize_user_agent_string_component(
+                    client_config.user_agent_appid, allow_hash=False
+                )
                 if len(appid) > USERAGENT_APPID_MAXLEN:
                     logger.warning(
                         'The configured value for user_agent_appid exceeds the '

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -55,6 +55,9 @@ LEGACY_GLOBAL_STS_REGIONS = [
     'us-west-1',
     'us-west-2',
 ]
+# Maximum allowed length of the ``user_agent_appid`` config field. Longer
+# values get truncated and result in a warning-level log message.
+USERAGENT_APPID_MAXLEN = 50
 
 
 class ClientArgsCreator:
@@ -198,6 +201,17 @@ class ClientArgsCreator:
         if client_config is not None:
             if client_config.user_agent is not None:
                 user_agent = client_config.user_agent
+            if client_config.user_agent_appid is not None:
+                appid = client_config.user_agent_appid
+                if len(appid) > USERAGENT_APPID_MAXLEN:
+                    logger.warning(
+                        'The configured value for user_agent_appid exceeds the '
+                        f'maximum length of {USERAGENT_APPID_MAXLEN} '
+                        'characters and will be truncated. The original value '
+                        f'is: {client_config.user_agent_appid}'
+                    )
+                    appid = appid[:USERAGENT_APPID_MAXLEN]
+                user_agent += ' app/%s' % appid
             if client_config.user_agent_extra is not None:
                 user_agent += ' %s' % client_config.user_agent_extra
 

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -38,6 +38,12 @@ class Config:
     :param user_agent_extra: The value to append to the current User-Agent
         header value.
 
+    :type user_agent_appid: str
+    :param user_agent_appid: A value that gets included in the User-Agent
+        string in the format "app/<user_agent_appid>" which is consistent
+        across all AWS SDKs. Allowed characters are ASCII alphanumerics and
+        ``!$%&'*+-.^_`|~``. All other characters will be replaced by a ``-``.
+
     :type connect_timeout: float or int
     :param connect_timeout: The time in seconds till a timeout exception is
         thrown when attempting to make a connection. The default is 60
@@ -201,6 +207,7 @@ class Config:
             ('signature_version', None),
             ('user_agent', None),
             ('user_agent_extra', None),
+            ('user_agent_appid', None),
             ('connect_timeout', DEFAULT_TIMEOUT),
             ('read_timeout', DEFAULT_TIMEOUT),
             ('parameter_validation', True),

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -139,6 +139,8 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # We can't have a default here for v1 because we need to defer to
     # whatever the defaults are in _retry.json.
     'max_attempts': ('max_attempts', 'AWS_MAX_ATTEMPTS', None, int),
+    #
+    'user_agent_appid': ('sdk_ua_app_id', 'AWS_SDK_UA_APP_ID', None, None),
 }
 # A mapping for the s3 specific configuration vars. These are the configuration
 # vars that typically go in the s3 section of the config file. This mapping

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from string import ascii_letters, digits
+
+_USERAGENT_ALLOWED_CHARACTERS = ascii_letters + digits + "!$%&'*+-.^_`|~"
+
+
+def sanitize_user_agent_string_component(raw_str, allow_hash):
+    """Replaces all not allowed characters in the string with a dash ("-").
+
+    Allowed characters are ASCII alphanumerics and ``!$%&'*+-.^_`|~``. If
+    ``allow_hash`` is ``True``, "#"``" is also allowed.
+
+    :type allow_hash: bool
+    :param allow_hash: Whether "#" is considered an allowed character.
+    """
+    return ''.join(
+        c
+        if c in _USERAGENT_ALLOWED_CHARACTERS or (allow_hash and c == '#')
+        else '-'
+        for c in raw_str
+    )

--- a/tests/functional/test_user_agent.py
+++ b/tests/functional/test_user_agent.py
@@ -1,0 +1,143 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+from contextlib import contextmanager
+from datetime import datetime
+
+import pytest
+
+from botocore.config import Config
+from botocore.stub import Stubber
+
+
+@pytest.fixture
+def useragent_cap_client(patched_session):
+    @contextmanager
+    def wrapper(*args, **kwargs):
+        client = patched_session.create_client(*args, **kwargs)
+        client.captured_user_agent_string = None
+
+        def event_handler(params, **kwargs):
+            client.captured_user_agent_string = params['headers']['User-Agent']
+
+        client.meta.events.register_first(
+            'before-call.*.*',
+            event_handler,
+            unique_id='useragent_cap_client',
+        )
+
+        yield client
+
+        client.meta.events.unregister(
+            'before-call.*.*',
+            event_handler,
+            unique_id='useragent_cap_client',
+        )
+
+    return wrapper
+
+
+@pytest.fixture
+def stubbed_list_buckets():
+    """botocore.stubb.Stubber instance with a stubbed ``list_buckets`` method.
+
+    Use with an S3 client, for example:
+
+        client_s3 = session.create_client('s3')
+        with stubbed_list_buckets(client_s3) as stubber:
+            client_s3.list_buckets()
+        assert stubber.assert_no_pending_responses()
+
+    """
+    response = {
+        'Owner': {'ID': 'foo', 'DisplayName': 'bar'},
+        'Buckets': [
+            {'CreationDate': datetime(2099, 12, 31, 23, 59), 'Name': 'buck'}
+        ],
+    }
+
+    @contextmanager
+    def wrapper(client):
+        with Stubber(client) as stubber:
+            stubber.add_response('list_buckets', response, {})
+            yield stubber
+
+    return wrapper
+
+
+def test_user_agent_from_config(useragent_cap_client, stubbed_list_buckets):
+    client_cfg = Config(user_agent='my user agent str')
+    with useragent_cap_client('s3', config=client_cfg) as client_s3:
+        with stubbed_list_buckets(client_s3):
+            client_s3.list_buckets()
+
+    assert client_s3.captured_user_agent_string.startswith('my user agent str')
+
+
+def test_user_agent_includes_extra(useragent_cap_client, stubbed_list_buckets):
+    client_cfg = Config(user_agent_extra='extrastuff')
+    with useragent_cap_client('s3', config=client_cfg) as client_s3:
+        with stubbed_list_buckets(client_s3):
+            client_s3.list_buckets()
+
+    assert client_s3.captured_user_agent_string.endswith(' extrastuff')
+
+
+def test_user_agent_includes_appid(useragent_cap_client, stubbed_list_buckets):
+    client_cfg = Config(user_agent_appid='myappisbuiltwithbotocore')
+    with useragent_cap_client('s3', config=client_cfg) as client_s3:
+        with stubbed_list_buckets(client_s3):
+            client_s3.list_buckets()
+
+    uafields = client_s3.captured_user_agent_string.split(' ')
+    assert 'app/myappisbuiltwithbotocore' in uafields
+
+
+def test_user_agent_includes_all_config_values(
+    useragent_cap_client, stubbed_list_buckets
+):
+    client_cfg = Config(
+        user_agent='my user agent str',
+        user_agent_extra='extrastuff',
+        user_agent_appid='myappisbuiltwithbotocore',
+    )
+    with useragent_cap_client('s3', config=client_cfg) as client_s3:
+        with stubbed_list_buckets(client_s3):
+            client_s3.list_buckets()
+
+    uafields = client_s3.captured_user_agent_string.split(' ')
+    assert client_s3.captured_user_agent_string.startswith('my user agent str')
+    assert 'app/myappisbuiltwithbotocore' in uafields
+    assert client_s3.captured_user_agent_string.endswith(' extrastuff')
+
+
+def test_user_agent_long_appid_gets_truncated(
+    useragent_cap_client, stubbed_list_buckets, caplog
+):
+    # The maximum length for the user_agent_appid config is 50 characters
+    sixtychars = '000000000011111111112222222222333333333344444444445555555555'
+    client_cfg = Config(user_agent_appid=sixtychars)
+    with useragent_cap_client('s3', config=client_cfg) as client_s3:
+        with stubbed_list_buckets(client_s3):
+            with caplog.at_level(logging.INFO):
+                client_s3.list_buckets()
+
+    # given string should be truncated to 50 characters
+    uafields = client_s3.captured_user_agent_string.split(' ')
+    assert 'app/00000000001111111111222222222233333333334444444444' in uafields
+    # a warning-level log message should be raised
+    assert (
+        'The configured value for user_agent_appid exceeds the maximum length'
+        in caplog.text
+    )
+    assert sixtychars in caplog.text

--- a/tests/unit/test_useragent.py
+++ b/tests/unit/test_useragent.py
@@ -1,0 +1,43 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import pytest
+
+from botocore.useragent import sanitize_user_agent_string_component
+
+
+@pytest.mark.parametrize(
+    'raw_str, allow_hash, expected_str',
+    [
+        ('foo', False, 'foo'),
+        ('foo', True, 'foo'),
+        ('ExampleFramework (1.2.3)', False, 'ExampleFramework--1.2.3-'),
+        ('foo#1.2.3', False, 'foo-1.2.3'),
+        ('foo#1.2.3', True, 'foo#1.2.3'),
+        ('', False, ''),
+        ('', True, ''),
+        ('', False, ''),
+        ('#', False, '-'),
+        ('#', True, '#'),
+        (' ', False, '-'),
+        ('  ', False, '--'),
+        ('@=[]{ }/\\øß©', True, '------------'),
+        (
+            'Java_HotSpot_(TM)_64-Bit_Server_VM/25.151-b12',
+            True,
+            'Java_HotSpot_-TM-_64-Bit_Server_VM-25.151-b12',
+        ),
+    ],
+)
+def test_sanitize_ua_string_component(raw_str, allow_hash, expected_str):
+    actual_str = sanitize_user_agent_string_component(raw_str, allow_hash)
+    assert actual_str == expected_str


### PR DESCRIPTION
This PR adds support for the `AWS_SDK_UA_APP_ID` environment variable and `sdk_ua_app_id` setting in the [shared configuration file](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html). This is already supported by some other AWS SDKs today and will in future be the recommended way for third party apps that use botocore to inject an identifier into the User-Agent header. Botocore will also continue supporting the `user_agent` and `user_agent_extra` config settings for backwards compatibility.

For test coverage, this PR introduces new functional testing for all user agent header related config settings. While there are existing tests for user agent settings in [unit/test_client.py](https://github.com/boto/botocore/blob/develop/tests/unit/test_client.py), [unit/test_session.py](https://github.com/boto/botocore/blob/develop/tests/unit/test_session.py), and [unit/test_session_legacy.py](https://github.com/boto/botocore/blob/develop/tests/unit/test_session_legacy.py), they either test session-level settings (which get overridden or modified by client-level config) or mock the legacy endpoint resolver.

Open questions where for which I'd be particularly interested to hear feedback:

1. Naming of the config variable. Right now I made the config variable name similar to existing config variables but different from the config _file_ setting name.
2. Test fixtures: I wonder if there is an easier way to stub the requests that requires less setup and simply captures all outgoing requests. Probably not because it would require somehow aborting the request before the response is parsed...