### PR TITLE
docs: Fix a typo in DynamoDB export_table_to_point_in_time

### DIFF
--- a/botocore/data/dynamodb/2012-08-10/service-2.json
+++ b/botocore/data/dynamodb/2012-08-10/service-2.json
@@ -3663,7 +3663,7 @@
         },
         "ExportViewType":{
           "shape":"ExportViewType",
-          "documentation":"<p>The view type that was chosen for the export. Valid values are <code>NEW_AND_OLD_IMAGES</code> and <code>NEW_IMAGES</code>. The default value is <code>NEW_AND_OLD_IMAGES</code>.</p>"
+          "documentation":"<p>The view type that was chosen for the export. Valid values are <code>NEW_AND_OLD_IMAGES</code> and <code>NEW_IMAGE</code>. The default value is <code>NEW_AND_OLD_IMAGES</code>.</p>"
         }
       },
       "documentation":"<p>Optional object containing the parameters specific to an incremental export.</p>"


### PR DESCRIPTION
This commit fixes a typo in DynamoDB export_table_to_point_in_time page by replacing NEW_IMAGES with NEW_IMAGE