### PR TITLE
fix: header parsing in a 100 continue response.

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -92,7 +92,7 @@ class AWSConnection:
             self._expect_header_set = True
         else:
             self._expect_header_set = False
-            self.response_class = self._original_response_cls
+        self.response_class = self._original_response_cls
         rval = super().request(method, url, body, headers, *args, **kwargs)
         self._expect_header_set = False
         return rval

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -486,6 +486,46 @@ class TestAWSHTTPConnection(unittest.TestCase):
             response = conn.getresponse()
             self.assertEqual(response.status, 307)
 
+    def test_expect_100_continue_followed_by_another_request(self):
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
+            # Shows the server first sending a 200 ok response
+            # then a 200 ok response.
+            s = FakeSocket(
+                b'HTTP/1.1 200 OK\r\n'
+                b'Content-Length: 0\r\n'
+                b'\r\n'
+                b'HTTP/1.1 100 Continue\r\n'
+                b'\r\n'
+                b'HTTP/1.1 200 OK\r\n'
+                b'Content-Length: 0\r\n'
+            )
+            conn = AWSHTTPConnection('s3.amazonaws.com', 443)
+            conn.sock = s
+            wait_mock.return_value = True
+
+            # The first request expecting a 100 continue response.
+            # But the server will send a 200 ok instead.
+            conn.request(
+                'PUT', '/bucket/foo', b'body', {'Expect': b'100-continue'}
+            )
+            # Assert that we waited for the 100-continue response
+            self.assertEqual(wait_mock.call_count, 1)
+            response = conn.getresponse()
+            self.assertEqual(response.status, 200)
+            response.close()
+
+            # The client send the second request, expecting 100 continue either, 
+            # using the same connection
+            conn.request(
+                'PUT', '/bucket/foo', b'body', {'Expect': b'100-continue'}
+            )
+            self.assertEqual(wait_mock.call_count, 2)
+            response = conn.getresponse()
+
+            # The second 'HTTP/1.1 200 OK\r\n' should be consumed by http.client.HTTPResponse._read_status().
+            # Only after this, the following header will be parsed correctly by email.parser.Parser.parsestr().
+            assert not getattr(response.headers, "defects", [])
+
     def test_message_body_is_file_like_object(self):
         # Shows the server first sending a 100 continue response
         # then a 200 ok response.


### PR DESCRIPTION
Restore `response_class` attribute unconditionally, regardless of whether header `Expect: 100-continue` appears.

The event flow to reproduce the bug:
1. The client sends a request with Expect: 100-continue header.
2. The server sends a normal response other than 100 Continue.
3. The client consumes the response, both header and body.

Until now, everything is fine.
4. The client sends another request with Expect: 100-continue header.
5. The server sends a 100 continue response.
6. The client then continue to send body to server.
7. The server sends a normal response other than 100 Continue.

After all the operations above, the client begin to consume the response. But it will skip the status line, and leave it with the headers, then feed them to the header parser, email.parser.Parser().parsestr(), and the parser will fail with an error called 'MissingHeaderBodySeparatorDefect'. 

Since the headers including 'Content-Length' not be parsed, the content length of the response will be None. So the client will try to read 65536 bytes from the socket connection. Actually there may be no more data sent from the server, so the read() on socket will be blocked, until timeout or the server close the connection.

Why the client skip the status line? Because the AWSConnection class replace the response_class attribute with a wrapped class, when the `Expect: 100-continue` in the request header but server sends a non-100 response. The wrapped class has a fixed status line, it will not consume the real status line, so the real status line will be fed to header parser together with the real header fields. Then the `MissingHeaderBodySeparatorDefect` occurs.