### PR TITLE
Update implicitGlobalRegion for aws-cn

### DIFF
--- a/botocore/data/partitions.json
+++ b/botocore/data/partitions.json
@@ -110,7 +110,7 @@
     "outputs" : {
       "dnsSuffix" : "amazonaws.com.cn",
       "dualStackDnsSuffix" : "api.amazonwebservices.com.cn",
-      "implicitGlobalRegion" : "cn-northwest-1",
+      "implicitGlobalRegion" : "cn-north-1",
       "name" : "aws-cn",
       "supportsDualStack" : true,
       "supportsFIPS" : true


### PR DESCRIPTION
Resolves https://github.com/boto/botocore/issues/3317

> In [botocore/data/partitions.json](https://github.com/boto/botocore/blob/f49ead849aa5a4ea428d9f378de14db6f4c6d645/botocore/data/partitions.json#L113) aws-cn has its implicitGlobalRegion set as cn-northwest-1 when it should be cn-north-1
