### PR TITLE
Fix event stream regression

### DIFF
--- a/.changes/next-release/bugfix-s3-44124.json
+++ b/.changes/next-release/bugfix-s3-44124.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Fixed SelectObjectContent regression from `#3284 <https://github.com/boto/botocore/issues/3284>`__."
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1245,7 +1245,11 @@ def document_expires_shape(section, event_name, **kwargs):
 def _handle_200_error(operation_model, response_dict, **kwargs):
     # S3 can return a 200 response with an error embedded in the body.
     # Convert the 200 to a 500 for retry resolution in ``_update_status_code``.
-    if not response_dict or operation_model.has_streaming_output:
+    if (
+        not response_dict
+        or operation_model.has_streaming_output
+        or operation_model.has_event_stream_output
+    ):
         # Operations with streaming response blobs are excluded as they
         # can't be reliably distinguished from an S3 error.
         return


### PR DESCRIPTION
This PR addresses a regression in the `SelectObjectContent` functionality that was introduced in Botocore `1.35.45`. This issue was identified in issue #3284.