### PR TITLE
explicit virtual addressing presigning bug

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -838,4 +838,6 @@ def _should_use_global_endpoint(client):
             and client.meta.config.region_name == 'us-east-1'
         ):
             return False
+        if s3_config.get('addressing_style') == 'virtual':
+            return False
     return True

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -3506,6 +3506,46 @@ def _addressing_for_presigned_url_test_cases():
         expected_url="https://s3.us-west-2.amazonaws.com/foo.b.biz/key",
     )
 
+    # virtual style addressing expicitly requested always uses
+    # regional endpoints except for us-east-1 and aws-global
+    yield dict(
+        region="us-west-2",
+        bucket="bucket",
+        key="key",
+        signature_version="s3",
+        s3_config={"addressing_style": "virtual"},
+        expected_url="https://bucket.s3.us-west-2.amazonaws.com/key",
+    )
+    yield dict(
+        region="us-east-2",
+        bucket="bucket",
+        key="key",
+        signature_version="s3v4",
+        s3_config={"addressing_style": "virtual"},
+        expected_url="https://bucket.s3.us-east-2.amazonaws.com/key",
+    )
+    yield dict(
+        region="us-west-2",
+        bucket="bucket",
+        key="key",
+        s3_config={"addressing_style": "virtual"},
+        expected_url="https://bucket.s3.us-west-2.amazonaws.com/key",
+    )
+    yield dict(
+        region="us-east-1",
+        bucket="bucket",
+        key="key",
+        s3_config={"addressing_style": "virtual"},
+        expected_url="https://bucket.s3.amazonaws.com/key",
+    )
+    yield dict(
+        region="aws-global",
+        bucket="bucket",
+        key="key",
+        s3_config={"addressing_style": "virtual"},
+        expected_url="https://bucket.s3.amazonaws.com/key",
+    )
+
 
 @pytest.mark.parametrize(
     "test_case", _addressing_for_presigned_url_test_cases()


### PR DESCRIPTION
This addresses a bug introduced with the endpoints refactor from last year. Previously, if a customer had explicitly set `addressing_style` to `virtual` in their s3 config, the SDK [ignored the `use_global_endpoint` setting on the request context](https://github.com/boto/botocore/blob/febc9ea08510c8b90c67b456f85a9faa64a69c69/botocore/utils.py#L2600-L2602). Instead, it would use the [endpoint URL from the legacy endpoint resolver](https://github.com/boto/botocore/blob/baf3fd32ee93017903f24e8946cd6c11b506962c/botocore/signers.py#L667) which was always regionalized except in the cases of `aws-global` and `us-east-1`. This has caused some issues where a regional endpoint is expected when using signature version 4 to sign URLs.

It was likely missed during the refactor because it followed a confusing codepath that was decoupled from `_should_use_global_endpoint`. For clarity and simplicity, a simple check is added to the function.