### PR TITLE
Move urllib3 2.x pin for Python 3.10+

### DIFF
--- a/.changes/next-release/enhancement-urllib3-72501.json
+++ b/.changes/next-release/enhancement-urllib3-72501.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``urllib3``",
+  "description": "Added support for urllib3 2.2.1+ in Python 3.10+"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ requires_dist =
     jmespath>=0.7.1,<2.0.0
     python-dateutil>=2.1,<3.0.0
     urllib3>=1.25.4,<1.27; python_version<"3.10"
-    urllib3>=1.25.4,<2.1; python_version>="3.10"
+    urllib3>=1.25.4,!=2.2.0,<3; python_version>="3.10"
 
 [options.extras_require]
 crt = awscrt==0.19.19

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,11 @@ def find_version(*file_paths):
 requires = [
     'jmespath>=0.7.1,<2.0.0',
     'python-dateutil>=2.1,<3.0.0',
+    # Prior to Python 3.10, Python doesn't require openssl 1.1.1
+    # but urllib3 2.0+ does. This means all botocore users will be
+    # broken by default on Amazon Linux 2 and AWS Lambda without this pin.
     'urllib3>=1.25.4,<1.27 ; python_version < "3.10"',
-    'urllib3>=1.25.4,<2.1 ; python_version >= "3.10"',
+    'urllib3>=1.25.4,!=2.2.0,<3 ; python_version >= "3.10"',
 ]
 
 extras_require = {


### PR DESCRIPTION
This PR will move our pin for Python 3.10+ to allow the full range of releases for urllib3 2.x. This should unblock further upgrades and unblock other projects from moving pins for these version ranges. This should resolve #3138 in the next release of Botocore once merged.