### PR TITLE
Add ClientError getters for common attributes

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -553,6 +553,31 @@ class ClientError(Exception):
         # module. So at the very least return a ClientError back.
         return ClientError, (self.response, self.operation_name)
 
+    @property
+    def code(self):
+        """The error code returned by the AWS service."""
+        return self.response.get('Error', {}).get('Code', 'Unknown')
+
+    @property
+    def message(self):
+        """The error message returned by the AWS service."""
+        return self.response.get('Error', {}).get('Message', 'Unknown')
+
+    @property
+    def request_id(self):
+        """The request ID returned by the AWS service."""
+        return self.response.get('ResponseMetadata').get('RequestId')
+
+    @property
+    def http_status_code(self):
+        """The HTTP status code returned by the AWS service."""
+        return self.response.get('ResponseMetadata', {}).get('HTTPStatusCode')
+
+    @property
+    def http_headers(self):
+        """The HTTP headers returned by the AWS service."""
+        return self.response.get('ResponseMetadata', {}).get('HTTPHeaders', {})
+
 
 class EventStreamError(ClientError):
     pass

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -23,6 +23,17 @@ def test_client_error_can_handle_missing_code_or_message():
     response = {'Error': {}}
     expect = 'An error occurred (Unknown) when calling the blackhole operation: Unknown'
     assert str(exceptions.ClientError(response, 'blackhole')) == expect
+    assert exceptions.ClientError.code == 'Unknown'
+    assert exceptions.ClientError.message == 'Unknown'
+
+
+def test_client_error_can_handle_missing_response_metadata():
+    response = {'Error': {}}
+    assert (
+        exceptions.ClientError(response, 'blackhole').http_status_code is None
+    )
+    assert exceptions.ClientError(response, 'blackhole').request_id is None
+    assert exceptions.ClientError(response, 'blackhole').http_headers == {}
 
 
 def test_client_error_has_operation_name_set():


### PR DESCRIPTION
Most errors returned from AWS APIs are captured in the ClientError class. When writing Python code that interacts with the AWS APIs, you frequently want to parse the specific error and/or error message.

The boto3 documentation [describes](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html) how this can be accomplished by parsing the error code:

```python
from botocore.exceptions import ClientError
import boto3

client = boto3.client('kinesis')

try:
    client.describe_stream(StreamName='myDataStream')
except ClientError as error:
    if error.response['Error']['Code'] == 'LimitExceededException':
        logger.warn('API call limit exceeded; backing off and retrying...')
    else:
        raise error
```

Looking at the [botocore unit tests for exceptions](https://github.com/boto/botocore/blob/1fd6e6945f22e5f9494d8582ed60db560c03bbb6/tests/unit/test_exceptions.py#L22) there is a test case that checks if ClientError exceptions still work even if the Code or Message is not available. 

That seems to indicate that this is an actual possibility which means the above suggested code could unexpectedly fail. To properly evaluate an error, the code should be something like this:

```python
    if error.response.get('Error', {}).get('Code') == 'LimitExceededException':
```

This is even more verbose than the boto3 documentation indicates, and might impact existing customers.

There are additional fields available that provide even more details of the error that can be useful. Extract from the boto3 documentation gives the following example.

```python
    if err.response['Error']['Code'] == 'InternalError': # Generic error
        # We grab the message, request ID, and HTTP code to give to customer support
        print('Error Message: {}'.format(err.response['Error']['Message']))
        print('Request ID: {}'.format(err.response['ResponseMetadata']['RequestId']))
        print('Http code: {}'.format(err.response['ResponseMetadata']['HTTPStatusCode']))
```

It's great the information is available, but it's not easy to find the appropriate dictionary key names without looking at the documentation.

This pull requests adds getters (property) to the ClientError class to extract these values. The added benefit is that IDE's will be able to autocomplete the getters and inline documentation. It will also lead to less verbose code for users of the library.

Here's an example of how it improves readability for the users of the library:

```python
from botocore.exceptions import ClientError
import boto3

client = boto3.client('kinesis')

try:
    client.describe_stream(StreamName='myDataStream')
except ClientError as error:
    if error.code == 'LimitExceededException':
        print('API call limit exceeded; backing off and retrying...')
        print(error.message)
        print(error.request_id)
        print(error.http_status_code)
        print(error.http_headers)
    else:
        raise error
```
