### PR TITLE
Account ID endpoint routing

### DIFF
--- a/.changes/next-release/feature-endpoints-57979.json
+++ b/.changes/next-release/feature-endpoints-57979.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "endpoints",
+  "description": "Enables account ID endpoint routing"
+}

--- a/.changes/next-release/feature-endpoints-57979.json
+++ b/.changes/next-release/feature-endpoints-57979.json
@@ -1,5 +1,5 @@
 {
   "type": "feature",
   "category": "endpoints",
-  "description": "Enables account ID endpoint routing"
+  "description": "Adds support for account ID endpoint routing"
 }

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -626,8 +626,8 @@ class ClientArgsCreator:
         )
         # This only includes CredentialBuiltinResolver for now, but may grow
         # as more endpoint builtins are added.
-        builtin_resolvers = {'credentials': credential_builtin_resolver}
-        return EndpointBuiltinResolver(builtin_resolvers)
+        resolver_map = {'credentials': credential_builtin_resolver}
+        return EndpointBuiltinResolver(resolver_map)
 
     def _build_endpoint_resolver(
         self,

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -166,6 +166,7 @@ class ClientArgsCreator:
             endpoint_bridge,
             event_emitter,
             credentials,
+            new_config.account_id_endpoint_mode,
         )
 
         # Copy the session's user agent factory and adds client configuration.
@@ -631,6 +632,7 @@ class ClientArgsCreator:
         endpoint_bridge,
         event_emitter,
         credentials,
+        account_id_endpoint_mode,
     ):
         if endpoints_ruleset_data is None:
             return None
@@ -681,6 +683,7 @@ class ClientArgsCreator:
             use_ssl=is_secure,
             requested_auth_scheme=sig_version,
             credentials=credentials,
+            account_id_endpoint_mode=account_id_endpoint_mode,
         )
 
     def compute_endpoint_resolver_builtin_defaults(

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -25,6 +25,7 @@ import botocore.parsers
 import botocore.serialize
 from botocore.config import Config
 from botocore.endpoint import EndpointCreator
+from botocore.regions import CredentialBuiltinResolver
 from botocore.regions import EndpointResolverBuiltins as EPRBuiltins
 from botocore.regions import EndpointRulesetResolver
 from botocore.signers import RequestSigner
@@ -152,7 +153,10 @@ class ClientArgsCreator:
             protocol, parameter_validation
         )
         response_parser = botocore.parsers.create_parser(protocol)
-
+        credential_builtin_resolver = CredentialBuiltinResolver(
+            credentials=credentials,
+            account_id_endpoint_mode=new_config.account_id_endpoint_mode,
+        )
         ruleset_resolver = self._build_endpoint_resolver(
             endpoints_ruleset_data,
             partition_data,
@@ -165,8 +169,7 @@ class ClientArgsCreator:
             is_secure,
             endpoint_bridge,
             event_emitter,
-            credentials,
-            new_config.account_id_endpoint_mode,
+            credential_builtin_resolver,
         )
 
         # Copy the session's user agent factory and adds client configuration.
@@ -631,8 +634,7 @@ class ClientArgsCreator:
         is_secure,
         endpoint_bridge,
         event_emitter,
-        credentials,
-        account_id_endpoint_mode,
+        credential_builtin_resolver,
     ):
         if endpoints_ruleset_data is None:
             return None
@@ -682,8 +684,7 @@ class ClientArgsCreator:
             event_emitter=event_emitter,
             use_ssl=is_secure,
             requested_auth_scheme=sig_version,
-            credentials=credentials,
-            account_id_endpoint_mode=account_id_endpoint_mode,
+            credential_builtin_resolver=credential_builtin_resolver,
         )
 
     def compute_endpoint_resolver_builtin_defaults(

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -624,8 +624,6 @@ class ClientArgsCreator:
         credential_builtin_resolver = CredentialBuiltinResolver(
             credentials, client_config.account_id_endpoint_mode
         )
-        # This only includes CredentialBuiltinResolver for now, but may grow
-        # as more endpoint builtins are added.
         resolver_map = {'credentials': credential_builtin_resolver}
         return EndpointBuiltinResolver(resolver_map)
 

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -230,8 +230,18 @@ class Config:
     :type account_id_endpoint_mode: str
     :param account_id_endpoint_mode: Enables or disables account ID based
         endpoint routing for supported operations.
+        Valid options are:
 
-        Defaults to None.
+        * ``preferred`` -- Attempt to resolve account ID during endpoint
+            resolution if supported by the service. If account ID cannot be
+            resolved, fallback to a different endpoint.
+        * ``required`` -- Require account ID to be resolved during endpoint
+            resolution. If account ID cannot be resolved, raises
+            ``AccountIDNotFound`` exception.
+        * ``disabled`` -- Disable account ID based endpoint routing. The SDK
+            will not attempt to resolve account ID during endpoint resolution.
+
+        If not specified, the default behavior is ``preferred``.
     """
 
     OPTION_DEFAULTS = OrderedDict(

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -228,18 +228,14 @@ class Config:
         documentation. Invalid parameters or ones that are not used by the
         specified service will be ignored.
     :type account_id_endpoint_mode: str
-    :param account_id_endpoint_mode: Enables or disables account ID based
-        endpoint routing for supported operations.
+    :param account_id_endpoint_mode: Set account ID based endpoint behavior
+        for supported operations.
         Valid options are:
 
-        * ``preferred`` -- Attempt to resolve account ID during endpoint
-            resolution if supported by the service. If account ID cannot be
-            resolved, fallback to a different endpoint.
-        * ``required`` -- Require account ID to be resolved during endpoint
-            resolution. If account ID cannot be resolved, raises
-            ``AccountIDNotFound`` exception.
-        * ``disabled`` -- Disable account ID based endpoint routing. The SDK
-            will not attempt to resolve account ID during endpoint resolution.
+        * ``preferred`` -- Use account ID based endpoint routing if available.
+        * ``required`` -- Raise ``AccountIDNotFound`` exception if account ID
+            based endpoint routing is unavailable.
+        * ``disabled`` -- Disable account ID based endpoint routing.
 
         If not specified, the default behavior is ``preferred``.
     """

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -227,6 +227,9 @@ class Config:
         the ``Client Context Parameters`` section of the service client's
         documentation. Invalid parameters or ones that are not used by the
         specified service will be ignored.
+    :type account_id_endpoint_mode: str
+    :param account_id_endpoint_mode: Enables or disables account ID based
+        endpoint routing for supported operations.
 
         Defaults to None.
     """
@@ -257,6 +260,7 @@ class Config:
             ('request_min_compression_size_bytes', None),
             ('disable_request_compression', None),
             ('client_context_params', None),
+            ('account_id_endpoint_mode', None),
         ]
     )
 

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -233,7 +233,7 @@ class Config:
         Valid options are:
 
         * ``preferred`` -- Use account ID based endpoint routing if available.
-        * ``required`` -- Raise ``AccountIDNotFound`` exception if account ID
+        * ``required`` -- Raise ``AccountIdNotFound`` exception if account ID
             based endpoint routing is unavailable.
         * ``disabled`` -- Disable account ID based endpoint routing.
 

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -227,6 +227,7 @@ class Config:
         the ``Client Context Parameters`` section of the service client's
         documentation. Invalid parameters or ones that are not used by the
         specified service will be ignored.
+
     :type account_id_endpoint_mode: str
     :param account_id_endpoint_mode: Set account ID based endpoint behavior
         for supported operations.

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -161,6 +161,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         False,
         utils.ensure_boolean,
     ),
+    'account_id_endpoint_mode': (
+        'account_id_endpoint_mode',
+        'AWS_ACCOUNT_ID_ENDPOINT_MODE',
+        'preferred',
+        None,
+    ),
 }
 # A mapping for the s3 specific configuration vars. These are the configuration
 # vars that typically go in the s3 section of the config file. This mapping

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1084,9 +1084,8 @@ class ProcessProvider(CredentialProvider):
         return creds_dict
 
     def _resolve_account_id(self, parsed_response):
-        return parsed_response.get('AccountId') or self.profile_config.get(
-            'aws_account_id'
-        )
+        account_id = parsed_response.get('AccountId')
+        return account_id or self.profile_config.get('aws_account_id')
 
     @property
     def _credential_process(self):
@@ -1096,9 +1095,8 @@ class ProcessProvider(CredentialProvider):
     def profile_config(self):
         if self._loaded_config is None:
             self._loaded_config = self._load_config()
-        return self._loaded_config.get('profiles', {}).get(
-            self._profile_name, {}
-        )
+        profiles = self._loaded_config.get('profiles', {})
+        return profiles.get(self._profile_name, {})
 
 
 class InstanceMetadataProvider(CredentialProvider):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1251,10 +1251,7 @@ class EnvProvider(CredentialProvider):
                     provider=method, cred_var=mapping['expiry_time']
                 )
 
-            credentials['account_id'] = None
-            account_id = environ.get(mapping['account_id'], '')
-            if account_id:
-                credentials['account_id'] = account_id
+            credentials['account_id'] = environ.get(mapping['account_id'])
 
             return credentials
 

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -799,9 +799,8 @@ class BaseAssumeRoleCredentialFetcher(CachedCredentialFetcher):
             try:
                 account_id = self._arn_parser.parse_arn(user_arn)['account']
             except InvalidArnException:
-                logger.debug(
-                    'Unable to parse account ID from ARN: %s', user_arn
-                )
+                log_msg = 'Unable to parse account ID from ARN: %s'
+                logger.debug(log_msg, user_arn)
             else:
                 response['Credentials']['AccountId'] = account_id
 

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -817,4 +817,4 @@ class UnknownEndpointResolutionBuiltInName(EndpointProviderError):
 
 
 class AccountIdNotFound(EndpointResolutionError):
-    fmt = '"account_id_endpoint_mode" is set to "required" but no account ID was found.'
+    fmt = '{msg}'

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -814,3 +814,7 @@ class EndpointResolutionError(EndpointProviderError):
 
 class UnknownEndpointResolutionBuiltInName(EndpointProviderError):
     fmt = 'Unknown builtin variable name: {name}'
+
+
+class AccountIDNotFound(EndpointResolutionError):
+    fmt = '`account_id_endpoint_mode is set to `required` but no account ID was found.'

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -817,4 +817,4 @@ class UnknownEndpointResolutionBuiltInName(EndpointProviderError):
 
 
 class AccountIDNotFound(EndpointResolutionError):
-    fmt = '`account_id_endpoint_mode is set to `required` but no account ID was found.'
+    fmt = '"account_id_endpoint_mode" is set to "required" but no account ID was found.'

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -816,5 +816,5 @@ class UnknownEndpointResolutionBuiltInName(EndpointProviderError):
     fmt = 'Unknown builtin variable name: {name}'
 
 
-class AccountIDNotFound(EndpointResolutionError):
+class AccountIdNotFound(EndpointResolutionError):
     fmt = '"account_id_endpoint_mode" is set to "required" but no account ID was found.'

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -490,7 +490,8 @@ class CredentialBuiltinResolver:
         if account_id is None:
             msg = (
                 f'"account_id_endpoint_mode" is set to "{acct_id_ep_mode}", '
-                'but account ID could not be resolved.'
+                'but account ID could not be resolved. Retrieved credentials '
+                f'using: "{self._credentials.method}".'
             )
             if acct_id_ep_mode == 'preferred':
                 LOG.debug(msg)

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -26,8 +26,10 @@ from botocore.auth import AUTH_TYPE_MAPS, HAS_CRT
 from botocore.crt import CRT_SUPPORTED_AUTH_TYPES
 from botocore.endpoint_provider import EndpointProvider
 from botocore.exceptions import (
+    AccountIDNotFound,
     EndpointProviderError,
     EndpointVariantError,
+    InvalidConfigError,
     InvalidEndpointConfigurationError,
     InvalidHostLabelError,
     MissingDependencyException,
@@ -46,6 +48,12 @@ from botocore.utils import ensure_boolean, instance_cache
 LOG = logging.getLogger(__name__)
 DEFAULT_URI_TEMPLATE = '{service}.{region}.{dnsSuffix}'  # noqa
 DEFAULT_SERVICE_DATA = {'endpoints': {}}
+# Allowed values for the ``account_id_endpoint_mode`` config field.
+VALID_ACCOUNT_ID_ENDPOINT_MODES = [
+    'preferred',
+    'disabled',
+    'required',
+]
 
 
 class BaseEndpointResolver:
@@ -450,6 +458,8 @@ class EndpointResolverBuiltins(str, Enum):
     AWS_S3_DISABLE_MRAP = "AWS::S3::DisableMultiRegionAccessPoints"
     # Whether a custom endpoint has been configured (str)
     SDK_ENDPOINT = "SDK::Endpoint"
+    # An account ID sourced from the credential resolution process.
+    AWS_ACCOUNT_ID = "AWS::Auth::AccountId"
 
 
 class EndpointRulesetResolver:
@@ -465,6 +475,7 @@ class EndpointRulesetResolver:
         event_emitter,
         use_ssl=True,
         requested_auth_scheme=None,
+        credentials=None,
     ):
         self._provider = EndpointProvider(
             ruleset_data=endpoint_ruleset_data,
@@ -478,6 +489,7 @@ class EndpointRulesetResolver:
         self._use_ssl = use_ssl
         self._requested_auth_scheme = requested_auth_scheme
         self._instance_cache = {}
+        self._credentials = credentials
 
     def construct_endpoint(
         self,
@@ -546,6 +558,7 @@ class EndpointRulesetResolver:
         customized_builtins = self._get_customized_builtins(
             operation_model, call_args, request_context
         )
+        self._resolve_account_id_builtin(request_context, customized_builtins)
         for param_name, param_def in self._param_definitions.items():
             param_val = self._resolve_param_from_context(
                 param_name=param_name,
@@ -561,6 +574,71 @@ class EndpointRulesetResolver:
                 provider_params[param_name] = param_val
 
         return provider_params
+
+    def _resolve_account_id_builtin(self, request_context, builtins):
+        """Resolve the ``AWS::Auth::AccountId`` builtin if configured in the
+        ruleset, account ID based routing is enabled and it has not already
+        been resolved in a custom handler.
+        """
+        if 'AccountId' in self._param_definitions:
+            act_id_ep_mode = self._resolve_account_id_endpoint_mode(
+                request_context
+            )
+            act_id_builtin_key = EndpointResolverBuiltins.AWS_ACCOUNT_ID
+            if act_id_ep_mode == 'disabled':
+                # if account ID has been set with a custom handler, but the mode
+                # is disabled, we must unset it so it won't be passed to the
+                # endpoint provider.
+                builtins[act_id_builtin_key] = None
+                return
+
+            act_id_builtin = builtins.get(act_id_builtin_key)
+            if act_id_builtin is None:
+                self._do_resolve_account_id_builtin(act_id_ep_mode, builtins)
+
+    def _resolve_account_id_endpoint_mode(self, request_context):
+        """Resolve the account ID endpoint mode for the request. Account ID
+        based routing is always disabled for presigned and unsigned requests.
+        Otherwise, the mode is determined by the ``account_id_endpoint_mode``
+        config setting.
+        """
+        not_presign = not request_context.get('is_presign_request', False)
+        should_sign = self._requested_auth_scheme != UNSIGNED
+        creds_available = self._credentials is not None
+        if all((not_presign, should_sign, creds_available)):
+            config = request_context['client_config']
+            act_id_ep_mode = config.account_id_endpoint_mode
+            return self._validate_account_id_endpoint_mode(act_id_ep_mode)
+        return 'disabled'
+
+    def _validate_account_id_endpoint_mode(self, account_id_endpoint_mode):
+        if account_id_endpoint_mode not in VALID_ACCOUNT_ID_ENDPOINT_MODES:
+            valid_modes_str = ', '.join(VALID_ACCOUNT_ID_ENDPOINT_MODES)
+            error_msg = (
+                f"Invalid value '{account_id_endpoint_mode}' for "
+                "account_id_endpoint_mode. Valid values are: "
+                f"{valid_modes_str}."
+            )
+            raise InvalidConfigError(error_msg=error_msg)
+        return account_id_endpoint_mode
+
+    def _do_resolve_account_id_builtin(
+        self, account_id_endpoint_mode, builtins
+    ):
+        # This will make a call to resolve credentials if they are not already
+        # or need to be refreshed.
+        frozen_creds = self._credentials.get_frozen_credentials()
+        account_id = frozen_creds.account_id
+        if account_id is None:
+            if account_id_endpoint_mode == 'preferred':
+                LOG.debug(
+                    '`account_id_endpoint_mode` is set to `preferred`, but no '
+                    'account ID was found.'
+                )
+            elif account_id_endpoint_mode == 'required':
+                raise AccountIDNotFound()
+        else:
+            builtins[EndpointResolverBuiltins.AWS_ACCOUNT_ID] = account_id
 
     def _resolve_param_from_context(
         self, param_name, operation_model, call_args

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -513,8 +513,8 @@ class CredentialBuiltinResolver:
 class EndpointBuiltinResolver:
     """Resolves endpoint builtins during endpoint construction"""
 
-    def __init__(self, builtin_resolvers):
-        self._builtin_resolvers = builtin_resolvers
+    def __init__(self, resolver_map):
+        self._resolver_map = resolver_map
 
     def resolve(self, param_definitions, builtins):
         """Resolve endpoint builtins"""
@@ -529,7 +529,7 @@ class EndpointBuiltinResolver:
         )
         acct_id_builtin_key = EndpointResolverBuiltins.AWS_ACCOUNT_ID
         current_builtin_value = builtins.get(acct_id_builtin_key)
-        credential_resolver = self._builtin_resolvers['credentials']
+        credential_resolver = self._resolver_map['credentials']
         account_id = credential_resolver.resolve_account_id_builtin(
             builtin_configured, current_builtin_value
         )

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -512,13 +512,13 @@ class CredentialBuiltinResolver:
 
 
 class EndpointBuiltinResolver:
-    """Resolves endpoint builtins during endpoint construction"""
+    """Resolves endpoint builtins during endpoint construction."""
 
     def __init__(self, resolver_map):
         self._resolver_map = resolver_map
 
     def resolve(self, param_definitions, builtins):
-        """Resolve endpoint builtins"""
+        """Resolve endpoint builtins."""
         self._resolve_credential_builtins(param_definitions, builtins)
 
     def _resolve_credential_builtins(self, param_definitions, builtins):

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -583,7 +583,6 @@ class EndpointRulesetResolver:
 
     def _resolve_account_id_builtin(self, builtins):
         """Resolve the ``AWS::Auth::AccountId`` builtin."""
-        # do this check separately so mode is only validated if it's being used
         if 'AccountId' not in self._param_definitions:
             return
 
@@ -592,9 +591,8 @@ class EndpointRulesetResolver:
         if not self._should_resolve_account_id_builtin():
             # Unset the account ID if endpoint mode is disabled.
             builtins[acct_id_builtin_key] = None
-            return
 
-        if builtins.get(acct_id_builtin_key) is None:
+        elif builtins.get(acct_id_builtin_key) is None:
             self._do_resolve_account_id_builtin(builtins)
 
     def _validate_account_id_endpoint_mode(self):

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -466,23 +466,50 @@ class CredentialBuiltinResolver:
         'disabled',
         'required',
     )
+    REFRESHABLE_CREDENTIAL_METHODS = (
+        'custom-process',
+        'assume-role',
+        'assume-role-with-web-identity',
+        'sso',
+    )
+    STATIC_CREDENTIAL_METHODS = (
+        'explicit',
+        'env',
+        'shared-credentials-file',
+        'config-file',
+    )
+    SUPPORTED_CREDENTIAL_METHODS = (
+        REFRESHABLE_CREDENTIAL_METHODS + STATIC_CREDENTIAL_METHODS
+    )
 
     def __init__(self, credentials, account_id_endpoint_mode):
         self._credentials = credentials
         if account_id_endpoint_mode is None:
             account_id_endpoint_mode = self.DEFAULT_ACCOUNT_ID_ENDPOINT_MODE
         self._account_id_endpoint_mode = account_id_endpoint_mode
-
-    def resolve_account_id_builtin(self, builtins, signing_enabled):
-        """Resolve the ``AWS::Auth::AccountId`` builtin."""
         self._validate_account_id_endpoint_mode()
-        acct_id_builtin_key = EndpointResolverBuiltins.AWS_ACCOUNT_ID
-        if not self._should_resolve_account_id_builtin(signing_enabled):
-            # Unset the account ID if endpoint mode is disabled.
-            builtins[acct_id_builtin_key] = None
 
-        elif builtins.get(acct_id_builtin_key) is None:
-            self._do_resolve_account_id_builtin(builtins)
+    def resolve_account_id_builtin(self, builtin_configured, builtin_value):
+        """Resolve the ``AWS::Auth::AccountId`` builtin."""
+        acct_id_ep_mode = self._account_id_endpoint_mode
+        mode_disabled = acct_id_ep_mode == 'disabled'
+        no_credentials = self._credentials is None
+        if not builtin_configured or mode_disabled or no_credentials:
+            return None
+
+        if builtin_value is not None:
+            return builtin_value
+
+        frozen_creds = self._credentials.get_frozen_credentials()
+        account_id = frozen_creds.account_id
+        if account_id is None:
+            msg = self._create_no_account_id_message()
+            if acct_id_ep_mode == 'preferred':
+                LOG.debug(msg)
+            elif acct_id_ep_mode == 'required':
+                raise AccountIdNotFound(msg=msg)
+
+        return account_id
 
     def _validate_account_id_endpoint_mode(self):
         valid_modes = self.VALID_ACCOUNT_ID_ENDPOINT_MODES
@@ -494,23 +521,31 @@ class CredentialBuiltinResolver:
             )
             raise InvalidConfigError(error_msg=error_msg)
 
-    def _should_resolve_account_id_builtin(self, signing_enabled):
-        creds_available = self._credentials is not None
-        mode_enabled = self._account_id_endpoint_mode != 'disabled'
-        return signing_enabled and creds_available and mode_enabled
-
-    def _do_resolve_account_id_builtin(self, builtins):
-        frozen_creds = self._credentials.get_frozen_credentials()
-        account_id = frozen_creds.account_id
-        if account_id is None:
-            acct_id_ep_mode = self._account_id_endpoint_mode
-            msg = f'"account_id_endpoint_mode" is set to {acct_id_ep_mode}'
-            if acct_id_ep_mode == 'preferred':
-                LOG.debug('%s, but account ID was not found.', msg)
-            elif acct_id_ep_mode == 'required':
-                raise AccountIdNotFound(msg=msg)
+    def _create_no_account_id_message(self):
+        acct_id_ep_mode = self._account_id_endpoint_mode
+        method = self._credentials.method
+        base_msg = (
+            f'"account_id_endpoint_mode" is set to {acct_id_ep_mode}, '
+            f'but account ID could not be resolved from source "{method}". '
+        )
+        if method in self.STATIC_CREDENTIAL_METHODS:
+            msg = (
+                f'{base_msg} Credential source "{method}" does not have '
+                'an account ID associated with it. Please check your '
+                'configuration and try again.'
+            )
+        elif method in self.REFRESHABLE_CREDENTIAL_METHODS:
+            msg = (
+                f'{base_msg} Please ensure that your credential '
+                'source is configured to return an account ID.'
+            )
         else:
-            builtins[EndpointResolverBuiltins.AWS_ACCOUNT_ID] = account_id
+            supported = ", ".join(self.SUPPORTED_CREDENTIAL_METHODS)
+            msg = (
+                f'{base_msg} Please change your credential source to one of: '
+                f'{supported} or set "account_id_endpoint_mode" to "disabled".'
+            )
+        return msg
 
 
 class EndpointRulesetResolver:
@@ -526,8 +561,7 @@ class EndpointRulesetResolver:
         event_emitter,
         use_ssl=True,
         requested_auth_scheme=None,
-        credentials=None,
-        account_id_endpoint_mode=None,
+        credential_builtin_resolver=None,
     ):
         self._provider = EndpointProvider(
             ruleset_data=endpoint_ruleset_data,
@@ -541,9 +575,7 @@ class EndpointRulesetResolver:
         self._use_ssl = use_ssl
         self._requested_auth_scheme = requested_auth_scheme
         self._instance_cache = {}
-        self._credential_builtin_resolver = CredentialBuiltinResolver(
-            credentials, account_id_endpoint_mode
-        )
+        self._credential_builtin_resolver = credential_builtin_resolver
 
     def construct_endpoint(
         self,
@@ -630,11 +662,24 @@ class EndpointRulesetResolver:
         return provider_params
 
     def _resolve_credential_builtins(self, builtins):
+        if self._credential_builtin_resolver is None:
+            return
+
+        self._resolve_account_id_builtin(builtins)
+
+    def _resolve_account_id_builtin(self, builtins):
         resolver = self._credential_builtin_resolver
-        signing_enabled = self._requested_auth_scheme != UNSIGNED
-        param_def = self._param_definitions.get('AccountId')
-        if param_def is not None and param_def.builtin is not None:
-            resolver.resolve_account_id_builtin(builtins, signing_enabled)
+        builtin_configured = self._builtin_configured('AccountId')
+        acct_id_builtin_key = EndpointResolverBuiltins.AWS_ACCOUNT_ID
+        current_builtin_value = builtins.get(acct_id_builtin_key)
+        account_id = resolver.resolve_account_id_builtin(
+            builtin_configured, current_builtin_value
+        )
+        builtins[acct_id_builtin_key] = account_id
+
+    def _builtin_configured(self, param_name):
+        param_def = self._param_definitions.get(param_name)
+        return param_def is not None and param_def.builtin is not None
 
     def _resolve_param_from_context(
         self, param_name, operation_model, call_args

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -632,7 +632,8 @@ class EndpointRulesetResolver:
     def _resolve_credential_builtins(self, builtins):
         resolver = self._credential_builtin_resolver
         signing_enabled = self._requested_auth_scheme != UNSIGNED
-        if 'AccountId' in self._param_definitions:
+        param_def = self._param_definitions.get('AccountId')
+        if param_def is not None and param_def.builtin is not None:
             resolver.resolve_account_id_builtin(builtins, signing_enabled)
 
     def _resolve_param_from_context(

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -607,14 +607,12 @@ class EndpointRulesetResolver:
         return 'disabled'
 
     def _validate_account_id_endpoint_mode(self, account_id_endpoint_mode):
-        if (
-            account_id_endpoint_mode
-            not in self.VALID_ACCOUNT_ID_ENDPOINT_MODES
-        ):
+        valid_modes = self.VALID_ACCOUNT_ID_ENDPOINT_MODES
+        if account_id_endpoint_mode not in valid_modes:
             error_msg = (
-                f"Invalid value '{account_id_endpoint_mode}' for "
-                "account_id_endpoint_mode. Valid values are: "
-                f"{', '.join(self.VALID_ACCOUNT_ID_ENDPOINT_MODES)}."
+                f'Invalid value "{account_id_endpoint_mode}" for '
+                'account_id_endpoint_mode. Valid values are: '
+                f'{", ".join(valid_modes)}.'
             )
             raise InvalidConfigError(error_msg=error_msg)
         return account_id_endpoint_mode

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -587,11 +587,11 @@ class EndpointRulesetResolver:
             request_context
         )
         acct_id_builtin_key = EndpointResolverBuiltins.AWS_ACCOUNT_ID
-        acct_id_builtin = builtins.get(acct_id_builtin_key)
         if acct_id_ep_mode == 'disabled':
             # Unset the account ID if endpoint mode is disabled.
             builtins[acct_id_builtin_key] = None
-        elif acct_id_builtin is None:
+
+        elif builtins.get(acct_id_builtin_key) is None:
             self._do_resolve_account_id_builtin(acct_id_ep_mode, builtins)
 
     def _resolve_account_id_endpoint_mode(self, request_context):
@@ -599,7 +599,8 @@ class EndpointRulesetResolver:
         not_presign = not request_context.get('is_presign_request', False)
         should_sign = self._requested_auth_scheme != UNSIGNED
         creds_available = self._credentials is not None
-        if all((not_presign, should_sign, creds_available)):
+
+        if not_presign and should_sign and creds_available:
             ep_mode = request_context['client_config'].account_id_endpoint_mode
             return self._validate_account_id_endpoint_mode(ep_mode)
         return 'disabled'

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -919,7 +919,6 @@ class Session:
         :type aws_account_id: string
         :param aws_account_id: The AWS account ID to use when creating the client.
             Same semantics as aws_access_key_id above.
-
         """
         default_client_config = self.get_default_client_config()
         # If a config is provided and a default config is set, then

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -499,7 +499,7 @@ class Session:
             credentials.
 
         :type account_id: str
-        :param account_id: The account ID part of the credentials.
+        :param account_id: The account ID for the credentials.
         """
         self._credentials = botocore.credentials.Credentials(
             access_key, secret_key, token, account_id=account_id

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -479,7 +479,9 @@ class Session:
         """
         self._client_config = client_config
 
-    def set_credentials(self, access_key, secret_key, token=None):
+    def set_credentials(
+        self, access_key, secret_key, token=None, account_id=None
+    ):
         """
         Manually create credentials for this session.  If you would
         prefer to use botocore without a config file, environment variables,
@@ -495,9 +497,13 @@ class Session:
         :type token: str
         :param token: An option session token used by STS session
             credentials.
+
+        :type account_id: str
+        :param account_id: An optional account ID associated with the
+            credentials.
         """
         self._credentials = botocore.credentials.Credentials(
-            access_key, secret_key, token
+            access_key, secret_key, token, account_id=account_id
         )
 
     def get_credentials(self):
@@ -841,6 +847,7 @@ class Session:
         aws_secret_access_key=None,
         aws_session_token=None,
         config=None,
+        aws_account_id=None,
     ):
         """Create a botocore client.
 
@@ -910,6 +917,10 @@ class Session:
         :rtype: botocore.client.BaseClient
         :return: A botocore client instance
 
+        :type aws_account_id: string
+        :param aws_account_id: The AWS account ID to use when creating the client.
+            Same semantics as aws_access_key_id above.
+
         """
         default_client_config = self.get_default_client_config()
         # If a config is provided and a default config is set, then
@@ -945,6 +956,7 @@ class Session:
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,
                 token=aws_session_token,
+                account_id=aws_account_id,
             )
         elif self._missing_cred_vars(aws_access_key_id, aws_secret_access_key):
             raise PartialCredentialsError(

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -479,7 +479,9 @@ class Session:
         """
         self._client_config = client_config
 
-    def set_credentials(self, access_key, secret_key, token=None):
+    def set_credentials(
+        self, access_key, secret_key, token=None, account_id=None
+    ):
         """
         Manually create credentials for this session.  If you would
         prefer to use botocore without a config file, environment variables,
@@ -495,9 +497,12 @@ class Session:
         :type token: str
         :param token: An option session token used by STS session
             credentials.
+
+        :type account_id: str
+        :param account_id: The account ID part of the credentials.
         """
         self._credentials = botocore.credentials.Credentials(
-            access_key, secret_key, token
+            access_key, secret_key, token, account_id=account_id
         )
 
     def get_credentials(self):

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -479,9 +479,7 @@ class Session:
         """
         self._client_config = client_config
 
-    def set_credentials(
-        self, access_key, secret_key, token=None, account_id=None
-    ):
+    def set_credentials(self, access_key, secret_key, token=None):
         """
         Manually create credentials for this session.  If you would
         prefer to use botocore without a config file, environment variables,
@@ -497,13 +495,9 @@ class Session:
         :type token: str
         :param token: An option session token used by STS session
             credentials.
-
-        :type account_id: str
-        :param account_id: An optional account ID associated with the
-            credentials.
         """
         self._credentials = botocore.credentials.Credentials(
-            access_key, secret_key, token, account_id=account_id
+            access_key, secret_key, token
         )
 
     def get_credentials(self):

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -198,7 +198,7 @@ class BaseAssumeRoleTest(BaseEnvVar):
             },
             'AssumedRoleUser': {
                 'AssumedRoleId': 'myroleid',
-                'Arn': 'arn:aws:iam::1234567890:user/myuser',
+                'Arn': f'arn:aws:iam::{credentials.account_id}:user/myuser',
             },
         }
 
@@ -209,6 +209,7 @@ class BaseAssumeRoleTest(BaseEnvVar):
             'fake-%s' % random_chars(15),
             'fake-%s' % random_chars(35),
             'fake-%s' % random_chars(45),
+            account_id='fake-%s' % random_chars(12),
         )
 
     def assert_creds_equal(self, c1, c2):

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -790,7 +790,8 @@ class TestAssumeRoleWithWebIdentity(BaseAssumeRoleTest):
         expected_creds = self.create_random_credentials()
         response = self.create_assume_role_response(expected_creds)
         session = StubbedSession(**kwargs)
-        stubber = session.stub('sts')
+        config = Config(signature_version=UNSIGNED)
+        stubber = session.stub('sts', config=config)
         stubber.add_response(
             'assume_role_with_web_identity', response, expected_params
         )

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -790,8 +790,7 @@ class TestAssumeRoleWithWebIdentity(BaseAssumeRoleTest):
         expected_creds = self.create_random_credentials()
         response = self.create_assume_role_response(expected_creds)
         session = StubbedSession(**kwargs)
-        config = Config(signature_version=UNSIGNED)
-        stubber = session.stub('sts', config=config)
+        stubber = session.stub('sts')
         stubber.add_response(
             'assume_role_with_web_identity', response, expected_params
         )

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -72,7 +72,10 @@ class TestCredentialPrecedence(BaseEnvVar):
         )
 
         credentials_cls.assert_called_with(
-            access_key='code', secret_key='code-secret', token=mock.ANY
+            access_key='code',
+            secret_key='code-secret',
+            token=mock.ANY,
+            account_id=mock.ANY,
         )
 
     def test_profile_env_vs_code(self):
@@ -97,7 +100,10 @@ class TestCredentialPrecedence(BaseEnvVar):
         )
 
         credentials_cls.assert_called_with(
-            access_key='code', secret_key='code-secret', token=mock.ANY
+            access_key='code',
+            secret_key='code-secret',
+            token=mock.ANY,
+            account_id=mock.ANY,
         )
 
     def test_access_secret_env_vs_profile_code(self):

--- a/tests/unit/data/endpoints/valid-rules/aws-account-id.json
+++ b/tests/unit/data/endpoints/valid-rules/aws-account-id.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    },
+    "AccountId": {
+      "type": "string",
+      "builtIn": "AWS::Auth::AccountId",
+      "documentation": "The account ID to dispatch this request, eg. `123456789012`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the account ID into the URI when account ID is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{AccountId}.amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Fallback when account ID isn't set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -614,6 +614,30 @@ class TestCreateClientArgs(unittest.TestCase):
         config = client_args['client_config']
         self.assertFalse(config.disable_request_compression)
 
+    def test_account_id_endpoint_mode_config_store(self):
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'preferred'
+        )
+        config = self.call_get_client_args()['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'preferred')
+
+    def test_account_id_endpoint_mode_client_config(self):
+        config = Config(account_id_endpoint_mode='preferred')
+        config = self.call_get_client_args(client_config=config)
+        client_config = config['client_config']
+        self.assertEqual(client_config.account_id_endpoint_mode, 'preferred')
+
+    def test_account_id_endpoint_mode_client_config_overrides_config_store(
+        self,
+    ):
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'preferred'
+        )
+        config = Config(account_id_endpoint_mode='required')
+        config = self.call_get_client_args(client_config=config)
+        client_config = config['client_config']
+        self.assertEqual(client_config.account_id_endpoint_mode, 'required')
+
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):
@@ -679,6 +703,7 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             bins['AWS::S3::DisableMultiRegionAccessPoints'], False
         )
         self.assertEqual(bins['SDK::Endpoint'], None)
+        self.assertEqual(bins['AWS::Auth::AccountId'], None)
 
     def test_aws_region(self):
         bins = self.call_compute_endpoint_resolver_builtin_defaults(

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -627,9 +627,7 @@ class TestCreateClientArgs(unittest.TestCase):
         client_config = config['client_config']
         self.assertEqual(client_config.account_id_endpoint_mode, 'preferred')
 
-    def test_account_id_endpoint_mode_client_config_overrides_config_store(
-        self,
-    ):
+    def test_acct_id_ep_mode_client_cfg_overrides_cfg_store(self):
         self.config_store.set_config_variable(
             'account_id_endpoint_mode', 'preferred'
         )

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -614,28 +614,6 @@ class TestCreateClientArgs(unittest.TestCase):
         config = client_args['client_config']
         self.assertFalse(config.disable_request_compression)
 
-    def test_account_id_endpoint_mode_config_store(self):
-        self.config_store.set_config_variable(
-            'account_id_endpoint_mode', 'preferred'
-        )
-        config = self.call_get_client_args()['client_config']
-        self.assertEqual(config.account_id_endpoint_mode, 'preferred')
-
-    def test_account_id_endpoint_mode_client_config(self):
-        config = Config(account_id_endpoint_mode='preferred')
-        config = self.call_get_client_args(client_config=config)
-        client_config = config['client_config']
-        self.assertEqual(client_config.account_id_endpoint_mode, 'preferred')
-
-    def test_acct_id_ep_mode_client_cfg_overrides_cfg_store(self):
-        self.config_store.set_config_variable(
-            'account_id_endpoint_mode', 'preferred'
-        )
-        config = Config(account_id_endpoint_mode='required')
-        config = self.call_get_client_args(client_config=config)
-        client_config = config['client_config']
-        self.assertEqual(client_config.account_id_endpoint_mode, 'required')
-
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -265,7 +265,6 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
             'secret_key': response['Credentials']['SecretAccessKey'],
             'token': response['Credentials']['SessionToken'],
             'expiry_time': expiration,
-            'account_id': None,
         }
 
     def some_future_time(self):
@@ -285,7 +284,6 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         refresher = credentials.AssumeRoleCredentialFetcher(
             client_creator, self.source_creds, self.role_arn
         )
-
         expected_response = self.get_expected_creds_from_response(response)
         response = refresher.fetch_credentials()
 
@@ -772,7 +770,6 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
             'secret_key': response['Credentials']['SecretAccessKey'],
             'token': response['Credentials']['SessionToken'],
             'expiry_time': expiration,
-            'account_id': None,
         }
 
     def test_no_cache(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -191,10 +191,18 @@ class TestRefreshableCredentials(TestCredentials):
             self.creds.access_key
 
     def test_account_id_refresh(self):
+        # set the expiry to now so the creds will need a refresh again
+        now = datetime.now(tzlocal())
+        self.mock_time.return_value = now
+        metadata = self.metadata.copy()
+        metadata['expiry_time'] = now.isoformat()
+        self.refresher.return_value = metadata
+        self.assertTrue(self.creds.refresh_needed())
+        self.assertIsNone(self.creds.account_id)
+        # set the account id in the mocked refresher
         metadata = self.metadata.copy()
         metadata['account_id'] = '123456789012'
         self.refresher.return_value = metadata
-        self.mock_time.return_value = datetime.now(tzlocal())
         self.assertTrue(self.creds.refresh_needed())
         self.assertEqual(self.creds.account_id, '123456789012')
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -190,16 +190,13 @@ class TestRefreshableCredentials(TestCredentials):
         with self.assertRaises(botocore.exceptions.CredentialRetrievalError):
             self.creds.access_key
 
-    def test_account_id_refresh(self):
-        # set the expiry to now so the creds will need a refresh again
-        now = datetime.now(tzlocal())
-        self.mock_time.return_value = now
-        metadata = self.metadata.copy()
-        metadata['expiry_time'] = now.isoformat()
-        self.refresher.return_value = metadata
+    def test_account_id_unset(self):
+        self.mock_time.return_value = datetime.now(tzlocal())
         self.assertTrue(self.creds.refresh_needed())
         self.assertIsNone(self.creds.account_id)
-        # set the account id in the mocked refresher
+
+    def test_account_id_set(self):
+        self.mock_time.return_value = datetime.now(tzlocal())
         metadata = self.metadata.copy()
         metadata['account_id'] = '123456789012'
         self.refresher.return_value = metadata

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -284,6 +284,7 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         refresher = credentials.AssumeRoleCredentialFetcher(
             client_creator, self.source_creds, self.role_arn
         )
+
         expected_response = self.get_expected_creds_from_response(response)
         response = refresher.fetch_credentials()
 

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -686,17 +686,32 @@ def test_account_id_endpoint_mode_input_error_cases(
         )
 
 
+@pytest.mark.parametrize(
+    "credential_method, expected_message",
+    [  # refreshable method
+        ("assume-role", "ensure that your credential source is configured"),
+        # static method
+        ("env", "check your configuration and try again"),
+        # unsupported method
+        ("foo", "change your credential source to one of"),
+    ],
+)
 def test_required_mode_no_account_id(
-    account_id_ruleset, operation_model_empty_context_params
+    account_id_ruleset,
+    operation_model_empty_context_params,
+    credential_method,
+    expected_message,
 ):
-    credentials = Credentials(access_key="a", secret_key="b", token="c")
+    credentials = Credentials(
+        access_key="a", secret_key="b", token="c", method=credential_method
+    )
     resolver = create_ruleset_resolver(
         account_id_ruleset,
         BUILTINS_WITH_UNRESOLVED_ACCOUNT_ID,
         credentials,
         REQUIRED,
     )
-    with pytest.raises(AccountIdNotFound):
+    with pytest.raises(AccountIdNotFound, match=expected_message):
         resolver.construct_endpoint(
             operation_model=operation_model_empty_context_params,
             request_context={},

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -568,12 +568,12 @@ def create_ruleset_resolver(
 ):
     service_model = Mock()
     service_model.client_context_parameters = []
-    builtin_resolvers = {
+    resolver_map = {
         "credentials": CredentialBuiltinResolver(
             credentials, account_id_endpoint_mode
         )
     }
-    builtin_resolver = EndpointBuiltinResolver(builtin_resolvers)
+    builtin_resolver = EndpointBuiltinResolver(resolver_map)
     return EndpointRulesetResolver(
         endpoint_ruleset_data=ruleset,
         partition_data={},

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -31,7 +31,7 @@ from botocore.endpoint_provider import (
     TreeRule,
 )
 from botocore.exceptions import (
-    AccountIDNotFound,
+    AccountIdNotFound,
     EndpointResolutionError,
     InvalidConfigError,
     MissingDependencyException,
@@ -721,7 +721,7 @@ def test_account_id_builtin(
             Credentials(access_key="foo", secret_key="bar", token="baz"),
             None,
             ACT_ID_REQUIRED_CONTEXT,
-            AccountIDNotFound,
+            AccountIdNotFound,
         ),
     ],
 )

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -556,9 +556,9 @@ CREDENTIALS = Credentials(
     token="token",
     account_id="1234567890",
 )
-REQUIRED = 'required'
-PREFERRED = 'preferred'
-DISABLED = 'disabled'
+REQUIRED = "required"
+PREFERRED = "preferred"
+DISABLED = "disabled"
 URL_NO_ACCOUNT_ID = "https://amazonaws.com"
 URL_WITH_ACCOUNT_ID = "https://1234567890.amazonaws.com"
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -549,6 +549,23 @@ class TestCreateClient(BaseSessionTest):
                 aws_secret_access_key='foo',
             )
 
+    @mock.patch('botocore.client.ClientCreator')
+    def test_credential_params(self, client_creator):
+        self.session.create_client(
+            'sts',
+            'us-west-2',
+            aws_access_key_id='foo',
+            aws_secret_access_key='bar',
+            aws_session_token='baz',
+            aws_account_id='123456789012',
+        )
+        call_args = client_creator.return_value.create_client.call_args[1]
+        credentials = call_args['credentials']
+        self.assertEqual(credentials.access_key, 'foo')
+        self.assertEqual(credentials.secret_key, 'bar')
+        self.assertEqual(credentials.token, 'baz')
+        self.assertEqual(credentials.account_id, '123456789012')
+
     def test_cred_provider_not_called_on_unsigned_client(self):
         cred_provider = mock.Mock()
         self.session.register_component('credential_provider', cred_provider)


### PR DESCRIPTION
Adds the ability for AWS services to route customers to account ID-specific endpoints. This PR can be reviewed in two parts.

## Part 1 (commits 1-2)
Adds `account_id` as an optional input to `Credentials`, `RefreshableCredentials` and `ReadOnlyCredentials`. It is also added to `DeferredRefreshableCredentials` as an internal variable.

It is resolved to a non-null value when possible in a number of supported credential providers:
* `AssumeRoleProvider`/`AssumeRoleWithWebIdentityProvider`: parsed from `AssumedRoleUser.Arn` in assume role response.
* `SSOProvider`: sourced from `sso_account_id` profile parameter in AWS config file
* `EnvProvider`: sourced from `AWS_ACCOUNT_ID` environment variable
* `ConfigProvider`: sourced from `aws_account_id` profile parameter in AWS config file
* `SharedCredentialsProvider`: sourced from `aws_account_id` profile parameter in AWS shared credentials file
* `ProcessProvider`: sourced from `AccountId` parameter returned in credential process response or `aws_account_id` profile parameter if the former isn't available.

It can also be configured statically to a botocore client via the `aws_account_id` arg in `Session.create_client` or the `account_id` arg in `Session.set_credentials`

## Part 2 (commits 3-4)
Adds the config setting `account_id_endpoint_mode` and used during endpoint resolution. When enabled and configured in a service's ruleset, the endpoint resolver will attempt to resolve `AccountId` as an input parameter to the endpoint provider.
* Account ID is treated as an endpoint builtin parameter `Aws::Auth::AccountId` defaulting to `None`. If the config setting is enabled, the parameter is configured in the ruleset and the builtin hasn't been set during the `before-endpoint-resolution` event, account ID will be resolved from credentials.
* valid config settings for `account_id_endpoint_mode` are `preferred`, `required` and `disabled` (case sensitive). Defaults to `preferred` if not supplied by a customer.
* Account ID based routing is always disabled for `UNSIGNED` requests and presigned URLs

## Updates since opening the PR
* Account ID based routing is not disabled for presigned URLs
* endpoint builtin resolution is layered through a couple of abstractions. `CredentialBuiltinResolver` is responsible for actually resolving the account ID value (and future credential builtin values). If/when other types of builtin resolvers are required they will all be passed to `EndpointBuiltinResolver`. This construct has one public API `resolve` which is called by the ruleset resolver.