### PR TITLE
Add option to set the source IP address

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -147,6 +147,7 @@ class ClientArgsCreator:
             socket_options=socket_options,
             client_cert=new_config.client_cert,
             proxies_config=new_config.proxies_config,
+            source_address=new_config.source_address,
         )
 
         serializer = botocore.serialize.create_serializer(
@@ -271,6 +272,7 @@ class ClientArgsCreator:
                 sigv4a_signing_region_set=(
                     client_config.sigv4a_signing_region_set
                 ),
+                source_address=client_config.source_address,
             )
         self._compute_retry_config(config_kwargs)
         self._compute_connect_timeout(config_kwargs)

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -235,6 +235,13 @@ class Config:
         specified service will be ignored.
 
         Defaults to None.
+
+    :type source_address: tuple
+    :param source_address: A tuple with 2 values (host, port) for the socket to
+        bind to as its source address before connecting. If host or port are '' or 0
+        respectively the OS default behaviour will be used.
+
+        Defaults to None.
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -264,6 +271,7 @@ class Config:
             ('disable_request_compression', None),
             ('client_context_params', None),
             ('sigv4a_signing_region_set', None),
+            ('source_address', None),
         ]
     )
 

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -401,6 +401,7 @@ class EndpointCreator:
         socket_options=None,
         client_cert=None,
         proxies_config=None,
+        source_address=None,
     ):
         if not is_valid_endpoint_url(
             endpoint_url
@@ -420,6 +421,7 @@ class EndpointCreator:
             socket_options=socket_options,
             client_cert=client_cert,
             proxies_config=proxies_config,
+            source_address=source_address,
         )
 
         return Endpoint(

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -293,6 +293,7 @@ class URLLib3Session:
         socket_options=None,
         client_cert=None,
         proxies_config=None,
+        source_address=None,
     ):
         self._verify = verify
         self._proxy_config = ProxyConfiguration(
@@ -319,6 +320,7 @@ class URLLib3Session:
         self._socket_options = socket_options
         if socket_options is None:
             self._socket_options = []
+        self._source_address = source_address
         self._proxy_managers = {}
         self._manager = PoolManager(**self._get_pool_manager_kwargs())
         self._manager.pool_classes_by_scheme = self._pool_classes_by_scheme
@@ -342,6 +344,8 @@ class URLLib3Session:
             'cert_file': self._cert_file,
             'key_file': self._key_file,
         }
+        if self._source_address:
+            pool_manager_kwargs['source_address'] = self._source_address
         pool_manager_kwargs.update(**extra_kwargs)
         return pool_manager_kwargs
 

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -117,6 +117,7 @@ class TestCreateClientArgs(unittest.TestCase):
             'proxies_config': None,
             'socket_options': self.default_socket_options,
             'client_cert': None,
+            'source_address': None,
         }
         call_kwargs.update(**override_kwargs)
         mock_endpoint.return_value.create_endpoint.assert_called_with(

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -488,3 +488,15 @@ class TestEndpointCreator(unittest.TestCase):
         )
         session_args = self.mock_session.call_args[1]
         self.assertEqual(session_args.get('socket_options'), socket_options)
+
+    def test_source_address(self):
+        source_address = ('192.168.1.1', 1234)
+        self.creator.create_endpoint(
+            self.service_model,
+            region_name='us-west-2',
+            endpoint_url='https://example.com',
+            http_session_cls=self.mock_session,
+            source_address=source_address,
+        )
+        session_args = self.mock_session.call_args[1]
+        self.assertEqual(session_args.get('source_address'), source_address)

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -447,6 +447,25 @@ class TestURLLib3Session(unittest.TestCase):
             socket_options=socket_options,
         )
 
+    def test_session_forwards_source_address_to_pool_manager(self):
+        source_address = ('192.168.1.1', 1234)
+        URLLib3Session(source_address=source_address)
+        self.assert_pool_manager_call(source_address=source_address)
+
+    def test_session_forwards_source_address_to_proxy_manager(self):
+        proxies = {'http': 'http://proxy.com'}
+        source_address = ('192.168.1.1', 1234)
+        session = URLLib3Session(
+            proxies=proxies,
+            source_address=source_address,
+        )
+        session.send(self.request.prepare())
+        self.assert_proxy_manager_call(
+            proxies['http'],
+            proxy_headers={},
+            source_address=source_address,
+        )
+
     def make_request_with_error(self, error):
         self.connection.urlopen.side_effect = error
         session = URLLib3Session()


### PR DESCRIPTION
I was looking into how I could set the source IP address and port when using boto3 but could not find a way. It turns out that I was not the only one looking into that. See #2742.

I looked into the botocore code and tried to add this functionality. Please let me know if something is not right.

I tested my code by creating a simple s3 listing where I specified my config with the new `source_address` parameter.

```python3
boto_config = Config(source_address=('...', 0))

s3 = boto3.client('s3', config=boto_config)
response = s3.list_objects_v2(Bucket='...', Prefix='...')

for content in response['Contents']:
    print(content['Key'])
```

Then I captured all packets using wireshark and ran my script. Confirmed on wireshark that the traffic to AWS was using the source address I specified in the `Config` object.