### PR TITLE
Add account_id_endpoint_mode and consume account_id in ruleset

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -880,19 +880,28 @@ class ClientArgsCreator:
         config_kwargs[config_key] = value
 
     def _compute_account_id_endpoint_mode_config(self, config_kwargs):
-        account_id_endpoint_mode = config_kwargs.get(
-            'account_id_endpoint_mode'
-        )
+        config_key = 'account_id_endpoint_mode'
+        account_id_endpoint_mode = config_kwargs.get(config_key)
+
         if account_id_endpoint_mode is None:
             account_id_endpoint_mode = self._config_store.get_config_variable(
-                'account_id_endpoint_mode'
+                config_key
             )
+
+        if isinstance(account_id_endpoint_mode, str):
+            account_id_endpoint_mode = account_id_endpoint_mode.lower()
+
         if (
             account_id_endpoint_mode
             not in VALID_ACCOUNT_ID_ENDPOINT_MODE_CONFIG
         ):
             raise botocore.exceptions.InvalidConfigError(
-                error_msg=f"The configured value '{account_id_endpoint_mode}' for 'account_id_endpoint_mode' is "
+                error_msg=f"The configured value '{account_id_endpoint_mode}' for '{config_key}' is "
                 f"invalid. Valid values are: {VALID_ACCOUNT_ID_ENDPOINT_MODE_CONFIG}."
             )
-        config_kwargs['account_id_endpoint_mode'] = account_id_endpoint_mode
+
+        signature_version = config_kwargs.get('signature_version')
+        if signature_version is botocore.UNSIGNED:
+            account_id_endpoint_mode = 'disabled'
+
+        config_kwargs[config_key] = account_id_endpoint_mode

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -78,6 +78,12 @@ PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = (
     'ec2',
 )
 
+VALID_ACCOUNT_ID_ENDPOINT_MODE_CONFIG = (
+    'preferred',
+    'disabled',
+    'required',
+)
+
 
 class ClientArgsCreator:
     def __init__(
@@ -136,6 +142,7 @@ class ClientArgsCreator:
         configured_endpoint_url = final_args['configured_endpoint_url']
         signing_region = endpoint_config['signing_region']
         endpoint_region_name = endpoint_config['region_name']
+        endpoint_mode = config_kwargs['account_id_endpoint_mode']
 
         event_emitter = copy.copy(self._event_emitter)
         signer = RequestSigner(
@@ -183,6 +190,8 @@ class ClientArgsCreator:
             is_secure,
             endpoint_bridge,
             event_emitter,
+            credentials,
+            endpoint_mode,
         )
 
         # Copy the session's user agent factory and adds client configuration.
@@ -294,6 +303,7 @@ class ClientArgsCreator:
                 response_checksum_validation=(
                     client_config.response_checksum_validation
                 ),
+                account_id_endpoint_mode=client_config.account_id_endpoint_mode,
             )
         self._compute_retry_config(config_kwargs)
         self._compute_connect_timeout(config_kwargs)
@@ -301,6 +311,7 @@ class ClientArgsCreator:
         self._compute_request_compression_config(config_kwargs)
         self._compute_sigv4a_signing_region_set_config(config_kwargs)
         self._compute_checksum_config(config_kwargs)
+        self._compute_account_id_endpoint_mode_config(config_kwargs)
         s3_config = self.compute_s3_config(client_config)
 
         is_s3_service = self._is_s3_service(service_name)
@@ -645,6 +656,8 @@ class ClientArgsCreator:
         is_secure,
         endpoint_bridge,
         event_emitter,
+        credentials,
+        endpoint_mode,
     ):
         if endpoints_ruleset_data is None:
             return None
@@ -669,6 +682,8 @@ class ClientArgsCreator:
             endpoint_bridge=endpoint_bridge,
             client_endpoint_url=endpoint_url,
             legacy_endpoint_url=endpoint.host,
+            credentials=credentials,
+            endpoint_mode=endpoint_mode,
         )
         # Client context params for s3 conflict with the available settings
         # in the `s3` parameter on the `Config` object. If the same parameter
@@ -704,6 +719,8 @@ class ClientArgsCreator:
         endpoint_bridge,
         client_endpoint_url,
         legacy_endpoint_url,
+        credentials,
+        endpoint_mode,
     ):
         # EndpointRulesetResolver rulesets may accept an "SDK::Endpoint" as
         # input. If the endpoint_url argument of create_client() is set, it
@@ -778,6 +795,12 @@ class ClientArgsCreator:
                 's3_disable_multiregion_access_points', False
             ),
             EPRBuiltins.SDK_ENDPOINT: given_endpoint,
+            EPRBuiltins.ACCOUNT_ID: credentials.get_deferred_property(
+                'account_id'
+            )
+            if credentials
+            else None,
+            EPRBuiltins.ACCOUNT_ID_ENDPOINT_MODE: endpoint_mode,
         }
 
     def _compute_user_agent_appid_config(self, config_kwargs):
@@ -855,3 +878,21 @@ class ClientArgsCreator:
                 valid_options=valid_options,
             )
         config_kwargs[config_key] = value
+
+    def _compute_account_id_endpoint_mode_config(self, config_kwargs):
+        account_id_endpoint_mode = config_kwargs.get(
+            'account_id_endpoint_mode'
+        )
+        if account_id_endpoint_mode is None:
+            account_id_endpoint_mode = self._config_store.get_config_variable(
+                'account_id_endpoint_mode'
+            )
+        if (
+            account_id_endpoint_mode
+            not in VALID_ACCOUNT_ID_ENDPOINT_MODE_CONFIG
+        ):
+            raise botocore.exceptions.InvalidConfigError(
+                error_msg=f"The configured value '{account_id_endpoint_mode}' for 'account_id_endpoint_mode' is "
+                f"invalid. Valid values are: {VALID_ACCOUNT_ID_ENDPOINT_MODE_CONFIG}."
+            )
+        config_kwargs['account_id_endpoint_mode'] = account_id_endpoint_mode

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -881,8 +881,15 @@ class ClientArgsCreator:
 
     def _compute_account_id_endpoint_mode_config(self, config_kwargs):
         config_key = 'account_id_endpoint_mode'
-        account_id_endpoint_mode = config_kwargs.get(config_key)
 
+        # Disable account id based endpoint routing for unsigned requests
+        # since there are no credentials to resolve.
+        signature_version = config_kwargs.get('signature_version')
+        if signature_version is botocore.UNSIGNED:
+            config_kwargs[config_key] = 'disabled'
+            return
+
+        account_id_endpoint_mode = config_kwargs.get(config_key)
         if account_id_endpoint_mode is None:
             account_id_endpoint_mode = self._config_store.get_config_variable(
                 config_key
@@ -899,9 +906,5 @@ class ClientArgsCreator:
                 error_msg=f"The configured value '{account_id_endpoint_mode}' for '{config_key}' is "
                 f"invalid. Valid values are: {VALID_ACCOUNT_ID_ENDPOINT_MODE_CONFIG}."
             )
-
-        signature_version = config_kwargs.get('signature_version')
-        if signature_version is botocore.UNSIGNED:
-            account_id_endpoint_mode = 'disabled'
 
         config_kwargs[config_key] = account_id_endpoint_mode

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -142,7 +142,7 @@ class ClientArgsCreator:
         configured_endpoint_url = final_args['configured_endpoint_url']
         signing_region = endpoint_config['signing_region']
         endpoint_region_name = endpoint_config['region_name']
-        endpoint_mode = config_kwargs['account_id_endpoint_mode']
+        account_id_endpoint_mode = config_kwargs['account_id_endpoint_mode']
 
         event_emitter = copy.copy(self._event_emitter)
         signer = RequestSigner(
@@ -191,7 +191,7 @@ class ClientArgsCreator:
             endpoint_bridge,
             event_emitter,
             credentials,
-            endpoint_mode,
+            account_id_endpoint_mode,
         )
 
         # Copy the session's user agent factory and adds client configuration.
@@ -657,7 +657,7 @@ class ClientArgsCreator:
         endpoint_bridge,
         event_emitter,
         credentials,
-        endpoint_mode,
+        account_id_endpoint_mode,
     ):
         if endpoints_ruleset_data is None:
             return None
@@ -683,7 +683,7 @@ class ClientArgsCreator:
             client_endpoint_url=endpoint_url,
             legacy_endpoint_url=endpoint.host,
             credentials=credentials,
-            endpoint_mode=endpoint_mode,
+            account_id_endpoint_mode=account_id_endpoint_mode,
         )
         # Client context params for s3 conflict with the available settings
         # in the `s3` parameter on the `Config` object. If the same parameter
@@ -720,7 +720,7 @@ class ClientArgsCreator:
         client_endpoint_url,
         legacy_endpoint_url,
         credentials,
-        endpoint_mode,
+        account_id_endpoint_mode,
     ):
         # EndpointRulesetResolver rulesets may accept an "SDK::Endpoint" as
         # input. If the endpoint_url argument of create_client() is set, it
@@ -800,7 +800,7 @@ class ClientArgsCreator:
             )
             if credentials
             else None,
-            EPRBuiltins.ACCOUNT_ID_ENDPOINT_MODE: endpoint_mode,
+            EPRBuiltins.ACCOUNT_ID_ENDPOINT_MODE: account_id_endpoint_mode,
         }
 
     def _compute_user_agent_appid_config(self, config_kwargs):

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -266,6 +266,18 @@ class Config:
           supported and the ``requestValidationModeMember`` member is set to ``ENABLED``.
 
         Defaults to None.
+
+    :type account_id_endpoint_mode: str
+    :param account_id_endpoint_mode: The value used to determine the client's
+        behavior for account ID based endpoint routing. Valid values are:
+
+        * ``preferred`` - The endpoint should include account ID if available.
+        * ``disabled`` - A resolved endpoint does not include account ID.
+        * ``required`` - The endpoint must include account ID. If the account ID
+          isn't available, an exception will be raised.
+        If a value is not provided, the client will default to ``preferred``.
+
+        Defaults to None.
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -297,6 +309,7 @@ class Config:
             ('sigv4a_signing_region_set', None),
             ('request_checksum_calculation', None),
             ('response_checksum_validation', None),
+            ('account_id_endpoint_mode', None),
         ]
     )
 

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -275,6 +275,7 @@ class Config:
         * ``disabled`` - A resolved endpoint does not include account ID.
         * ``required`` - The endpoint must include account ID. If the account ID
           isn't available, an exception will be raised.
+
         If a value is not provided, the client will default to ``preferred``.
 
         Defaults to None.

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -180,6 +180,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         "when_supported",
         None,
     ),
+    'account_id_endpoint_mode': (
+        'account_id_endpoint_mode',
+        'AWS_ACCOUNT_ID_ENDPOINT_MODE',
+        'preferred',
+        None,
+    ),
 }
 
 # Evaluate AWS_STS_REGIONAL_ENDPOINTS settings

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -344,6 +344,12 @@ class Credentials:
             self.access_key, self.secret_key, self.token, self.account_id
         )
 
+    def get_deferred_property(self, property_name):
+        def get_property():
+            return getattr(self, property_name, None)
+
+        return get_property
+
 
 class RefreshableCredentials(Credentials):
     """

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -432,10 +432,10 @@ class EndpointResolverBuiltins(str, Enum):
     # Whether the UseDualStackEndpoint configuration option has been enabled
     # for the SDK client (bool)
     AWS_USE_DUALSTACK = "AWS::UseDualStack"
-    # Whether the global endpoint should be used with STS, rather the the
+    # Whether the global endpoint should be used with STS, rather than the
     # regional endpoint for us-east-1 (bool)
     AWS_STS_USE_GLOBAL_ENDPOINT = "AWS::STS::UseGlobalEndpoint"
-    # Whether the global endpoint should be used with S3, rather then the
+    # Whether the global endpoint should be used with S3, rather than the
     # regional endpoint for us-east-1 (bool)
     AWS_S3_USE_GLOBAL_ENDPOINT = "AWS::S3::UseGlobalEndpoint"
     # Whether S3 Transfer Acceleration has been requested (bool)
@@ -452,8 +452,9 @@ class EndpointResolverBuiltins(str, Enum):
     AWS_S3_DISABLE_MRAP = "AWS::S3::DisableMultiRegionAccessPoints"
     # Whether a custom endpoint has been configured (str)
     SDK_ENDPOINT = "SDK::Endpoint"
-    # Currently not implemented:
+    # An AWS account ID that can be optionally configured for the SDK client (str)
     ACCOUNT_ID = "AWS::Auth::AccountId"
+    # Whether an endpoint should include an account ID (str)
     ACCOUNT_ID_ENDPOINT_MODE = "AWS::Auth::AccountIdEndpointMode"
 
 
@@ -620,7 +621,10 @@ class EndpointRulesetResolver:
     def _resolve_param_as_builtin(self, builtin_name, builtins):
         if builtin_name not in EndpointResolverBuiltins.__members__.values():
             raise UnknownEndpointResolutionBuiltInName(name=builtin_name)
-        return builtins.get(builtin_name)
+        builtin = builtins.get(builtin_name)
+        if callable(builtin):
+            return builtin()
+        return builtin
 
     @instance_cache
     def _get_static_context_params(self, operation_model):

--- a/tests/functional/test_account_id_endpoints.py
+++ b/tests/functional/test_account_id_endpoints.py
@@ -1,0 +1,198 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from botocore.config import Config
+from botocore.exceptions import EndpointResolutionError
+from tests import ClientHTTPStubber, patch_load_service_model
+
+FAKE_RULESET = {
+    "version": "1.0",
+    "parameters": {
+        "AccountId": {
+            "type": "String",
+            "builtIn": "AWS::Auth::AccountId",
+            "documentation": "The AWS account ID used for the request, eg. `123456789012`.",
+        },
+        "AccountIdEndpointMode": {
+            "type": "String",
+            "builtIn": "AWS::Auth::AccountIdEndpointMode",
+            "documentation": "The behavior for account ID based endpoint routing, eg. `preferred`.",
+        },
+    },
+    "rules": [
+        {
+            "documentation": "Template account ID into the URI when account ID is set and AccountIdEndpointMode is "
+            "set to preferred.",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "AccountId"}]},
+                {"fn": "isSet", "argv": [{"ref": "AccountIdEndpointMode"}]},
+                {
+                    "fn": "stringEquals",
+                    "argv": [{"ref": "AccountIdEndpointMode"}, "preferred"],
+                },
+            ],
+            "endpoint": {
+                "url": "https://{AccountId}.otherservice.us-west-2.amazonaws.com"
+            },
+            "type": "endpoint",
+        },
+        {
+            "documentation": "Do not template account ID into the URI when AccountIdEndpointMode is set to disabled.",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "AccountId"}]},
+                {"fn": "isSet", "argv": [{"ref": "AccountIdEndpointMode"}]},
+                {
+                    "fn": "stringEquals",
+                    "argv": [{"ref": "AccountIdEndpointMode"}, "disabled"],
+                },
+            ],
+            "endpoint": {
+                "url": "https://otherservice.us-west-2.amazonaws.com/"
+            },
+            "type": "endpoint",
+        },
+        {
+            "documentation": "Raise an error when account ID is unset but AccountIdEndpointMode is set to required.",
+            "conditions": [
+                {
+                    "fn": "not",
+                    "argv": [{"fn": "isSet", "argv": [{"ref": "AccountId"}]}],
+                },
+                {"fn": "isSet", "argv": [{"ref": "AccountIdEndpointMode"}]},
+                {
+                    "fn": "stringEquals",
+                    "argv": [{"ref": "AccountIdEndpointMode"}, "required"],
+                },
+            ],
+            "error": "AccountIdEndpointMode is required but no AccountID was provided",
+            "type": "error",
+        },
+    ],
+}
+
+FAKE_SERVICE_MODEL = {
+    "version": "2.0",
+    "documentation": "",
+    "metadata": {
+        "apiVersion": "2020-02-02",
+        "endpointPrefix": "otherservice",
+        "protocol": "rest-xml",
+        "serviceFullName": "Other Service",
+        "serviceId": "Other Service",
+        "signatureVersion": "v4",
+        "signingName": "otherservice",
+        "uid": "otherservice-2020-02-02",
+    },
+    "operations": {
+        "MockOperation": {
+            "name": "MockOperation",
+            "http": {"method": "GET", "requestUri": "/"},
+            "input": {"shape": "MockOperationRequest"},
+            "documentation": "",
+        },
+    },
+    "shapes": {
+        "MockOpParam": {
+            "type": "string",
+        },
+        "MockOperationRequest": {
+            "type": "structure",
+            "required": ["MockOpParam"],
+            "members": {
+                "MockOpParam": {
+                    "shape": "MockOpParam",
+                    "documentation": "",
+                    "location": "uri",
+                    "locationName": "param",
+                },
+            },
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "account_id_endpoint_mode, expected_endpoint, expected_error, account_id_in_url",
+    [
+        # Test case for 'preferred' mode: Account ID is in the URL
+        (
+            'preferred',
+            'https://123456789012.otherservice.us-west-2.amazonaws.com/',
+            None,
+            True,
+        ),
+        # Test case for 'disabled' mode: Account ID is not in the URL
+        (
+            'disabled',
+            'https://otherservice.us-west-2.amazonaws.com/',
+            None,
+            False,
+        ),
+        # Test case for 'required' mode: Error is raised due to missing Account ID
+        (
+            'required',
+            None,
+            'AccountIdEndpointMode is required but no AccountID was provided',
+            False,
+        ),
+    ],
+)
+def test_account_id_endpoint_resolution(
+    account_id_endpoint_mode,
+    expected_endpoint,
+    expected_error,
+    account_id_in_url,
+    patched_session,
+    monkeypatch,
+):
+    account_id = '123456789012'
+    patch_load_service_model(
+        patched_session, monkeypatch, FAKE_SERVICE_MODEL, FAKE_RULESET
+    )
+
+    if account_id_endpoint_mode != 'required':
+        monkeypatch.setenv('AWS_ACCOUNT_ID', account_id)
+
+    client = patched_session.create_client(
+        'otherservice',
+        region_name='us-west-2',
+        config=Config(account_id_endpoint_mode=account_id_endpoint_mode),
+    )
+
+    # If we expect an error, assert that the error is raised
+    if expected_error:
+        with pytest.raises(EndpointResolutionError) as exc_info:
+            with ClientHTTPStubber(client, strict=True) as http_stubber:
+                http_stubber.add_response()
+                client.mock_operation(MockOpParam='mock-op-param-value')
+        assert str(exc_info.value) == expected_error
+    else:
+        # If no error is expected, verify the endpoint resolution
+        with ClientHTTPStubber(client, strict=True) as http_stubber:
+            http_stubber.add_response(status=200, body=b'{}')
+            client.mock_operation(MockOpParam='mock-op-param-value')
+            request = http_stubber.requests[0]
+
+            if account_id_in_url:
+                assert (
+                    account_id in request.url
+                ), f"Account ID should be in the URL, but it's not: {request.url}"
+            else:
+                assert (
+                    account_id not in request.url
+                ), f"Account ID should not be in the URL, but it is: {request.url}"
+            assert (
+                request.url == expected_endpoint
+            ), f"Expected endpoint '{expected_endpoint}', but got: {request.url}"

--- a/tests/unit/data/endpoints/test-cases/account-id.json
+++ b/tests/unit/data/endpoints/test-cases/account-id.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "Test case for basic AccountID templating",
+      "params": {
+        "AccountId": "123456789001",
+        "AccountIdEndpointMode": "preferred"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://123456789001.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "Test case where AccountID is set but AccountIdEndpointMode is set to disabled",
+      "params": {
+        "AccountId": "123456789001",
+        "AccountIdEndpointMode": "disabled"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "Test case where AccountID is unset but AccountIdEndpointMode is set to required",
+      "params": {
+        "AccountIdEndpointMode": "required"
+      },
+      "expect": {
+        "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded"
+      }
+    },
+    {
+      "documentation": "Test case where AccountID and AccountIdEndpointMode are unset",
+      "params": {},
+      "expect": {
+        "endpoint": {
+          "url": "https://amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/account-id.json
+++ b/tests/unit/data/endpoints/valid-rules/account-id.json
@@ -1,0 +1,130 @@
+{
+  "version": "1.0",
+  "parameters": {
+    "AccountId": {
+      "type": "String",
+      "builtIn": "AWS::Auth::AccountId",
+      "documentation": "The AWS account ID used in the endpoint for a request, eg. `123456789012`."
+    },
+    "AccountIdEndpointMode": {
+      "type": "String",
+      "builtIn": "AWS::Auth::AccountIdEndpointMode",
+      "documentation": "The behavior for account ID based endpoint routing, eg. `preferred`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template account ID into the URI when account ID is set and AccountIdEndpointMode is set to preferred.",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            },
+            "preferred"
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{AccountId}.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Do not template account ID into the URI when AccountIdEndpointMode is set to disabled.",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            },
+            "disabled"
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Raise an error when account ID is unset but AccountIdEndpointMode is set to required.",
+      "conditions": [
+        {
+          "fn": "not",
+          "argv": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "AccountId"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            },
+            "required"
+          ]
+        }
+      ],
+      "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded",
+      "type": "error"
+    },
+    {
+      "documentation": "Fallback when AccountID and AccountIdEndpointMode are unset",
+      "conditions": [],
+      "endpoint": {
+        "url": "https://amazonaws.com"
+      },
+      "type": "endpoint"
+    }
+  ]
+}

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -15,6 +15,7 @@ import socket
 
 from botocore import args, exceptions
 from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
+from botocore import UNSIGNED, args, exceptions
 from botocore.client import ClientEndpointBridge
 from botocore.config import Config
 from botocore.configprovider import ConfigValueStore
@@ -752,6 +753,11 @@ class TestCreateClientArgs(unittest.TestCase):
         )
         with self.assertRaises(exceptions.InvalidConfigError):
             self.call_get_client_args()
+
+    def test_account_id_endpoint_mode_disabled_on_unsigned_request(self):
+        self._set_endpoint_bridge_resolve(signature_version=UNSIGNED)
+        config = self.call_get_client_args()['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'disabled')
 
 
 class TestEndpointResolverBuiltins(unittest.TestCase):

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -19,6 +19,7 @@ from botocore.client import ClientEndpointBridge
 from botocore.config import Config
 from botocore.configprovider import ConfigValueStore
 from botocore.exceptions import UnsupportedServiceProtocolsError
+from botocore.credentials import Credentials
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel
 from botocore.parsers import PROTOCOL_PARSERS
@@ -718,6 +719,40 @@ class TestCreateClientArgs(unittest.TestCase):
         ):
             self.call_compute_client_args()
 
+    def test_account_id_endpoint_mode_set_on_config_store(self):
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'preferred'
+        )
+        config = self.call_get_client_args()['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'preferred')
+
+    def test_account_id_endpoint_mode_set_on_client_config(self):
+        config = self.call_get_client_args(
+            client_config=Config(account_id_endpoint_mode='required')
+        )['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'required')
+
+    def test_account_id_endpoint_mode_client_config_overrides_config_store(
+        self,
+    ):
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'preferred'
+        )
+        config = self.call_get_client_args(
+            client_config=Config(account_id_endpoint_mode='disabled')
+        )['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'disabled')
+
+    def test_account_id_endpoint_mode_bad_value(self):
+        with self.assertRaises(exceptions.InvalidConfigError):
+            config = Config(account_id_endpoint_mode='foo')
+            self.call_get_client_args(client_config=config)
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'foo'
+        )
+        with self.assertRaises(exceptions.InvalidConfigError):
+            self.call_get_client_args()
+
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):
@@ -761,6 +796,8 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             'endpoint_bridge': self.bridge,
             'client_endpoint_url': None,
             'legacy_endpoint_url': 'https://my.legacy.endpoint.com',
+            'credentials': None,
+            'endpoint_mode': 'preferred',
         }
         kwargs = {**defaults, **overrides}
         return self.args_create.compute_endpoint_resolver_builtin_defaults(
@@ -783,6 +820,8 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             bins['AWS::S3::DisableMultiRegionAccessPoints'], False
         )
         self.assertEqual(bins['SDK::Endpoint'], None)
+        self.assertEqual(bins['AWS::Auth::AccountId'], None)
+        self.assertEqual(bins['AWS::Auth::AccountIdEndpointMode'], 'preferred')
 
     def test_aws_region(self):
         bins = self.call_compute_endpoint_resolver_builtin_defaults(
@@ -946,6 +985,20 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             legacy_endpoint_url='https://my.legacy.endpoint.com',
         )
         self.assertEqual(bins['SDK::Endpoint'], None)
+
+    def test_account_id_set_with_credentials(self):
+        bins = self.call_compute_endpoint_resolver_builtin_defaults(
+            credentials=Credentials(
+                access_key='foo', secret_key='bar', account_id='baz'
+            )
+        )
+        self.assertEqual(bins['AWS::Auth::AccountId'](), 'baz')
+
+    def test_account_id_endpoint_mode_set_to_disabled(self):
+        bins = self.call_compute_endpoint_resolver_builtin_defaults(
+            endpoint_mode='disabled'
+        )
+        self.assertEqual(bins['AWS::Auth::AccountIdEndpointMode'], 'disabled')
 
 
 class TestProtocolPriorityList:

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -803,7 +803,7 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             'client_endpoint_url': None,
             'legacy_endpoint_url': 'https://my.legacy.endpoint.com',
             'credentials': None,
-            'endpoint_mode': 'preferred',
+            'account_id_endpoint_mode': 'preferred',
         }
         kwargs = {**defaults, **overrides}
         return self.args_create.compute_endpoint_resolver_builtin_defaults(
@@ -1002,7 +1002,7 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
 
     def test_account_id_endpoint_mode_set_to_disabled(self):
         bins = self.call_compute_endpoint_resolver_builtin_defaults(
-            endpoint_mode='disabled'
+            account_id_endpoint_mode='disabled'
         )
         self.assertEqual(bins['AWS::Auth::AccountIdEndpointMode'], 'disabled')
 

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -13,14 +13,13 @@
 # language governing permissions and limitations under the License.
 import socket
 
-from botocore import args, exceptions
-from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
 from botocore import UNSIGNED, args, exceptions
+from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
 from botocore.client import ClientEndpointBridge
 from botocore.config import Config
 from botocore.configprovider import ConfigValueStore
-from botocore.exceptions import UnsupportedServiceProtocolsError
 from botocore.credentials import Credentials
+from botocore.exceptions import UnsupportedServiceProtocolsError
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel
 from botocore.parsers import PROTOCOL_PARSERS

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3882,3 +3882,15 @@ class TestSSOProvider(unittest.TestCase):
         # If any required configuration is missing we should get an error
         with self.assertRaises(botocore.exceptions.InvalidConfigError):
             self.provider.load()
+
+
+@pytest.mark.parametrize(
+    "account_id, expected", [("123456789012", "123456789012"), (None, None)]
+)
+def test_get_deferred_property_account_id(account_id, expected):
+    creds = Credentials(
+        access_key='foo', secret_key='bar', token='baz', account_id=account_id
+    )
+    deferred_account_id = creds.get_deferred_property('account_id')
+    assert callable(deferred_account_id)
+    assert deferred_account_id() == expected

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -137,6 +137,7 @@ def endpoint_rule():
 
 def ruleset_testcases():
     filenames = [
+        "account-id",
         "array-index",
         "aws-region",
         "default-values",


### PR DESCRIPTION
## Account ID Endpoint Mode
This PR introduces the `account_id_endpoint_mode` configuration setting, which determines the client’s behavior for account ID based endpoint routing. When enabled and configured in a service’s ruleset, the endpoint resolver will attempt to resolve the account ID as an input parameter to the endpoint provider. The valid values for this setting are:
* `preferred`: The endpoint should include the account ID if available.
* `disabled`: The endpoint will not include the account ID, even if available.
* `required`: The endpoint must include the account ID. An exception will be raised if the account ID is unavailable.

If no value is provided, the default behavior will be `preferred`.

## Consuming Account ID in the Ruleset
This PR also adds support for consuming the account ID in the ruleset during endpoint resolution. Specifically, the following built-in parameters will now be resolved:
* `AWS::Auth::AccountId`: The AWS account ID that can be optionally configured for the SDK client.
* `AWS::Auth::AccountIdEndpointMode`: The setting that determines whether the endpoint should include the account ID.

Account ID will be treated as a deferred property, using the `get_deferred_property` method in the `Credentials` class. This ensures that the account ID is resolved only when needed, deferring the resource-intensive resolution of account ID tied to `DeferredRefreshableCredentials` until endpoint resolution time. This approach avoids unnecessary credential fetches during client initialization and aligns with the behavior of deferred credentials.