### PR TITLE
improve error messaging on stubs for missing api call

### DIFF
--- a/botocore/stub.py
+++ b/botocore/stub.py
@@ -247,6 +247,19 @@ class Stubber:
         http_response = AWSResponse(None, 200, {}, None)
 
         operation_name = self.client.meta.method_to_api_mapping.get(method)
+        if not operation_name:
+            raise ParamValidationError(
+                report=(
+                    "Unable to map method '{}' to api operation. ".format(
+                        method
+                    )
+                    + "Please note that some client methods do not map to api calls "
+                    + "and are therefore unsupported by stubs. "
+                    + "Supported client methods:\n{}".format(
+                        list(self.client.meta.method_to_api_mapping.keys())
+                    )
+                )
+            )
         self._validate_operation_response(operation_name, service_response)
 
         # Add the service_response to the queue for returning responses

--- a/tests/unit/test_stub.py
+++ b/tests/unit/test_stub.py
@@ -108,6 +108,17 @@ class TestStubber(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.stubber.add_response('foo', {})
 
+    def test_add_response_fails_when_missing_api_mapping(self):
+        self.client.meta.method_to_api_mapping.get.return_value = None
+        self.client.meta.method_to_api_mapping.keys.return_value = ["method_1"]
+        with self.assertRaises(ParamValidationError) as error:
+            self.stubber.add_response('foo', {})
+
+        self.assertIn(
+            "Unable to map method 'foo' to api operation.",
+            str(error.exception),
+        )
+
     def test_validates_service_response(self):
         self.stubber.add_response('foo', {})
         self.assertTrue(self.validate_parameters_mock.called)


### PR DESCRIPTION
I've been trying to adopt the stub helpers (it's pretty nice!)

I've now hit this issue a couple times, with `s3_client.download_file` and `s3_client.generate_presigned_post`.

Before, the error message looked like:
```
self = ServiceModel(s3), operation_name = None                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                      
    @instance_cache                                                                                                                                                                                                                                                                                   
    def operation_model(self, operation_name):                                                                                                                                                                                                                                                        
        try:                                                                                                                                                                                                                                                                                          
>           model = self._service_description['operations'][operation_name]                                                                                                                                                                                                                           
E           KeyError: None                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                      
/usr/local/lib/python3.11/site-packages/botocore/model.py:366: KeyError 
```

It took me some gnarly pdb stepping to figure out what was actually going on.

I figure this is a little nicer:
```
/usr/local/lib/python3.11/site-packages/botocore/stub.py:237: in add_response
    self._add_response(method, service_response, expected_params)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <botocore.stub.Stubber object at 0x7f65019b5f90>, method = 'generate_presigned_post', service_response = {'josh': 'invalid'}, expected_params = <ANY>

    def _add_response(self, method, service_response, expected_params):
        if not hasattr(self.client, method):
            raise ValueError(
                "Client %s does not have method: %s"
                % (self.client.meta.service_model.service_name, method)
            )
    
        # Create a successful http response
        http_response = AWSResponse(None, 200, {}, None)
    
        operation_name = self.client.meta.method_to_api_mapping.get(method)
        if not operation_name:
>           raise ParamValidationError(
                report=(
                    "Unable to map method '{}' to api operation. ".format(method) +
                    "Please note that some client methods do not map to api calls " +
                    "and are therefore unsupported by stubs. " +
                    "Supported client methods:\n{}".format(
                        list(self.client.meta.method_to_api_mapping.keys())
                    )
                )
            )
E           botocore.exceptions.ParamValidationError: Parameter validation failed:
E           Unable to map method 'generate_presigned_post' to api operation. Please note that some client methods do not map to api calls and are therefore unsupported by stubs. Supported client methods:
E           ['abort_multipart_upload', 'complete_multipart_upload', 'copy_object', 'create_bucket', 'create_multipart_upload', 'delete_bucket', 'delete_bucket_analytics_configuration', 'delete_bucket_cors', 'delete_bucket_encryption', 'delete_bucket_intelligent_tiering_configuration', 'delete_bucket_inventory_configuration', 'delete_bucket_lifecycle', 'delete_bucket_metrics_configuration', 'delete_bucket_ownership_controls', 'delete_bucket_policy', 'delete_bucket_replication', 'delete_bucket_tagging', 'delete_bucket_website', 'delete_object', 'delete_object_tagging', 'delete_objects', 'delete_public_access_block', 'get_bucket_accelerate_configuration', 'get_bucket_acl', 'get_bucket_analytics_configuration', 'get_bucket_cors', 'get_bucket_encryption', 'get_bucket_intelligent_tiering_configuration', 'get_bucket_inventory_configuration', 'get_bucket_lifecycle', 'get_bucket_lifecycle_configuration', 'get_bucket_location', 'get_bucket_logging', 'get_bucket_metrics_configuration', 'get_bucket_notification', 'get_bucket_notification_configuration', 'get_bucket_ownership_controls', 'get_bucket_policy', 'get_bucket_policy_status', 'get_bucket_replication', 'get_bucket_request_payment', 'get_bucket_tagging', 'get_bucket_versioning', 'get_bucket_website', 'get_object', 'get_object_acl', 'get_object_attributes', 'get_object_legal_hold', 'get_object_lock_configuration', 'get_object_retention', 'get_object_tagging', 'get_object_torrent', 'get_public_access_block', 'head_bucket', 'head_object', 'list_bucket_analytics_configurations', 'list_bucket_intelligent_tiering_configurations', 'list_bucket_inventory_configurations', 'list_bucket_metrics_configurations', 'list_buckets', 'list_multipart_uploads', 'list_object_versions', 'list_objects', 'list_objects_v2', 'list_parts', 'put_bucket_accelerate_configuration', 'put_bucket_acl', 'put_bucket_analytics_configuration', 'put_bucket_cors', 'put_bucket_encryption', 'put_bucket_intelligent_tiering_configuration', 'put_bucket_inventory_configuration', 'put_bucket_lifecycle', 'put_bucket_lifecycle_configuration', 'put_bucket_logging', 'put_bucket_metrics_configuration', 'put_bucket_notification', 'put_bucket_notification_configuration', 'put_bucket_ownership_controls', 'put_bucket_policy', 'put_bucket_replication', 'put_bucket_request_payment', 'put_bucket_tagging', 'put_bucket_versioning', 'put_bucket_website', 'put_object', 'put_object_acl', 'put_object_legal_hold', 'put_object_lock_configuration', 'put_object_retention', 'put_object_tagging', 'put_public_access_block', 'restore_object', 'select_object_content', 'upload_part', 'upload_part_copy', 'write_get_object_response']
```

Hopefully this will save some future devs some time.