### PR TITLE
Add support for CRC64NVME when the CRT is available.

### DIFF
--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -109,6 +109,19 @@ class CrtCrc32cChecksum(BaseChecksum):
         return self._int_crc32c.to_bytes(4, byteorder="big")
 
 
+class CrtCrc64NvmeChecksum(BaseChecksum):
+    # Note: This class is only used if the CRT is available
+    def __init__(self):
+        self._int_crc64nvme = 0
+
+    def update(self, chunk):
+        new_checksum = crt_checksums.crc64nvme(chunk, self._int_crc64nvme)
+        self._int_crc64nvme = new_checksum & 0xFFFFFFFFFFFFFFFF
+
+    def digest(self):
+        return self._int_crc64nvme.to_bytes(8, byteorder="big")
+
+
 class Sha1Checksum(BaseChecksum):
     def __init__(self):
         self._checksum = sha1()
@@ -465,12 +478,13 @@ _CHECKSUM_CLS = {
     "sha1": Sha1Checksum,
     "sha256": Sha256Checksum,
 }
-_CRT_CHECKSUM_ALGORITHMS = ["crc32", "crc32c"]
+_CRT_CHECKSUM_ALGORITHMS = ["crc32", "crc32c", "crc64nvme"]
 if HAS_CRT:
     # Use CRT checksum implementations if available
     _CRT_CHECKSUM_CLS = {
         "crc32": CrtCrc32Checksum,
         "crc32c": CrtCrc32cChecksum,
+        "crc64nvme": CrtCrc64NvmeChecksum,
     }
     _CHECKSUM_CLS.update(_CRT_CHECKSUM_CLS)
     # Validate this list isn't out of sync with _CRT_CHECKSUM_CLS keys
@@ -478,4 +492,4 @@ if HAS_CRT:
         name in _CRT_CHECKSUM_ALGORITHMS for name in _CRT_CHECKSUM_CLS.keys()
     )
 _SUPPORTED_CHECKSUM_ALGORITHMS = list(_CHECKSUM_CLS.keys())
-_ALGORITHMS_PRIORITY_LIST = ['crc32c', 'crc32', 'sha1', 'sha256']
+_ALGORITHMS_PRIORITY_LIST = ['crc32c', 'crc32', 'crc64nvme', 'sha1', 'sha256']

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -492,4 +492,4 @@ if HAS_CRT:
         name in _CRT_CHECKSUM_ALGORITHMS for name in _CRT_CHECKSUM_CLS.keys()
     )
 _SUPPORTED_CHECKSUM_ALGORITHMS = list(_CHECKSUM_CLS.keys())
-_ALGORITHMS_PRIORITY_LIST = ['crc32c', 'crc32', 'crc64nvme', 'sha1', 'sha256']
+_ALGORITHMS_PRIORITY_LIST = ['crc64nvme', 'crc32c', 'crc32', 'sha1', 'sha256']


### PR DESCRIPTION
## Overview
This PR adds support for the CRC64NVME checksum algorithm made available in `awscrt-0.22.0`. Similar to the existing CRC32C checskum algorithm, CRC64NVME will only be available when users have installed the optional CRT dependency. If CRT isn't installed and users try to this algorithm, a `MissingDependencyException` will be thrown.
> [!IMPORTANT]
> ~~Tests are currently expected to fail until https://github.com/boto/botocore/pull/3274 is merged.~~ https://github.com/boto/botocore/pull/3274 is merged and tests are passing.

