### PR TITLE
fix: tcp_keepalive socket

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -548,37 +548,54 @@ class ClientArgsCreator:
             scoped_config.get("tcp_keepalive", False)
         )
         # Enables TCP Keepalive if specified in client config object or shared config file.
-        if not client_keepalive and not scoped_keepalive:
-            return socket_options
+        if client_keepalive or scoped_keepalive:
+            socket_options.append((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1))
+        return socket_options
 
-        seconds_in_a_minute = 60
+    def _compute_socket_options(self, scoped_config, client_config=None):
+        # This disables Nagle's algorithm and is the default socket options in urllib3.
+        socket_options = [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
 
-        client_read_timeout = client_config and client_config.read_timeout
-        scoped_read_timeout = scoped_config.get("read_timeout", None)
-
-        read_timeout = (
-            scoped_read_timeout if scoped_read_timeout else client_read_timeout
-        ) or seconds_in_a_minute
-
-        maximum_keepalive_probes = int(read_timeout / seconds_in_a_minute) or 1
-        keep_idle = (
-            seconds_in_a_minute
-            if read_timeout > seconds_in_a_minute
-            else read_timeout
+        # Enables TCP Keepalive if specified in client config object or shared config file.
+        client_keepalive = client_config and client_config.tcp_keepalive
+        scoped_keepalive = scoped_config and self._ensure_boolean(
+            scoped_config.get("tcp_keepalive", False)
         )
+        if client_keepalive or scoped_keepalive:
+            socket_options.append((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1))
 
-        socket_options.extend(
-            [
-                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, keep_idle),
-                (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, keep_idle),
+        # Enables TCP Keepidle if specified in client config object or shared config file.
+        client_keepidle = client_config and client_config.tcp_keepidle
+        scoped_keepidle = scoped_config and scoped_config.get("tcp_keepidle", False)
+        if client_keepidle or scoped_keepidle:
+            socket_options.append(
                 (
                     socket.IPPROTO_TCP,
-                    socket.TCP_KEEPCNT,
-                    maximum_keepalive_probes,
-                ),
-            ],
-        )
+                    socket.TCP_KEEPIDLE,
+                    client_keepidle or scoped_keepidle,
+                )
+            )
+
+        # Enables TCP Keepinvtl if specified in client config object or shared config file.
+        client_keepintvl = client_config and client_config.tcp_keepintvl
+        scoped_keepintvl = scoped_config and scoped_config.get("tcp_keepintvl", False)
+        if client_keepintvl or scoped_keepintvl:
+            socket_options.append(
+                (
+                    socket.IPPROTO_TCP,
+                    socket.TCP_KEEPINTVL,
+                    client_keepintvl or scoped_keepintvl,
+                )
+            )
+
+        # Enables TCP Keepcnt if specified in client config object or shared config file.
+        client_keepcnt = client_config and client_config.tcp_keepcnt
+        scoped_keepcnt = scoped_config and scoped_config.get("tcp_keepcnt", False)
+        if client_keepcnt or scoped_keepcnt:
+            socket_options.append(
+                (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, client_keepcnt or scoped_keepcnt)
+            )
+
         return socket_options
 
     def _compute_retry_config(self, config_kwargs):

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -210,6 +210,24 @@ class Config:
 
         Defaults to False.
 
+    :type tcp_keepidle: int
+    :param tcp_keepidle: Time (in seconds) the connection must remain idle 
+        before sending keepalives.
+
+        Defaults to None.
+    
+    :type tcp_keepintvl: int
+    :param tcp_keepintvl: Time (in seconds) between individual keepalive 
+        probes.
+
+        Defaults to None.
+
+    :type tcp_keepcnt: int
+    :param tcp_keepcnt: Number of unacknowledged probes before the connection 
+        is considered dead.
+
+        Defaults to None.
+
     :type request_min_compression_size_bytes: int
     :param request_min_compression_size_bytes: The minimum size in bytes that a
         request body should be to trigger compression. All requests with
@@ -313,6 +331,9 @@ class Config:
             ('ignore_configured_endpoint_urls', None),
             ('defaults_mode', None),
             ('tcp_keepalive', None),
+            ('tcp_keepidle', None),
+            ('tcp_keepintvl', None),
+            ('tcp_keepcnt', None),
             ('request_min_compression_size_bytes', None),
             ('disable_request_compression', None),
             ('client_context_params', None),

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -247,7 +247,12 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+                + [
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
+                ],
             )
 
     def test_tcp_keepalive_not_specified(self):
@@ -272,7 +277,12 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+                + [
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
+                ],
             )
             self.call_get_client_args(
                 scoped_config={'tcp_keepalive': 'false'},
@@ -281,7 +291,41 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+                + [
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
+                ],
+            )
+            self.call_get_client_args(
+                scoped_config={'tcp_keepalive': 'false'},
+                client_config=Config(tcp_keepalive=True, read_timeout=30),
+            )
+            self.assert_create_endpoint_call(
+                m,
+                socket_options=self.default_socket_options
+                + [
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
+                ],
+                timeout=(60, 30),
+            )
+            self.call_get_client_args(
+                scoped_config={'tcp_keepalive': 'false', 'read_timeout': 900},
+                client_config=Config(tcp_keepalive=True),
+            )
+            self.assert_create_endpoint_call(
+                m,
+                socket_options=self.default_socket_options
+                + [
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 15),
+                ],
             )
 
     def test_tcp_keepalive_explicitly_disabled(self):
@@ -299,7 +343,12 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+                + [
+                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
+                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
+                ],
             )
 
     def test_client_config_has_use_dualstack_endpoint_flag(self):

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -247,12 +247,7 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [
-                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
-                ],
+                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
             )
 
     def test_tcp_keepalive_not_specified(self):
@@ -277,12 +272,7 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [
-                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
-                ],
+                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
             )
             self.call_get_client_args(
                 scoped_config={'tcp_keepalive': 'false'},
@@ -291,41 +281,7 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [
-                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
-                ],
-            )
-            self.call_get_client_args(
-                scoped_config={'tcp_keepalive': 'false'},
-                client_config=Config(tcp_keepalive=True, read_timeout=30),
-            )
-            self.assert_create_endpoint_call(
-                m,
-                socket_options=self.default_socket_options
-                + [
-                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
-                ],
-                timeout=(60, 30),
-            )
-            self.call_get_client_args(
-                scoped_config={'tcp_keepalive': 'false', 'read_timeout': 900},
-                client_config=Config(tcp_keepalive=True),
-            )
-            self.assert_create_endpoint_call(
-                m,
-                socket_options=self.default_socket_options
-                + [
-                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 15),
-                ],
+                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
             )
 
     def test_tcp_keepalive_explicitly_disabled(self):
@@ -343,12 +299,7 @@ class TestCreateClientArgs(unittest.TestCase):
             self.assert_create_endpoint_call(
                 m,
                 socket_options=self.default_socket_options
-                + [
-                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
-                    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 1),
-                ],
+                + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
             )
 
     def test_client_config_has_use_dualstack_endpoint_flag(self):
@@ -853,6 +804,98 @@ class TestCreateClientArgs(unittest.TestCase):
         )
         with self.assertRaises(exceptions.InvalidConfigError):
             self.call_get_client_args()
+    
+    def test_tcp_keepalive_legacy_enabled(self):
+        config = Config(tcp_keepalive=True)
+        opts = self.args_create._compute_socket_options({}, config)
+        self.assertEqual(
+            opts,
+            self.default_socket_options + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+        )
+
+
+    def test_tcp_keepalive_legacy_disabled(self):
+        config = Config(tcp_keepalive=False)
+        opts = self.args_create._compute_socket_options({}, config)
+        self.assertEqual(opts, self.default_socket_options)
+
+
+    def test_tcp_keepalive_enabled_with_advanced_options(self):
+        config = Config(
+            tcp_keepalive=True,
+            tcp_keepidle=120,
+            tcp_keepintvl=30,
+            tcp_keepcnt=5,
+        )
+        opts = self.args_create._compute_socket_options({}, config)
+        self.assertIn((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 120), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5), opts)
+
+
+    def test_tcp_keepalive_enabled_with_partial_advanced_options(self):
+        config = Config(
+            tcp_keepalive=True,
+            tcp_keepidle=120,
+            tcp_keepcnt=7,
+        )
+        opts = self.args_create._compute_socket_options({}, config)
+        self.assertIn((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 120), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 7), opts)
+        # TCP_KEEPINTVL should not be set if not specified
+        self.assertTrue(all(opt[1] != socket.TCP_KEEPINTVL for opt in opts))
+
+
+    def test_tcp_keepalive_enabled_scoped_config_only(self):
+        scoped_config = {"tcp_keepalive": "true"}
+        opts = self.args_create._compute_socket_options(scoped_config, None)
+        self.assertEqual(
+            opts,
+            self.default_socket_options + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+        )
+
+
+    def test_tcp_keepalive_disabled_scoped_config(self):
+        scoped_config = {"tcp_keepalive": "false"}
+        opts = self.args_create._compute_socket_options(scoped_config, None)
+        self.assertEqual(opts, self.default_socket_options)
+
+
+    def test_tcp_keepalive_enabled_with_scoped_and_client_config(self):
+        scoped_config = {"tcp_keepalive": "true"}
+        config = Config(tcp_keepalive=True)
+        opts = self.args_create._compute_socket_options(scoped_config, config)
+        self.assertIn((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1), opts)
+
+
+    def test_tcp_keepalive_enabled_with_scoped_and_partial_advanced_options(self):
+        scoped_config = {"tcp_keepalive": "true", "tcp_keepidle": 120}
+        opts = self.args_create._compute_socket_options(scoped_config, None)
+        self.assertIn((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 120), opts)
+
+        self.assertTrue(
+            all(
+                opt[1] != socket.TCP_KEEPINTVL and opt[1] != socket.TCP_KEEPCNT
+                for opt in opts
+            )
+        )
+
+
+    def test_tcp_keepalive_enabled_with_scoped_and_advanced_client_config(self):
+        scoped_config = {"tcp_keepalive": "true"}
+        config = Config(
+            tcp_keepalive=True,
+            tcp_keepidle=100,
+            tcp_keepintvl=20,
+            tcp_keepcnt=3,
+        )
+        opts = self.args_create._compute_socket_options(scoped_config, config)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 100), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 20), opts)
+        self.assertIn((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3), opts)
 
 
 class TestEndpointResolverBuiltins(unittest.TestCase):


### PR DESCRIPTION
When using the botocore.config.Config option tcp_keepalive=True, the TCP socket is configured with the keep alive socket option (`socket.SO_KEEPALIVE`). By default, Linux sets the TCP keepalive time parameter to 7200 seconds, which exceeds the AWS NAT Gateway default timeout of 350 seconds [[source](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-troubleshooting.html#nat-gateway-troubleshooting-timeout)].

This limitation leads to an inability to receive a response from a Lambda function under the following conditions:

- The Lambda function is invoked in synchronous mode (InvocationType='RequestResponse').
- The invocation occurs within VPC where a NAT gateway is required to access the internet from a private subnet.
- The execution time of the Lambda function exceeds 350 seconds.

Therefore, by configuring `socket.TCP_KEEPIDLE`, `socket.TCP_KEEPINTVL` and `socket.TCP_KEEPCNT` when `tcp_keepalive` during the `_compute_socket_options` function call we can overcome this limitation. 

`socket.IPPROTO_TCP` is used to support cross platform compatibility. 

The code submitted automatically calculates these values based on the read timeout. Another option would be to have supplied in the scope/client object.

Fixes issues: https://github.com/boto/boto3/issues/2424, https://github.com/boto/boto3/issues/2510 and https://github.com/boto/botocore/issues/2916.

Fargate recently had a similar solution implemented to support this use case: https://aws.amazon.com/blogs/containers/announcing-additional-linux-controls-for-amazon-ecs-tasks-on-aws-fargate/.