### PR TITLE
Fallback for situations where Python's fromtimestamp() raises OSError or OverflowError

### DIFF
--- a/.changes/next-release/bugfix-Parsers-42740.json
+++ b/.changes/next-release/bugfix-Parsers-42740.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "Parsers",
-  "description": "fixes `#3642 <https://github.com/boto/botocore/issues/3642>`__, `#2564 <https://github.com/boto/botocore/issues/2564>`__, `#2355 <https://github.com/boto/botocore/issues/2355>`__, `#1783 <https://github.com/boto/botocore/issues/1783>`__, boto/boto3`#2069 <https://github.com/boto/botocore/issues/2069>`__"
+  "description": "Fixes parsing of negative and out-of-range timestamp values (`#2564 <https://github.com/boto/botocore/issues/2564>`__)."
 }

--- a/.changes/next-release/bugfix-Parsers-42740.json
+++ b/.changes/next-release/bugfix-Parsers-42740.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "Parsers",
-  "description": "Fixes parsing of negative and out-of-range timestamp values (`#2564 <https://github.com/boto/botocore/issues/2564>`__)."
+  "description": "Fixes datetime parse error handling for out-of-range and negative timestamps (`#2564 <https://github.com/boto/botocore/issues/2564>`__)."
 }

--- a/.changes/next-release/bugfix-Parsers-42740.json
+++ b/.changes/next-release/bugfix-Parsers-42740.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Parsers",
+  "description": "fixes `#3642 <https://github.com/boto/botocore/issues/3642>`__, `#2564 <https://github.com/boto/botocore/issues/2564>`__, `#2355 <https://github.com/boto/botocore/issues/2355>`__, `#1783 <https://github.com/boto/botocore/issues/1783>`__, boto/boto3`#2069 <https://github.com/boto/botocore/issues/2069>`__"
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -904,6 +904,22 @@ def percent_encode(input_str, safe=SAFE_CHARS):
     return quote(input_str, safe=safe)
 
 
+def _epoch_seconds_to_datetime(value, tzinfo):
+    """Parse numerical epoch timestamps (seconds since 1970) into a
+    ``datetime.datetime`` in UTC using ``datetime.timedelta``. This is intended
+    as fallback when ``fromtimestamp`` raises ``OverflowError`` or ``OSError``.
+
+    :type value: float or int
+    :param value: The Unix timestamps as number.
+
+    :type tzinfo: callable
+    :param tzinfo: A ``datetime.tzinfo`` class or compatible callable.
+    """
+    epoch_zero = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=tzutc())
+    epoch_zero_localized = epoch_zero.astimezone(tzinfo())
+    return epoch_zero_localized + datetime.timedelta(seconds=value)
+
+
 def _parse_timestamp_with_tzinfo(value, tzinfo):
     """Parse timestamp with pluggable tzinfo options."""
     if isinstance(value, (int, float)):
@@ -935,12 +951,35 @@ def parse_timestamp(value):
     This will return a ``datetime.datetime`` object.
 
     """
-    for tzinfo in get_tzinfo_options():
+    tzinfo_options = get_tzinfo_options()
+    for tzinfo in tzinfo_options:
         try:
+            print(f"_parse_timestamp_with_tzinfo({value}, {tzinfo})")
             return _parse_timestamp_with_tzinfo(value, tzinfo)
-        except OSError as e:
+        except (OSError, OverflowError) as e:
             logger.debug(
                 'Unable to parse timestamp with "%s" timezone info.',
+                tzinfo.__name__,
+                exc_info=e,
+            )
+    # For numeric values attempt fallback to using fromtimestamp-free method.
+    # From Python's ``datetime.datetime.fromtimestamp`` documentation: "This
+    # may raise ``OverflowError``, if the timestamp is out of the range of
+    # values supported by the platform C localtime() function, and ``OSError``
+    # on localtime() failure. It's common for this to be restricted to years
+    # from 1970 through 2038."
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        pass
+    else:
+        try:
+            for tzinfo in tzinfo_options:
+                return _epoch_seconds_to_datetime(numeric_value, tzinfo=tzinfo)
+        except (OSError, OverflowError) as e:
+            logger.debug(
+                'Unable to parse timestamp using fallback method with "%s" '
+                'timezone info.',
                 tzinfo.__name__,
                 exc_info=e,
             )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -424,6 +424,18 @@ class TestParseTimestamps(unittest.TestCase):
             datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=tzutc()),
         )
 
+    def test_parse_epoch_negative_time(self):
+        self.assertEqual(
+            parse_timestamp(-2208988800),
+            datetime.datetime(1900, 1, 1, 0, 0, 0, tzinfo=tzutc()),
+        )
+
+    def test_parse_epoch_beyond_2038(self):
+        self.assertEqual(
+            parse_timestamp(2524608000),
+            datetime.datetime(2050, 1, 1, 0, 0, 0, tzinfo=tzutc()),
+        )
+
     def test_parse_epoch_as_string(self):
         self.assertEqual(
             parse_timestamp('1222172800'),


### PR DESCRIPTION
This addresses various issues where calling `datetime.datetime.fromtimestamp()` fails with `OverflowError` or `OSError`. These behaviors are platform-dependent and currently seem to affect mainly Windows. [The Python documentation mentions the existence of these failure mode](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp).

This PR adds a fallback for when parsing a numeric timestamp fails that uses `timedelta` to create a datetime that is offset from the epoch (Jan 1, 1970) by the given number of seconds. This has the same effect as calling `fromtimestamp()` without calling the C `localtime()` function.

Some related issues:

* #2564
* #2355
* #1783
* #1939
* boto/boto3#2069
* boto/boto3#3642

The general theme of these issues is that a service returns a timestamp that falls outside the timespan between 1970 and 2038. Examples I have seen include Quicksight dashboards with time axes starting in the early 1900s, ACM certificates that expire after 2038, and SSM Patches with incorrect `InstalledTime` fields claiming patch dates before 1970.

#1970 and #1939 have been previous attempts to address a subset of these problems. The former has not been merged, the solution from the latter remains in place after this PR. (An aside: Note the coincidence that PR ID 1970 addresses an issue related to epoch times!)

Q: Why not also replace the use of `fromtimestamp()` in `credentials.py`?

A: In order to preserve existing code paths, this new fallback is not implemented as a drop-in replacement for Python's `fromtimestamp`. As a result, I could not use it to also replace the one remaining use of `fromtimestamp()` in `credentials.py`. That's also why I made `_epoch_seconds_to_datetime` private (with leading `_`). This remaining instance of `fromtimestamp()` is unlikely to yield the exceptions addressed in this PR because timestamps in credentials do not fall outside the "safe" timespan between 1970 and 2038 (currently and in the foreseeable future).