### PR TITLE
Redact sensitive headers in AWSPreparedRequest repr method

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -508,7 +508,8 @@ class AWSPreparedRequest:
             '<AWSPreparedRequest stream_output=%s, method=%s, url=%s, '
             'headers=%s>'
         )
-        return fmt % (self.stream_output, self.method, self.url, self.headers)
+        headers = self._redact_headers()
+        return fmt % (self.stream_output, self.method, self.url, headers)
 
     def reset_stream(self):
         """Resets the streaming body to it's initial position.
@@ -532,6 +533,17 @@ class AWSPreparedRequest:
         except Exception as e:
             logger.debug("Unable to rewind stream: %s", e)
             raise UnseekableStreamError(stream_object=self.body)
+
+    def _redact_headers(self):
+        """Redacts sensitive header values when calling the ``repr`` method."""
+
+        headers = self.headers.copy()
+        sensitive_headers = ["authorization", "x-amz-security-token"]
+        for key in sensitive_headers:
+            if key in headers and headers[key]:
+                headers[key] = "REDACTED"
+
+        return headers
 
 
 class AWSResponse:

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -125,6 +125,24 @@ class TestAWSRequest(unittest.TestCase):
         request_repr = repr(self.prepared_request)
         self.assertEqual(request_repr, expected_repr)
 
+    def test_prepared_request_repr_redacted_headers(self):
+        headers = {
+            "Foo": "bar",
+            "Authorization": "foo",
+            "X-Amz-Security-Token": "bar",
+        }
+        request = AWSRequest(
+            method='GET', url='http://example.com', headers=headers
+        )
+        prepared_request = request.prepare()
+        expected_repr = (
+            "<AWSPreparedRequest stream_output=False, method=GET, "
+            "url=http://example.com, headers={'Foo': 'bar', "
+            "'Authorization': 'REDACTED', 'X-Amz-Security-Token': 'REDACTED'}>"
+        )
+        request_repr = repr(prepared_request)
+        self.assertEqual(request_repr, expected_repr)
+
     def test_can_prepare_url_params(self):
         request = AWSRequest(url='http://example.com/', params={'foo': 'bar'})
         prepared_request = request.prepare()


### PR DESCRIPTION
Hi there,

This is a small change that redacts the information in two headers that contain credentials or authorization information in the [AWSPreparedRequest](https://github.com/boto/botocore/blob/97ba59024bdc313df6d18865f9ef233d24d60f95/botocore/awsrequest.py#L486) class. 

This object is [frequently logged](https://github.com/boto/botocore/blob/97ba59024bdc313df6d18865f9ef233d24d60f95/botocore/endpoint.py#L265) when sending requests to AWS services, and the `repr` method is returning a string that shows the contents of the request headers in plaintext. These headers contain customer signatures and credential information, which, ideally should not be logged as its an attack vector if logs are mismanaged. 

I understand that the [docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/boto3.html#boto3.set_stream_logger) call out the use of DEBUG level logging and that wire level information that gets logged may contain sensitive data. I agree that it may be difficult to determine what is sensitive info vs what is not in all logs, making redacting information a hard problem. 

However, not having protection for fields that are generally known to contain sensitive customer information is a significant security hole.

Relying on a notice in the documentation to be wary of using debug mode only helps so much. If customers mistakenly or unknowingly set their log level to debug, Botocore should still offer some level of protection against logging customer secrets, signatures or other sensitive information. 

Issues I found related to or similar to logging sensitive info:
- #2626
- #1211
- https://github.com/boto/boto3/issues/2292
- https://github.com/boto/boto3/issues/1203
