### PR TITLE
Fix unconditional key removal from `request.headers`

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -98,6 +98,8 @@ def _get_body_as_dict(request):
         data = json.loads(data)
     return data
 
+def _replace_header(headers, key, value):
+    
 
 class BaseSigner:
     REQUIRES_REGION = False
@@ -815,7 +817,8 @@ class HmacV1Auth(BaseSigner):
         self, method, split, headers, expires=None, auth_path=None
     ):
         if self.credentials.token:
-            del headers['x-amz-security-token']
+            if 'X-Amz-Security-Token' in request.headers:
+                del request.headers['X-Amz-Security-Token']
             headers['x-amz-security-token'] = self.credentials.token
         string_to_sign = self.canonical_string(
             method, split, headers, auth_path=auth_path


### PR DESCRIPTION
This code mirrors https://github.com/boto/botocore/blob/97ba59024bdc313df6d18865f9ef233d24d60f95/botocore/auth.py#L191 and https://github.com/boto/botocore/blob/97ba59024bdc313df6d18865f9ef233d24d60f95/botocore/auth.py#L449