### PR TITLE
Handle 100 Continue in urllib3>=2.

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -84,16 +84,14 @@ class AWSConnection:
         self._expect_header_set = False
         self.response_class = self._original_response_cls
 
-    def _send_request(self, method, url, body, headers, *args, **kwargs):
+    def request(self, method, url, body=None, headers={}, *args, **kwargs):
         self._response_received = False
         if headers.get('Expect', b'') == b'100-continue':
             self._expect_header_set = True
         else:
             self._expect_header_set = False
             self.response_class = self._original_response_cls
-        rval = super()._send_request(
-            method, url, body, headers, *args, **kwargs
-        )
+        rval = super().request(method, url, body, headers, *args, **kwargs)
         self._expect_header_set = False
         return rval
 


### PR DESCRIPTION
This maintains compatibility from urllib3 1.25.4 to urllib3 2.0.3 at least by moving the code in _send_request to request. In urllib3>=2, the _send_request function of http.client.HTTPConnection is skipped in favor of a custom implementation.

Related to https://github.com/boto/botocore/issues/2926.