### PR TITLE
Raise python-dateutil Constraint to >=2.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 0
 [metadata]
 requires_dist =
     jmespath>=0.7.1,<2.0.0
-    python-dateutil>=2.1,<3.0.0
+    python-dateutil>=2.7,<3.0.0
     urllib3>=1.25.4,<1.27; python_version<"3.10"
     urllib3>=1.25.4,!=2.2.0,<3; python_version>="3.10"
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 
 requires = [
     'jmespath>=0.7.1,<2.0.0',
-    'python-dateutil>=2.1,<3.0.0',
+    'python-dateutil>=2.7,<3.0.0',
     # Prior to Python 3.10, Python doesn't require openssl 1.1.1
     # but urllib3 2.0+ does. This means all botocore users will be
     # broken by default on Amazon Linux 2 and AWS Lambda without this pin.


### PR DESCRIPTION
This PR updates the python-dateutil version constraint in botocore from >=2.1 to >=2.7

this fixes:
- #3339 (failing tests)
- #3338 (unpinned six)