### PR TITLE
fix: random crashes in credentials.py

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -651,7 +651,7 @@ class CachedCredentialFetcher:
 
     def _make_file_safe(self, filename):
         # Replace :, path sep, and / to make it the string filename safe.
-        filename = filename.replace(':', '_').replace(os.path.sep, '_')
+        filename = filename.replace(':', '_').replace(os.sep, '_')
         return filename.replace('/', '_')
 
     def _get_credentials(self):


### PR DESCRIPTION
os.path.sep and os.sep are supposed to do the same but os.path.sep can lead to random crashes in newer python versions with the following error

_AttributeError: module 'posixpath' has no attribute 'sep'_

This is also known to other projects and is caused by some broken python versions

https://github.com/pytest-dev/pytest/issues/10547
https://github.com/Toblerity/Fiona/issues/1143
https://github.com/pallets/jinja/issues/1697

The small proposed fix will avoid the issue altogether, even with broken python versions

