### PR TITLE
Remove non-existing arguments from docstring

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 class HTTPHeaders(HTTPMessage):
     pass
 
+
 from urllib.parse import (
     quote,
     urlencode,
@@ -54,12 +55,14 @@ from io import IOBase as _IOBase
 from base64 import encodebytes
 from email.utils import formatdate
 from itertools import zip_longest
+
 file_type = _IOBase
 zip = zip
 
 # In python3, unquote takes a str() object, url decodes it,
 # then takes the bytestring and decodes it to utf-8.
 unquote_str = unquote_plus
+
 
 def set_socket_timeout(http_response, timeout):
     """Set the timeout of the socket from an HTTPResponse.
@@ -69,14 +72,17 @@ def set_socket_timeout(http_response, timeout):
     """
     http_response._fp.fp.raw._sock.settimeout(timeout)
 
+
 def accepts_kwargs(func):
     # In python3.4.1, there's backwards incompatible
     # changes when using getargspec with functools.partials.
     return inspect.getfullargspec(func)[2]
 
+
 def ensure_unicode(s, encoding=None, errors=None):
     # NOOP in Python 3, because every string is already unicode
     return s
+
 
 def ensure_bytes(s, encoding='utf-8', errors='strict'):
     if isinstance(s, str):
@@ -158,9 +164,6 @@ def get_md5(*args, **kwargs):
     """
     Attempts to get an md5 hashing object.
 
-    :param raise_error_if_unavailable: raise an error if md5 is unavailable on
-        this system. If False, None will be returned if it is unavailable.
-    :type raise_error_if_unavailable: bool
     :param args: Args to pass to the MD5 constructor
     :param kwargs: Key word arguments to pass to the MD5 constructor
     :return: An MD5 hashing object if available. If it is unavailable, None
@@ -345,6 +348,7 @@ UNSAFE_URL_CHARS = frozenset('\t\r\n')
 # Detect if gzip is available for use
 try:
     import gzip
+
     HAS_GZIP = True
 except ImportError:
     HAS_GZIP = False

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -37,7 +37,6 @@ logger = logging.getLogger(__name__)
 class HTTPHeaders(HTTPMessage):
     pass
 
-
 from urllib.parse import (
     quote,
     urlencode,
@@ -55,14 +54,12 @@ from io import IOBase as _IOBase
 from base64 import encodebytes
 from email.utils import formatdate
 from itertools import zip_longest
-
 file_type = _IOBase
 zip = zip
 
 # In python3, unquote takes a str() object, url decodes it,
 # then takes the bytestring and decodes it to utf-8.
 unquote_str = unquote_plus
-
 
 def set_socket_timeout(http_response, timeout):
     """Set the timeout of the socket from an HTTPResponse.
@@ -72,17 +69,14 @@ def set_socket_timeout(http_response, timeout):
     """
     http_response._fp.fp.raw._sock.settimeout(timeout)
 
-
 def accepts_kwargs(func):
     # In python3.4.1, there's backwards incompatible
     # changes when using getargspec with functools.partials.
     return inspect.getfullargspec(func)[2]
 
-
 def ensure_unicode(s, encoding=None, errors=None):
     # NOOP in Python 3, because every string is already unicode
     return s
-
 
 def ensure_bytes(s, encoding='utf-8', errors='strict'):
     if isinstance(s, str):
@@ -348,7 +342,6 @@ UNSAFE_URL_CHARS = frozenset('\t\r\n')
 # Detect if gzip is available for use
 try:
     import gzip
-
     HAS_GZIP = True
 except ImportError:
     HAS_GZIP = False


### PR DESCRIPTION
Removes non-existing parameters from a docstring for a method; these parameters existed as a part of development of the function, but were removed in subsequent reviews of the original PR that introduced the method.  The docstring was not updated with the code.  