### PR TITLE
feat: add paginator for opensearch

### DIFF
--- a/botocore/data/opensearch/2021-01-01/paginators-1.json
+++ b/botocore/data/opensearch/2021-01-01/paginators-1.json
@@ -1,3 +1,97 @@
 {
-  "pagination": {}
+  "pagination": {
+    "DescribeDomainAutoTunes": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "AutoTunes"
+    },
+    "DescribeInboundConnections": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Connections"
+    },
+    "DescribeOutboundConnections": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Connections"
+    },
+    "DescribePackages": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "PackageDetailsList"
+    },
+    "DescribeReservedInstanceOfferings": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ReservedInstanceOfferings"
+    },
+    "DescribeReservedInstances": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ReservedInstances"
+    },
+    "GetUpgradeHistory": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "UpgradeHistories"
+    },
+    "ListDomainMaintenances": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DomainMaintenances"
+    },
+    "ListDomainsForPackage": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DomainPackageDetailsList"
+    },
+    "ListInstanceTypeDetails": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "InstanceTypeDetails"
+    },
+    "ListPackagesForDomain": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "DomainPackageDetailsList"
+    },
+    "ListScheduledActions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "ScheduledActions"
+    },
+    "ListVersions": {
+      "input_token": "NextToken",
+      "limit_key": "MaxResults",
+      "output_token": "NextToken",
+      "result_key": "Versions"
+    },
+    "ListVpcEndpointAccess": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "AuthorizedPrincipalList"
+    },
+    "ListVpcEndpoints": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "VpcEndpointSummaryList"
+    },
+    "ListVpcEndpointsForDomain": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "result_key": "VpcEndpointSummaryList"
+    }
+  }
 }


### PR DESCRIPTION
With this change, we can use paginator for the OpenSearch APIs with Max Results limit, instead of looping with NextToken manually.

```python
# a trivial example
instances = []
opensearch = boto3.client('opensearch')
paginator = opensearch.get_paginator('describe_reserved_instances')
for page in paginator.paginate():
    instances.extend(page['ReservedInstances'])
```

fixes: #3245