### PR TITLE
Add generic support for client context params

### DIFF
--- a/.changes/next-release/enhancement-Configuration-49047.json
+++ b/.changes/next-release/enhancement-Configuration-49047.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Configuration",
+  "description": "Adds client context params support to ``Config``."
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -643,15 +643,15 @@ class ClientArgsCreator:
             legacy_endpoint_url=endpoint.host,
         )
         # Client context params for s3 conflict with the available settings
-        # in the `s3` parameter on the `Config` object. The s3 config will
-        # always take precedence over the client context params for s3 and
-        # s3control if set.
-        if self._is_s3_service(service_name_raw) and s3_config_raw:
-            client_context = s3_config_raw
-        elif client_config is not None and client_config.client_context_params:
-            client_context = client_config.client_context_params
+        # in the `s3` parameter on the `Config` object. If the same parameter
+        # is set in both places, the value in the `s3` parameter takes priority.
+        if client_config is not None:
+            client_context = client_config.client_context_params or {}
         else:
             client_context = {}
+        if self._is_s3_service(service_name_raw):
+            client_context.update(s3_config_raw)
+
         sig_version = (
             client_config.signature_version
             if client_config is not None

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -223,10 +223,10 @@ class Config:
 
     :type client_context_params: dict
     :param client_context_params: A dictionary of parameters specific to
-        individual services. If available, valid parameters can be found in the
-        ``Client Context Parameters`` section of the service's client homepage.
-        Invalid parameters or ones that are not used by the specified service
-        will be ignored.
+        individual services. If available, valid parameters can be found in
+        the ``Client Context Parameters`` section of the service's client's
+        documentation. Invalid parameters or ones that are not used by the
+        specified service will be ignored.
 
         Defaults to None.
     """

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -220,6 +220,16 @@ class Config:
         set to True.
 
         Defaults to None.
+
+    :type client_context_params: dict
+    :param client_context_params: A dictionary of parameters specific to
+        individual services. If available, valid parameters can be found in the
+        ``Client Context Parameters`` section of the service's client homepage.
+        Invalid parameters or ones that are not used by the specified service
+        will be ignored.
+
+        Defaults to None.
+
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -247,6 +257,7 @@ class Config:
             ('tcp_keepalive', None),
             ('request_min_compression_size_bytes', None),
             ('disable_request_compression', None),
+            ('client_context_params', None),
         ]
     )
 

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -229,7 +229,6 @@ class Config:
         will be ignored.
 
         Defaults to None.
-
     """
 
     OPTION_DEFAULTS = OrderedDict(

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -224,7 +224,7 @@ class Config:
     :type client_context_params: dict
     :param client_context_params: A dictionary of parameters specific to
         individual services. If available, valid parameters can be found in
-        the ``Client Context Parameters`` section of the service's client's
+        the ``Client Context Parameters`` section of the service client's
         documentation. Invalid parameters or ones that are not used by the
         specified service will be ignored.
 

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 
+from botocore import xform_name
 from botocore.compat import OrderedDict
 from botocore.docs.bcdoc.restdoc import DocumentStructure
 from botocore.docs.example import ResponseExampleDocumenter
@@ -399,3 +400,46 @@ class ClientExceptionsDocumenter:
             shape,
             include=[self._GENERIC_ERROR_SHAPE],
         )
+
+
+class ClientContextParamsDocumenter:
+    _CONFIG_GUIDE_LINK = (
+        'https://boto3.amazonaws.com/'
+        'v1/documentation/api/latest/guide/configuration.html'
+    )
+
+    def __init__(self, service_name, context_params):
+        self._service_name = service_name
+        self._context_params = context_params
+
+    def document_context_params(self, section):
+        self._add_title(section)
+        self._add_overview(section)
+        self._add_context_params_list(section)
+
+    def _add_title(self, section):
+        section.style.h2('Client Context Parameters')
+
+    def _add_overview(self, section):
+        section.style.new_line()
+        section.write(
+            'Client context parameters are configurable on a client '
+            'instance via the ``client_context_params`` parameter in the '
+            '``Config`` object. For more detailed instructions and examples '
+            'on the exact usage of context params see the '
+        )
+        section.style.external_link(
+            title='configuration guide',
+            link=self._CONFIG_GUIDE_LINK,
+        )
+        section.write('.')
+        section.style.new_line()
+
+    def _add_context_params_list(self, section):
+        section.style.new_line()
+        sn = f'``{self._service_name}``'
+        section.writeln(f'The available {sn} client context params are:')
+        for param in self._context_params:
+            section.style.new_line()
+            name = f'``{xform_name(param.name)}``'
+            section.write(f'* {name} ({param.type}) - {param.documentation}')

--- a/botocore/docs/client.py
+++ b/botocore/docs/client.py
@@ -408,6 +408,16 @@ class ClientContextParamsDocumenter:
         'v1/documentation/api/latest/guide/configuration.html'
     )
 
+    OMITTED_CONTEXT_PARAMS = {
+        's3': (
+            'Accelerate',
+            'DisableMultiRegionAccessPoints',
+            'ForcePathStyle',
+            'UseArnRegion',
+        ),
+        's3control': ('UseArnRegion',),
+    }
+
     def __init__(self, service_name, context_params):
         self._service_name = service_name
         self._context_params = context_params

--- a/botocore/docs/service.py
+++ b/botocore/docs/service.py
@@ -20,16 +20,6 @@ from botocore.docs.paginator import PaginatorDocumenter
 from botocore.docs.waiter import WaiterDocumenter
 from botocore.exceptions import DataNotFoundError
 
-OMITTED_CONTEXT_PARAMS = {
-    's3': (
-        'Accelerate',
-        'DisableMultiRegionAccessPoints',
-        'ForcePathStyle',
-        'UseArnRegion',
-    ),
-    's3control': ('UseArnRegion',),
-}
-
 
 class ServiceDocumenter:
     def __init__(self, service_name, session, root_docs_path):
@@ -129,7 +119,8 @@ class ServiceDocumenter:
         return examples['examples']
 
     def client_context_params(self, section):
-        params_to_omit = OMITTED_CONTEXT_PARAMS.get(self._service_name, [])
+        omitted_params = ClientContextParamsDocumenter.OMITTED_CONTEXT_PARAMS
+        params_to_omit = omitted_params.get(self._service_name, [])
         service_model = self._client.meta.service_model
         raw_context_params = service_model.client_context_parameters
         context_params = [

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -11,7 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore import xform_name
-from botocore.docs.service import OMITTED_CONTEXT_PARAMS, ServiceDocumenter
+from botocore.docs.client import ClientContextParamsDocumenter
+from botocore.docs.service import ServiceDocumenter
 from tests.functional.docs import BaseDocsFunctionalTest
 
 
@@ -81,19 +82,21 @@ class TestS3Docs(BaseDocsFunctionalTest):
         )
 
     def test_s3_context_params_omitted(self):
-        omitted_params = OMITTED_CONTEXT_PARAMS['s3']
+        omitted_params = ClientContextParamsDocumenter.OMITTED_CONTEXT_PARAMS
+        s3_omitted_params = omitted_params['s3']
         content = ServiceDocumenter(
             's3', self._session, self.root_services_path
         ).document_service()
-        for param in omitted_params:
+        for param in s3_omitted_params:
             param_name = f'``{xform_name(param)}``'
             self.assert_not_contains_line(param_name, content)
 
     def test_s3control_context_params_omitted(self):
-        omitted_params = OMITTED_CONTEXT_PARAMS['s3control']
+        omitted_params = ClientContextParamsDocumenter.OMITTED_CONTEXT_PARAMS
+        s3control_omitted_params = omitted_params['s3control']
         content = ServiceDocumenter(
             's3control', self._session, self.root_services_path
         ).document_service()
-        for param in omitted_params:
+        for param in s3control_omitted_params:
             param_name = f'``{xform_name(param)}``'
             self.assert_not_contains_line(param_name, content)

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -10,7 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.docs.service import ServiceDocumenter
+from botocore import xform_name
+from botocore.docs.service import OMITTED_CONTEXT_PARAMS, ServiceDocumenter
 from tests.functional.docs import BaseDocsFunctionalTest
 
 
@@ -78,3 +79,21 @@ class TestS3Docs(BaseDocsFunctionalTest):
         self.assert_contains_line(
             "You can also provide this value as a dictionary", param_docs
         )
+
+    def test_s3_context_params_omitted(self):
+        omitted_params = OMITTED_CONTEXT_PARAMS['s3']
+        content = ServiceDocumenter(
+            's3', self._session, self.root_services_path
+        ).document_service()
+        for param in omitted_params:
+            param_name = f'``{xform_name(param)}``'
+            self.assert_not_contains_line(param_name, content)
+
+    def test_s3control_context_params_omitted(self):
+        omitted_params = OMITTED_CONTEXT_PARAMS['s3control']
+        content = ServiceDocumenter(
+            's3control', self._session, self.root_services_path
+        ).document_service()
+        for param in omitted_params:
+            param_name = f'``{xform_name(param)}``'
+            self.assert_not_contains_line(param_name, content)

--- a/tests/functional/test_context_params.py
+++ b/tests/functional/test_context_params.py
@@ -59,6 +59,11 @@ FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM = {
             "documentation": "",
             "type": "String",
         },
+        "BarClientContextParamName": {
+            "required": False,
+            "documentation": "",
+            "type": "String",
+        },
     },
 }
 
@@ -134,7 +139,11 @@ FAKE_MODEL_WITH_CLIENT_CONTEXT_PARAM = {
         "FooClientContextParamName": {
             "documentation": "My mock client context parameter",
             "type": "string",
-        }
+        },
+        "BarClientContextParamName": {
+            "documentation": "My mock client context parameter",
+            "type": "string",
+        },
     },
 }
 
@@ -227,14 +236,30 @@ FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM = {
 CLIENT_CONTEXT_PARAM_INPUT = {
     "foo_client_context_param_name": "foo_context_param_value"
 }
+OTHER_CLIENT_CONTEXT_PARAM_INPUT = {
+    "bar_client_context_param_name": "bar_value"
+}
+
 CONFIG_WITH_S3 = Config(s3=CLIENT_CONTEXT_PARAM_INPUT)
 CONFIG_WITH_CLIENT_CONTEXT_PARAMS = Config(
     client_context_params=CLIENT_CONTEXT_PARAM_INPUT
+)
+CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS = Config(
+    s3=CLIENT_CONTEXT_PARAM_INPUT,
+    client_context_params=OTHER_CLIENT_CONTEXT_PARAM_INPUT,
+)
+CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS = Config(
+    s3=CLIENT_CONTEXT_PARAM_INPUT,
+    client_context_params={"foo_client_context_param_name": "bar_value"},
 )
 NO_CTX_PARAM_EXPECTED_CALL_KWARGS = {"Region": "us-east-1"}
 CTX_PARAM_EXPECTED_CALL_KWARGS = {
     **NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
     "FooClientContextParamName": "foo_context_param_value",
+}
+MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS = {
+    **CTX_PARAM_EXPECTED_CALL_KWARGS,
+    "BarClientContextParamName": "bar_value",
 }
 
 
@@ -277,6 +302,22 @@ CTX_PARAM_EXPECTED_CALL_KWARGS = {
             CONFIG_WITH_CLIENT_CONTEXT_PARAMS,
             CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
+        # use both s3 and client_context_params when they don't overlap
+        (
+            's3',
+            FAKE_S3_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS,
+            MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS,
+        ),
+        # use s3 over client_context_params when they overlap
+        (
+            's3',
+            FAKE_S3_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
+        ),
         # s3control
         (
             's3control',
@@ -311,6 +352,22 @@ CTX_PARAM_EXPECTED_CALL_KWARGS = {
             FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
             FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
             CONFIG_WITH_CLIENT_CONTEXT_PARAMS,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
+        ),
+        # use both s3 and client_context_params when they don't overlap
+        (
+            's3control',
+            FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS,
+            MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS,
+        ),
+        # use s3 over client_context_params when they overlap
+        (
+            's3control',
+            FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS,
             CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         # otherservice

--- a/tests/unit/docs/test_client.py
+++ b/tests/unit/docs/test_client.py
@@ -10,7 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
+from botocore.docs.client import (
+    ClientContextParamsDocumenter,
+    ClientDocumenter,
+    ClientExceptionsDocumenter,
+)
 from tests.unit.docs import BaseDocsTest
 
 
@@ -166,4 +170,40 @@ class TestClientExceptionsDocumenter(BaseDocsTest):
             self.get_nested_service_contents(
                 'myservice', 'client/exceptions', 'SomeException'
             ),
+        )
+
+
+class TestClientContextParamsDocumenter(BaseDocsTest):
+    def setUp(self):
+        super().setUp()
+        self.json_model['clientContextParams'] = {
+            'ClientContextParam1': {
+                'type': 'string',
+                'documentation': 'A client context param',
+            },
+            'ClientContextParam2': {
+                'type': 'boolean',
+                'documentation': 'A second client context param',
+            },
+        }
+        self.setup_client()
+        service_model = self.client.meta.service_model
+        self.context_params_documenter = ClientContextParamsDocumenter(
+            service_model.service_name, service_model.client_context_parameters
+        )
+
+    def test_client_context_params(self):
+        self.context_params_documenter.document_context_params(
+            self.doc_structure
+        )
+        self.assert_contains_lines_in_order(
+            [
+                '========================',
+                'Client Context Parameters',
+                '========================',
+                'Client context parameters are configurable',
+                'The available ``myservice`` client context params are:',
+                '* ``client_context_param1`` (string) - A client context param',
+                '* ``client_context_param2`` (boolean) - A second client context param',
+            ]
         )

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -21,6 +21,9 @@ from tests.unit.docs import BaseDocsTest
 class TestServiceDocumenter(BaseDocsTest):
     def setUp(self):
         super().setUp()
+        self.setup_documenter()
+
+    def setup_documenter(self):
         self.add_shape_to_params('Biz', 'String')
         self.setup_client()
         with mock.patch(
@@ -97,3 +100,22 @@ class TestServiceDocumenter(BaseDocsTest):
         os.remove(self.waiter_model_file)
         contents = self.service_documenter.document_service().decode('utf-8')
         self.assertNotIn('Waiters', contents)
+
+    def test_document_service_no_context_params(self):
+        contents = self.service_documenter.document_service().decode('utf-8')
+        self.assertNotIn('Client Context Parameters', contents)
+
+    def test_document_service_context_params(self):
+        self.json_model['clientContextParams'] = {
+            'ClientContextParam1': {
+                'type': 'string',
+                'documentation': 'A client context param',
+            },
+            'ClientContextParam2': {
+                'type': 'boolean',
+                'documentation': 'A second client context param',
+            },
+        }
+        self.setup_documenter()
+        contents = self.service_documenter.document_service().decode('utf-8')
+        self.assertIn('Client Context Parameters', contents)


### PR DESCRIPTION
Adds client context parameters generically across all AWS services and adds them to docs. This PR can be reviewed in two parts. Should be merged in tandem with https://github.com/boto/boto3/pull/3894.

## Commit 1
Adds `client_context_params` config option. If the service is s3 or s3control, still use the s3 config param over client context params if it is set. Params are modeled as capital case but are expected in snake case by the endpoint resolver. This commit also includes some code cleanup for the existing client context params test.

## Commit 2
Adds client context params docs to each service client's homepage if any are modeled. Existing s3/s3control params are excluded because overlapping behavior already exists in the s3 config. There are no other modeled client context params today, but when one is added to a service model, the new docs section will look something like this:

<img width="809" alt="Screenshot 2023-10-11 at 2 58 03 PM" src="https://github.com/boto/botocore/assets/45697098/a3415acf-eb69-4ca8-b615-9f1498d7c3d6">
