### PR TITLE
Configured endpoint URL resolution

### DIFF
--- a/.changes/next-release/bugfix-configprovider-46546.json
+++ b/.changes/next-release/bugfix-configprovider-46546.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "configprovider",
+  "description": "Fix bug when deep copying config value store where overrides were not preserved"
+}

--- a/.changes/next-release/enhancement-configprovider-27540.json
+++ b/.changes/next-release/enhancement-configprovider-27540.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "configprovider",
+  "description": "Always use shallow copy of session config value store for clients"
+}

--- a/.changes/next-release/feature-configuration-3829.json
+++ b/.changes/next-release/feature-configuration-3829.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "configuration",
+  "description": "Configure the endpoint URL in the shared configuration file or via an environment variable for a specific AWS service or all AWS services."
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -287,9 +287,11 @@ class ClientArgsCreator:
         }
 
     def _compute_configured_endpoint_url(self, client_config, endpoint_url):
-        if endpoint_url is not None or self._ignore_configured_endpoint_urls(
-            client_config
-        ):
+        if endpoint_url is not None:
+            return endpoint_url
+
+        if self._ignore_configured_endpoint_urls(client_config):
+            logger.debug("Ignoring configured endpoint URLs.")
             return endpoint_url
 
         return self._config_store.get_config_variable('endpoint_url')

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -115,7 +115,7 @@ class ClientArgsCreator:
         s3_config = final_args['s3_config']
         partition = endpoint_config['metadata'].get('partition', None)
         socket_options = final_args['socket_options']
-
+        configured_endpoint_url = final_args['configured_endpoint_url']
         signing_region = endpoint_config['signing_region']
         endpoint_region_name = endpoint_config['region_name']
 
@@ -160,7 +160,7 @@ class ClientArgsCreator:
             service_model,
             endpoint_region_name,
             region_name,
-            endpoint_url,
+            configured_endpoint_url,
             endpoint,
             is_secure,
             endpoint_bridge,
@@ -210,10 +210,16 @@ class ClientArgsCreator:
                 parameter_validation = ensure_boolean(raw_value)
 
         s3_config = self.compute_s3_config(client_config)
+
+        configured_endpoint_url = self._compute_configured_endpoint_url(
+            client_config=client_config,
+            endpoint_url=endpoint_url,
+        )
+
         endpoint_config = self._compute_endpoint_config(
             service_name=service_name,
             region_name=region_name,
-            endpoint_url=endpoint_url,
+            endpoint_url=configured_endpoint_url,
             is_secure=is_secure,
             endpoint_bridge=endpoint_bridge,
             s3_config=s3_config,
@@ -270,6 +276,7 @@ class ClientArgsCreator:
         return {
             'service_name': service_name,
             'parameter_validation': parameter_validation,
+            'configured_endpoint_url': configured_endpoint_url,
             'endpoint_config': endpoint_config,
             'protocol': protocol,
             'config_kwargs': config_kwargs,
@@ -278,6 +285,25 @@ class ClientArgsCreator:
                 scoped_config, client_config
             ),
         }
+
+    def _compute_configured_endpoint_url(self, client_config, endpoint_url):
+        if endpoint_url is not None or self._ignore_configured_endpoint_urls(
+            client_config
+        ):
+            return endpoint_url
+
+        return self._config_store.get_config_variable('endpoint_url')
+
+    def _ignore_configured_endpoint_urls(self, client_config):
+        if (
+            client_config
+            and client_config.ignore_configured_endpoint_urls is not None
+        ):
+            return client_config.ignore_configured_endpoint_urls
+
+        return self._config_store.get_config_variable(
+            'ignore_configured_endpoint_urls'
+        )
 
     def compute_s3_config(self, client_config):
         s3_configuration = self._config_store.get_config_variable('s3')

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -194,6 +194,13 @@ class Config:
 
         Defaults to None.
 
+    :type ignore_configured_endpoint_urls: bool
+    :param ignore_configured_endpoint_urls: Setting to True disables use
+        of endpoint URLs provided via environment variables and
+        the shared configuration file.
+
+        Defaults to None.
+
     :type tcp_keepalive: bool
     :param tcp_keepalive: Enables the TCP Keep-Alive socket option used when
         creating new connections if set to True.
@@ -221,6 +228,7 @@ class Config:
             ('endpoint_discovery_enabled', None),
             ('use_dualstack_endpoint', None),
             ('use_fips_endpoint', None),
+            ('ignore_configured_endpoint_urls', None),
             ('defaults_mode', None),
             ('tcp_keepalive', None),
         ]

--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -200,6 +200,17 @@ def _parse_nested(config_value):
     return parsed
 
 
+def _parse_section(key, values):
+    result = {}
+    try:
+        parts = shlex.split(key)
+    except ValueError:
+        return result
+    if len(parts) == 2:
+        result[parts[1]] = values
+    return result
+
+
 def build_profile_map(parsed_ini_config):
     """Convert the parsed INI config into a profile map.
 
@@ -254,22 +265,15 @@ def build_profile_map(parsed_ini_config):
     parsed_config = copy.deepcopy(parsed_ini_config)
     profiles = {}
     sso_sessions = {}
+    services = {}
     final_config = {}
     for key, values in parsed_config.items():
         if key.startswith("profile"):
-            try:
-                parts = shlex.split(key)
-            except ValueError:
-                continue
-            if len(parts) == 2:
-                profiles[parts[1]] = values
+            profiles.update(_parse_section(key, values))
         elif key.startswith("sso-session"):
-            try:
-                parts = shlex.split(key)
-            except ValueError:
-                continue
-            if len(parts) == 2:
-                sso_sessions[parts[1]] = values
+            sso_sessions.update(_parse_section(key, values))
+        elif key.startswith("services"):
+            services.update(_parse_section(key, values))
         elif key == 'default':
             # default section is special and is considered a profile
             # name but we don't require you use 'profile "default"'
@@ -279,4 +283,5 @@ def build_profile_map(parsed_ini_config):
             final_config[key] = values
     final_config['profiles'] = profiles
     final_config['sso_sessions'] = sso_sessions
+    final_config['services'] = services
     return final_config

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -18,6 +18,7 @@ import logging
 import os
 
 from botocore import utils
+from botocore.exceptions import InvalidConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     'use_fips_endpoint': (
         'use_fips_endpoint',
         'AWS_USE_FIPS_ENDPOINT',
+        None,
+        utils.ensure_boolean,
+    ),
+    'ignore_configured_endpoint_urls': (
+        'ignore_configured_endpoint_urls',
+        'AWS_IGNORE_CONFIGURED_ENDPOINT_URLS',
         None,
         utils.ensure_boolean,
     ),
@@ -852,3 +859,159 @@ class ConstantProvider(BaseProvider):
 
     def __repr__(self):
         return 'ConstantProvider(value=%s)' % self._value
+
+
+class ConfiguredEndpointProvider(BaseProvider):
+    """Lookup an endpoint URL from environment variable or shared cong file.
+
+    NOTE: This class is considered private and is subject to abrupt breaking
+    changes or removal without prior announcement. Please do not use it
+    directly.
+    """
+
+    _ENDPOINT_URL_LOOKUP_ORDER = [
+        'environment_service',
+        'environment_global',
+        'config_service',
+        'config_global',
+    ]
+
+    def __init__(
+        self,
+        full_config,
+        scoped_config,
+        client_name,
+        environ=None,
+    ):
+        """Initialize a ConfiguredEndpointProviderChain.
+
+        :type full_config: dict
+        :param full_config: This is the dict representing the full
+            configuration file.
+
+        :type scoped_config: dict
+        :param scoped_config: This is the dict representing the configuration
+            for the current profile for the session.
+
+        :type client_name: str
+        :param client_name: The name used to instantiate a client using
+            botocore.session.Session.create_client.
+
+        :type environ: dict
+        :param environ: A mapping to use for environment variables. If this
+            is not provided it will default to use os.environ.
+        """
+        self._full_config = full_config
+        self._scoped_config = scoped_config
+        self._client_name = client_name
+
+        if environ is None:
+            environ = os.environ
+        self._environ = environ
+
+    def provide(self):
+        """Lookup the configured endpoint URL.
+
+        The order is:
+
+        1. The value provided by a service-specific environment variable.
+        2. The value provided by the global endpoint environment variable
+           (AWS_ENDPOINT_URL).
+        3. The value provided by a service-specific parameter from a services
+           definition section in the shared configuration file.
+        4. The value provided by the global parameter from a services
+           definition section in the shared configuration file.
+        """
+        for location in self._ENDPOINT_URL_LOOKUP_ORDER:
+            logger.debug(
+                'Looking for endpoint for %s via: %s',
+                self._client_name,
+                location,
+            )
+
+            endpoint_url = getattr(self, f'_get_endpoint_url_{location}')()
+
+            if endpoint_url:
+                logger.info(
+                    'Found endpoint for %s via: %s.',
+                    self._client_name,
+                    location,
+                )
+                return endpoint_url
+
+        logger.debug('No configured endpoint found.')
+        return None
+
+    def _get_snake_case_service_id(self, client_name):
+        # Use lookups to get the serice ID without loading the service data
+        # file. `client_name`` refers to the name used to instantiate a client
+        # through botocore.session.Session.create_client (parameter name there
+        # is `service_name`). This client name is generally the hyphenized
+        # service ID.  We need to look up services that have been renamed
+        # (SERVICE_NAME_ALIASES) as well as services that do not use
+        # the service ID as their data directory name
+        # (CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES).
+        client_name = utils.SERVICE_NAME_ALIASES.get(client_name, client_name)
+        hyphenized_service_id = (
+            utils.CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES.get(
+                client_name, client_name
+            )
+        )
+        return hyphenized_service_id.replace('-', '_')
+
+    def _get_service_env_var_name(self):
+        transformed_service_id_env = self._get_snake_case_service_id(
+            self._client_name
+        ).upper()
+        return f'AWS_ENDPOINT_URL_{transformed_service_id_env}'
+
+    def _get_services_config(self):
+        if 'services' not in self._scoped_config:
+            return {}
+
+        section_name = self._scoped_config['services']
+        services_section = self._full_config.get('services', {}).get(
+            section_name
+        )
+
+        if not services_section:
+            error_msg = (
+                f'The profile is configured to use the services '
+                f'section but the "{section_name}" services '
+                f'configuration does not exist.'
+            )
+            raise InvalidConfigError(error_msg=error_msg)
+
+        return services_section
+
+    def _get_endpoint_url_config_service(self):
+        snakecase_service_id = self._get_snake_case_service_id(
+            self._client_name
+        ).lower()
+        return (
+            self._get_services_config()
+            .get(snakecase_service_id, {})
+            .get('endpoint_url')
+        )
+
+    def _get_endpoint_url_config_global(self):
+        return self._scoped_config.get('endpoint_url')
+
+    def _get_endpoint_url_environment_service(self):
+        return EnvironmentProvider(
+            name=self._get_service_env_var_name(), env=self._environ
+        ).provide()
+
+    def _get_endpoint_url_environment_global(self):
+        return EnvironmentProvider(
+            name='AWS_ENDPOINT_URL', env=self._environ
+        ).provide()
+
+    def __repr__(self):
+        return (
+            f'ConfiguredEndpointProvider('
+            f'full_config={self._full_config}, '
+            f'scoped_config={self._scoped_config}, '
+            f'client_name={self._client_name}, '
+            f'environ={self._environ})'
+        )

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -998,12 +998,3 @@ class ConfiguredEndpointProvider(BaseProvider):
         return EnvironmentProvider(
             name='AWS_ENDPOINT_URL', env=self._environ
         ).provide()
-
-    def __repr__(self):
-        return (
-            f'ConfiguredEndpointProvider('
-            f'full_config={self._full_config}, '
-            f'scoped_config={self._scoped_config}, '
-            f'client_name={self._client_name}, '
-            f'environ={self._environ})'
-        )

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -403,7 +403,11 @@ class ConfigValueStore:
                 self.set_config_provider(logical_name, provider)
 
     def __deepcopy__(self, memo):
-        return ConfigValueStore(copy.deepcopy(self._mapping, memo))
+        config_store = ConfigValueStore(copy.deepcopy(self._mapping, memo))
+        for logical_name, override_value in self._overrides.items():
+            config_store.set_config_variable(logical_name, override_value)
+
+        return config_store
 
     def get_config_variable(self, logical_name):
         """

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -409,6 +409,13 @@ class ConfigValueStore:
 
         return config_store
 
+    def __copy__(self):
+        config_store = ConfigValueStore(copy.copy(self._mapping))
+        for logical_name, override_value in self._overrides.items():
+            config_store.set_config_variable(logical_name, override_value)
+
+        return config_store
+
     def get_config_variable(self, logical_name):
         """
         Retrieve the value associeated with the specified logical_name
@@ -547,24 +554,28 @@ class SmartDefaultsConfigStoreFactory:
         return 'standard'
 
     def _update_provider(self, config_store, variable, value):
-        provider = config_store.get_config_provider(variable)
+        original_provider = config_store.get_config_provider(variable)
         default_provider = ConstantProvider(value)
-        if isinstance(provider, ChainProvider):
-            provider.set_default_provider(default_provider)
-            return
-        elif isinstance(provider, BaseProvider):
+        if isinstance(original_provider, ChainProvider):
+            chain_provider_copy = copy.deepcopy(original_provider)
+            chain_provider_copy.set_default_provider(default_provider)
+            default_provider = chain_provider_copy
+        elif isinstance(original_provider, BaseProvider):
             default_provider = ChainProvider(
-                providers=[provider, default_provider]
+                providers=[original_provider, default_provider]
             )
         config_store.set_config_provider(variable, default_provider)
 
     def _update_section_provider(
         self, config_store, section_name, variable, value
     ):
-        section_provider = config_store.get_config_provider(section_name)
-        section_provider.set_default_provider(
+        section_provider_copy = copy.deepcopy(
+            config_store.get_config_provider(section_name)
+        )
+        section_provider_copy.set_default_provider(
             variable, ConstantProvider(value)
         )
+        config_store.set_config_provider(section_name, section_provider_copy)
 
     def _set_retryMode(self, config_store, value):
         self._update_provider(config_store, 'retry_mode', value)

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -73,6 +73,7 @@ from botocore.compat import MD5_AVAILABLE  # noqa
 from botocore.exceptions import MissingServiceIdError  # noqa
 from botocore.utils import hyphenize_service_id  # noqa
 from botocore.utils import is_global_accesspoint  # noqa
+from botocore.utils import SERVICE_NAME_ALIASES  # noqa
 
 
 logger = logging.getLogger(__name__)
@@ -98,8 +99,6 @@ VALID_S3_ARN = re.compile('|'.join([_ACCESSPOINT_ARN, _OUTPOST_ARN]))
 # botocore/data/s3/2006-03-01/endpoints-rule-set-1.json
 S3_SIGNING_NAMES = ('s3', 's3-outposts', 's3-object-lambda')
 VERSION_ID_SUFFIX = re.compile(r'\?versionId=[^\s]+$')
-
-SERVICE_NAME_ALIASES = {'runtime.sagemaker': 'sagemaker-runtime'}
 
 
 def handle_service_name_alias(service_name, **kwargs):

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -957,7 +957,7 @@ class Session:
         auth_token = self.get_auth_token()
         endpoint_resolver = self._get_internal_component('endpoint_resolver')
         exceptions_factory = self._get_internal_component('exceptions_factory')
-        config_store = self.get_component('config_store')
+        config_store = copy.copy(self.get_component('config_store'))
         user_agent_creator = self.get_component('user_agent_creator')
         # Session configuration values for the user agent string are applied
         # just before each client creation because they may have been modified
@@ -972,7 +972,6 @@ class Session:
             smart_defaults_factory = self._get_internal_component(
                 'smart_defaults_factory'
             )
-            config_store = copy.deepcopy(config_store)
             smart_defaults_factory.merge_smart_defaults(
                 config_store, defaults_mode, region_name
             )

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3353,3 +3353,79 @@ class JSONFileCache:
                 return value.isoformat()
             return value.strftime('%Y-%m-%dT%H:%M:%S%Z')
         return value
+
+
+# This parameter is not part of the public interface and is subject to abrupt
+# breaking changes or removal without prior announcement.
+# Mapping of services that have been renamed for backwards compatibility reasons.
+# Keys are the previous name that should be allowed, values are the documented
+# and preferred client name.
+SERVICE_NAME_ALIASES = {'runtime.sagemaker': 'sagemaker-runtime'}
+
+
+# This parameter is not part of the public interface and is subject to abrupt
+# breaking changes or removal without prior announcement.
+# Mapping to determine the service ID for services that do not use it as the
+# model data directory name. The keys are the data directory name and the
+# values are the transformed service IDs (lower case and hyphenated).
+CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES = {
+    # Actual service name we use -> Allowed computed service name.
+    'alexaforbusiness': 'alexa-for-business',
+    'apigateway': 'api-gateway',
+    'application-autoscaling': 'application-auto-scaling',
+    'appmesh': 'app-mesh',
+    'autoscaling': 'auto-scaling',
+    'autoscaling-plans': 'auto-scaling-plans',
+    'ce': 'cost-explorer',
+    'cloudhsmv2': 'cloudhsm-v2',
+    'cloudsearchdomain': 'cloudsearch-domain',
+    'cognito-idp': 'cognito-identity-provider',
+    'config': 'config-service',
+    'cur': 'cost-and-usage-report-service',
+    'datapipeline': 'data-pipeline',
+    'directconnect': 'direct-connect',
+    'devicefarm': 'device-farm',
+    'discovery': 'application-discovery-service',
+    'dms': 'database-migration-service',
+    'ds': 'directory-service',
+    'dynamodbstreams': 'dynamodb-streams',
+    'elasticbeanstalk': 'elastic-beanstalk',
+    'elastictranscoder': 'elastic-transcoder',
+    'elb': 'elastic-load-balancing',
+    'elbv2': 'elastic-load-balancing-v2',
+    'es': 'elasticsearch-service',
+    'events': 'eventbridge',
+    'globalaccelerator': 'global-accelerator',
+    'iot-data': 'iot-data-plane',
+    'iot-jobs-data': 'iot-jobs-data-plane',
+    'iot1click-devices': 'iot-1click-devices-service',
+    'iot1click-projects': 'iot-1click-projects',
+    'iotevents-data': 'iot-events-data',
+    'iotevents': 'iot-events',
+    'iotwireless': 'iot-wireless',
+    'kinesisanalytics': 'kinesis-analytics',
+    'kinesisanalyticsv2': 'kinesis-analytics-v2',
+    'kinesisvideo': 'kinesis-video',
+    'lex-models': 'lex-model-building-service',
+    'lexv2-models': 'lex-models-v2',
+    'lex-runtime': 'lex-runtime-service',
+    'lexv2-runtime': 'lex-runtime-v2',
+    'logs': 'cloudwatch-logs',
+    'machinelearning': 'machine-learning',
+    'marketplacecommerceanalytics': 'marketplace-commerce-analytics',
+    'marketplace-entitlement': 'marketplace-entitlement-service',
+    'meteringmarketplace': 'marketplace-metering',
+    'mgh': 'migration-hub',
+    'sms-voice': 'pinpoint-sms-voice',
+    'resourcegroupstaggingapi': 'resource-groups-tagging-api',
+    'route53': 'route-53',
+    'route53domains': 'route-53-domains',
+    's3control': 's3-control',
+    'sdb': 'simpledb',
+    'secretsmanager': 'secrets-manager',
+    'serverlessrepo': 'serverlessapplicationrepository',
+    'servicecatalog': 'service-catalog',
+    'servicecatalog-appregistry': 'service-catalog-appregistry',
+    'stepfunctions': 'sfn',
+    'storagegateway': 'storage-gateway',
+}

--- a/tests/functional/configured_endpoint_urls/__init__.py
+++ b/tests/functional/configured_endpoint_urls/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/configured_endpoint_urls/profile-tests.json
+++ b/tests/functional/configured_endpoint_urls/profile-tests.json
@@ -1,0 +1,478 @@
+{
+  "description": [
+    "These are test descriptions that describe how specific data should be loaded from a profile file based on a ",
+    "profile name."
+  ],
+
+  "testSuites": [
+    {
+      "profiles": {
+        "default": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "region": "fake-region-10"
+        },
+        "service_localhost_global_only": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "region": "fake-region-10",
+          "endpoint_url": "http://localhost:1234"
+        },
+        "service_global_only": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "region": "fake-region-10",
+          "endpoint_url": "https://global.endpoint.aws"
+        },
+        "service_specific_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "services": "service_specific_s3",
+          "region": "fake-region-10"
+        },
+        "global_and_service_specific_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "endpoint_url": "https://global.endpoint.aws",
+          "services": "service_specific_s3",
+          "region": "fake-region-10"
+        },
+        "ignore_global_and_service_specific_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "endpoint_url": "https://global.endpoint.aws",
+          "services": "service_specific_s3",
+          "region": "fake-region-10",
+          "ignore_configured_endpoint_urls": "true"
+        },
+        "service_specific_dynamodb_and_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "services": "service_specific_dynamodb_and_s3",
+          "region": "fake-region-10"
+        }
+      },
+
+      "services": {
+        "service_specific_s3": {
+          "s3": {
+            "endpoint_url": "https://s3.endpoint.aws"
+          }
+        },
+        "service_specific_dynamodb_and_s3": {
+          "dynamodb": {
+            "endpoint_url": "https://dynamodb.endpoint.aws"
+          },
+          "s3": {
+            "endpoint_url": "https://s3.endpoint.aws"
+          }
+        }
+      },
+
+      "client_configs": {
+        "default": {},
+        "endpoint_url_provided":{
+          "endpoint_url": "https://client-config.endpoint.aws"
+        }
+      },
+
+      "environments": {
+        "default": {},
+        "global_only": {
+          "AWS_ENDPOINT_URL": "https://global-from-envvar.endpoint.aws"
+        },
+        "service_specific_s3": {
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws"
+        },
+        "global_and_service_specific_s3": {
+          "AWS_ENDPOINT_URL": "https://global-from-envvar.endpoint.aws",
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws"
+
+        },
+        "ignore_global_and_service_specific_s3": {
+          "AWS_ENDPOINT_URL": "https://global-from-envvar.endpoint.aws",
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws",
+          "AWS_IGNORE_CONFIGURED_ENDPOINT_URLS": "true"
+        },
+        "service_specific_dynamodb_and_s3": {
+          "AWS_ENDPOINT_URL_DYNAMODB": "https://dynamodb-from-envvar.endpoint.aws",
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+
+    "endpointUrlTests": [
+      {
+        "name": "Global endpoint url is read from services section and used for an S3 client.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service specific endpoint url is read from services section and used for an S3 client.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.endpoint.aws"
+        }
+      },
+      {
+        "name": "S3 Service-specific endpoint URL from configuration file takes precedence over global endpoint URL from configuration file.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precedence over the value resolved by the SDK.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precendence over global endpoint configuration option.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precendence over service-specific endpoint configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precendence over global endpoint configuration option and service-specific endpoint configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the value resolved by the SDK.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the services-specific endpoint url configuration option and the global endpoint url configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable and the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable and the the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable, the service-specific endpoint URL configuration option, and the global endpoint URL configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over value provided by the SDK.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url from services section and used for an S3 client.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service specific endpoint url from services section and used for an S3 client.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over S3 Service-specific endpoint URL from configuration file and global endpoint URL from configuration file.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable and global endpoint configuration option.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable and service-specific endpoint configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable, global endpoint configuration option, and service-specific endpoint configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable and the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable and the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the services-specific endpoint url configuration option, and the global endpoint url configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable and the global endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the global endpoint url environment variable, and the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the global endpoint url environment variable, and the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the global endpoint url environment variable, the service-specific endpoint URL configuration option, and the global endpoint URL configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "All configured endpoints ignored due to environment variable.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "ignore_global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.fake-region-10.amazonaws.com"
+        }
+      },
+      {
+        "name": "All configured endpoints ignored due to shared config variable.",
+        "profile": "ignore_global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.fake-region-10.amazonaws.com"
+        }
+      },
+      {
+        "name": "Environment variable and shared config file configured endpoints ignored due to ignore shared config variable and client configured endpoint is used.",
+        "profile": "ignore_global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Environment variable and shared config file configured endpoints ignored due to ignore environment variable and client configured endpoint is used.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "ignore_global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "DynamoDB service-specific endpoint url shared config variable is used when service-specific S3 shared config variable is also present.",
+        "profile": "service_specific_dynamodb_and_s3",
+        "client_config": "default",
+        "environment": "default",
+        "service": "dynamodb",
+        "output": {
+          "endpointUrl": "https://dynamodb.endpoint.aws"
+        }
+      },
+      {
+        "name": "DynamoDB service-specific endpoint url environment variable is used when service-specific S3 environment variable is also present.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "service_specific_dynamodb_and_s3",
+        "service": "dynamodb",
+        "output": {
+          "endpointUrl": "https://dynamodb-from-envvar.endpoint.aws"
+        }
+      }
+
+    ]
+  }
+  ]
+}

--- a/tests/functional/configured_endpoint_urls/profile-tests.json
+++ b/tests/functional/configured_endpoint_urls/profile-tests.json
@@ -73,6 +73,13 @@
         "default": {},
         "endpoint_url_provided":{
           "endpoint_url": "https://client-config.endpoint.aws"
+        },
+        "ignore_configured_endpoint_urls": {
+          "ignore_configured_endpoint_urls": true
+        },
+        "provide_and_ignore_configured_endpoint_urls": {
+          "ignore_configured_endpoint_urls": true,
+          "endpoint_url": "https://client-config.endpoint.aws"
         }
       },
 
@@ -432,6 +439,16 @@
         }
       },
       {
+        "name": "All configured endpoints ignored due to ignore client config parameter.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "ignore_configured_endpoint_urls",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.fake-region-10.amazonaws.com"
+        }
+      },
+      {
         "name": "Environment variable and shared config file configured endpoints ignored due to ignore shared config variable and client configured endpoint is used.",
         "profile": "ignore_global_and_service_specific_s3",
         "client_config": "endpoint_url_provided",
@@ -446,6 +463,16 @@
         "profile": "global_and_service_specific_s3",
         "client_config": "endpoint_url_provided",
         "environment": "ignore_global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Environment variable and shared config file configured endpoints ignored due to ignore client config variable and client configured endpoint is used.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "provide_and_ignore_configured_endpoint_urls",
+        "environment": "global_and_service_specific_s3",
         "service": "s3",
         "output": {
           "endpointUrl": "https://client-config.endpoint.aws"

--- a/tests/functional/configured_endpoint_urls/test_configured_endpoint_url.py
+++ b/tests/functional/configured_endpoint_urls/test_configured_endpoint_url.py
@@ -158,7 +158,7 @@ def assert_endpoint_url_used_for_operation(
     )
 
 
-def _known_service_names_and_models():
+def _known_service_names_and_ids():
     my_session = botocore.session.get_session()
     loader = my_session.get_component('data_loader')
     available_services = loader.list_available_services('service-2')
@@ -166,7 +166,7 @@ def _known_service_names_and_models():
     result = []
     for service_name in available_services:
         model = my_session.get_service_model(service_name)
-        result.append((model.service_name, model))
+        result.append((model.service_name, model.service_id))
     return sorted(result)
 
 
@@ -192,12 +192,12 @@ def test_resolve_configured_endpoint_url(test_case, client_creator):
 
 
 @pytest.mark.parametrize(
-    'service_name,service_model', _known_service_names_and_models()
+    'service_name,service_id', _known_service_names_and_ids()
 )
 def test_expected_service_env_var_name_is_respected(
-    service_name, service_model, client_creator
+    service_name, service_id, client_creator
 ):
-    transformed_service_id = service_model.service_id.replace(' ', '_').upper()
+    transformed_service_id = service_id.replace(' ', '_').upper()
 
     client = client_creator(
         service=service_name,
@@ -220,12 +220,12 @@ def test_expected_service_env_var_name_is_respected(
 
 
 @pytest.mark.parametrize(
-    'service_name,service_model', _known_service_names_and_models()
+    'service_name,service_id', _known_service_names_and_ids()
 )
 def test_expected_service_config_section_name_is_respected(
-    service_name, service_model, client_creator
+    service_name, service_id, client_creator
 ):
-    transformed_service_id = service_model.service_id.replace(' ', '_').lower()
+    transformed_service_id = service_id.replace(' ', '_').lower()
 
     client = client_creator(
         service=service_name,

--- a/tests/functional/configured_endpoint_urls/test_configured_endpoint_url.py
+++ b/tests/functional/configured_endpoint_urls/test_configured_endpoint_url.py
@@ -1,0 +1,228 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import botocore.configprovider
+import botocore.utils
+from botocore.compat import urlsplit
+from tests import ClientHTTPStubber
+
+ENDPOINT_TESTDATA_FILE = Path(__file__).parent / "profile-tests.json"
+
+
+def dict_to_ini_section(ini_dict, section_header):
+    section_str = f'[{section_header}]\n'
+    for key, value in ini_dict.items():
+        if isinstance(value, dict):
+            section_str += f"{key} =\n"
+            for new_key, new_value in value.items():
+                section_str += f"  {new_key}={new_value}\n"
+        else:
+            section_str += f"{key}={value}\n"
+    return section_str + "\n"
+
+
+def create_cases():
+    with open(ENDPOINT_TESTDATA_FILE) as f:
+        test_suite = json.load(f)['testSuites'][0]
+
+    for test_case_data in test_suite['endpointUrlTests']:
+        yield pytest.param(
+            {
+                'service': test_case_data['service'],
+                'profile': test_case_data['profile'],
+                'expected_endpoint_url': test_case_data['output'][
+                    'endpointUrl'
+                ],
+                'client_args': test_suite['client_configs'].get(
+                    test_case_data['client_config'], {}
+                ),
+                'config_file_contents': get_config_file_contents(
+                    test_case_data['profile'], test_suite
+                ),
+                'environment': test_suite['environments'].get(
+                    test_case_data['environment'], {}
+                ),
+            },
+            id=test_case_data['name'],
+        )
+
+
+def get_config_file_contents(profile_name, test_suite):
+    profile = test_suite['profiles'][profile_name]
+
+    profile_str = dict_to_ini_section(
+        profile,
+        section_header=f"profile {profile_name}",
+    )
+
+    services_section_name = profile.get('services', None)
+
+    if services_section_name is None:
+        return profile_str
+
+    services_section = test_suite['services'][services_section_name]
+
+    service_section_str = dict_to_ini_section(
+        services_section,
+        section_header=f'services {services_section_name}',
+    )
+
+    return profile_str + service_section_str
+
+
+@pytest.fixture
+def client_creator(tmp_path):
+    tmp_config_file_path = tmp_path / 'config'
+    environ = {'AWS_CONFIG_FILE': str(tmp_config_file_path)}
+
+    def _do_create_client(
+        service,
+        profile,
+        client_args=None,
+        config_file_contents=None,
+        environment=None,
+    ):
+        environ.update(environment)
+        with open(tmp_config_file_path, 'w') as f:
+            f.write(config_file_contents)
+            f.flush()
+
+        return botocore.session.Session(profile=profile).create_client(
+            service, **client_args
+        )
+
+    with mock.patch('os.environ', environ):
+        yield _do_create_client
+
+
+def _normalize_endpoint(url):
+    split_endpoint = urlsplit(url)
+    actual_endpoint = f"{split_endpoint.scheme}://{split_endpoint.netloc}"
+    return actual_endpoint
+
+
+def assert_client_endpoint_url(client, expected_endpoint_url):
+    assert client.meta.endpoint_url == expected_endpoint_url
+
+
+def assert_endpoint_url_used_for_operation(
+    client, expected_endpoint_url, operation, params
+):
+    http_stubber = ClientHTTPStubber(client)
+    http_stubber.start()
+    http_stubber.add_response()
+
+    # Call an operation on the client
+    getattr(client, operation)(**params)
+
+    assert (
+        _normalize_endpoint(http_stubber.requests[0].url)
+        == expected_endpoint_url
+    )
+
+
+def _known_service_names_and_models():
+    my_session = botocore.session.get_session()
+    loader = my_session.get_component('data_loader')
+    available_services = loader.list_available_services('service-2')
+
+    result = []
+    for service_name in available_services:
+        model = my_session.get_service_model(service_name)
+        result.append((model.service_name, model))
+    return sorted(result)
+
+
+SERVICE_TO_OPERATION = {'s3': 'list_buckets', 'dynamodb': 'list_tables'}
+
+
+@pytest.mark.parametrize("test_case", create_cases())
+def test_resolve_configured_endpoint_url(test_case, client_creator):
+    client = client_creator(
+        service=test_case['service'],
+        profile=test_case['profile'],
+        client_args=test_case['client_args'],
+        config_file_contents=test_case['config_file_contents'],
+        environment=test_case['environment'],
+    )
+
+    assert_endpoint_url_used_for_operation(
+        client=client,
+        expected_endpoint_url=test_case['expected_endpoint_url'],
+        operation=SERVICE_TO_OPERATION[test_case['service']],
+        params={},
+    )
+
+
+@pytest.mark.parametrize(
+    'service_name,service_model', _known_service_names_and_models()
+)
+def test_expected_service_env_var_name_is_respected(
+    service_name, service_model, client_creator
+):
+    transformed_service_id = service_model.service_id.replace(' ', '_').upper()
+
+    client = client_creator(
+        service=service_name,
+        profile='default',
+        client_args={},
+        config_file_contents=(
+            '[profile default]\n'
+            'aws_access_key_id=123\n'
+            'aws_secret_access_key=456\n'
+            'region=fake-region-10\n'
+        ),
+        environment={
+            f'AWS_ENDPOINT_URL_{transformed_service_id}': 'https://endpoint-override'
+        },
+    )
+
+    assert_client_endpoint_url(
+        client=client, expected_endpoint_url='https://endpoint-override'
+    )
+
+
+@pytest.mark.parametrize(
+    'service_name,service_model', _known_service_names_and_models()
+)
+def test_expected_service_config_section_name_is_respected(
+    service_name, service_model, client_creator
+):
+    transformed_service_id = service_model.service_id.replace(' ', '_').lower()
+
+    client = client_creator(
+        service=service_name,
+        profile='default',
+        client_args={},
+        config_file_contents=(
+            f'[profile default]\n'
+            f'services=my-services\n'
+            f'aws_access_key_id=123\n'
+            f'aws_secret_access_key=456\n'
+            f'region=fake-region-10\n\n'
+            f'[services my-services]\n'
+            f'{transformed_service_id} = \n'
+            f'  endpoint_url = https://endpoint-override\n\n'
+        ),
+        environment={},
+    )
+
+    assert_client_endpoint_url(
+        client=client, expected_endpoint_url='https://endpoint-override'
+    )

--- a/tests/functional/configured_endpoint_urls/test_configured_endpoint_url.py
+++ b/tests/functional/configured_endpoint_urls/test_configured_endpoint_url.py
@@ -20,6 +20,7 @@ import pytest
 import botocore.configprovider
 import botocore.utils
 from botocore.compat import urlsplit
+from botocore.config import Config
 from tests import ClientHTTPStubber
 
 ENDPOINT_TESTDATA_FILE = Path(__file__).parent / "profile-tests.json"
@@ -49,8 +50,10 @@ def create_cases():
                 'expected_endpoint_url': test_case_data['output'][
                     'endpointUrl'
                 ],
-                'client_args': test_suite['client_configs'].get(
-                    test_case_data['client_config'], {}
+                'client_args': get_create_client_args(
+                    test_suite['client_configs'].get(
+                        test_case_data['client_config'], {}
+                    )
                 ),
                 'config_file_contents': get_config_file_contents(
                     test_case_data['profile'], test_suite
@@ -61,6 +64,24 @@ def create_cases():
             },
             id=test_case_data['name'],
         )
+
+
+def get_create_client_args(test_case_client_config):
+    create_client_args = {}
+
+    if 'endpoint_url' in test_case_client_config:
+        create_client_args['endpoint_url'] = test_case_client_config[
+            'endpoint_url'
+        ]
+
+    if 'ignore_configured_endpoint_urls' in test_case_client_config:
+        create_client_args['config'] = Config(
+            ignore_configured_endpoint_urls=test_case_client_config[
+                'ignore_configured_endpoint_urls'
+            ]
+        )
+
+    return create_client_args
 
 
 def get_config_file_contents(profile_name, test_suite):

--- a/tests/functional/models/sdk-default-configuration.json
+++ b/tests/functional/models/sdk-default-configuration.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "base": {
+    "retryMode": "standard",
+    "stsRegionalEndpoints": "regional",
+    "s3UsEast1RegionalEndpoints": "regional",
+    "connectTimeoutInMillis": 9999000,
+    "tlsNegotiationTimeoutInMillis": 9999000
+  },
+  "modes": {
+    "standard": {
+      "connectTimeoutInMillis": {
+        "override": 9999000
+      },
+      "tlsNegotiationTimeoutInMillis": {
+        "override": 9999000
+      }
+    },
+    "in-region": {
+    },
+    "cross-region": {
+      "connectTimeoutInMillis": {
+        "override": 9999000
+      },
+      "tlsNegotiationTimeoutInMillis": {
+        "override": 9999000
+      }
+    },
+    "mobile": {
+      "connectTimeoutInMillis": {
+        "override": 99999000
+      },
+      "tlsNegotiationTimeoutInMillis": {
+        "override": 99999000
+      }
+    }
+  },
+  "documentation": {
+    "modes": {
+      "standard": "<p>FOR TESTING ONLY: The STANDARD mode provides the latest recommended default values that should be safe to run in most scenarios</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "in-region": "<p>FOR TESTING ONLY: The IN_REGION mode builds on the standard mode and includes optimization tailored for applications which call AWS services from within the same AWS region</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "cross-region": "<p>FOR TESTING ONLY: The CROSS_REGION mode builds on the standard mode and includes optimization tailored for applications which call AWS services in a different region</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "mobile": "<p>FOR TESTING ONLY: The MOBILE mode builds on the standard mode and includes optimization tailored for mobile applications</p><p>Note that the default values vended from this mode might change as best practices may evolve. As a result, it is encouraged to perform tests when upgrading the SDK</p>",
+      "auto": "<p>FOR TESTING ONLY: The AUTO mode is an experimental mode that builds on the standard mode. The SDK will attempt to discover the execution environment to determine the appropriate settings automatically.</p><p>Note that the auto detection is heuristics-based and does not guarantee 100% accuracy. STANDARD mode will be used if the execution environment cannot be determined. The auto detection might query <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html\">EC2 Instance Metadata service</a>, which might introduce latency. Therefore we recommend choosing an explicit defaults_mode instead if startup latency is critical to your application</p>",
+      "legacy": "<p>FOR TESTING ONLY: The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>"
+    },
+    "configuration": {
+      "retryMode": "<p>FOR TESTING ONLY: A retry mode specifies how the SDK attempts retries. See <a href=\"https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-retry_mode.html\">Retry Mode</a></p>",
+      "stsRegionalEndpoints": "<p>FOR TESTING ONLY: Specifies how the SDK determines the AWS service endpoint that it uses to talk to the AWS Security Token Service (AWS STS). See <a href=\"https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-sts_regional_endpoints.html\">Setting STS Regional endpoints</a></p>",
+      "s3UsEast1RegionalEndpoints": "<p>FOR TESTING ONLY: Specifies how the SDK determines the AWS service endpoint that it uses to talk to the Amazon S3 for the us-east-1 region</p>",
+      "connectTimeoutInMillis": "<p>FOR TESTING ONLY: The amount of time after making an initial connection attempt on a socket, where if the client does not receive a completion of the connect handshake, the client gives up and fails the operation</p>",
+      "tlsNegotiationTimeoutInMillis": "<p>FOR TESTING ONLY: The maximum amount of time that a TLS handshake is allowed to take from the time the CLIENT HELLO message is sent to ethe time the client and server have fully negotiated ciphers and exchanged keys</p>"
+    }
+  }
+}

--- a/tests/functional/test_config_provider.py
+++ b/tests/functional/test_config_provider.py
@@ -10,8 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from pathlib import Path
+
 import pytest
 
+import botocore.exceptions
 from botocore.config import Config
 from botocore.session import get_session
 
@@ -26,6 +29,13 @@ _SDK_DEFAULT_CONFIGURATION_VALUES_ALLOWLIST = (
 session = get_session()
 loader = session.get_component('data_loader')
 sdk_default_configuration = loader.load_data('sdk-default-configuration')
+
+
+def assert_client_uses_standard_defaults(client):
+    assert client.meta.config.s3['us_east_1_regional_endpoint'] == 'regional'
+    assert client.meta.config.connect_timeout == 3.1
+    assert client.meta.endpoint_url == 'https://sts.us-west-2.amazonaws.com'
+    assert client.meta.config.retries['mode'] == 'standard'
 
 
 @pytest.mark.parametrize("mode", sdk_default_configuration['base'])
@@ -45,7 +55,69 @@ def test_default_configurations_resolve_correctly():
     client = session.create_client(
         'sts', config=config, region_name='us-west-2'
     )
+    assert_client_uses_standard_defaults(client)
+
+
+@pytest.fixture
+def loader():
+    test_models_dir = Path(__file__).parent / 'models'
+    loader = botocore.loaders.Loader()
+    loader.search_paths.insert(0, test_models_dir)
+    return loader
+
+
+@pytest.fixture
+def session(loader):
+    session = botocore.session.Session()
+    session.register_component('data_loader', loader)
+    return session
+
+
+def assert_client_uses_legacy_defaults(client):
+    assert client.meta.config.s3 is None
+    assert client.meta.config.connect_timeout == 60
+    assert client.meta.endpoint_url == 'https://sts.amazonaws.com'
+    assert client.meta.config.retries['mode'] == 'legacy'
+
+
+def assert_client_uses_testing_defaults(client):
     assert client.meta.config.s3['us_east_1_regional_endpoint'] == 'regional'
-    assert client.meta.config.connect_timeout == 3.1
-    assert client.meta.endpoint_url == 'https://sts.us-west-2.amazonaws.com'
+    assert client.meta.config.connect_timeout == 9999
+    assert client.meta.endpoint_url == 'https://sts.amazonaws.com'
     assert client.meta.config.retries['mode'] == 'standard'
+
+
+class TestConfigurationDefaults:
+    def test_defaults_mode_resolved_from_config_store(self, session):
+        config_store = session.get_component('config_store')
+        config_store.set_config_variable('defaults_mode', 'standard')
+        client = session.create_client('sts', 'us-west-2')
+        assert_client_uses_testing_defaults(client)
+
+    def test_no_mutate_session_provider(self, session):
+        # Using the standard default mode should change the connect timeout
+        # on the client, but not the session
+        standard_client = session.create_client(
+            'sts', 'us-west-2', config=Config(defaults_mode='standard')
+        )
+        assert_client_uses_testing_defaults(standard_client)
+
+        # Using the legacy default mode should not change the connect timeout
+        # on the client or the session. By default the connect timeout for a client
+        # is 60 seconds, and unset on the session.
+        legacy_client = session.create_client('sts', 'us-west-2')
+        assert_client_uses_legacy_defaults(legacy_client)
+
+    def test_defaults_mode_resolved_from_client_config(self, session):
+        config = Config(defaults_mode='standard')
+        client = session.create_client('sts', 'us-west-2', config=config)
+        assert_client_uses_testing_defaults(client)
+
+    def test_defaults_mode_resolved_invalid_mode_exception(self, session):
+        with pytest.raises(botocore.exceptions.InvalidDefaultsMode):
+            config = Config(defaults_mode='invalid_default_mode')
+            session.create_client('sts', 'us-west-2', config=config)
+
+    def test_defaults_mode_resolved_legacy(self, session):
+        client = session.create_client('sts', 'us-west-2')
+        assert_client_uses_legacy_defaults(client)

--- a/tests/functional/test_endpoints.py
+++ b/tests/functional/test_endpoints.py
@@ -13,69 +13,7 @@
 import pytest
 
 from botocore.session import get_session
-
-SERVICE_RENAMES = {
-    # Actual service name we use -> Allowed computed service name.
-    'alexaforbusiness': 'alexa-for-business',
-    'apigateway': 'api-gateway',
-    'application-autoscaling': 'application-auto-scaling',
-    'appmesh': 'app-mesh',
-    'autoscaling': 'auto-scaling',
-    'autoscaling-plans': 'auto-scaling-plans',
-    'ce': 'cost-explorer',
-    'cloudhsmv2': 'cloudhsm-v2',
-    'cloudsearchdomain': 'cloudsearch-domain',
-    'cognito-idp': 'cognito-identity-provider',
-    'config': 'config-service',
-    'cur': 'cost-and-usage-report-service',
-    'datapipeline': 'data-pipeline',
-    'directconnect': 'direct-connect',
-    'devicefarm': 'device-farm',
-    'discovery': 'application-discovery-service',
-    'dms': 'database-migration-service',
-    'ds': 'directory-service',
-    'dynamodbstreams': 'dynamodb-streams',
-    'elasticbeanstalk': 'elastic-beanstalk',
-    'elastictranscoder': 'elastic-transcoder',
-    'elb': 'elastic-load-balancing',
-    'elbv2': 'elastic-load-balancing-v2',
-    'es': 'elasticsearch-service',
-    'events': 'eventbridge',
-    'globalaccelerator': 'global-accelerator',
-    'iot-data': 'iot-data-plane',
-    'iot-jobs-data': 'iot-jobs-data-plane',
-    'iot1click-devices': 'iot-1click-devices-service',
-    'iot1click-projects': 'iot-1click-projects',
-    'iotevents-data': 'iot-events-data',
-    'iotevents': 'iot-events',
-    'iotwireless': 'iot-wireless',
-    'kinesisanalytics': 'kinesis-analytics',
-    'kinesisanalyticsv2': 'kinesis-analytics-v2',
-    'kinesisvideo': 'kinesis-video',
-    'lex-models': 'lex-model-building-service',
-    'lexv2-models': 'lex-models-v2',
-    'lex-runtime': 'lex-runtime-service',
-    'lexv2-runtime': 'lex-runtime-v2',
-    'logs': 'cloudwatch-logs',
-    'machinelearning': 'machine-learning',
-    'marketplacecommerceanalytics': 'marketplace-commerce-analytics',
-    'marketplace-entitlement': 'marketplace-entitlement-service',
-    'meteringmarketplace': 'marketplace-metering',
-    'mgh': 'migration-hub',
-    'sms-voice': 'pinpoint-sms-voice',
-    'resourcegroupstaggingapi': 'resource-groups-tagging-api',
-    'route53': 'route-53',
-    'route53domains': 'route-53-domains',
-    's3control': 's3-control',
-    'sdb': 'simpledb',
-    'secretsmanager': 'secrets-manager',
-    'serverlessrepo': 'serverlessapplicationrepository',
-    'servicecatalog': 'service-catalog',
-    'servicecatalog-appregistry': 'service-catalog-appregistry',
-    'stepfunctions': 'sfn',
-    'storagegateway': 'storage-gateway',
-}
-
+from botocore.utils import CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES
 
 ENDPOINT_PREFIX_OVERRIDE = {
     # entry in endpoints.json -> actual endpoint prefix.
@@ -163,7 +101,7 @@ def test_endpoint_matches_service(endpoint_prefix):
 
 
 @pytest.mark.parametrize("service_name", AVAILABLE_SERVICES)
-def test_service_name_matches_endpoint_prefix(service_name):
+def test_client_name_matches_hyphenized_service_id(service_name):
     """Generates tests for each service to verify that the computed service
     named based on the service id matches the service name used to
     create a client (i.e the directory name in botocore/data)
@@ -174,7 +112,9 @@ def test_service_name_matches_endpoint_prefix(service_name):
 
     # Handle known exceptions where we have renamed the service directory
     # for one reason or another.
-    actual_service_name = SERVICE_RENAMES.get(service_name, service_name)
+    actual_service_name = CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES.get(
+        service_name, service_name
+    )
 
     err_msg = (
         f"Actual service name `{actual_service_name}` does not match "

--- a/tests/unit/cfg/aws_services_config
+++ b/tests/unit/cfg/aws_services_config
@@ -1,0 +1,9 @@
+[default]
+endpoint_url = https://localhost:1234/
+services = my-services
+
+[services my-services]
+s3 =
+  endpoint_url = https://localhost:5678/
+dynamodb =
+  endpoint_url = https://localhost:8888/

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -21,6 +21,7 @@ from botocore.configprovider import (
     BaseProvider,
     ChainProvider,
     ConfigChainFactory,
+    ConfiguredEndpointProvider,
     ConfigValueStore,
     ConstantProvider,
     DefaultConfigResolver,
@@ -942,3 +943,206 @@ class TestSmartDefaults:
             )
             mode = smart_defaults_factory.resolve_auto_mode('us-west-2')
             assert mode == 'standard'
+
+
+def create_cases():
+    service = 'batch'
+
+    return [
+        dict(
+            service=service,
+            environ_map={},
+            full_config_map={},
+            expected_value=None,
+        ),
+        dict(
+            service=service,
+            environ_map={'AWS_ENDPOINT_URL': 'global-from-env'},
+            full_config_map={},
+            expected_value='global-from-env',
+        ),
+        dict(
+            service=service,
+            environ_map={
+                f'AWS_ENDPOINT_URL_{service.upper()}': 'service-from-env',
+                'AWS_ENDPOINT_URL': 'global-from-env',
+            },
+            full_config_map={},
+            expected_value='service-from-env',
+        ),
+        dict(
+            service=service,
+            environ_map={
+                'AWS_ENDPOINT_URL': 'global-from-env',
+                'AWS_ENDPOINT_URL_S3': 's3-endpoint-url',
+            },
+            full_config_map={},
+            expected_value='global-from-env',
+        ),
+        dict(
+            service=service,
+            environ_map={},
+            full_config_map={
+                'profiles': {'default': {'endpoint_url': 'global-from-config'}}
+            },
+            expected_value='global-from-config',
+        ),
+        dict(
+            service=service,
+            environ_map={},
+            full_config_map={
+                'profiles': {
+                    'default': {
+                        'services': 'my-services',
+                    }
+                },
+                'services': {
+                    'my-services': {
+                        service: {'endpoint_url': "service-from-config"}
+                    }
+                },
+            },
+            expected_value='service-from-config',
+        ),
+        dict(
+            service=service,
+            environ_map={},
+            full_config_map={
+                'profiles': {
+                    'default': {
+                        'services': 'my-services',
+                        'endpoint_url': 'global-from-config',
+                    }
+                },
+                'services': {
+                    'my-services': {
+                        service: {'endpoint_url': "service-from-config"}
+                    }
+                },
+            },
+            expected_value='service-from-config',
+        ),
+        dict(
+            service=service,
+            environ_map={
+                'AWS_ENDPOINT_URL': 'global-from-env',
+            },
+            full_config_map={
+                'profiles': {
+                    'default': {
+                        'endpoint_url': 'global-from-config',
+                    }
+                },
+            },
+            expected_value='global-from-env',
+        ),
+        dict(
+            service=service,
+            environ_map={
+                f'AWS_ENDPOINT_URL_{service.upper()}': 'service-from-env',
+            },
+            full_config_map={
+                'profiles': {
+                    'default': {
+                        'endpoint_url': 'global-from-config',
+                    }
+                },
+            },
+            expected_value='service-from-env',
+        ),
+        dict(
+            service='s3',
+            environ_map={},
+            full_config_map={
+                'profiles': {
+                    'default': {
+                        'services': 'my-services',
+                        'endpoint_url': 'global-from-config',
+                    }
+                },
+                'services': {
+                    'my-services': {
+                        service: {'endpoint_url': "service-from-config"}
+                    }
+                },
+            },
+            expected_value='global-from-config',
+        ),
+        dict(
+            service='runtime.sagemaker',
+            environ_map={},
+            full_config_map={
+                'profiles': {
+                    'default': {
+                        'services': 'my-services',
+                    }
+                },
+                'services': {
+                    'my-services': {
+                        'sagemaker_runtime': {
+                            'endpoint_url': "service-from-config"
+                        }
+                    }
+                },
+            },
+            expected_value='service-from-config',
+        ),
+        dict(
+            service='apigateway',
+            environ_map={},
+            full_config_map={
+                'profiles': {
+                    'default': {
+                        'services': 'my-services',
+                    }
+                },
+                'services': {
+                    'my-services': {
+                        'api_gateway': {'endpoint_url': "service-from-config"}
+                    }
+                },
+            },
+            expected_value='service-from-config',
+        ),
+    ]
+
+
+class TestConfiguredEndpointProvider:
+    def assert_does_provide(
+        self,
+        service,
+        environ_map,
+        full_config_map,
+        expected_value,
+    ):
+        scoped_config_map = full_config_map.get('profiles', {}).get(
+            'default', {}
+        )
+
+        chain = ConfiguredEndpointProvider(
+            scoped_config=scoped_config_map,
+            full_config=full_config_map,
+            client_name=service,
+            environ=environ_map,
+        )
+        value = chain.provide()
+        assert value == expected_value
+
+    @pytest.mark.parametrize('test_case', create_cases())
+    def test_does_provide(self, test_case):
+        self.assert_does_provide(**test_case)
+
+    def test_is_deepcopyable(self):
+        env = {'AWS_ENDPOINT_URL_BATCH': 'https://endpoint-override'}
+        provider = ConfiguredEndpointProvider(
+            full_config={}, scoped_config={}, client_name='batch', environ=env
+        )
+
+        provider_deepcopy = copy.deepcopy(provider)
+        assert provider is not provider_deepcopy
+        assert provider.provide() == 'https://endpoint-override'
+        assert provider_deepcopy.provide() == 'https://endpoint-override'
+
+        env['AWS_ENDPOINT_URL_BATCH'] = 'https://another-new-endpoint-override'
+        assert provider.provide() == 'https://another-new-endpoint-override'
+        assert provider_deepcopy.provide() == 'https://endpoint-override'

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -363,6 +363,16 @@ class TestConfigValueStore(unittest.TestCase):
         self.assertIsInstance(provider, ConstantProvider)
         self.assertEqual(value, 'bar')
 
+    def test_deepcopy_preserves_overrides(self):
+        provider = ConstantProvider(100)
+        config_store = ConfigValueStore(mapping={'fake_variable': provider})
+        config_store.set_config_variable('fake_variable', 'override-value')
+
+        config_store_deepcopy = copy.deepcopy(config_store)
+
+        value = config_store_deepcopy.get_config_variable('fake_variable')
+        self.assertEqual(value, 'override-value')
+
 
 class TestInstanceVarProvider(unittest.TestCase):
     def assert_provides_value(self, name, instance_map, expected_value):

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -188,6 +188,24 @@ class TestConfigLoader(unittest.TestCase):
         self.assertEqual(sso_config['sso_region'], 'us-east-1')
         self.assertEqual(sso_config['sso_start_url'], 'https://example.com')
 
+    def test_services_config(self):
+        filename = path('aws_services_config')
+        loaded_config = load_config(filename)
+        self.assertIn('profiles', loaded_config)
+        self.assertIn('default', loaded_config['profiles'])
+        self.assertIn('services', loaded_config)
+        self.assertIn('my-services', loaded_config['services'])
+        services_config = loaded_config['services']['my-services']
+        self.assertIn('s3', services_config)
+        self.assertIn('dynamodb', services_config)
+        self.assertEqual(
+            services_config['s3']['endpoint_url'], 'https://localhost:5678/'
+        )
+        self.assertEqual(
+            services_config['dynamodb']['endpoint_url'],
+            'https://localhost:8888/',
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -772,34 +772,6 @@ class TestCreateClient(BaseSessionTest):
             ]
             self.assertEqual(call_kwargs['api_version'], override_api_version)
 
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_from_config_store(self, client_creator):
-        config_store = self.session.get_component('config_store')
-        config_store.set_config_variable('defaults_mode', 'standard')
-        self.session.create_client('sts', 'us-west-2')
-        self.assertIsNot(client_creator.call_args[0][-1], config_store)
-
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_from_client_config(self, client_creator):
-        config_store = self.session.get_component('config_store')
-        config = botocore.config.Config(defaults_mode='standard')
-        self.session.create_client('sts', 'us-west-2', config=config)
-        self.assertIsNot(client_creator.call_args[0][-1], config_store)
-
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_invalid_mode_exception(
-        self, client_creator
-    ):
-        with self.assertRaises(botocore.exceptions.InvalidDefaultsMode):
-            config = botocore.config.Config(defaults_mode='foo')
-            self.session.create_client('sts', 'us-west-2', config=config)
-
-    @mock.patch('botocore.client.ClientCreator')
-    def test_defaults_mode_resolved_legacy(self, client_creator):
-        config_store = self.session.get_component('config_store')
-        self.session.create_client('sts', 'us-west-2')
-        self.assertIs(client_creator.call_args[0][-1], config_store)
-
 
 class TestSessionComponent(BaseSessionTest):
     def test_internal_component(self):


### PR DESCRIPTION
This PR implements the proposal for configuring endpoints per service:

https://github.com/aws/aws-sdk/pull/230

Adds a config provider to resolve the endpoint URL provided in an environment variable or shared configuration file. It resolves the endpoint in the following manner:

1. The value provided through the `endpoint_url` parameter provided to the client constructor.
2. The value provided by a service-specific environment variable.
3. The value provided by the global endpoint environment variable (`AWS_ENDPOINT_URL`).
4. The value provided by a service-specific parameter from a services definition section in the shared configuration file.
5. The value provided by the global parameter from a services definition section in the shared configuration file.
6. The value resolved when no configured endpoint URL is provided.

The endpoint config provider uses the client name (name used to instantiate a client object) for construction and add to the config value store. This uses multiple client/service name lookups to handle service name changes for backwards compatibility.