### PR TITLE
Fix calculation of truncated binary exponential backoff

### DIFF
--- a/.changes/next-release/bugfix-retries-19921.json
+++ b/.changes/next-release/bugfix-retries-19921.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "retries",
+  "description": "Fix backoff calculation for truncated binary exponential backoff (`#3178 <https://github.com/boto/botocore/issues/3178>`__)"
+}

--- a/botocore/retries/standard.py
+++ b/botocore/retries/standard.py
@@ -263,7 +263,7 @@ class ExponentialBackoff(BaseRetryBackoff):
         This class implements truncated binary exponential backoff
         with jitter::
 
-            t_i = min(rand(0, 1) * 2 ** attempt, MAX_BACKOFF)
+            t_i = rand(0, 1) * min(2 ** attempt, MAX_BACKOFF)
 
         where ``i`` is the request attempt (0 based).
 
@@ -271,8 +271,8 @@ class ExponentialBackoff(BaseRetryBackoff):
         # The context.attempt_number is a 1-based value, but we have
         # to calculate the delay based on i based a 0-based value.  We
         # want the first delay to just be ``rand(0, 1)``.
-        return min(
-            self._random() * (self._base ** (context.attempt_number - 1)),
+        return self._random() * min(
+            (self._base ** (context.attempt_number - 1)),
             self._max_backoff,
         )
 


### PR DESCRIPTION
The intent of the jitter in the exponential backoff calculation is to create a uniform random distribution.  However, the current calculation applies the truncation after the randomization.  This results in clamped/truncated distribution which is not what we want.

This only affects cases where the calculated backoff exceeds the `MAX_BACKOFF`, and is more pronounced the more you exceed `MAX_BACKOFF`. The current default of 3 max attempts is well below this value so this change has no effect on the default behavior.  A user would have to have a max attempts of at least 6 before this started to affect backoff times.

As an example, this is a distribution based on 10,000 events with `attempt=10` (x-axis is backoff time in seconds):

![current](https://github.com/boto/botocore/assets/368057/0967e991-1385-4117-9b42-a4b58fa4e19c)

And here's the distribution with 10,000 events with `attempt=10` with the changes in this PR:

![fixed](https://github.com/boto/botocore/assets/368057/f2a678cb-8883-4315-8224-79a9cb607da9)