### PR TITLE
fix param name for `request_min_compression_size_bytes`

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -208,7 +208,7 @@ class Config:
         Defaults to False.
 
     :type request_min_compression_size_bytes: int
-    :param request_min_compression_bytes: The minimum size in bytes that a
+    :param request_min_compression_size_bytes: The minimum size in bytes that a
         request body should be to trigger compression. All requests with
         streaming input that don't contain the ``requiresLength`` trait will be
         compressed regardless of this setting.


### PR DESCRIPTION
Follow up to https://github.com/boto/botocore/pull/3015. The param name is incorrect. Fixing this also fixes the type rendering in html as well.

Current:
![Screenshot 2023-09-20 at 2 18 55 PM](https://github.com/boto/botocore/assets/45697098/ddbb178b-f21b-422b-8fdb-17a22e531d4c)

With PR:
![Screenshot 2023-09-20 at 2 19 36 PM](https://github.com/boto/botocore/assets/45697098/d005a605-755b-4ff9-91cb-d4bd9ec48f11)
