### PR TITLE
Rectify nearly all type errors revealed by `mypy` on current repo

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -61,7 +61,7 @@ BOTOCORE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 # Used to specify anonymous (unsigned) request signature
-class UNSIGNED:
+class _UNSIGNED:
     def __copy__(self):
         return self
 
@@ -69,7 +69,7 @@ class UNSIGNED:
         return self
 
 
-UNSIGNED = UNSIGNED()
+UNSIGNED = _UNSIGNED()
 
 
 def xform_name(name, sep='_', _xform_cache=_xform_cache):

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 import logging
 
+from typing import Dict
+
 from botocore import waiter, xform_name
 from botocore.args import ClientArgsCreator
 from botocore.auth import AUTH_TYPE_MAPS, resolve_auth_type
@@ -864,7 +866,7 @@ class BaseClient:
     # snake_case name, but we need to know the ListObjects form.
     # xform_name() does the ListObjects->list_objects conversion, but
     # we need the reverse mapping here.
-    _PY_TO_OP_NAME = {}
+    _PY_TO_OP_NAME : Dict[str, str] = {}
 
     def __init__(
         self,

--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -35,7 +35,19 @@ logger = logging.getLogger(__name__)
 
 
 class HTTPHeaders(HTTPMessage):
-    pass
+    @classmethod
+    def from_dict(cls, d):
+        new_instance = cls()
+        for key, value in d.items():
+            new_instance[key] = value
+        return new_instance
+
+    @classmethod
+    def from_pairs(cls, pairs):
+        new_instance = cls()
+        for key, value in pairs:
+            new_instance[key] = value
+        return new_instance
 
 from urllib.parse import (
     quote,
@@ -86,9 +98,9 @@ def ensure_bytes(s, encoding='utf-8', errors='strict'):
     raise ValueError(f"Expected str or bytes, received {type(s)}.")
 
 
-try:
+if sys.version_info < (3,9):
     import xml.etree.cElementTree as ETree
-except ImportError:
+else:
     # cElementTree does not exist from Python3.9+
     import xml.etree.ElementTree as ETree
 XMLParseError = ETree.ParseError
@@ -103,27 +115,6 @@ def filter_ssl_warnings():
         category=exceptions.InsecurePlatformWarning,
         module=r".*urllib3\.util\.ssl_",
     )
-
-
-@classmethod
-def from_dict(cls, d):
-    new_instance = cls()
-    for key, value in d.items():
-        new_instance[key] = value
-    return new_instance
-
-
-@classmethod
-def from_pairs(cls, pairs):
-    new_instance = cls()
-    for key, value in pairs:
-        new_instance[key] = value
-    return new_instance
-
-
-HTTPHeaders.from_dict = from_dict
-HTTPHeaders.from_pairs = from_pairs
-
 
 def copy_kwargs(kwargs):
     """

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -18,6 +18,7 @@ import copy
 import logging
 import os
 
+from typing import Callable, Dict, List, Optional, Tuple, Union
 from botocore import utils
 from botocore.exceptions import InvalidConfigError
 
@@ -50,7 +51,12 @@ logger = logging.getLogger(__name__)
 #: found.
 #: NOTE: Fixing the spelling of this variable would be a breaking change.
 #: Please leave as is.
-BOTOCORE_DEFAUT_SESSION_VARIABLES = {
+BOTOCORE_DEFAUT_SESSION_VARIABLES : Dict[str, Tuple[
+    Optional[str],                       # Config key (or None)
+    Union[str, List[str], None],          # Env var or list of env vars
+    Union[str, int, dict, None],          # Default value (None, str, int, or dict)
+    Optional[Callable[[str], Union[str, int, None]]]  # Conversion function (e.g., int) or None
+]] = {
     # logical:  config_file, env_var,        default_value, conversion_func
     'profile': (None, ['AWS_DEFAULT_PROFILE', 'AWS_PROFILE'], None, None),
     'region': ('region', 'AWS_DEFAULT_REGION', None, None),

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -26,6 +26,8 @@ from hashlib import sha1
 from dateutil.parser import parse
 from dateutil.tz import tzlocal, tzutc
 
+from typing import Optional
+
 import botocore.compat
 import botocore.configloader
 from botocore import UNSIGNED
@@ -939,7 +941,7 @@ class AssumeRoleWithWebIdentityCredentialFetcher(
 
 class CredentialProvider:
     # A short name to identify the provider within botocore.
-    METHOD = None
+    METHOD : Optional[str] = None
 
     # A name to identify the provider for use in cross-sdk features like
     # assume role's `credential_source` configuration option. These names
@@ -947,7 +949,7 @@ class CredentialProvider:
     # implemented in botocore MUST prefix their canonical names with
     # 'custom' or we DO NOT guarantee that it will work with any features
     # that this provides.
-    CANONICAL_NAME = None
+    CANONICAL_NAME : Optional[str] = None
 
     def __init__(self, session=None):
         self.session = session

--- a/botocore/crt/auth.py
+++ b/botocore/crt/auth.py
@@ -13,7 +13,7 @@
 
 import datetime
 from io import BytesIO
-
+from typing import Dict, Type
 from botocore.auth import (
     SIGNED_HEADERS_BLACKLIST,
     STREAMING_UNSIGNED_PAYLOAD_TRAILER,
@@ -618,7 +618,7 @@ class CrtS3SigV4QueryAuth(CrtSigV4QueryAuth):
 
 # Defined at the bottom of module to ensure all Auth
 # classes are defined.
-CRT_AUTH_TYPE_MAPS = {
+CRT_AUTH_TYPE_MAPS : Dict[str, Type[BaseSigner]] = {
     'v4': CrtSigV4Auth,
     'v4-query': CrtSigV4QueryAuth,
     'v4a': CrtSigV4AsymAuth,

--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -78,7 +78,7 @@ def get_official_service_name(service_model):
 
 
 _DocumentedShape = namedtuple(
-    'DocumentedShape',
+    '_DocumentedShape',
     [
         'name',
         'type_name',

--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -20,7 +20,7 @@ from botocore.utils import EVENT_ALIASES
 logger = logging.getLogger(__name__)
 
 
-_NodeList = namedtuple('NodeList', ['first', 'middle', 'last'])
+_NodeList = namedtuple('_NodeList', ['first', 'middle', 'last'])
 _FIRST = 0
 _MIDDLE = 1
 _LAST = 2

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -4,6 +4,7 @@ import os.path
 import socket
 import sys
 import warnings
+
 from base64 import b64encode
 
 from urllib3 import PoolManager, Timeout, proxy_from_url
@@ -85,7 +86,7 @@ try:
     from certifi import where
 except ImportError:
 
-    def where():
+    def where() -> str:
         return DEFAULT_CA_BUNDLE
 
 

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -105,12 +105,14 @@ which don't represent the actual service api.
 import logging
 import os
 
+from typing import Callable, Dict, IO
+
 from botocore import BOTOCORE_ROOT
 from botocore.compat import HAS_GZIP, OrderedDict, json
 from botocore.exceptions import DataNotFoundError, UnknownServiceError
 from botocore.utils import deep_merge
 
-_JSON_OPEN_METHODS = {
+_JSON_OPEN_METHODS : Dict[str, Callable[..., IO[str]]] = {
     '.json': open,
 }
 

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -121,6 +121,8 @@ import json
 import logging
 import re
 
+from typing import Optional, Type
+
 from botocore.compat import ETree, XMLParseError
 from botocore.eventstream import EventStream, NoInitialResponseError
 from botocore.utils import (
@@ -200,7 +202,7 @@ class ResponseParser:
     """
 
     DEFAULT_ENCODING = 'utf-8'
-    EVENT_STREAM_PARSER_CLS = None
+    EVENT_STREAM_PARSER_CLS : Optional[Type['BaseEventStreamParser']] = None
 
     def __init__(self, timestamp_parser=None, blob_parser=None):
         if timestamp_parser is None:

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -21,6 +21,7 @@ import copy
 import logging
 import re
 from enum import Enum
+from typing import Dict
 
 from botocore import UNSIGNED, xform_name
 from botocore.auth import AUTH_TYPE_MAPS, HAS_CRT
@@ -46,7 +47,7 @@ from botocore.utils import ensure_boolean, instance_cache
 
 LOG = logging.getLogger(__name__)
 DEFAULT_URI_TEMPLATE = '{service}.{region}.{dnsSuffix}'  # noqa
-DEFAULT_SERVICE_DATA = {'endpoints': {}}
+DEFAULT_SERVICE_DATA : Dict[str, Dict[str, str]] = {'endpoints': {}}
 
 
 class BaseEndpointResolver:


### PR DESCRIPTION
This PR resolves nearly all of the errors produced by `mypy` and passes the same number of tests as before, reducing the number of type errors from 43 to 7 (6 of which are in the vendored code from `six`). This is laying the groundwork for a more extensive effort at annotating this code.

### Before:
```
Found 43 errors in 13 files (checked 74 source files)
```

### After:
```
Found 7 errors in 2 files (checked 74 source files)
```

### Command line:
```
% mypy --install-types --non-interactive --ignore-missing-imports botocore
```

