### PR TITLE
Update pins and permissions for GHA

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -2,11 +2,18 @@ name: Closed Issue Message
 on:
     issues:
        types: [closed]
+
+
+permissions:
+  contents: read
+
 jobs:
     auto_comment:
         runs-on: ubuntu-latest
+        permissions:
+            issues: write
         steps:
-        - uses: aws-actions/closed-issue-message@v1
+        - uses: aws-actions/closed-issue-message@8b6324312193476beecf11f8e8539d73a3553bf4
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -3,7 +3,6 @@ on:
     issues:
        types: [closed]
 
-
 permissions:
   contents: read
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
       with:
         python-version: 3.9
     - name: Run pre-commit
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches-ignore: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: '${{ matrix.os }}'
@@ -15,9 +18,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Install dependencies and CRT

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
         run: |
           python scripts/ci/run-tests --with-cov --with-xdist
       - name: Run codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           directory: tests
 
@@ -42,9 +42,9 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - name: 'Set up Python 3.10'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
+    - uses: aws-actions/stale-issue-cleanup@f290bcce1d77c9abc0357b7faed3c1c7c2f7d78f
       with:
         issue-types: issues
         stale-issue-message: Greetings! It looks like this issue hasn’t been 


### PR DESCRIPTION
This PR will formalize the pins for all GHAs and fix remaining permissions in the aws-actions now that we've verified they'll work as expected.

Current scorecard for reference: https://securityscorecards.dev/viewer/?uri=github.com/boto/botocore
Note the "Token Permissions" and "Pinned-Dependencies" sections.