### PR TITLE
Simplify and speed up timestamp parsing

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -269,6 +269,8 @@ def _windows_shell_split(s):
 
 
 def get_tzinfo_options():
+    # This function is not used internally anymore.
+
     # Due to dateutil/dateutil#197, Windows may fail to parse times in the past
     # with the system clock. We can alternatively fallback to tzwininfo when
     # this happens, which will get time info from the Windows registry.

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -28,7 +28,6 @@ from math import floor
 
 from botocore.vendored import six
 from botocore.exceptions import MD5UnavailableError
-from dateutil.tz import tzlocal
 from urllib3 import exceptions
 
 logger = logging.getLogger(__name__)
@@ -266,20 +265,6 @@ def _windows_shell_split(s):
         components.append(''.join(buff))
 
     return components
-
-
-def get_tzinfo_options():
-    # This function is not used internally anymore.
-
-    # Due to dateutil/dateutil#197, Windows may fail to parse times in the past
-    # with the system clock. We can alternatively fallback to tzwininfo when
-    # this happens, which will get time info from the Windows registry.
-    if sys.platform == 'win32':
-        from dateutil.tz import tzwinlocal
-
-        return (tzlocal, tzwinlocal)
-    else:
-        return (tzlocal,)
 
 
 # Detect if CRT is available for use

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -27,6 +27,7 @@ import time
 import warnings
 import weakref
 from datetime import datetime as _DatetimeClass
+from email.utils import parsedate_to_datetime
 from ipaddress import ip_address
 from pathlib import Path
 from urllib.request import getproxies, proxy_bypass
@@ -684,7 +685,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
         if expiration is None:
             return
         try:
-            expiration = datetime.datetime.strptime(
+            expiration = _DatetimeClass.strptime(
                 expiration, "%Y-%m-%dT%H:%M:%SZ"
             )
             refresh_interval = self._config.get(
@@ -951,7 +952,7 @@ def _epoch_seconds_to_datetime(value):
     :param value: The Unix timestamps as number.
     """
     try:
-        return datetime.datetime.fromtimestamp(value, tz=tzutc())
+        return _DatetimeClass.fromtimestamp(value, tz=tzutc())
     except (OverflowError, OSError):
         # For numeric values attempt fallback to using fromtimestamp-free method.
         # From Python's ``datetime.datetime.fromtimestamp`` documentation: "This
@@ -972,8 +973,22 @@ def parse_timestamp(value):
         * epoch (value is an integer)
 
     This will return a ``datetime.datetime`` object.
-
     """
+    if isinstance(value, str):
+        if value.endswith("GMT"):
+            # Fast path: assume RFC822-with-GMT
+            try:
+                return parsedate_to_datetime(value).replace(tzinfo=tzutc())
+            except Exception:
+                pass
+        if value.endswith(("Z", "+00:00", "+0000")):
+            # Fast path: looks like ISO8601 UTC
+            try:
+                # New in version 3.7
+                return _DatetimeClass.fromisoformat(value)
+            except Exception:
+                pass
+
     if isinstance(value, (int, float)):
         try:
             # Possibly an epoch time.

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -975,13 +975,16 @@ def parse_timestamp(value):
 
     """
     if isinstance(value, (int, float)):
-        # Possibly an epoch time.
-        return _epoch_seconds_to_datetime(value)
+        try:
+            # Possibly an epoch time.
+            return _epoch_seconds_to_datetime(value)
+        except OverflowError:
+            pass
 
     # Possibly something we can cast to an epoch time and convert.
     try:
         return _epoch_seconds_to_datetime(float(value))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         pass
 
     try:

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -958,12 +958,18 @@ def _epoch_seconds_to_datetime(value, tzinfo):
 
 def _parse_timestamp_with_tzinfo(value, tzinfo):
     """Parse timestamp with pluggable tzinfo options."""
+    # For numeric values attempt fallback to using fromtimestamp-free method.
+    # From Python's ``datetime.datetime.fromtimestamp`` documentation: "This
+    # may raise ``OverflowError``, if the timestamp is out of the range of
+    # values supported by the platform C localtime() function, and ``OSError``
+    # on localtime() failure. It's common for this to be restricted to years
+    # from 1970 through 2038."
     if isinstance(value, (int, float)):
         # Possibly an epoch time.
-        return datetime.datetime.fromtimestamp(value, tzinfo())
+        return _epoch_seconds_to_datetime(value, tzinfo)
     else:
         try:
-            return datetime.datetime.fromtimestamp(float(value), tzinfo())
+            return _epoch_seconds_to_datetime(float(value), tzinfo)
         except (TypeError, ValueError):
             pass
     try:
@@ -997,30 +1003,7 @@ def parse_timestamp(value):
                 tzinfo.__name__,
                 exc_info=e,
             )
-    # For numeric values attempt fallback to using fromtimestamp-free method.
-    # From Python's ``datetime.datetime.fromtimestamp`` documentation: "This
-    # may raise ``OverflowError``, if the timestamp is out of the range of
-    # values supported by the platform C localtime() function, and ``OSError``
-    # on localtime() failure. It's common for this to be restricted to years
-    # from 1970 through 2038."
-    try:
-        numeric_value = float(value)
-    except (TypeError, ValueError):
-        pass
-    else:
-        try:
-            for tzinfo in tzinfo_options:
-                return _epoch_seconds_to_datetime(numeric_value, tzinfo=tzinfo)
-        except (OSError, OverflowError) as e:
-            logger.debug(
-                'Unable to parse timestamp using fallback method with "%s" '
-                'timezone info.',
-                tzinfo.__name__,
-                exc_info=e,
-            )
-    raise RuntimeError(
-        f'Unable to calculate correct timezone offset for "{value}"'
-    )
+    raise RuntimeError(f'Unable to parse timestamp {value!r}')
 
 
 def parse_to_aware_datetime(value):

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -56,7 +56,6 @@ from botocore.compat import (
     OrderedDict,
     get_current_datetime,
     get_md5,
-    get_tzinfo_options,
     json,
     quote,
     urlparse,
@@ -940,45 +939,27 @@ def percent_encode(input_str, safe=SAFE_CHARS):
     return quote(input_str, safe=safe)
 
 
-def _epoch_seconds_to_datetime(value, tzinfo):
+_EPOCH_ZERO = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=tzutc())
+
+
+def _epoch_seconds_to_datetime(value):
     """Parse numerical epoch timestamps (seconds since 1970) into a
     ``datetime.datetime`` in UTC using ``datetime.timedelta``. This is intended
     as fallback when ``fromtimestamp`` raises ``OverflowError`` or ``OSError``.
 
     :type value: float or int
     :param value: The Unix timestamps as number.
-
-    :type tzinfo: callable
-    :param tzinfo: A ``datetime.tzinfo`` class or compatible callable.
     """
-    epoch_zero = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=tzutc())
-    epoch_zero_localized = epoch_zero.astimezone(tzinfo())
-    return epoch_zero_localized + datetime.timedelta(seconds=value)
-
-
-def _parse_timestamp_with_tzinfo(value, tzinfo):
-    """Parse timestamp with pluggable tzinfo options."""
-    # For numeric values attempt fallback to using fromtimestamp-free method.
-    # From Python's ``datetime.datetime.fromtimestamp`` documentation: "This
-    # may raise ``OverflowError``, if the timestamp is out of the range of
-    # values supported by the platform C localtime() function, and ``OSError``
-    # on localtime() failure. It's common for this to be restricted to years
-    # from 1970 through 2038."
-    if isinstance(value, (int, float)):
-        # Possibly an epoch time.
-        return _epoch_seconds_to_datetime(value, tzinfo)
-    else:
-        try:
-            return _epoch_seconds_to_datetime(float(value), tzinfo)
-        except (TypeError, ValueError):
-            pass
     try:
-        # In certain cases, a timestamp marked with GMT can be parsed into a
-        # different time zone, so here we provide a context which will
-        # enforce that GMT == UTC.
-        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
-    except (TypeError, ValueError) as e:
-        raise ValueError(f'Invalid timestamp "{value}": {e}')
+        return datetime.datetime.fromtimestamp(value, tz=tzutc())
+    except (OverflowError, OSError):
+        # For numeric values attempt fallback to using fromtimestamp-free method.
+        # From Python's ``datetime.datetime.fromtimestamp`` documentation: "This
+        # may raise ``OverflowError``, if the timestamp is out of the range of
+        # values supported by the platform C localtime() function, and ``OSError``
+        # on localtime() failure. It's common for this to be restricted to years
+        # from 1970 through 2038."
+        return _EPOCH_ZERO + datetime.timedelta(seconds=value)
 
 
 def parse_timestamp(value):
@@ -993,17 +974,23 @@ def parse_timestamp(value):
     This will return a ``datetime.datetime`` object.
 
     """
-    tzinfo_options = get_tzinfo_options()
-    for tzinfo in tzinfo_options:
-        try:
-            return _parse_timestamp_with_tzinfo(value, tzinfo)
-        except (OSError, OverflowError) as e:
-            logger.debug(
-                'Unable to parse timestamp with "%s" timezone info.',
-                tzinfo.__name__,
-                exc_info=e,
-            )
-    raise RuntimeError(f'Unable to parse timestamp {value!r}')
+    if isinstance(value, (int, float)):
+        # Possibly an epoch time.
+        return _epoch_seconds_to_datetime(value)
+
+    # Possibly something we can cast to an epoch time and convert.
+    try:
+        return _epoch_seconds_to_datetime(float(value))
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        # In certain cases, a timestamp marked with GMT can be parsed into a
+        # different time zone, so here we provide a context which will
+        # enforce that GMT == UTC.
+        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
+    except (TypeError, ValueError) as e:
+        raise ValueError(f'Invalid timestamp "{value}": {e}')
 
 
 def parse_to_aware_datetime(value):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -19,7 +19,6 @@ from botocore.compat import (
     compat_shell_split,
     ensure_bytes,
     get_md5,
-    get_tzinfo_options,
     total_seconds,
     unquote_str,
 )
@@ -206,15 +205,6 @@ class ShellSplitTestRunner:
     def assert_raises(self, s, exception_cls, platform):
         with pytest.raises(exception_cls):
             compat_shell_split(s, platform)
-
-
-class TestTimezoneOperations(unittest.TestCase):
-    def test_get_tzinfo_options(self):
-        options = get_tzinfo_options()
-        self.assertTrue(len(options) > 0)
-
-        for tzinfo in options:
-            self.assertIsInstance(tzinfo(), datetime.tzinfo)
 
 
 class TestCRTIntegration(unittest.TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -598,18 +598,6 @@ class TestParseTimestamps(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_timestamp('invalid date')
 
-    def test_parse_timestamp_fails_with_bad_tzinfo(self):
-        mock_tzinfo = mock.Mock()
-        mock_tzinfo.__name__ = 'tzinfo'
-        mock_tzinfo.side_effect = OSError()
-        mock_get_tzinfo_options = mock.MagicMock(return_value=(mock_tzinfo,))
-
-        with mock.patch(
-            'botocore.utils.get_tzinfo_options', mock_get_tzinfo_options
-        ):
-            with self.assertRaises(RuntimeError):
-                parse_timestamp(0)
-
     @contextmanager
     def mocked_fromtimestamp_that_raises(self, exception_type):
         class MockDatetime(datetime.datetime):


### PR DESCRIPTION
As mentioned in https://github.com/boto/botocore/pull/2972#issuecomment-1811904061:

`_parse_timestamp_with_tzinfo()` already attempts to do `fromtimestamp` parsing; not much point in doing that work twice for timestamp-esque strings (and failing in the cases described in #2972).

In the subsequent commits, this PR also cleans up remaining seemingly Useless Use of `tzlocal`.