### PR TITLE
Remove deprecated IOError

### DIFF
--- a/botocore/vendored/requests/exceptions.py
+++ b/botocore/vendored/requests/exceptions.py
@@ -10,7 +10,7 @@ This module contains the set of Requests' exceptions.
 from .packages.urllib3.exceptions import HTTPError as BaseHTTPError
 
 
-class RequestException(IOError):
+class RequestException(OSError):
     """There was an ambiguous exception that occurred while handling your
     request."""
 


### PR DESCRIPTION
Since python version 3.3 IOError has been deprecated and merged (with various different errors) into OSError.