### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.changes/next-release/enhancement-Python-365.json
+++ b/.changes/next-release/enhancement-Python-365.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Added provisional Python 3.13 support to Botocore"
+}

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # Python 3.8 and 3.9 do not run on m1 hardware which is now standard for
         # macOS-latest.
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '${{ matrix.python-version }}'
+          cache: 'pip'
+          allow-prereleases: true
       - name: Install dependencies and CRT
         run: |
           python scripts/ci/install --extras crt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # Python 3.8 and 3.9 do not run on m1 hardware which is now standard for
         # macOS-latest.
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '${{ matrix.python-version }}'
+          cache: 'pip'
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python scripts/ci/install

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py38,py39,py310,py311,py312,py313
 
 skipsdist = True
 


### PR DESCRIPTION
This PR will start provisional testing on the recently released beta for Python 3.13. This will be used to catch any issues early before the official release in October.