### PR TITLE
Make bucket name injection for S3Express more generic

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -461,7 +461,7 @@ class ClientCreator:
 
     def _inject_s3_input_parameters(self, params, context, **kwargs):
         context['input_params'] = {}
-        inject_parameters = ['Bucket', 'Delete', 'Key', 'Prefix']
+        inject_parameters = ('Bucket', 'Delete', 'Key', 'Prefix')
         for inject_parameter in inject_parameters:
             if inject_parameter in params:
                 context['input_params'][inject_parameter] = params[

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -400,6 +400,9 @@ class ClientCreator:
         self._set_s3_presign_signature_version(
             client.meta, client_config, scoped_config
         )
+        client.meta.events.register(
+            'before-parameter-build.s3', self._inject_s3_input_parameters
+        )
 
     def _register_s3_control_events(
         self,
@@ -455,6 +458,15 @@ class ClientCreator:
         client_meta.events.register(
             'choose-signer.s3', self._default_s3_presign_to_sigv2
         )
+
+    def _inject_s3_input_parameters(self, params, context, **kwargs):
+        context['input_params'] = {}
+        inject_parameters = ['Bucket', 'Delete', 'Key', 'Prefix']
+        for inject_parameter in inject_parameters:
+            if inject_parameter in params:
+                context['input_params'][inject_parameter] = params[
+                    inject_parameter
+                ]
 
     def _default_s3_presign_to_sigv2(self, signature_version, **kwargs):
         """

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1668,22 +1668,15 @@ class S3ExpressIdentityResolver:
     def register(self, event_emitter=None):
         logger.debug('Registering S3Express Identity Resolver')
         emitter = event_emitter or self._client.meta.events
-        emitter.register(
-            'before-parameter-build.s3', self.inject_signing_cache_key
-        )
         emitter.register('before-call.s3', self.apply_signing_cache_key)
         emitter.register('before-sign.s3', self.resolve_s3express_identity)
-
-    def inject_signing_cache_key(self, params, context, **kwargs):
-        if 'Bucket' in params:
-            context['S3Express'] = {'bucket_name': params['Bucket']}
 
     def apply_signing_cache_key(self, params, context, **kwargs):
         endpoint_properties = context.get('endpoint_properties', {})
         backend = endpoint_properties.get('backend', None)
 
         # Add cache key if Bucket supplied for s3express request
-        bucket_name = context.get('S3Express', {}).get('bucket_name')
+        bucket_name = context.get('input_params', {}).get('Bucket')
         if backend == 'S3Express' and bucket_name is not None:
             context.setdefault('signing', {})
             context['signing']['cache_key'] = bucket_name


### PR DESCRIPTION
Abstracts the s3 Express bucket name from the context to be generically usable as well as adding additional keys to be stored