### PR TITLE
chore: update ancient issue bot

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -41,7 +41,7 @@ jobs:
         # Issue timing
         days-before-stale: 5
         days-before-close: 2
-        days-before-ancient: 365
+        days-before-ancient: 36500
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v4
+    - uses: aws-actions/stale-issue-cleanup@v6
       with:
         issue-types: issues
         stale-issue-message: Greetings! It looks like this issue hasn’t been 

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -17,12 +17,6 @@ jobs:
     - uses: aws-actions/stale-issue-cleanup@v4
       with:
         issue-types: issues
-        ancient-issue-message: Greetings! It looks like this issue hasn’t been active in longer 
-          than one year. We encourage you to check if this is still an issue in the latest release. 
-          In the absence of more information, we will be closing this issue soon. 
-          If you find that this is still a problem, please feel free to provide a comment or upvote 
-          with a reaction on the initial post to prevent automatic closure. If the issue is already closed, 
-          please feel free to open a new one.
         stale-issue-message: Greetings! It looks like this issue hasn’t been 
           active in longer than five days. We encourage you to check if this is still an issue in the latest release. 
           In the absence of more information, we will be closing this issue soon. 
@@ -41,7 +35,6 @@ jobs:
         # Issue timing
         days-before-stale: 5
         days-before-close: 2
-        days-before-ancient: 36500
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
Update ancient issue time so that we are not automatically closing old GitHub issues.