### PR TITLE
This change fixes region redirect issues for opt-in regions

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1778,7 +1778,7 @@ class S3RegionRedirectorv2:
         is_permanent_redirect = error_code == 'PermanentRedirect'
         is_opt_in_region = (
             error_code == 'IllegalLocationConstraintException'
-            and operation.name == 'GetObject'
+            and operation.name != 'CreateBucket'
         )
         if not any(
             [

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1776,6 +1776,10 @@ class S3RegionRedirectorv2:
             0
         ].status_code in (301, 302, 307)
         is_permanent_redirect = error_code == 'PermanentRedirect'
+        is_opt_in_region = (
+            error_code == 'IllegalLocationConstraintException'
+            and operation.name == 'GetObject'
+        )
         if not any(
             [
                 is_special_head_object,
@@ -1783,6 +1787,7 @@ class S3RegionRedirectorv2:
                 is_permanent_redirect,
                 is_special_head_bucket,
                 is_redirect_status,
+                is_opt_in_region,
             ]
         ):
             return

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1776,7 +1776,7 @@ class S3RegionRedirectorv2:
             0
         ].status_code in (301, 302, 307)
         is_permanent_redirect = error_code == 'PermanentRedirect'
-        is_opt_in_region = (
+        is_opt_in_region_redirect = (
             error_code == 'IllegalLocationConstraintException'
             and operation.name != 'CreateBucket'
         )
@@ -1787,7 +1787,7 @@ class S3RegionRedirectorv2:
                 is_permanent_redirect,
                 is_special_head_bucket,
                 is_redirect_status,
-                is_opt_in_region,
+                is_opt_in_region_redirect,
             ]
         ):
             return

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1879,7 +1879,7 @@ class TestS3RegionRedirector(unittest.TestCase):
         )
         self.assertIsNone(redirect_response)
 
-    def test_redirect_in_get_opt_in_region(self):
+    def test_redirects_on_illegal_location_constraint_from_opt_in_region(self):
         request_dict = {
             'url': 'https://il-central-1.amazonaws.com/foo',
             'context': {
@@ -1907,7 +1907,7 @@ class TestS3RegionRedirector(unittest.TestCase):
         )
         self.assertEqual(redirect_response, 0)
 
-    def test_no_redirect_if_create_bucket_IllegalLocationConstraintException(
+    def test_no_redirect_on_illegal_location_constraint_from_bad_location_constraint(
         self,
     ):
         request_dict = {

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1810,37 +1810,6 @@ class TestS3RegionRedirector(unittest.TestCase):
         )
         self.assertIsNone(redirect_response)
 
-    def test_redirect_get_opt_in_region(self):
-        request_dict = {
-            'url': 'https://il-central-1.amazonaws.com/foo',
-            'context': {
-                's3_redirect': {
-                    'bucket': 'foo',
-                    'redirected': False,
-                    'params': {'Bucket': 'foo'},
-                },
-                'signing': {},
-            },
-        }
-        response = (
-            None,
-            {
-                'Error': {
-                    'Code': 'IllegalLocationConstraintException',
-                    'Message': 'Bad Request',
-                },
-                'ResponseMetadata': {
-                    'HTTPHeaders': {'x-amz-bucket-region': 'eu-central-1'}
-                },
-            },
-        )
-
-        self.operation.name = 'GetObject'
-        redirect_response = self.redirector.redirect_from_error(
-            request_dict, response, self.operation
-        )
-        self.assertEqual(redirect_response, 0)
-
     def test_redirects_400_head_bucket(self):
         request_dict = {
             'url': 'https://us-west-2.amazonaws.com/foo',


### PR DESCRIPTION
When accessing an S3 bucket from the wrong region for opt-in regions, a 400 `IllegalLocationConstraintException` error is thrown. Botocore already has a functionality to automatically redirect requests to the correct region. This fix adds an additional condition to ensure that redirection happens whenever a request is made to the wrong region from opt-in regions.