### PR TITLE
Remove outdated comment

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -55,10 +55,6 @@ _xform_cache = {
     ('ExecutePartiQLBatch', '_'): 'execute_partiql_batch',
     ('ExecutePartiQLBatch', '-'): 'execute-partiql-batch',
 }
-# The items in this dict represent partial renames to apply globally to all
-# services which might have a matching argument or operation. This way a
-# common mis-translation can be fixed without having to call out each
-# individual case.
 ScalarTypes = ('string', 'integer', 'boolean', 'timestamp', 'float', 'double')
 
 BOTOCORE_ROOT = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This commit removes a comment that references a variable that was [removed in 1.10.47](https://github.com/boto/botocore/commit/715ab124fd9474e6b2d3be76431b72f1161b4e28).