### PR TITLE
Move 100-continue behavior to use high-level request interface

### DIFF
--- a/.changes/next-release/enhancement-HTTP-88756.json
+++ b/.changes/next-release/enhancement-HTTP-88756.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "HTTP",
+  "description": "Move 100-continue behavior to use `HTTPConnections` request interface."
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,3 +33,24 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: tests
+
+
+  urllib3:
+    name: 'urllib3 1.x'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Set up Python 3.10'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python scripts/ci/install
+          python  -m pip install "urllib3<2"
+      - name: Run tests
+        run: |
+          python scripts/ci/run-tests --with-cov --with-xdist

--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -66,34 +66,34 @@ class AWSConnection:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._original_response_cls = self.response_class
-        # We'd ideally hook into httplib's states, but they're all
-        # __mangled_vars so we use our own state var.  This variable is set
-        # when we receive an early response from the server.  If this value is
-        # set to True, any calls to send() are noops.  This value is reset to
-        # false every time _send_request is called.  This is to workaround the
-        # fact that py2.6 (and only py2.6) has a separate send() call for the
-        # body in _send_request, as opposed to endheaders(), which is where the
-        # body is sent in all versions > 2.6.
+        # This variable is set when we receive an early response from the
+        # server. If this value is set to True, any calls to send() are noops.
+        # This value is reset to false every time _send_request is called.
+        # This is to workaround changes in urllib3 2.0 which uses separate
+        # send() calls in request() instead of delegating to endheaders(),
+        # which is where the body is sent in CPython's HTTPConnection.
         self._response_received = False
         self._expect_header_set = False
+        self._send_called = False
 
     def close(self):
         super().close()
         # Reset all of our instance state we were tracking.
         self._response_received = False
         self._expect_header_set = False
+        self._send_called = False
         self.response_class = self._original_response_cls
 
-    def _send_request(self, method, url, body, headers, *args, **kwargs):
+    def request(self, method, url, body=None, headers=None, *args, **kwargs):
+        if headers is None:
+            headers = {}
         self._response_received = False
         if headers.get('Expect', b'') == b'100-continue':
             self._expect_header_set = True
         else:
             self._expect_header_set = False
             self.response_class = self._original_response_cls
-        rval = super()._send_request(
-            method, url, body, headers, *args, **kwargs
-        )
+        rval = super().request(method, url, body, headers, *args, **kwargs)
         self._expect_header_set = False
         return rval
 
@@ -210,10 +210,15 @@ class AWSConnection:
 
     def send(self, str):
         if self._response_received:
-            logger.debug(
-                "send() called, but reseponse already received. "
-                "Not sending data."
-            )
+            if not self._send_called:
+                # urllib3 2.0 chunks and calls send potentially
+                # thousands of times inside `request` unlike the
+                # standard library. Only log this once for sanity.
+                logger.debug(
+                    "send() called, but response already received. "
+                    "Not sending data."
+                )
+            self._send_called = True
             return
         return super().send(str)
 


### PR DESCRIPTION
## Overview

Starting in urllib3 2.0, the HTTPConnection behavior was reorganized to incorporate request chunking under the same top-level `request` method. This removed the underlying call to `_send_request` that's utilized by CPython's HTTPConnection which is the parent class of the urllib3 implementation. This change effectively short circuited botocore's provisional HTTP 100-continue support.

To provide a path forward for supporting urllib3 2.0, we're moving to us urllib3's `request` interface. Fortunately, this also exists in CPython as a [thin wrapper around `_send_request`](https://github.com/python/cpython/blob/main/Lib/http/client.py#L1316-L1319). This will reenable _most_ of our internal patches to the class to support 100-continue.


## Changes in urllib3's behavior
The only significant pain point this will introduce is urllib3 has moved from using `endheaders` to send the body in CPython to bundling the send logic in `request` itself. That circumvents our ability to drop sending the body since it's not dispatched to another method that can be overwritten. In order to work around this, we need to stub out all `send` calls to be no-op once a non-100 response is observed. We're able to do this relatively easily because urllib3's current behavior matches what was in the standard library prior to Python 2.7.

The only other issue we needed to work around was a ~50% regression in response time for non-100 responses. This is due to the number of times urllib3 invokes send with its forced chunking. We previously only saw one `send` call but now for large bodies it's potentially thousands of invocations. When logging is enabled, this not only pollutes the logs but takes a non-trivial amount of time. We'll move our logging to only fire once on the first `send` call and let the others pass silently.

## Release plan

This PR will add a new GHA test runner that will always use "urllib3<2" to ensure we're still operational with urllib3 1.26.x. It will also move to the new provisional interface that should be compatible across both urllib3 major versions _without_ moving the urllib3 pin.

This let's us ensure we don't have any unexpected gaps and unblocks distro maintainers from migrating their code/test suites to use urllib3 2.0 if needed. Once we have confidence in the change, we'll look at moving the pin. There isn't a strict timeline on this as there are still OpenSSL issues that may affect some Lambda/Codebuild environments. We'll provide an update to the tracking ticket #2926 once we have more specifics.