### PR TITLE
Fixes the issue in EndpointExceptionError by changing the format of the error message.

### DIFF
--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -638,7 +638,7 @@ class ParameterDefinition:
                 return self.default
             if self.required:
                 raise EndpointResolutionError(
-                    f"Cannot find value for required parameter {self.name}"
+                    msg=f"Cannot find value for required parameter {self.name}"
                 )
             # in all other cases, the parameter will keep the value None
         else:


### PR DESCRIPTION
The current base class for EndpointResolutionError takes variable-length arguments; kwarg, and passing a positional argument to it returns a TypeError. This fix solves it by passing an argument in a proper format. 