### PR TITLE
Remove strict kwarg that was deprecated in Python 3.4

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -335,7 +335,6 @@ class URLLib3Session:
 
     def _get_pool_manager_kwargs(self, **extra_kwargs):
         pool_manager_kwargs = {
-            'strict': True,
             'timeout': self._timeout,
             'maxsize': self._max_pool_connections,
             'ssl_context': self._get_ssl_context(),

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -148,7 +148,6 @@ class TestURLLib3Session(unittest.TestCase):
 
     def _assert_manager_call(self, manager, *assert_args, **assert_kwargs):
         call_kwargs = {
-            'strict': True,
             'maxsize': mock.ANY,
             'timeout': mock.ANY,
             'ssl_context': mock.ANY,


### PR DESCRIPTION
This PR will stop passing the no-longer required `strict` argument to the urllib3 ConnectionPool class. This argument was originally needed in `Python<3.5` (specifically Python 2) to specify support for older HTTP status lines before http/1.0. The functionality went away in HTTPConnection in Python 3.4 ([ref](https://docs.python.org/3/library/http.client.html#http.client.HTTPConnection)).

Starting in urllib3 2.1, this parameter will be removed from the APIs we're using. Given it has no effect on version of Python we support, this should be a no-op for users on _all_ versions of urllib3 we support. You can find a [similar PR](https://github.com/psf/requests/pull/6434) where we've done this in Requests which has been in place for ~6 months without issue.