### PR TITLE
Config doc bug fix

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -209,15 +209,15 @@ class Config:
 
     :type request_min_compression_size_bytes: int
     :param request_min_compression_bytes: The minimum size in bytes that a
-    request body should be to trigger compression. All requests with streaming
-    input that don't contain the `requiresLength` trait will be compressed
-    regardless of this setting.
+        request body should be to trigger compression. All requests with
+        streaming input that don't contain the `requiresLength` trait will be
+        compressed regardless of this setting.
 
         Defaults to None.
 
     :type disable_request_compression: bool
     :param disable_request_compression: Disables request body compression if
-    set to True.
+        set to True.
 
         Defaults to None.
     """

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -210,7 +210,7 @@ class Config:
     :type request_min_compression_size_bytes: int
     :param request_min_compression_bytes: The minimum size in bytes that a
         request body should be to trigger compression. All requests with
-        streaming input that don't contain the `requiresLength` trait will be
+        streaming input that don't contain the ``requiresLength`` trait will be
         compressed regardless of this setting.
 
         Defaults to None.


### PR DESCRIPTION
This fixes a couple of minor issues in the `Config`[ reference in our docs](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html). Subsequent lines of parameter definitions in the object's doc strings must be indented to render correctly. This also adds another set of backticks to `requiresLength` so it renders as highlighted rather than italicized.

Current
![Screenshot 2023-09-15 at 3 01 37 PM](https://github.com/boto/botocore/assets/45697098/1fcce09e-1141-44c0-87cb-69cc695c65dc)

With Changes in this PR
![Screenshot 2023-09-15 at 3 02 21 PM](https://github.com/boto/botocore/assets/45697098/5a6783c5-720a-4e6a-ac4c-61aebb939ab9)

