### PR TITLE
Add support for urllib3 2.0 in Python 3.10+

### DIFF
--- a/.changes/next-release/enhancement-Dependencies-60903.json
+++ b/.changes/next-release/enhancement-Dependencies-60903.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Dependencies",
+  "description": "Add support for urllib3 2.0 for Python 3.10+"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ universal = 0
 requires_dist =
     jmespath>=0.7.1,<2.0.0
     python-dateutil>=2.1,<3.0.0
-    urllib3>=1.25.4,<1.27
+    urllib3>=1.25.4,<1.27; python_version<"3.10"
+    urllib3>=1.25.4,<2.1; python_version>="3.10"
 
 [options.extras_require]
 crt = awscrt==0.16.26

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,13 @@ def find_version(*file_paths):
 requires = [
     'jmespath>=0.7.1,<2.0.0',
     'python-dateutil>=2.1,<3.0.0',
-    'urllib3>=1.25.4,<1.27',
+    'urllib3>=1.25.4,<1.27 ; python_version < "3.10"',
+    'urllib3>=1.25.4,<2.1 ; python_version >= "3.10"',
 ]
+
+extras_require = {
+    'crt': ['awscrt==0.16.26'],
+}
 
 setup(
     name='botocore',
@@ -43,6 +48,7 @@ setup(
     },
     include_package_data=True,
     install_requires=requires,
+    extras_require=extras_require,
     license="Apache License 2.0",
     python_requires=">= 3.7",
     classifiers=[


### PR DESCRIPTION
Starting in Python 3.10, the introduction of [PEP 644](https://peps.python.org/pep-0644/) requires that new versions of Python require OpenSSL 1.1.1+. This will let us confidently move the pin for Python 3.10+ to support the growing adoption of urllib3 2.0.

Details on the current blockers for allowing this for all version can be found in the [main tracking thread](https://github.com/boto/botocore/issues/2926#issuecomment-1673963526). Long term, we'll continue looking at options to expand support safely for users as we find other opportunities. For now, we'd encourage anyone looking to use urllib3 2.0 with Botocore to migrate to Python 3.10 or later.