### PR TITLE
Fix pytest-8.0.0 test failures due to incorrect `pytest.warns()`

### DIFF
--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -781,9 +781,7 @@ class TestSessionComponent(BaseSessionTest):
             self.session._get_internal_component('internal'), component
         )
         with self.assertRaises(ValueError):
-            # get_component has been deprecated to the public
-            with pytest.warns(DeprecationWarning):
-                self.session.get_component('internal')
+            self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -795,9 +795,7 @@ class TestSessionComponent(BaseSessionTest):
             self.session._get_internal_component('internal'), component
         )
         with self.assertRaises(ValueError):
-            # get_component has been deprecated to the public
-            with pytest.warns(DeprecationWarning):
-                self.session.get_component('internal')
+            self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(


### PR DESCRIPTION
Remove two incorrect `pytest.warns()` invocations
for `.get_component('internal')`, in order to fix test failures with pytest 8.0.0.  This version of pytest fixes `pytest.warns()` to work inside `pytest.raises()`, and therefore causes the tests to fail because the warning is not emitted when `get_component()` raises `ValueError`.