### PR TITLE
feat: clamp PageSize to metadata-defined min/max

### DIFF
--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -687,6 +687,10 @@ class Paginator:
                     page_size = str(page_size)
             else:
                 page_size = int(page_size)
+                metadata = limit_key_shape.metadata or {}
+                page_size = max(page_size, metadata.get("min", page_size))
+                page_size = min(page_size, metadata.get("max", page_size))
+
         return {
             'MaxItems': max_items,
             'StartingToken': pagination_config.get('StartingToken', None),


### PR DESCRIPTION
Clamps the user-supplied PageSize in PaginationConfig to the min/max values specified in the limit key's shape metadata. This removes the need for users to manually account for operation-specific PageSize limits (e.g., 50 for list_regions, 1000 for list_images).