### PR TITLE
Replace deprecated datetime.datetime.utcnow() call with datetime.datetime.now(datetime.UTC)

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -416,7 +416,7 @@ class SigV4Auth(BaseSigner):
     def add_auth(self, request):
         if self.credentials is None:
             raise NoCredentialsError()
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
@@ -554,7 +554,7 @@ class S3ExpressPostAuth(S3ExpressAuth):
     REQUIRES_IDENTITY_CACHE = True
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}
@@ -813,7 +813,7 @@ class S3SigV4PostAuth(SigV4Auth):
     """
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}

--- a/botocore/crt/auth.py
+++ b/botocore/crt/auth.py
@@ -56,7 +56,7 @@ class CrtSigV4Auth(BaseSigner):
 
         # Use utcnow() because that's what gets mocked by tests, but set
         # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
+        datetime_now = datetime.datetime.now(datetime.UTC).replace(
             tzinfo=datetime.timezone.utc
         )
 
@@ -253,7 +253,7 @@ class CrtSigV4AsymAuth(BaseSigner):
 
         # Use utcnow() because that's what gets mocked by tests, but set
         # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
+        datetime_now = datetime.datetime.now(datetime.UTC).replace(
             tzinfo=datetime.timezone.utc
         )
 

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -152,7 +152,7 @@ class Endpoint:
     def _calculate_ttl(
         self, response_received_timestamp, date_header, read_timeout
     ):
-        local_timestamp = datetime.datetime.utcnow()
+        local_timestamp = datetime.datetime.now(datetime.UTC)
         date_conversion = datetime.datetime.strptime(
             date_header, "%a, %d %b %Y %H:%M:%S %Z"
         )
@@ -169,7 +169,7 @@ class Endpoint:
         has_streaming_input = retries_context.get('has_streaming_input')
         if response_date_header and not has_streaming_input:
             try:
-                response_received_timestamp = datetime.datetime.utcnow()
+                response_received_timestamp = datetime.datetime.now(datetime.UTC)
                 retries_context['ttl'] = self._calculate_ttl(
                     response_received_timestamp,
                     response_date_header,

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -607,7 +607,7 @@ class S3PostPresigner:
         policy = {}
 
         # Create an expiration date for the policy
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         expire_date = datetime_now + datetime.timedelta(seconds=expires_in)
         policy['expiration'] = expire_date.strftime(botocore.auth.ISO8601)
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -673,7 +673,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
             )
             jitter = random.randint(120, 600)  # Between 2 to 10 minutes
             refresh_interval_with_jitter = refresh_interval + jitter
-            current_time = datetime.datetime.utcnow()
+            current_time = datetime.datetime.now(datetime.UTC)
             refresh_offset = datetime.timedelta(
                 seconds=refresh_interval_with_jitter
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -573,7 +573,7 @@ class FreezeTime(ContextDecorator):
 
     def __init__(self, module, date=None):
         if date is None:
-            date = datetime.datetime.utcnow()
+            date = datetime.datetime.now(datetime.UTC)
         self.date = date
         self.datetime_patcher = mock.patch.object(
             module, 'datetime', mock.Mock(wraps=datetime.datetime)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3051,7 +3051,7 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
 
     def _get_datetime(self, dt=None, offset=None, offset_func=operator.add):
         if dt is None:
-            dt = datetime.datetime.utcnow()
+            dt = datetime.datetime.now(datetime.UTC)
         if offset is not None:
             dt = offset_func(dt, offset)
 


### PR DESCRIPTION
### Description
Replace deprecated datetime.datetime.utcnow() call with datetime.datetime.now(datetime.UTC).

[From the Python 3.12 readme](https://docs.python.org/3/whatsnew/3.12.html):

>[datetime](https://docs.python.org/3/library/datetime.html#module-datetime): [datetime.datetime](https://docs.python.org/3/library/datetime.html#datetime.datetime)’s [utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) and [utcfromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call [now()](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) and [fromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) with the tz parameter set to [datetime.UTC](https://docs.python.org/3/library/datetime.html#datetime.UTC). (Contributed by Paul Ganssle in [gh-103857](https://github.com/python/cpython/issues/103857).)

Fixes https://github.com/boto/botocore/issues/3088.