### PR TITLE
Shallow copy config value store and providers

### DIFF
--- a/.changes/next-release/enhancement-configprovider-27540.json
+++ b/.changes/next-release/enhancement-configprovider-27540.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "configprovider",
+  "description": "Always use shallow copy of session config value store for clients"
+}

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -952,13 +952,13 @@ class Session:
         auth_token = self.get_auth_token()
         endpoint_resolver = self._get_internal_component('endpoint_resolver')
         exceptions_factory = self._get_internal_component('exceptions_factory')
-        config_store = self.get_component('config_store')
+
+        config_store = copy.copy(self.get_component('config_store'))
         defaults_mode = self._resolve_defaults_mode(config, config_store)
         if defaults_mode != 'legacy':
             smart_defaults_factory = self._get_internal_component(
                 'smart_defaults_factory'
             )
-            config_store = copy.deepcopy(config_store)
             smart_defaults_factory.merge_smart_defaults(
                 config_store, defaults_mode, region_name
             )

--- a/tests/functional/models/sdk-default-configuration.json
+++ b/tests/functional/models/sdk-default-configuration.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "base": {
+    "retryMode": "standard",
+    "stsRegionalEndpoints": "regional",
+    "s3UsEast1RegionalEndpoints": "regional",
+    "connectTimeoutInMillis": 9999000,
+    "tlsNegotiationTimeoutInMillis": 9999000
+  },
+  "modes": {
+    "standard": {
+      "connectTimeoutInMillis": {
+        "override": 9999000
+      },
+      "tlsNegotiationTimeoutInMillis": {
+        "override": 9999000
+      }
+    },
+    "in-region": {
+    },
+    "cross-region": {
+      "connectTimeoutInMillis": {
+        "override": 9999000
+      },
+      "tlsNegotiationTimeoutInMillis": {
+        "override": 9999000
+      }
+    },
+    "mobile": {
+      "connectTimeoutInMillis": {
+        "override": 99999000
+      },
+      "tlsNegotiationTimeoutInMillis": {
+        "override": 99999000
+      }
+    }
+  },
+  "documentation": {
+    "modes": {
+      "standard": "<p>FOR TESTING ONLY: The STANDARD mode provides the latest recommended default values that should be safe to run in most scenarios</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "in-region": "<p>FOR TESTING ONLY: The IN_REGION mode builds on the standard mode and includes optimization tailored for applications which call AWS services from within the same AWS region</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "cross-region": "<p>FOR TESTING ONLY: The CROSS_REGION mode builds on the standard mode and includes optimization tailored for applications which call AWS services in a different region</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "mobile": "<p>FOR TESTING ONLY: The MOBILE mode builds on the standard mode and includes optimization tailored for mobile applications</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "auto": "<p>FOR TESTING ONLY: The AUTO mode is an experimental mode that builds on the standard mode. The SDK will attempt to discover the execution environment to determine the appropriate settings automatically.</p><p>Note that the auto detection is heuristics-based and does not guarantee 100% accuracy. STANDARD mode will be used if the execution environment cannot be determined. The auto detection might query <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html\">EC2 Instance Metadata service</a>, which might introduce latency. Therefore we recommend choosing an explicit defaults_mode instead if startup latency is critical to your application</p>",
+      "legacy": "<p>FOR TESTING ONLY: The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>"
+    },
+    "configuration": {
+      "retryMode": "<p>FOR TESTING ONLY: A retry mode specifies how the SDK attempts retries. See <a href=\"https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-retry_mode.html\">Retry Mode</a></p>",
+      "stsRegionalEndpoints": "<p>FOR TESTING ONLY: Specifies how the SDK determines the AWS service endpoint that it uses to talk to the AWS Security Token Service (AWS STS). See <a href=\"https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-sts_regional_endpoints.html\">Setting STS Regional endpoints</a></p>",
+      "s3UsEast1RegionalEndpoints": "<p>FOR TESTING ONLY: Specifies how the SDK determines the AWS service endpoint that it uses to talk to the Amazon S3 for the us-east-1 region</p>",
+      "connectTimeoutInMillis": "<p>FOR TESTING ONLY: The amount of time after making an initial connection attempt on a socket, where if the client does not receive a completion of the connect handshake, the client gives up and fails the operation</p>",
+      "tlsNegotiationTimeoutInMillis": "<p>FOR TESTING ONLY: The maximum amount of time that a TLS handshake is allowed to take from the time the CLIENT HELLO message is sent to ethe time the client and server have fully negotiated ciphers and exchanged keys</p>"
+    }
+  }
+}

--- a/tests/functional/test_config_provider.py
+++ b/tests/functional/test_config_provider.py
@@ -10,8 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from pathlib import Path
+
 import pytest
 
+import botocore.exceptions
 from botocore.config import Config
 from botocore.session import get_session
 
@@ -26,6 +29,13 @@ _SDK_DEFAULT_CONFIGURATION_VALUES_ALLOWLIST = (
 session = get_session()
 loader = session.get_component('data_loader')
 sdk_default_configuration = loader.load_data('sdk-default-configuration')
+
+
+def assert_client_uses_standard_defaults(client):
+    assert client.meta.config.s3['us_east_1_regional_endpoint'] == 'regional'
+    assert client.meta.config.connect_timeout == 3.1
+    assert client.meta.endpoint_url == 'https://sts.us-west-2.amazonaws.com'
+    assert client.meta.config.retries['mode'] == 'standard'
 
 
 @pytest.mark.parametrize("mode", sdk_default_configuration['base'])
@@ -45,7 +55,69 @@ def test_default_configurations_resolve_correctly():
     client = session.create_client(
         'sts', config=config, region_name='us-west-2'
     )
+    assert_client_uses_standard_defaults(client)
+
+
+@pytest.fixture
+def loader():
+    test_models_dir = Path(__file__).parent / 'models'
+    loader = botocore.loaders.Loader()
+    loader.search_paths.insert(0, test_models_dir)
+    return loader
+
+
+@pytest.fixture
+def session(loader):
+    session = botocore.session.Session()
+    session.register_component('data_loader', loader)
+    return session
+
+
+def assert_client_uses_legacy_defaults(client):
+    assert client.meta.config.s3 is None
+    assert client.meta.config.connect_timeout == 60
+    assert client.meta.endpoint_url == 'https://sts.amazonaws.com'
+    assert client.meta.config.retries['mode'] == 'legacy'
+
+
+def assert_client_uses_testing_defaults(client):
     assert client.meta.config.s3['us_east_1_regional_endpoint'] == 'regional'
-    assert client.meta.config.connect_timeout == 3.1
-    assert client.meta.endpoint_url == 'https://sts.us-west-2.amazonaws.com'
+    assert client.meta.config.connect_timeout == 9999
+    assert client.meta.endpoint_url == 'https://sts.amazonaws.com'
     assert client.meta.config.retries['mode'] == 'standard'
+
+
+class TestConfigurationDefaults:
+    def test_defaults_mode_resolved_from_config_store(self, session):
+        config_store = session.get_component('config_store')
+        config_store.set_config_variable('defaults_mode', 'standard')
+        client = session.create_client('sts', 'us-west-2')
+        assert_client_uses_testing_defaults(client)
+
+    def test_no_mutate_session_provider(self, session):
+        # Using the standard default mode should change the connect timeout
+        # on the client, but not the session
+        standard_client = session.create_client(
+            'sts', 'us-west-2', config=Config(defaults_mode='standard')
+        )
+        assert_client_uses_testing_defaults(standard_client)
+
+        # Using the legacy default mode should not change the connect timeout
+        # on the client or the session. By default the connect timeout for a client
+        # is 60 seconds, and unset on the session.
+        legacy_client = session.create_client('sts', 'us-west-2')
+        assert_client_uses_legacy_defaults(legacy_client)
+
+    def test_defaults_mode_resolved_from_client_config(self, session):
+        config = Config(defaults_mode='standard')
+        client = session.create_client('sts', 'us-west-2', config=config)
+        assert_client_uses_testing_defaults(client)
+
+    def test_defaults_mode_resolved_invalid_mode_exception(self, session):
+        with pytest.raises(botocore.exceptions.InvalidDefaultsMode):
+            config = Config(defaults_mode='invalid_default_mode')
+            session.create_client('sts', 'us-west-2', config=config)
+
+    def test_defaults_mode_resolved_legacy(self, session):
+        client = session.create_client('sts', 'us-west-2')
+        assert_client_uses_legacy_defaults(client)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -772,34 +772,6 @@ class TestCreateClient(BaseSessionTest):
             ]
             self.assertEqual(call_kwargs['api_version'], override_api_version)
 
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_from_config_store(self, client_creator):
-        config_store = self.session.get_component('config_store')
-        config_store.set_config_variable('defaults_mode', 'standard')
-        self.session.create_client('sts', 'us-west-2')
-        self.assertIsNot(client_creator.call_args[0][-1], config_store)
-
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_from_client_config(self, client_creator):
-        config_store = self.session.get_component('config_store')
-        config = botocore.config.Config(defaults_mode='standard')
-        self.session.create_client('sts', 'us-west-2', config=config)
-        self.assertIsNot(client_creator.call_args[0][-1], config_store)
-
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_invalid_mode_exception(
-        self, client_creator
-    ):
-        with self.assertRaises(botocore.exceptions.InvalidDefaultsMode):
-            config = botocore.config.Config(defaults_mode='foo')
-            self.session.create_client('sts', 'us-west-2', config=config)
-
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_legacy(self, client_creator):
-        config_store = self.session.get_component('config_store')
-        self.session.create_client('sts', 'us-west-2')
-        self.assertIs(client_creator.call_args[0][-1], config_store)
-
 
 class TestSessionComponent(BaseSessionTest):
     def test_internal_component(self):


### PR DESCRIPTION
Instead of deep copying, use a shallow copy of the config value store when using it for creating a new client from a session.

Update behavior of the smart defaults update functions to use a copy of the existing config providers in all cases. Update the logic for determining which new provider to create.

Add a `__copy__` method to all config providers that need it, or for uniformity.

Move unit tests for config provider smart defaults to functional tests and rework them to better test behavior. A mocked defaults  data file is used to confirm that the correct values are loaded to protect against changes to the live data file.