### PR TITLE
Add S3 tests to ensure dot segments are preserved

### DIFF
--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -3686,3 +3686,44 @@ class TestParameterInjection(BaseS3OperationTest):
             request.context['input_params']['Bucket'], self.BUCKET
         )
         self.assertEqual(request.context['input_params']['Key'], self.KEY)
+
+
+@pytest.mark.parametrize(
+    "bucket, key, expected_path, expected_hostname",
+    [
+        (
+            "mybucket",
+            "../key.txt",
+            "/../key.txt",
+            "mybucket.s3.us-west-2.amazonaws.com",
+        ),
+        (
+            "mybucket",
+            "foo/../key.txt",
+            "/foo/../key.txt",
+            "mybucket.s3.us-west-2.amazonaws.com",
+        ),
+        (
+            "mybucket",
+            "foo/../../key.txt",
+            "/foo/../../key.txt",
+            "mybucket.s3.us-west-2.amazonaws.com",
+        ),
+    ],
+)
+def test_dot_segments_preserved_in_url_path(
+    patched_session, bucket, key, expected_path, expected_hostname
+):
+    s3 = patched_session.create_client(
+        's3',
+        'us-west-2',
+        config=Config(
+            s3={"addressing_style": "virtual"},
+        ),
+    )
+    with ClientHTTPStubber(s3) as http_stubber:
+        http_stubber.add_response()
+        s3.get_object(Bucket=bucket, Key=key)
+        url_parts = urlsplit(http_stubber.requests[0].url)
+        assert url_parts.path == expected_path
+        assert url_parts.hostname == expected_hostname


### PR DESCRIPTION
### Summary

This PR adds s3 specific tests to ensures the following:
* Leading dot segments in the key value are preserved in the URL path.
  * Example: `../key.txt`
* Embedded dot segments in the key value are preserved in the URL path.
  * * Example: `foo/../key.txt`
