### PR TITLE
Add support for tuples in get_attr

### DIFF
--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -173,9 +173,9 @@ class RuleSetStandardLibrary:
         :type path: str
         :rtype: Any
         """
-        if value is None:
-            return None
         for part in path.split("."):
+            if value is None:
+                return None
             match = GET_ATTR_RE.search(part)
             if match is not None:
                 name, index = match.groups()

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -173,12 +173,14 @@ class RuleSetStandardLibrary:
         :type path: str
         :rtype: Any
         """
+        if value is None:
+            return None
         for part in path.split("."):
             match = GET_ATTR_RE.search(part)
             if match is not None:
                 name, index = match.groups()
                 index = int(index)
-                if name and value is not None:
+                if name:
                     value = value.get(name)
                 if index >= len(value):
                     return None

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -42,7 +42,7 @@ from botocore.utils import (
 logger = logging.getLogger(__name__)
 
 TEMPLATE_STRING_RE = re.compile(r"\{[a-zA-Z#]+\}")
-GET_ATTR_RE = re.compile(r"(\w+)\[(\d+)\]")
+GET_ATTR_RE = re.compile(r"(\w*)\[(\d+)\]")
 VALID_HOST_LABEL_RE = re.compile(
     r"^(?!-)[a-zA-Z\d-]{1,63}(?<!-)$",
 )
@@ -169,7 +169,7 @@ class RuleSetStandardLibrary:
         names indicates the one to the right is nested. The index will always occur at
         the end of the path.
 
-        :type value: dict or list
+        :type value: dict or tuple
         :type path: str
         :rtype: Any
         """
@@ -178,9 +178,10 @@ class RuleSetStandardLibrary:
             if match is not None:
                 name, index = match.groups()
                 index = int(index)
-                value = value.get(name)
                 if value is None or index >= len(value):
                     return None
+                if name:
+                    value = value.get(name)
                 return value[index]
             else:
                 value = value[part]

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -174,15 +174,13 @@ class RuleSetStandardLibrary:
         :rtype: Any
         """
         for part in path.split("."):
-            if value is None:
-                return None
             match = GET_ATTR_RE.search(part)
             if match is not None:
                 name, index = match.groups()
                 index = int(index)
                 if name:
                     value = value.get(name)
-                if index >= len(value):
+                if value is None or index >= len(value):
                     return None
                 return value[index]
             else:

--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -178,10 +178,10 @@ class RuleSetStandardLibrary:
             if match is not None:
                 name, index = match.groups()
                 index = int(index)
-                if value is None or index >= len(value):
-                    return None
-                if name:
+                if name and value is not None:
                     value = value.get(name)
+                if index >= len(value):
+                    return None
                 return value[index]
             else:
                 value = value[part]

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -517,6 +517,16 @@ def test_get_attr_can_get_dictionary_index(rule_lib):
     assert result == "bar"
 
 
+def test_get_attr_returns_none_on_missing_key(rule_lib):
+    result = rule_lib.get_attr({"foo": ['bar']}, 'baz[0]')
+    assert result is None
+
+
+def test_get_attr_returns_none_on_too_high_index(rule_lib):
+    result = rule_lib.get_attr({"foo": ['bar']}, 'foo[1]')
+    assert result is None
+
+
 def test_get_attr_can_get_list_index(rule_lib):
     result = rule_lib.get_attr(("foo",), '[0]')
     assert result == "foo"

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -510,3 +510,11 @@ def test_aws_is_virtual_hostable_s3_bucket_allow_subdomains(
         rule_lib.aws_is_virtual_hostable_s3_bucket(bucket, True)
         == expected_value
     )
+
+def test_get_attr_can_get_dictionary_index(rule_lib):
+    result = rule_lib.get_attr({"foo": ['bar']}, 'foo[0]')
+    assert result == "bar"
+
+def test_get_attr_can_get_list_index(rule_lib):
+    result = rule_lib.get_attr(("foo"), '[0]')
+    assert result == "foo"

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -516,5 +516,5 @@ def test_get_attr_can_get_dictionary_index(rule_lib):
     assert result == "bar"
 
 def test_get_attr_can_get_list_index(rule_lib):
-    result = rule_lib.get_attr(("foo"), '[0]')
+    result = rule_lib.get_attr(("foo",), '[0]')
     assert result == "foo"

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -512,21 +512,19 @@ def test_aws_is_virtual_hostable_s3_bucket_allow_subdomains(
     )
 
 
-def test_get_attr_can_get_dictionary_index(rule_lib):
-    result = rule_lib.get_attr({"foo": ['bar']}, 'foo[0]')
-    assert result == "bar"
-
-
-def test_get_attr_returns_none_on_missing_key(rule_lib):
-    result = rule_lib.get_attr({"foo": ['bar']}, 'baz[0]')
-    assert result is None
-
-
-def test_get_attr_returns_none_on_too_high_index(rule_lib):
-    result = rule_lib.get_attr({"foo": ['bar']}, 'foo[1]')
-    assert result is None
-
-
-def test_get_attr_can_get_list_index(rule_lib):
-    result = rule_lib.get_attr(("foo",), '[0]')
-    assert result == "foo"
+@pytest.mark.parametrize(
+    "value, path, expected_value",
+    [
+        ({"foo": ['bar']}, 'baz[0]', None),  # Missing index
+        ({"foo": ['bar']}, 'foo[1]', None),  # Out of range index
+        ({"foo": ['bar']}, 'foo[0]', "bar"),  # Named index
+        (("foo",), '[0]', "foo"),  # Bare index
+        ({"foo": {'bar': []}}, 'foo.baz[0]', None),  # Missing subindex
+        ({"foo": {'bar': []}}, 'foo.bar[0]', None),  # Out of range subindex
+        ({"foo": {"bar": "baz"}}, 'foo.bar', "baz"),  # Subindex with named index
+        ({"foo": {"bar": ["baz"]}}, 'foo.bar[0]', "baz"),  # Subindex with numeric index
+    ],
+)
+def test_get_attr(rule_lib, value, path, expected_value):
+    result = rule_lib.get_attr(value, path)
+    assert result == expected_value

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -511,9 +511,11 @@ def test_aws_is_virtual_hostable_s3_bucket_allow_subdomains(
         == expected_value
     )
 
+
 def test_get_attr_can_get_dictionary_index(rule_lib):
     result = rule_lib.get_attr({"foo": ['bar']}, 'foo[0]')
     assert result == "bar"
+
 
 def test_get_attr_can_get_list_index(rule_lib):
     result = rule_lib.get_attr(("foo",), '[0]')

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -519,10 +519,22 @@ def test_aws_is_virtual_hostable_s3_bucket_allow_subdomains(
         ({"foo": ['bar']}, 'foo[1]', None),  # Out of range index
         ({"foo": ['bar']}, 'foo[0]', "bar"),  # Named index
         (("foo",), '[0]', "foo"),  # Bare index
-        ({"foo": {'bar': []}}, 'foo.baz[0]', None),  # Missing subindex
-        ({"foo": {'bar': []}}, 'foo.bar[0]', None),  # Out of range subindex
-        ({"foo": {"bar": "baz"}}, 'foo.bar', "baz"),  # Subindex with named index
-        ({"foo": {"bar": ["baz"]}}, 'foo.bar[0]', "baz"),  # Subindex with numeric index
+        ({"foo": {}}, 'foo.bar[0]', None),  # Missing index from split path
+        (
+            {"foo": {'bar': []}},
+            'foo.bar[0]',
+            None,
+        ),  # Out of range from split path
+        (
+            {"foo": {"bar": "baz"}},
+            'foo.bar',
+            "baz",
+        ),  # Split path with named index
+        (
+            {"foo": {"bar": ["baz"]}},
+            'foo.bar[0]',
+            "baz",
+        ),  # Split path with numeric index
     ],
 )
 def test_get_attr(rule_lib, value, path, expected_value):


### PR DESCRIPTION
The get_attr function is intended to be able to support an input with a path such as `[0]` and a value of `['foo']`and parse out the fist index of the value to get `foo` as the result.  

Without the change in this PR, the such an input will not match the indexing regex, and instead it will reach the else statement and reach the code intended to access dictionary indexes.  This will fail with a type error, so this PR updates the regex to properly reach the part of the code that handles indexes without a word string before them.  

That code still fails for the same input; it assumes that it is getting the index of a list from a dictionary, so it attempts to call `.get()` on the base input.  This will not work if the input value is not a dictionary, so we need to add the conditional to only call `.get()` if there is a string before the first open bracket in the part of the path that we are parsing.  

Finally, this code can't be reached currently with a list due to how we memoize input parameters to endpoints; all parameter types have to be hash-able. While this function could theoretically get called with a list as input from another context, this is a private interface and it is only internally called from the endpoint provider.  Because of this, I've updated the docblock to specify `tuple` as the input type instead of `list`.