### PR TITLE
Add sse_md5 hook for CompleteMultipartUpload

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1242,6 +1242,7 @@ BUILTIN_HANDLERS = [
     ('before-parameter-build.s3.UploadPart', sse_md5),
     ('before-parameter-build.s3.UploadPartCopy', sse_md5),
     ('before-parameter-build.s3.UploadPartCopy', copy_source_sse_md5),
+    ('before-parameter-build.s3.CompleteMultipartUpload', sse_md5),
     ('before-parameter-build.s3.SelectObjectContent', sse_md5),
     ('before-parameter-build.ec2.RunInstances', base64_encode_user_data),
     (


### PR DESCRIPTION
We'll need to start properly encoding our SSE parameters for CompleteMultipartUpload. This was previously broken when passing bytes to this operation unlike our other *MultipartUpload operations. This patch will ensure all bytes input is properly base64 encoded before being sent to S3.