### PR TITLE
Fix generate_presigned_url for S3 operations where the modeled request URI contains a query component 

### DIFF
--- a/.changes/next-release/bugfix-s3-68869.json
+++ b/.changes/next-release/bugfix-s3-68869.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "fixes `#2962 <https://github.com/boto/botocore/issues/2962>`__"
+}

--- a/.changes/next-release/bugfix-s3-68869.json
+++ b/.changes/next-release/bugfix-s3-68869.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "s3",
-  "description": "fixes `#2962 <https://github.com/boto/botocore/issues/2962>`__"
+  "description": "Fix s3 presigned URLs for operations with query components (`#2962 <https://github.com/boto/botocore/issues/2962>`__)"
 }

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1050,6 +1050,10 @@ def remove_bucket_from_url_paths_from_model(params, model, context, **kwargs):
     bucket_path = '/{Bucket}'
     if req_uri.startswith(bucket_path):
         model.http['requestUri'] = req_uri[len(bucket_path) :]
+        # Strip query off the requestUri before using as authPath. The
+        # HmacV1Auth signer will append query params to the authPath during
+        # signing.
+        req_uri = req_uri.split('?')[0]
         # If the request URI is ONLY a bucket, the auth_path must be
         # terminated with a '/' character to generate a signature that the
         # server will accept.


### PR DESCRIPTION
Addresses https://github.com/boto/botocore/issues/2962

Fixes a bug where, for certain S3 operations and when using the default signer, the URL used in the signature string was invalid. This resulted in invalid presigned URLs.

**Context**

Botocore uses a JSON file that defines the [S3 service model](https://github.com/boto/botocore/blob/develop/botocore/data/s3/2006-03-01/service-2.json) for constructing request URLs for S3 API requests. For example, the `GetObjectAcl` operation is modeled with request URI `/{Bucket}/{Key+}?acl`. Since the introduction of [virtual-hosted-style addressing](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html), botocore has dropped the leading `/{Bucket}` from the service model's request URIs. Separate S3-specific logic then re-introduces the bucket name back into the URL later, either in virtual-hosted or path style addressing depending on configuration and bucket name. However, irrespective of addressing style, the bucket name must be included in the URL path used for [Signature Version 2 signatures](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#ConstructingTheCanonicalizedResourceElement).

Botocore version 1.28.0 contains a change for how these special rules for constructing S3 service URLs from the service model are implemented. This change failed to account for modeled request URIs that contain a query component. For example, [PutBucketCors](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html) has the modeled request URI `/{Bucket}?cors`. As reported in https://github.com/boto/botocore/issues/2962, the `"?cors"` string was incorrectly included in the signed string twice. 

**Solution**

In the `remove_bucket_from_url_paths_from_model` event handler, the query is removed from the request URI before it is copied into the `authPath` field.

(Note that the `remove_bucket_from_url_paths_from_model` event handler is applied for every request in the `s3` client during the `before-parameter-build`. However, the event handler is idempotent and only transforms the model once during the first request for each operation.)

**Testing**

I decided against creating an integration test for this case because using presigned URLs for any of the affected S3 operations requires non-trivial custom code on top of what botocore provides. For example, the repo code in https://github.com/boto/botocore/issues/2962 constructs a XML request body and calculates a checksum header. Such an integration test would provide more test coverage for custom test code than for botocore logic itself.

The newly introduced unit test for the `remove_bucket_from_url_paths_from_model` event handler should be sufficient to avoid regressions on the bug.

The repro code provided in https://github.com/boto/botocore/issues/2962 works with `MODIFY_FUNC = False` after this change.