### PR TITLE
Keep overrides when deep copying config value store

### DIFF
--- a/.changes/next-release/bugfix-configprovider-46546.json
+++ b/.changes/next-release/bugfix-configprovider-46546.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "configprovider",
+  "description": "Fix bug when deep copying config value store where overrides were not preserved"
+}

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -402,7 +402,11 @@ class ConfigValueStore:
                 self.set_config_provider(logical_name, provider)
 
     def __deepcopy__(self, memo):
-        return ConfigValueStore(copy.deepcopy(self._mapping, memo))
+        config_store = ConfigValueStore(copy.deepcopy(self._mapping, memo))
+        for logical_name, override_value in self._overrides.items():
+            config_store.set_config_variable(logical_name, override_value)
+
+        return config_store
 
     def get_config_variable(self, logical_name):
         """

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -363,6 +363,16 @@ class TestConfigValueStore(unittest.TestCase):
         self.assertIsInstance(provider, ConstantProvider)
         self.assertEqual(value, 'bar')
 
+    def test_deepcopy_preserves_overrides(self):
+        provider = ConstantProvider(100)
+        config_store = ConfigValueStore(mapping={'fake_variable': provider})
+        config_store.set_config_variable('fake_variable', 'override-value')
+
+        config_store_deepcopy = copy.deepcopy(config_store)
+
+        value = config_store_deepcopy.get_config_variable('fake_variable')
+        self.assertEqual(value, 'override-value')
+
 
 class TestInstanceVarProvider(unittest.TestCase):
     def assert_provides_value(self, name, instance_map, expected_value):


### PR DESCRIPTION
Config providers were updated for smart default support to be deep copy-able. This PR fixes a bug when deep copying the config value store. Previously, override values were not preserved. The fix adds the override values to the new copy of the value store.

A test was added to confirm that the overrides are preserved in the copy.