### PR TITLE
Sigv4a signing region set config bugfix

### DIFF
--- a/.changes/next-release/bugfix-Config-98372.json
+++ b/.changes/next-release/bugfix-Config-98372.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "Config",
-  "description": "Properly picks up sigv4a_signing_region_set settings from environment or config file"
+  "description": "Fixed sigv4a_signing_region_set resolution when set in environment or config file."
 }

--- a/.changes/next-release/bugfix-Config-98372.json
+++ b/.changes/next-release/bugfix-Config-98372.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Config",
+  "description": "Properly picks up sigv4a_signing_region_set settings from environment or config file"
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -276,6 +276,7 @@ class ClientArgsCreator:
         self._compute_connect_timeout(config_kwargs)
         self._compute_user_agent_appid_config(config_kwargs)
         self._compute_request_compression_config(config_kwargs)
+        self._compute_sigv4a_signing_region_set(config_kwargs)
         s3_config = self.compute_s3_config(client_config)
 
         is_s3_service = self._is_s3_service(service_name)
@@ -771,3 +772,14 @@ class ClientArgsCreator:
                 f'maximum length of {USERAGENT_APPID_MAXLEN} characters.'
             )
         config_kwargs['user_agent_appid'] = user_agent_appid
+
+    def _compute_sigv4a_signing_region_set(self, config_kwargs):
+        sigv4a_signing_region_set = config_kwargs.get('sigv4a_signing_region_set')
+        if sigv4a_signing_region_set is None:
+            sigv4a_signing_region_set = self._config_store.get_config_variable(
+                'sigv4a_signing_region_set'
+            )
+        if not sigv4a_signing_region_set:
+            raise botocore.exceptions.InvalidConfigError(
+                error_msg="sigv4a_signing_region_set configuration must be non-empty")
+        config_kwargs['sigv4a_signing_region_set'] = sigv4a_signing_region_set

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -774,12 +774,15 @@ class ClientArgsCreator:
         config_kwargs['user_agent_appid'] = user_agent_appid
 
     def _compute_sigv4a_signing_region_set(self, config_kwargs):
-        sigv4a_signing_region_set = config_kwargs.get('sigv4a_signing_region_set')
+        sigv4a_signing_region_set = config_kwargs.get(
+            'sigv4a_signing_region_set'
+        )
         if sigv4a_signing_region_set is None:
             sigv4a_signing_region_set = self._config_store.get_config_variable(
                 'sigv4a_signing_region_set'
             )
         if not sigv4a_signing_region_set:
             raise botocore.exceptions.InvalidConfigError(
-                error_msg="sigv4a_signing_region_set configuration must be non-empty")
+                error_msg="sigv4a_signing_region_set configuration must be non-empty"
+            )
         config_kwargs['sigv4a_signing_region_set'] = sigv4a_signing_region_set

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -781,8 +781,4 @@ class ClientArgsCreator:
             sigv4a_signing_region_set = self._config_store.get_config_variable(
                 'sigv4a_signing_region_set'
             )
-        if not sigv4a_signing_region_set:
-            raise botocore.exceptions.InvalidConfigError(
-                error_msg="sigv4a_signing_region_set configuration must be non-empty"
-            )
         config_kwargs['sigv4a_signing_region_set'] = sigv4a_signing_region_set

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -276,7 +276,7 @@ class ClientArgsCreator:
         self._compute_connect_timeout(config_kwargs)
         self._compute_user_agent_appid_config(config_kwargs)
         self._compute_request_compression_config(config_kwargs)
-        self._compute_sigv4a_signing_region_set(config_kwargs)
+        self._compute_sigv4a_signing_region_set_config(config_kwargs)
         s3_config = self.compute_s3_config(client_config)
 
         is_s3_service = self._is_s3_service(service_name)
@@ -773,7 +773,7 @@ class ClientArgsCreator:
             )
         config_kwargs['user_agent_appid'] = user_agent_appid
 
-    def _compute_sigv4a_signing_region_set(self, config_kwargs):
+    def _compute_sigv4a_signing_region_set_config(self, config_kwargs):
         sigv4a_signing_region_set = config_kwargs.get(
             'sigv4a_signing_region_set'
         )

--- a/tests/functional/test_auth_config.py
+++ b/tests/functional/test_auth_config.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import pytest
 
+from botocore.config import Config
 from tests import create_session, mock
 
 # In the future, a service may have a list of credentials requirements where one
@@ -77,13 +78,39 @@ def assert_all_requirements_match(auth_config, message):
     assert len(auth_requirements) == 1
 
 
-def test_sigv4a_signing_region_set_config_from_environment():
-    environ = {
-        'AWS_CONFIG_FILE': 'no-exist-foo',
-        'AWS_SIGV4A_SIGNING_REGION_SET': 'foo',
-    }
+@pytest.mark.parametrize(
+    "client_config_val, env_var_val, config_file_val, expected",
+    [
+        ("foo", "bar", "baz", "foo"),
+        ("foo", None, None, "foo"),
+        (None, "foo", "bar", "foo"),
+        (None, None, "foo", "foo"),
+        ("foo", None, "bar", "foo"),
+        (None, None, None, None),
+    ],
+)
+def test_sigv4a_signing_region_set_config_from_environment(
+    client_config_val, env_var_val, config_file_val, expected, tmp_path
+):
+    if config_file_val:
+        tmp_config_file_path = tmp_path / 'config'
+        tmp_config_file_path.write_text(
+            f'[default]\nsigv4a_signing_region_set={config_file_val}\n'
+        )
+        environ = {'AWS_CONFIG_FILE': str(tmp_config_file_path)}
+    else:
+        environ = {'AWS_CONFIG_FILE': "file-does-not-exist"}
+
+    if env_var_val:
+        environ['AWS_SIGV4A_SIGNING_REGION_SET'] = env_var_val
+
+    if client_config_val:
+        config = Config(sigv4a_signing_region_set=client_config_val)
+    else:
+        config = Config()
+
     with mock.patch('os.environ', environ):
         session = create_session()
         session.config_filename = 'no-exist-foo'
-        s3 = session.create_client('s3')
-        assert s3.meta.config.sigv4a_signing_region_set == 'foo'
+        s3 = session.create_client('s3', config=config)
+        assert s3.meta.config.sigv4a_signing_region_set == expected

--- a/tests/functional/test_auth_config.py
+++ b/tests/functional/test_auth_config.py
@@ -86,6 +86,4 @@ def test_sigv4a_signing_region_set_config_from_environment():
         session = create_session()
         session.config_filename = 'no-exist-foo'
         s3 = session.create_client('s3')
-        assert (
-            s3.meta.config.sigv4a_signing_region_set == 'foo'
-        )
+        assert s3.meta.config.sigv4a_signing_region_set == 'foo'

--- a/tests/functional/test_auth_config.py
+++ b/tests/functional/test_auth_config.py
@@ -85,7 +85,7 @@ def test_sigv4a_signing_region_set_config_from_environment():
     with mock.patch('os.environ', environ):
         session = create_session()
         session.config_filename = 'no-exist-foo'
-        session.create_client('s3')
+        s3 = session.create_client('s3')
         assert (
-            session.get_config_variable('sigv4a_signing_region_set') == 'foo'
+            s3.meta.config.sigv4a_signing_region_set == 'foo'
         )

--- a/tests/functional/test_auth_config.py
+++ b/tests/functional/test_auth_config.py
@@ -75,7 +75,7 @@ def assert_all_requirements_match(auth_config, message):
     auth_requirements = set(
         AUTH_TYPE_REQUIREMENTS[auth_type] for auth_type in auth_config
     )
-    assert len(auth_requirements) == 1
+    assert len(auth_requirements) == 1, message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes a bug where the sigv4a_signing_region_set configuration in the config file and the corresponding environment variable would be ignored