### PR TITLE
Update issue creation link in README

### DIFF
--- a/.changes/next-release/enhancement-README-37611.json
+++ b/.changes/next-release/enhancement-README-37611.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "documentation",
+  "description": "Updates the GitHub issue creation link in our README"
+}

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ applicable for ``botocore``:
 
 * Ask a question on `Stack Overflow <https://stackoverflow.com/>`__ and tag it with `boto3 <https://stackoverflow.com/questions/tagged/boto3>`__
 * Open a support ticket with `AWS Support <https://console.aws.amazon.com/support/home#/>`__
-* If it turns out that you may have found a bug, please `open an issue <https://github.com/boto/botocore/issues/new>`__
+* If it turns out that you may have found a bug, please `open an issue <https://github.com/boto/botocore/issues/new/choose>`__
 
 
 Contributing


### PR DESCRIPTION
This PR updates the botocore README to point to https://github.com/boto/botocore/issues/new/choose which allows users to create a new issue using custom templates instead of the basic https://github.com/boto/botocore/issues/new