### PR TITLE
move test helper functions to tests/__init__.py

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -40,6 +40,16 @@ from botocore.stub import Stubber
 _LOADER = botocore.loaders.Loader()
 
 
+def _all_services():
+    session = botocore.session.Session()
+    service_names = session.get_available_services()
+    return [session.get_service_model(name) for name in service_names]
+
+
+# Only compute our service models once
+ALL_SERVICES = _all_services()
+
+
 def skip_unless_has_memory_collection(cls):
     """Class decorator to skip tests that require memory collection.
 
@@ -575,3 +585,16 @@ class FreezeTime(ContextDecorator):
 
     def __exit__(self, *args, **kwargs):
         self.datetime_patcher.stop()
+
+
+def patch_load_service_model(
+    session, monkeypatch, service_model_json, ruleset_json
+):
+    def mock_load_service_model(service_name, type_name, api_version=None):
+        if type_name == 'service-2':
+            return service_model_json
+        if type_name == 'endpoint-rule-set-1':
+            return ruleset_json
+
+    loader = session.get_component('data_loader')
+    monkeypatch.setattr(loader, 'load_service_model', mock_load_service_model)

--- a/tests/functional/test_context_params.py
+++ b/tests/functional/test_context_params.py
@@ -14,7 +14,7 @@
 import pytest
 
 from botocore.config import Config
-from tests import ClientHTTPStubber, mock
+from tests import ClientHTTPStubber, mock, patch_load_service_model
 
 # fake rulesets compatible with all fake service models below
 FAKE_RULESET_TEMPLATE = {
@@ -224,19 +224,6 @@ FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM = {
     **FAKE_MODEL_WITH_CLIENT_CONTEXT_PARAM,
     "metadata": S3CONTROL_METADATA,
 }
-
-
-def patch_load_service_model(
-    session, monkeypatch, service_model_json, ruleset_json
-):
-    def mock_load_service_model(service_name, type_name, api_version=None):
-        if type_name == 'service-2':
-            return service_model_json
-        if type_name == 'endpoint-rule-set-1':
-            return ruleset_json
-
-    loader = session.get_component('data_loader')
-    monkeypatch.setattr(loader, 'load_service_model', mock_load_service_model)
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_response_shadowing.py
+++ b/tests/functional/test_response_shadowing.py
@@ -12,17 +12,7 @@
 # language governing permissions and limitations under the License.
 import pytest
 
-from botocore.session import Session
-
-
-def _all_services():
-    session = Session()
-    service_names = session.get_available_services()
-    return [session.get_service_model(name) for name in service_names]
-
-
-# Only compute our service models once
-ALL_SERVICES = _all_services()
+from tests import ALL_SERVICES
 
 
 def _all_service_error_shapes():


### PR DESCRIPTION
https://github.com/boto/botocore/pull/2959 makes use of a couple of helper methods for tests that were defined in individual test files. This PR moves them to the base of the package so they can be easily imported across the entirety of it.