### PR TITLE
Move 3.8 and 3.9 builds back to macos-13

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -16,6 +16,15 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        # Python 3.8 and 3.9 do not run on m1 hardware which is now standard for
+        # macOS-latest.
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        exclude:
+        - { python-version: "3.8", os: "macos-latest" }
+        - { python-version: "3.9", os: "macos-latest" }
+        include:
+        - { python-version: "3.8", os: "macos-13" }
+        - { python-version: "3.9", os: "macos-13" }
 
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,15 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        # Python 3.8 and 3.9 do not run on m1 hardware which is now standard for
+        # macOS-latest.
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        exclude:
+        - { python-version: "3.8", os: "macos-latest" }
+        - { python-version: "3.9", os: "macos-latest" }
+        include:
+        - { python-version: "3.8", os: "macos-13" }
+        - { python-version: "3.9", os: "macos-13" }
 
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608


### PR DESCRIPTION
This PR addresses a recent change in GHA infrastructure to move macos-latest to macos 14 on m1 hardware. This platform doesn't have supported Python 3.8 or Python 3.9 runners, so we'll need to pin those back to macos-13.