### PR TITLE
Add experimental environment variable to opt out of 100 continue with empty body

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -346,6 +346,14 @@ def add_expect_header(model, params, **kwargs):
     if 'body' in params:
         body = params['body']
         if hasattr(body, 'read'):
+            check_body = utils.ensure_boolean(
+                os.environ.get(
+                    'BOTO_EXPERIMENTAL__NO_EMPTY_CONTINUE',
+                    '',
+                )
+            )
+            if check_body and utils.determine_content_length(body) == 0:
+                return
             # Any file like object will use an expect 100-continue
             # header regardless of size.
             logger.debug("Adding expect 100 continue header to request.")

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -349,7 +349,7 @@ def add_expect_header(model, params, **kwargs):
             check_body = utils.ensure_boolean(
                 os.environ.get(
                     'BOTO_EXPERIMENTAL__NO_EMPTY_CONTINUE',
-                    '',
+                    False,
                 )
             )
             if check_body and utils.determine_content_length(body) == 0:


### PR DESCRIPTION
Adds the header `BOTO_EXPERIMENTAL__NO_EMPTY_CONTINUE`; when enabled, we will make a best effort to inspect the size of the body and only add the 100 continue header if the body is non-empty.  

Note: this feature is marked as experimental and the functionality and may be altered or removed in a minor patch without warning.  Users relying on this feature should strictly pin their botocore version.