### PR TITLE
Inherit from standard ConnectionError in boto3.exceptions.ConnectionError

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -107,7 +107,7 @@ class HTTPClientError(BotoCoreError):
         )
 
 
-class ConnectionError(BotoCoreError):
+class ConnectionError(BotoCoreError, ConnectionError):
     fmt = 'An HTTP Client failed to establish a connection: {error}'
 
 


### PR DESCRIPTION
Please consider pulling this commit where boto3.exceptions.ConnectionError has multiple inheritance from the built-in ConnectionError and BotoCoreError.

It improves compatibility with error handling in Python by allowing `ConnectionError` from `boto3.exceptions` to be caught alongside other `ConnectionError` exceptions.