### PR TITLE
Resolve Python 3.12 `.utcnow()` `DeprecationWarning`

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -421,7 +421,9 @@ class SigV4Auth(BaseSigner):
     def add_auth(self, request):
         if self.credentials is None:
             raise NoCredentialsError()
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
@@ -559,7 +561,9 @@ class S3ExpressPostAuth(S3ExpressAuth):
     REQUIRES_IDENTITY_CACHE = True
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}
@@ -818,7 +822,9 @@ class S3SigV4PostAuth(SigV4Auth):
     """
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}

--- a/botocore/crt/auth.py
+++ b/botocore/crt/auth.py
@@ -54,11 +54,7 @@ class CrtSigV4Auth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        # Use utcnow() because that's what gets mocked by tests, but set
-        # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime_now = datetime.datetime.now(datetime.timezone.utc)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)
@@ -251,11 +247,7 @@ class CrtSigV4AsymAuth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        # Use utcnow() because that's what gets mocked by tests, but set
-        # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime_now = datetime.datetime.now(datetime.timezone.utc)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -150,7 +150,9 @@ class Endpoint:
     def _calculate_ttl(
         self, response_received_timestamp, date_header, read_timeout
     ):
-        local_timestamp = datetime.datetime.utcnow()
+        local_timestamp = datetime.datetime.now(datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         date_conversion = datetime.datetime.strptime(
             date_header, "%a, %d %b %Y %H:%M:%S %Z"
         )
@@ -167,7 +169,9 @@ class Endpoint:
         has_streaming_input = retries_context.get('has_streaming_input')
         if response_date_header and not has_streaming_input:
             try:
-                response_received_timestamp = datetime.datetime.utcnow()
+                response_received_timestamp = datetime.datetime.now(
+                    datetime.timezone.utc
+                ).replace(tzinfo=None)
                 retries_context['ttl'] = self._calculate_ttl(
                     response_received_timestamp,
                     response_date_header,

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -612,7 +612,9 @@ class S3PostPresigner:
         policy = {}
 
         # Create an expiration date for the policy
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         expire_date = datetime_now + datetime.timedelta(seconds=expires_in)
         policy['expiration'] = expire_date.strftime(botocore.auth.ISO8601)
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -671,7 +671,9 @@ class InstanceMetadataFetcher(IMDSFetcher):
             )
             jitter = random.randint(120, 600)  # Between 2 to 10 minutes
             refresh_interval_with_jitter = refresh_interval + jitter
-            current_time = datetime.datetime.utcnow()
+            current_time = datetime.datetime.now(
+                datetime.timezone.utc
+            ).replace(tzinfo=None)
             refresh_offset = datetime.timedelta(
                 seconds=refresh_interval_with_jitter
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -567,12 +567,14 @@ class FreezeTime(ContextDecorator):
     :param module: reference to imported module to patch (e.g. botocore.auth.datetime)
 
     :type date: datetime.datetime
-    :param date: datetime object specifying the output for utcnow()
+    :param date: datetime object specifying the output for now()
     """
 
     def __init__(self, module, date=None):
         if date is None:
-            date = datetime.datetime.utcnow()
+            date = datetime.datetime.now(datetime.timezone.utc).replace(
+                tzinfo=None
+            )
         self.date = date
         self.datetime_patcher = mock.patch.object(
             module, 'datetime', mock.Mock(wraps=datetime.datetime)
@@ -580,7 +582,7 @@ class FreezeTime(ContextDecorator):
 
     def __enter__(self, *args, **kwargs):
         mock = self.datetime_patcher.start()
-        mock.utcnow.return_value = self.date
+        mock.now.return_value = self.date
 
     def __exit__(self, *args, **kwargs):
         self.datetime_patcher.stop()

--- a/tests/functional/test_ec2.py
+++ b/tests/functional/test_ec2.py
@@ -98,7 +98,7 @@ class TestCopySnapshotCustomization(BaseSessionTest):
             mock.Mock(wraps=datetime.datetime),
         )
         self.mocked_datetime = self.datetime_patch.start()
-        self.mocked_datetime.utcnow.return_value = self.now
+        self.mocked_datetime.now.return_value = self.now
 
     def tearDown(self):
         super().tearDown()

--- a/tests/functional/test_lex.py
+++ b/tests/functional/test_lex.py
@@ -34,7 +34,7 @@ class TestLex(BaseSessionTest):
         timestamp = datetime(2017, 3, 22, 0, 0)
 
         with mock.patch('botocore.auth.datetime.datetime') as _datetime:
-            _datetime.utcnow.return_value = timestamp
+            _datetime.now.return_value = timestamp
             self.http_stubber.add_response(body=b'{}')
             with self.http_stubber:
                 self.client.post_content(**params)

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -114,7 +114,7 @@ class TestRetryHeader(BaseRetryTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = datetime_patcher.start()
-        mocked_datetime.utcnow.side_effect = utcnow_side_effects
+        mocked_datetime.now.side_effect = utcnow_side_effects
 
         client = self.session.create_client(
             'dynamodb', self.region, config=client_config

--- a/tests/functional/test_s3express.py
+++ b/tests/functional/test_s3express.py
@@ -108,7 +108,6 @@ class TestS3ExpressAuth:
 class TestS3ExpressIdentityCache:
     def test_default_s3_express_cache(self, default_s3_client, mock_datetime):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
 
         identity_cache = S3ExpressIdentityCache(
             default_s3_client,
@@ -126,7 +125,6 @@ class TestS3ExpressIdentityCache:
         self, default_s3_client, mock_datetime
     ):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
         bucket = 'my_bucket'
 
         identity_cache = S3ExpressIdentityCache(
@@ -151,7 +149,6 @@ class TestS3ExpressIdentityCache:
         self, default_s3_client, mock_datetime
     ):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
         bucket = 'my_bucket'
         other_bucket = 'other_bucket'
 
@@ -204,7 +201,7 @@ class TestS3ExpressRequests:
         )
 
     def test_create_bucket(self, default_s3_client, mock_datetime):
-        mock_datetime.utcnow.return_value = DATE
+        mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
             stubber.add_response()
@@ -228,7 +225,6 @@ class TestS3ExpressRequests:
         self._assert_standard_sigv4_signature(stubber.requests[0].headers)
 
     def test_get_object(self, default_s3_client, mock_datetime):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
@@ -250,7 +246,6 @@ class TestS3ExpressRequests:
     def test_cache_with_multiple_requests(
         self, default_s3_client, mock_datetime
     ):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
@@ -275,7 +270,6 @@ class TestS3ExpressRequests:
     def test_delete_objects_injects_correct_checksum(
         self, default_s3_client, mock_datetime
     ):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -39,7 +39,7 @@ class TestSTSPresignedUrl(BaseSessionTest):
     def test_presigned_url_contains_no_content_type(self):
         timestamp = datetime(2017, 3, 22, 0, 0)
         with mock.patch('botocore.auth.datetime.datetime') as _datetime:
-            _datetime.utcnow.return_value = timestamp
+            _datetime.now.return_value = timestamp
             url = self.client.generate_presigned_url('get_caller_identity', {})
 
         # There should be no 'content-type' in x-amz-signedheaders

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -30,7 +30,7 @@ class BaseTestWithFixedDate(unittest.TestCase):
         self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
         self.datetime_patch = mock.patch('botocore.auth.datetime.datetime')
         self.datetime_mock = self.datetime_patch.start()
-        self.datetime_mock.utcnow.return_value = self.fixed_date
+        self.datetime_mock.now.return_value = self.fixed_date
         self.datetime_mock.strptime.return_value = self.fixed_date
 
     def tearDown(self):
@@ -521,9 +521,9 @@ class TestSigV4(unittest.TestCase):
             'datetime',
             mock.Mock(wraps=datetime.datetime),
         ) as mock_datetime:
-            original_utcnow = datetime.datetime(2014, 1, 1, 0, 0)
+            original_now = datetime.datetime(2014, 1, 1, 0, 0)
 
-            mock_datetime.utcnow.return_value = original_utcnow
+            mock_datetime.now.return_value = original_now
             # Go through the add_auth process once. This will attach
             # a timestamp to the request at the beginning of auth.
             auth.add_auth(request)
@@ -531,7 +531,7 @@ class TestSigV4(unittest.TestCase):
             # Ensure the date is in the Authorization header
             self.assertIn('20140101', request.headers['Authorization'])
             # Now suppose the utc time becomes the next day all of a sudden
-            mock_datetime.utcnow.return_value = datetime.datetime(
+            mock_datetime.now.return_value = datetime.datetime(
                 2014, 1, 2, 0, 0
             )
             # Smaller methods like the canonical request and string_to_sign
@@ -796,9 +796,7 @@ class TestSigV4Presign(BasePresignTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
-            2014, 1, 1, 0, 0
-        )
+        mocked_datetime.now.return_value = datetime.datetime(2014, 1, 1, 0, 0)
 
     def tearDown(self):
         self.datetime_patcher.stop()
@@ -1100,9 +1098,7 @@ class TestS3SigV4Post(BaseS3PresignPostTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
-            2014, 1, 1, 0, 0
-        )
+        mocked_datetime.now.return_value = datetime.datetime(2014, 1, 1, 0, 0)
 
     def tearDown(self):
         self.datetime_patcher.stop()

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -128,7 +128,7 @@ class TestRefreshableCredentials(TestCredentials):
 
     def test_refresh_needed(self):
         # The expiry time was set for 30 minutes ago, so if we
-        # say the current time is utcnow(), then we should need
+        # say the current time is now(), then we should need
         # a refresh.
         self.mock_time.return_value = datetime.now(tzlocal())
         self.assertTrue(self.creds.refresh_needed())
@@ -315,7 +315,9 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -749,7 +751,9 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -867,7 +871,9 @@ class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
         mock_loader_cls.assert_called_with('/some/path/token.jwt')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         cache_key = 'c29461feeacfbed43017d20612606ff76abc073d'
@@ -2037,7 +2043,9 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(expiry_time, '2016-11-06T01:30:00UTC')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         self.fake_config['profiles']['development']['role_arn'] = 'myrole'
 
@@ -2066,7 +2074,9 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(creds.token, 'baz-cached')
 
     def test_chain_prefers_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         # The profile we will be using has a cache entry, but the profile it

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -691,7 +691,7 @@ class TestS3PostPresigner(BaseSignerTest):
         self.datetime_mock = self.datetime_patch.start()
         self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
         self.fixed_delta = datetime.timedelta(seconds=3600)
-        self.datetime_mock.datetime.utcnow.return_value = self.fixed_date
+        self.datetime_mock.datetime.now.return_value = self.fixed_date
         self.datetime_mock.timedelta.return_value = self.fixed_delta
 
     def tearDown(self):
@@ -1146,7 +1146,7 @@ class TestGenerateDBAuthToken(BaseSignerTest):
         clock = datetime.datetime(2016, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             result = generate_db_auth_token(
                 self.client, hostname, port, username
             )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3045,7 +3045,9 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
 
     def _get_datetime(self, dt=None, offset=None, offset_func=operator.add):
         if dt is None:
-            dt = datetime.datetime.utcnow()
+            dt = datetime.datetime.now(datetime.timezone.utc).replace(
+                tzinfo=None
+            )
         if offset is not None:
             dt = offset_func(dt, offset)
 


### PR DESCRIPTION
This PR resolves the Python 3.12 `DeprecationWarning` thrown when botocore calls `datetime.datetime.utcnow()`.

@nateprewitt, this PR differs from other attempts posted to this repo by _ensuring `datetime` instances are still timezone-unaware_:


```python
import datetime

# Current form: timezone-unaware, raises DeprecationWarnings in >=py3.12
datetime.datetime.utcnow()

# Common transformation -- makes the instance timezone-aware!
datetime.datetime.now(datetime.timezone.utc)

# This PR's approach -- ensures instance is still timezone-unaware
datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
```

I ran this through CI in my own repo and [it passes cleanly](https://github.com/kurtmckee/pr-botocore/actions).

Fixes boto/boto3#3889.