### PR TITLE
Sanitize __type metadata out of response parsing for tagged unions

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -353,13 +353,15 @@ class ResponseParser:
 
     def _has_unknown_tagged_union_member(self, shape, value):
         if shape.is_tagged_union:
-            if len(value) != 1:
+            cleaned_value = value.copy()
+            cleaned_value.pop("__type", None)
+            if len(cleaned_value) != 1:
                 error_msg = (
                     "Invalid service response: %s must have one and only "
                     "one member set."
                 )
                 raise ResponseParserError(error_msg % shape.name)
-            tag = self._get_first_key(value)
+            tag = self._get_first_key(cleaned_value)
             if tag not in shape.members:
                 msg = (
                     "Received a tagged union response with member "

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -553,6 +553,34 @@ class TestTaggedUnions(unittest.TestCase):
         with self.assertRaises(parsers.ResponseParserError):
             parser.parse(response, output_shape)
 
+        parser = parsers.JSONParser()
+        response = b'{"Foo": "mystring", "__type": "mytype"}'
+        headers = {'x-amzn-requestid': 'request-id'}
+        output_shape = model.StructureShape(
+            'OutputShape',
+            {
+                'type': 'structure',
+                'union': True,
+                'members': {
+                    'Foo': {
+                        'shape': 'StringType',
+                    },
+                    'Bar': {
+                        'shape': 'StringType',
+                    },
+                },
+            },
+            model.ShapeResolver({'StringType': {'type': 'string'}}),
+        )
+
+        response = {
+            'body': response,
+            'headers': headers,
+            'status_code': 200,
+        }
+        parsed = parser.parse(response, output_shape)
+        self.assertEqual(parsed['Foo'], 'mystring')
+
 
 class TestHeaderResponseInclusion(unittest.TestCase):
     def create_parser(self):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -553,6 +553,7 @@ class TestTaggedUnions(unittest.TestCase):
         with self.assertRaises(parsers.ResponseParserError):
             parser.parse(response, output_shape)
 
+    def test_parser_accepts_type_metadata_with_union(self):
         parser = parsers.JSONParser()
         response = b'{"Foo": "mystring", "__type": "mytype"}'
         headers = {'x-amzn-requestid': 'request-id'}


### PR DESCRIPTION
Some AWS services will return the __type metadata in a response alongside a tagged union.  Since this isn't modeled as a response member, it's never shown to SDK users, but needs to be ignored in the response parser to allow prevent an error from being thrown.  