### PR TITLE
update to security lake paginator

### DIFF
--- a/botocore/data/securitylake/2018-05-10/paginators-1.json
+++ b/botocore/data/securitylake/2018-05-10/paginators-1.json
@@ -1,22 +1,22 @@
 {
   "pagination": {
-    "GetDatalakeStatus": {
+    "GetDataLakeSources": {
       "input_token": "nextToken",
       "output_token": "nextToken",
-      "limit_key": "maxAccountResults",
-      "result_key": "accountSourcesList"
+      "limit_key": "maxResults",
+      "result_key": "dataLakeSources"
     },
-    "ListDatalakeExceptions": {
+    "ListDataLakeExceptions": {
       "input_token": "nextToken",
       "output_token": "nextToken",
-      "limit_key": "maxFailures",
-      "result_key": "nonRetryableFailures"
+      "limit_key": "maxResults",
+      "result_key": "exceptions"
     },
     "ListLogSources": {
       "input_token": "nextToken",
       "output_token": "nextToken",
       "limit_key": "maxResults",
-      "result_key": "regionSourceTypesAccountsList"
+      "result_key": "sources"
     },
     "ListSubscribers": {
       "input_token": "nextToken",


### PR DESCRIPTION
This is a required manual update to the paginators for `securitylake`. This MUST NOT be merged until the morning of 5/30. Pagination config tests are expected to fail with this update.