### PR TITLE
Default sts client config to regional endpoints

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -453,7 +453,7 @@ class ClientArgsCreator:
             'sts_regional_endpoints'
         )
         if not sts_regional_endpoints_config:
-            sts_regional_endpoints_config = 'legacy'
+            sts_regional_endpoints_config = 'regional'
         if (
             sts_regional_endpoints_config
             not in VALID_REGIONAL_ENDPOINTS_CONFIG

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -393,18 +393,21 @@ class TestCreateClientArgs(unittest.TestCase):
             client_args['endpoint'].host, 'http://sts.amazonaws.com'
         )
 
-    def test_sts_regional_endpoints_defaults_to_legacy_if_not_set(self):
+    def test_sts_regional_endpoints_defaults_to_regional_if_not_set(self):
+        resolved_endpoint = 'https://resolved-endpoint'
+        resolved_region = 'resolved-region'
+        self._set_endpoint_bridge_resolve(
+            endpoint_url=resolved_endpoint, signing_region=resolved_region
+        )
         self.config_store.set_config_variable('sts_regional_endpoints', None)
         client_args = self.call_get_client_args(
             service_model=self._get_service_model('sts'),
             region_name='us-west-2',
             endpoint_url=None,
         )
+        self.assertEqual(client_args['endpoint'].host, resolved_endpoint)
         self.assertEqual(
-            client_args['endpoint'].host, 'https://sts.amazonaws.com'
-        )
-        self.assertEqual(
-            client_args['request_signer'].region_name, 'us-east-1'
+            client_args['request_signer'].region_name, resolved_region
         )
 
     def test_invalid_sts_regional_endpoints(self):
@@ -669,7 +672,7 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
         self.assertEqual(bins['AWS::Region'], 'ca-central-1')
         self.assertEqual(bins['AWS::UseFIPS'], False)
         self.assertEqual(bins['AWS::UseDualStack'], False)
-        self.assertEqual(bins['AWS::STS::UseGlobalEndpoint'], True)
+        self.assertEqual(bins['AWS::STS::UseGlobalEndpoint'], False)
         self.assertEqual(bins['AWS::S3::UseGlobalEndpoint'], False)
         self.assertEqual(bins['AWS::S3::Accelerate'], False)
         self.assertEqual(bins['AWS::S3::ForcePathStyle'], False)
@@ -723,7 +726,7 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
         bins = self.call_compute_endpoint_resolver_builtin_defaults(
             region_name='us-west-2',
         )
-        self.assertEqual(bins['AWS::STS::UseGlobalEndpoint'], True)
+        self.assertEqual(bins['AWS::STS::UseGlobalEndpoint'], False)
 
     def test_aws_sts_global_endpoint_with_default_and_nonlegacy_region(self):
         bins = self.call_compute_endpoint_resolver_builtin_defaults(


### PR DESCRIPTION
Around 2022, AWS announced that all new SDKs would change the default STS endpoint behavior from the `legacy` endpoint to `regional` as documented [here](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html).

> All new SDK major versions releasing after July 2022 will default to regional.
> New SDK major versions might remove this setting and use regional behavior.
> To reduce future impact regarding this change, we recommend you start using
> regional in your application when possible.

This is used when clients call `sts:AssumeRole`. Using the `legacy` behavior, clients connect to `sts.amazonaws.com,` which lives in `us-east-1.` Workloads outside of that region using this configuration unknowingly depend on that region since they are not using the `regional` endpoint where their code runs.

botocore was never updated, so today, all calls to the STS API, unless otherwise explicitly configured, will use the "global" endpoint in `us-east-1.`

There was an [outage in Aug 2024](https://health.aws.amazon.com/health/status?eventID=arn:aws:health:global::event/IAM/AWS_IAM_OPERATIONAL_ISSUE/AWS_IAM_OPERATIONAL_ISSUE_C9750_3CF4B9D9C39) which impacted STS in `us-east-1`.

Had botocore been updated, this specific event would not have impaired workloads running in other regions using a default client.

This PR attempts to align the new "default" to `regional` as specified by the documentation.

Should you require the old behavior, you can always set the environment variable to override the new default back to `legacy` (as documented):

```
export AWS_STS_REGIONAL_ENDPOINTS=legacy
```

A follow-up change to the documentation [here](https://github.com/boto/boto3/blob/f46cfc9eee4c5f3961ad53475d1623d7f01b6bef/docs/source/guide/configuration.rst?plain=1#L415) will be needed to reflect this change.

Not a Python guru here, so I did my best at a first crack.  Please review.

Thanks!