### PR TITLE
Fix documentation for ec2 import-key-pair for how to properly base64-encode keyfiles

### DIFF
--- a/botocore/data/ec2/2016-11-15/service-2.json
+++ b/botocore/data/ec2/2016-11-15/service-2.json
@@ -33658,7 +33658,7 @@
         },
         "PublicKeyMaterial":{
           "shape":"Blob",
-          "documentation":"<p>The public key. For API calls, the text must be base64-encoded. For command line tools, base64 encoding is performed for you.</p>",
+          "documentation":"<p>The public key. For API calls, the text must be base64-encoded. For command line tools, you can use `fileb://<keyfile_path>` to perform the base64-encoding.</p>",
           "locationName":"publicKeyMaterial"
         },
         "TagSpecifications":{


### PR DESCRIPTION
Fixes the long-running confusion around base64-encoding and CLI V2:
* https://github.com/aws/aws-cli/issues/41
* https://github.com/aws/aws-cli/issues/4969

AWS CLI V2 changed how it processes binary input types.

This means the CLI documentation was now incorrect - the CLI won't automatically do the base64 encoding for you when calling `aws ec2 import-key-pair` - you need to explicitly call `fileb://` yourself.

Very small doc change, which should hopefully reduce confusion - let me know if I've missed something.