### PR TITLE
Fix dynamodb consumed capacity value

### DIFF
--- a/.changes/next-release/bugfix-dynamodb-47642.json
+++ b/.changes/next-release/bugfix-dynamodb-47642.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "dynamodb",
+  "description": "fixes a bug where ConsumedCapacity would only display the value for the last page in the CLI"
+}

--- a/botocore/data/dynamodb/2012-08-10/paginators-1.json
+++ b/botocore/data/dynamodb/2012-08-10/paginators-1.json
@@ -19,10 +19,11 @@
       "result_key": [
         "Items",
         "Count",
-        "ScannedCount"
+        "ScannedCount",
+        "ConsumedCapacity.CapacityUnits"
       ],
       "non_aggregate_keys": [
-        "ConsumedCapacity"
+        "ConsumedCapacity.TableName"
       ]
     },
     "Scan": {
@@ -32,10 +33,11 @@
       "result_key": [
         "Items",
         "Count",
-        "ScannedCount"
+        "ScannedCount",
+        "ConsumedCapacity.CapacityUnits"
       ],
       "non_aggregate_keys": [
-        "ConsumedCapacity"
+        "ConsumedCapacity.TableName"
       ]
     },
     "ListTagsOfResource": {

--- a/botocore/data/dynamodb/2012-08-10/paginators-1.json
+++ b/botocore/data/dynamodb/2012-08-10/paginators-1.json
@@ -20,6 +20,7 @@
         "Items",
         "Count",
         "ScannedCount",
+        "ConsumedCapacity",
         "ConsumedCapacity.CapacityUnits"
       ],
       "non_aggregate_keys": [
@@ -34,6 +35,7 @@
         "Items",
         "Count",
         "ScannedCount",
+        "ConsumedCapacity",
         "ConsumedCapacity.CapacityUnits"
       ],
       "non_aggregate_keys": [

--- a/botocore/data/dynamodb/2012-08-10/paginators-1.json
+++ b/botocore/data/dynamodb/2012-08-10/paginators-1.json
@@ -20,7 +20,6 @@
         "Items",
         "Count",
         "ScannedCount",
-        "ConsumedCapacity",
         "ConsumedCapacity.CapacityUnits"
       ],
       "non_aggregate_keys": [
@@ -35,7 +34,6 @@
         "Items",
         "Count",
         "ScannedCount",
-        "ConsumedCapacity",
         "ConsumedCapacity.CapacityUnits"
       ],
       "non_aggregate_keys": [

--- a/tests/functional/test_paginator_config.py
+++ b/tests/functional/test_paginator_config.py
@@ -49,6 +49,8 @@ KNOWN_EXTRA_OUTPUT_KEYS = [
     'codedeploy.ListDeploymentGroups.applicationName',
     'dms.DescribeTableStatistics.ReplicationTaskArn',
     'dms.DescribeReplicationTaskAssessmentResults.BucketName',
+    'dynamodb.Query.ConsumedCapacity',
+    'dynamodb.Scan.ConsumedCapacity',
     'ec2.DescribeSpotFleetInstances.SpotFleetRequestId',
     'ec2.DescribeVpcEndpointServices.ServiceNames',
     'efs.DescribeFileSystems.Marker',


### PR DESCRIPTION
Fixes a bug where ConsumedCapacity would only display the value for the last page in the CLI