### PR TITLE
Disable auto-closing answered discussions

### DIFF
--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -14,5 +14,8 @@ jobs:
     steps:
       - name: Stale discussions action
         uses: aws-github-ops/handle-stale-discussions@v1
+        with:
+          # This will disable auto-closing answered discussions
+          close-answered-discussion: false
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This prevents auto-closing answered discussions with the bot since Github UI only searches open discussions and discoverability drops once you hide it from the default search experience.