### PR TITLE
Update broken Polly example

### DIFF
--- a/botocore/data/polly/2016-06-10/examples-1.json
+++ b/botocore/data/polly/2016-06-10/examples-1.json
@@ -123,7 +123,7 @@
     "PutLexicon": [
       {
         "input": {
-          "Content": "file://example.pls",
+          "Content": "lexiconcontent",
           "Name": "W3C"
         },
         "output": {

--- a/botocore/data/polly/2016-06-10/examples-1.json
+++ b/botocore/data/polly/2016-06-10/examples-1.json
@@ -123,7 +123,7 @@
     "PutLexicon": [
       {
         "input": {
-          "Content": "lexiconcontent",
+          "Content": "<Lexicon Content>",
           "Name": "W3C"
         },
         "output": {


### PR DESCRIPTION
Fixes [Boto3 #4920](https://github.com/boto/boto3/issues/4290)

The examples in Polly's docs is misleading; the current suggested input is for content is `file://example.pls`, but that will cause the literal string of `file://example.pls` to be uploaded as the content, resulting in the following error:

```
InvalidLexiconException: An error occurred (InvalidLexiconException) when calling the PutLexicon operation: Invalid PLS Lexicon
```

Polly expects this input to be a lexicon as defined by the [PLS specificiation](https://www.w3.org/TR/pronunciation-lexicon/#S4.1).  This PR is to make it clearer that we will not open and retrieve the file contents on behalf of the customer, and that they must provide the contents of the pls directly.  