### PR TITLE
Presigning content type bug

### DIFF
--- a/.changes/next-release/bugfix-generatepresignedurl-96454.json
+++ b/.changes/next-release/bugfix-generatepresignedurl-96454.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "generate_presigned_url",
+  "description": "Remove `Content-Type` header from bodiless request types."
+}

--- a/.changes/next-release/bugfix-generatepresignedurl-96454.json
+++ b/.changes/next-release/bugfix-generatepresignedurl-96454.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
-  "category": "generate_presigned_url",
-  "description": "Remove `Content-Type` header if transforming to a method without body semantics."
+  "category": "handlers",
+  "description": "Remove `Content-Type` header from Polly ``synthesize_speech`` URL presigning."
 }

--- a/.changes/next-release/bugfix-generatepresignedurl-96454.json
+++ b/.changes/next-release/bugfix-generatepresignedurl-96454.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "generate_presigned_url",
-  "description": "Remove `Content-Type` header from bodiless request types."
+  "description": "Remove `Content-Type` header if transforming to a method without body semantics."
 }

--- a/.changes/next-release/bugfix-generatepresignedurl-96454.json
+++ b/.changes/next-release/bugfix-generatepresignedurl-96454.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
-  "category": "handlers",
-  "description": "Remove `Content-Type` header from Polly ``synthesize_speech`` URL presigning."
+  "category": "``Polly``",
+  "description": "Remove `Content-Type` header from ``synthesize_speech`` URL presigning."
 }

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1137,7 +1137,7 @@ def customize_endpoint_resolver_builtins(
         builtins[EndpointResolverBuiltins.AWS_S3_USE_GLOBAL_ENDPOINT] = True
 
 
-def remove_content_type_header_for_polly_presigning(request, **kwargs):
+def remove_content_type_header_for_presigning(request, **kwargs):
     if (
         request.context.get('is_presign_request') is True
         and 'Content-Type' in request.headers
@@ -1250,7 +1250,7 @@ BUILTIN_HANDLERS = [
     ('before-sign.s3', remove_arn_from_signing_path),
     (
         'before-sign.polly.SynthesizeSpeech',
-        remove_content_type_header_for_polly_presigning,
+        remove_content_type_header_for_presigning,
     ),
     ('after-call.s3.ListObjects', decode_list_object),
     ('after-call.s3.ListObjectsV2', decode_list_object_v2),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1137,6 +1137,14 @@ def customize_endpoint_resolver_builtins(
         builtins[EndpointResolverBuiltins.AWS_S3_USE_GLOBAL_ENDPOINT] = True
 
 
+def remove_content_type_header_for_polly_presigning(request, **kwargs):
+    if (
+        request.context.get('is_presign_request') is True
+        and 'Content-Type' in request.headers
+    ):
+        del request.headers['Content-Type']
+
+
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be
 # automatically registered with that Session.
@@ -1240,6 +1248,10 @@ BUILTIN_HANDLERS = [
     ('before-parameter-build.route53', fix_route53_ids),
     ('before-parameter-build.glacier', inject_account_id),
     ('before-sign.s3', remove_arn_from_signing_path),
+    (
+        'before-sign.polly.SynthesizeSpeech',
+        remove_content_type_header_for_polly_presigning,
+    ),
     ('after-call.s3.ListObjects', decode_list_object),
     ('after-call.s3.ListObjectsV2', decode_list_object_v2),
     ('after-call.s3.ListObjectVersions', decode_list_object_versions),

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -682,13 +682,13 @@ def generate_presigned_url(
     if http_method is not None:
         request_dict['method'] = http_method
 
-    # If we're transforming to a method without formal body
-    # semantics we need to remove the Content-Type header.
-    if (
-        request_dict['method'].lower() in ('get', 'head', 'options')
-        and 'Content-Type' in request_dict['headers']
-    ):
-        del request_dict['headers']['Content-Type']
+        # If we're transforming to a method without formal body
+        # semantics we need to remove the Content-Type header.
+        if (
+            request_dict['method'].lower() in ('get', 'head', 'options')
+            and 'Content-Type' in request_dict['headers']
+        ):
+            del request_dict['headers']['Content-Type']
 
     # Generate the presigned url.
     return request_signer.generate_presigned_url(

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -682,6 +682,14 @@ def generate_presigned_url(
     if http_method is not None:
         request_dict['method'] = http_method
 
+    # Requests that are bodiless should not have the `Content-Type` header`
+    if (
+        request_dict['method'].lower()
+        in ('get', 'head', 'delete', 'options', 'trace')
+        and 'Content-Type' in request_dict['headers']
+    ):
+        del request_dict['headers']['Content-Type']
+
     # Generate the presigned url.
     return request_signer.generate_presigned_url(
         request_dict=request_dict,

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -682,7 +682,7 @@ def generate_presigned_url(
     if http_method is not None:
         request_dict['method'] = http_method
 
-    # Requests that are bodiless should not have the `Content-Type` header`
+    # Requests that are bodiless should not have the `Content-Type` header.
     if (
         request_dict['method'].lower() in ('get', 'head', 'options')
         and 'Content-Type' in request_dict['headers']

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -682,14 +682,6 @@ def generate_presigned_url(
     if http_method is not None:
         request_dict['method'] = http_method
 
-        # If we're transforming to a method without formal body
-        # semantics we need to remove the Content-Type header.
-        if (
-            http_method.lower() in ('get', 'head', 'options')
-            and 'Content-Type' in request_dict['headers']
-        ):
-            del request_dict['headers']['Content-Type']
-
     # Generate the presigned url.
     return request_signer.generate_presigned_url(
         request_dict=request_dict,

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -685,7 +685,7 @@ def generate_presigned_url(
         # If we're transforming to a method without formal body
         # semantics we need to remove the Content-Type header.
         if (
-            request_dict['method'].lower() in ('get', 'head', 'options')
+            http_method.lower() in ('get', 'head', 'options')
             and 'Content-Type' in request_dict['headers']
         ):
             del request_dict['headers']['Content-Type']

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -682,7 +682,8 @@ def generate_presigned_url(
     if http_method is not None:
         request_dict['method'] = http_method
 
-    # Requests that are bodiless should not have the `Content-Type` header.
+    # If we're transforming to a method without formal body
+    # semantics we need to remove the Content-Type header.
     if (
         request_dict['method'].lower() in ('get', 'head', 'options')
         and 'Content-Type' in request_dict['headers']

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -684,8 +684,7 @@ def generate_presigned_url(
 
     # Requests that are bodiless should not have the `Content-Type` header`
     if (
-        request_dict['method'].lower()
-        in ('get', 'head', 'delete', 'options', 'trace')
+        request_dict['method'].lower() in ('get', 'head', 'options')
         and 'Content-Type' in request_dict['headers']
     ):
         del request_dict['headers']['Content-Type']

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -1179,21 +1179,12 @@ class TestGenerateDBAuthToken(BaseSignerTest):
 
 
 @pytest.mark.parametrize(
-    'request_method, content_type_present',
-    [
-        ('GET', False),
-        ('HEAD', False),
-        ('OPTIONS', False),
-        ('POST', True),
-        ('PUT', True),
-        ('DELETE', True),
-        (None, True),
-    ],
+    'request_method',
+    ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'DELETE', None],
 )
-def test_generate_presigned_url_content_type_removal(
+def test_generate_presigned_url_content_type_removal_for_polly(
     polly_client,
     request_method,
-    content_type_present,
 ):
     url = polly_client.generate_presigned_url(
         'synthesize_speech',
@@ -1204,4 +1195,4 @@ def test_generate_presigned_url_content_type_removal(
         },
         HttpMethod=request_method,
     )
-    assert ('content-type' in url) == content_type_present
+    assert 'content-type' not in url

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -1195,4 +1195,4 @@ def test_generate_presigned_url_content_type_removal_for_polly(
         },
         HttpMethod=request_method,
     )
-    assert 'content-type' not in url
+    assert 'content-type' not in url.lower()

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -43,6 +43,7 @@ from tests import assert_url_equal, mock, unittest
 @pytest.fixture(scope='function')
 def polly_client():
     session = botocore.session.get_session()
+    session.set_credentials('key', 'secret')
     return session.create_client('polly', region_name='us-west-2')
 
 
@@ -1189,14 +1190,12 @@ class TestGenerateDBAuthToken(BaseSignerTest):
         (None, True),
     ],
 )
-@mock.patch('botocore.signers.RequestSigner.generate_presigned_url')
 def test_generate_presigned_url_content_type_removal(
-    generate_presigned_url_mock,
     polly_client,
     request_method,
     content_type_present,
 ):
-    polly_client.generate_presigned_url(
+    url = polly_client.generate_presigned_url(
         'synthesize_speech',
         Params={
             'OutputFormat': 'mp3',
@@ -1205,7 +1204,4 @@ def test_generate_presigned_url_content_type_removal(
         },
         HttpMethod=request_method,
     )
-    assert (
-        'Content-Type'
-        in generate_presigned_url_mock.call_args[1]['request_dict']['headers']
-    ) == content_type_present
+    assert ('content-type' in url) == content_type_present

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -40,7 +40,7 @@ from botocore.signers import (
 from tests import assert_url_equal, mock, unittest
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def polly_client():
     session = botocore.session.get_session()
     session.set_credentials('key', 'secret')

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -1184,6 +1184,7 @@ class TestGenerateDBAuthToken(BaseSignerTest):
         ('POST', True),
         ('PUT', True),
         ('DELETE', False),
+        (None, True),
     ],
 )
 def test_generate_presigned_url_content_type_removal(
@@ -1198,4 +1199,4 @@ def test_generate_presigned_url_content_type_removal(
         },
         HttpMethod=request_method,
     )
-    assert 'content-type' in url == content_type_present
+    assert ('content-type' in url) == content_type_present

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -43,7 +43,7 @@ from tests import assert_url_equal, mock, unittest
 @pytest.fixture(scope='function')
 def polly_client():
     session = botocore.session.get_session()
-    return session.create_client('polly')
+    return session.create_client('polly', region_name='us-west-2')
 
 
 class BaseSignerTest(unittest.TestCase):

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -1189,10 +1189,14 @@ class TestGenerateDBAuthToken(BaseSignerTest):
         (None, True),
     ],
 )
+@mock.patch('botocore.signers.RequestSigner.generate_presigned_url')
 def test_generate_presigned_url_content_type_removal(
-    polly_client, request_method, content_type_present
+    generate_presigned_url_mock,
+    polly_client,
+    request_method,
+    content_type_present,
 ):
-    url = polly_client.generate_presigned_url(
+    polly_client.generate_presigned_url(
         'synthesize_speech',
         Params={
             'OutputFormat': 'mp3',
@@ -1201,4 +1205,7 @@ def test_generate_presigned_url_content_type_removal(
         },
         HttpMethod=request_method,
     )
-    assert ('content-type' in url) == content_type_present
+    assert (
+        'Content-Type'
+        in generate_presigned_url_mock.call_args[1]['request_dict']['headers']
+    ) == content_type_present

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -1181,9 +1181,11 @@ class TestGenerateDBAuthToken(BaseSignerTest):
     'request_method, content_type_present',
     [
         ('GET', False),
+        ('HEAD', False),
+        ('OPTIONS', False),
         ('POST', True),
         ('PUT', True),
-        ('DELETE', False),
+        ('DELETE', True),
         (None, True),
     ],
 )


### PR DESCRIPTION
This addresses a bug in URL presigning. For certain operations, like Polly's `SynthesizeSpeech`, the URL used for presigning does not match what is modeled for the request. Typically it is sent as a `POST` with API parameters attached to a body, but through presigning, it is a `GET` with parameters attached in the URL query. 

This issue arises in the `RestJson` serializers where the input params are still treated as a body, so a `Content-Type` header is injected, causing a signature mismatch in the presigned URL that is returned.

This PR generally removes this header for presigning from requests using methods where bodies should not be present or should have no meaning.

UPDATE: After some issues were discovered when running presigning for the JSON-RPC protocol, we've decided to scale back this solution to only be applied as a customization for Polly's `synthesize_speech` when generating a presigned URL.