### PR TITLE
add support for memoryview objects

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -528,7 +528,7 @@ class AWSPreparedRequest:
         # the entire body contents again if we need to).
         # Same case if the body is a string/bytes/bytearray type.
 
-        non_seekable_types = (bytes, str, bytearray)
+        non_seekable_types = (bytes, str, bytearray, memoryview)
         if self.body is None or isinstance(self.body, non_seekable_types):
             return
         try:

--- a/botocore/compress.py
+++ b/botocore/compress.py
@@ -71,7 +71,7 @@ def _is_compressible_type(request_dict):
     if isinstance(body, dict):
         body = urlencode(body, doseq=True, encoding='utf-8').encode('utf-8')
         request_dict['body'] = body
-    is_supported_type = isinstance(body, (str, bytes, bytearray))
+    is_supported_type = isinstance(body, (str, bytes, bytearray, memoryview))
     return is_supported_type or hasattr(body, 'read')
 
 
@@ -90,7 +90,7 @@ def _get_body_size(body):
 def _gzip_compress_body(body):
     if isinstance(body, str):
         return gzip_compress(body.encode('utf-8'))
-    elif isinstance(body, (bytes, bytearray)):
+    elif isinstance(body, (bytes, bytearray, memoryview)):
         return gzip_compress(body)
     elif hasattr(body, 'read'):
         if hasattr(body, 'seek') and hasattr(body, 'tell'):

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -64,7 +64,7 @@ class BaseChecksum:
         fileobj.seek(start_position)
 
     def handle(self, body):
-        if isinstance(body, (bytes, bytearray)):
+        if isinstance(body, (bytes, bytearray, memoryview)):
             self.update(body)
         else:
             self._handle_fileobj(body)

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3239,7 +3239,7 @@ def get_encoding_from_headers(headers, default='ISO-8859-1'):
 
 
 def calculate_md5(body, **kwargs):
-    if isinstance(body, (bytes, bytearray)):
+    if isinstance(body, (bytes, bytearray, memoryview)):
         binary_md5 = _calculate_md5_from_bytes(body)
     else:
         binary_md5 = _calculate_md5_from_file(body)

--- a/botocore/validate.py
+++ b/botocore/validate.py
@@ -318,7 +318,7 @@ class ParamValidator:
         range_check(name, param, shape, 'invalid range', errors)
 
     def _validate_blob(self, param, shape, errors, name):
-        if isinstance(param, (bytes, bytearray, str)):
+        if isinstance(param, (bytes, bytearray, str, memoryview)):
             return
         elif hasattr(param, 'read'):
             # File like objects are also allowed for blob types.
@@ -328,7 +328,13 @@ class ParamValidator:
                 name,
                 'invalid type',
                 param=param,
-                valid_types=[str(bytes), str(bytearray), 'file-like object'],
+                valid_types=[
+                    str(bytes),
+                    str(bytearray),
+                    str(str),
+                    str(memoryview),
+                    'file-like object',
+                ],
             )
 
     @type_check(valid_types=(bool,))

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -426,6 +426,11 @@ class TestS3Objects(TestS3BaseWithBucket):
         body = bytearray(body_bytes)
         self.assert_can_put_object(body)
 
+    def test_can_put_object_memoryview(self):
+        body_bytes = b'*' * 1024
+        body = memoryview(body_bytes)
+        self.assert_can_put_object(body)
+
     def test_get_object_stream_wrapper(self):
         self.create_object('foobarbaz', body='body contents')
         response = self.client.get_object(

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -222,6 +222,13 @@ class TestAWSRequest(unittest.TestCase):
         # assert the request body doesn't change after reset_stream is called
         self.assertEqual(self.prepared_request.body, contents)
 
+    def test_can_reset_stream_handles_memoryview(self):
+        contents = memoryview(b'notastream')
+        self.prepared_request.body = contents
+        self.prepared_request.reset_stream()
+        # assert the request body doesn't change after reset_stream is called
+        self.assertEqual(self.prepared_request.body, contents)
+
     def test_can_reset_stream(self):
         contents = b'foobarbaz'
         with open(self.filename, 'wb') as f:

--- a/tests/unit/test_compress.py
+++ b/tests/unit/test_compress.py
@@ -160,6 +160,10 @@ def assert_request_compressed(request_dict, expected_body):
             OP_WITH_COMPRESSION,
         ),
         (
+            _request_dict(memoryview(REQUEST_BODY)),
+            OP_WITH_COMPRESSION,
+        ),
+        (
             _request_dict(headers={'Content-Encoding': 'identity'}),
             OP_WITH_COMPRESSION,
         ),

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1391,6 +1391,14 @@ class TestAddMD5(BaseMD5Test):
             request_dict['headers']['Content-MD5'], 'OFj2IjCsPJFfMAxmQxLGPw=='
         )
 
+    def test_add_md5_with_memoryview_object(self):
+        request_dict = {'body': memoryview(b'foobar'), 'headers': {}}
+        self.md5_digest.return_value = b'8X\xf6"0\xac<\x91_0\x0cfC\x12\xc6?'
+        conditionally_calculate_md5(request_dict)
+        self.assertEqual(
+            request_dict['headers']['Content-MD5'], 'OFj2IjCsPJFfMAxmQxLGPw=='
+        )
+
     def test_skip_md5_when_flexible_checksum_context(self):
         request_dict = {
             'body': io.BytesIO(b'foobar'),

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -254,6 +254,30 @@ class TestHttpChecksumHandlers(unittest.TestCase):
         apply_request_checksum(request)
         self.assertIn("x-amz-checksum-crc32", request["headers"])
 
+    def test_apply_request_checksum_flex_header_bytearray(self):
+        request = self._build_request(bytearray(b""))
+        request["context"]["checksum"] = {
+            "request_algorithm": {
+                "in": "header",
+                "algorithm": "crc32",
+                "name": "x-amz-checksum-crc32",
+            }
+        }
+        apply_request_checksum(request)
+        self.assertIn("x-amz-checksum-crc32", request["headers"])
+
+    def test_apply_request_checksum_flex_header_memoryview(self):
+        request = self._build_request(memoryview(b""))
+        request["context"]["checksum"] = {
+            "request_algorithm": {
+                "in": "header",
+                "algorithm": "crc32",
+                "name": "x-amz-checksum-crc32",
+            }
+        }
+        apply_request_checksum(request)
+        self.assertIn("x-amz-checksum-crc32", request["headers"])
+
     def test_apply_request_checksum_flex_header_readable(self):
         request = self._build_request(BytesIO(b""))
         request["context"]["checksum"] = {

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -636,6 +636,14 @@ class TestValidateTypeBlob(BaseTestValidate):
         error_msg = errors.generate_report()
         self.assertEqual(error_msg, '')
 
+    def test_validates_memoryview(self):
+        errors = self.get_validation_error_message(
+            given_shapes=self.shapes,
+            input_params={'Blob': memoryview(b'12345')},
+        )
+        error_msg = errors.generate_report()
+        self.assertEqual(error_msg, '')
+
     def test_validates_file_like_object(self):
         value = io.BytesIO(b'foo')
 


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/3423

I know it's been labeled needs-discussion, but I wanted to check if it really was as easy as just modifying a couple `isinstance` checks, and after trying it and seeing it really was just that I thought I might as well write up a PR for it.

I've been working on https://github.com/piskvorky/smart_open/issues/380 and it would save significant amounts of memory if it was possible to directly pass [`memoryview`](https://docs.python.org/3/library/stdtypes.html#memoryview) objects to botocore.

I opted to modify all cases where I found `isinstance.*bytearray` in the code, even though https://github.com/boto/boto3/issues/3423 only directly needs the modifications in `validate.py` and `utils.py` afaik. But I see no reason not to accept it in all those places.

I also noticed there was no test for `bytearray` + httpchecksum, and the error message for type validation didn't include `str` despite the `isinstance` line above accepting it, so quickly fixed those as well.