### PR TITLE
Update awcrt version to 0.19.12

### DIFF
--- a/.changes/next-release/enhancement-AWSCRT-3939.json
+++ b/.changes/next-release/enhancement-AWSCRT-3939.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "AWSCRT",
+  "description": "Update awscrt version to 0.19.12"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ requires_dist =
     urllib3>=1.25.4,<2.1; python_version>="3.10"
 
 [options.extras_require]
-crt = awscrt==0.19.10
+crt = awscrt==0.19.12
 
 [flake8]
 ignore = E203,E226,E501,E731,W503,W504

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requires = [
 ]
 
 extras_require = {
-    'crt': ['awscrt==0.19.10'],
+    'crt': ['awscrt==0.19.12'],
 }
 
 setup(


### PR DESCRIPTION
This PR will update to the latest release of the awscrt to resolve recent regressions in the awscrt on some platforms (https://github.com/awslabs/aws-crt-python/pull/524).