### PR TITLE
Show paginator/waiter return types in markdown

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -1113,7 +1113,7 @@ class BaseClient:
             pageable.  You can use the ``client.can_paginate`` method to
             check if an operation is pageable.
 
-        :rtype: L{botocore.paginate.Paginator}
+        :rtype: ``botocore.paginate.Paginator``
         :return: A paginator object.
 
         """
@@ -1212,7 +1212,7 @@ class BaseClient:
             section of the service docs for a list of available waiters.
 
         :returns: The specified waiter object.
-        :rtype: botocore.waiter.Waiter
+        :rtype: ``botocore.waiter.Waiter``
         """
         config = self._get_waiter_config()
         if not config:


### PR DESCRIPTION
See: https://github.com/boto/boto3/issues/3787#issuecomment-1647308630

Currently looks like:

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/get_paginator.html
![image](https://github.com/boto/botocore/assets/87778557/b80c11c4-da25-44c6-a589-8bfdcd70bb89)

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/get_waiter.html
![image](https://github.com/boto/botocore/assets/87778557/b75aa7ca-3760-4392-acab-a14b2675eb5b)

After changes:

![image](https://github.com/boto/botocore/assets/87778557/fed49752-8c5b-4162-8df8-2894d5b6c79e)
![image](https://github.com/boto/botocore/assets/87778557/d6cd8842-6da1-4ad9-9d89-aa657a2063ab)
