### PR TITLE
Remove leftover print statement

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -954,7 +954,6 @@ def parse_timestamp(value):
     tzinfo_options = get_tzinfo_options()
     for tzinfo in tzinfo_options:
         try:
-            print(f"_parse_timestamp_with_tzinfo({value}, {tzinfo})")
             return _parse_timestamp_with_tzinfo(value, tzinfo)
         except (OSError, OverflowError) as e:
             logger.debug(


### PR DESCRIPTION
Removes a `print()` statement that snuck through in https://github.com/boto/botocore/pull/2972