### PR TITLE
Add account ID to static credentials providers

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1293,11 +1293,11 @@ class SharedCredentialProvider(CredentialProvider):
 
     ACCESS_KEY = 'aws_access_key_id'
     SECRET_KEY = 'aws_secret_access_key'
-    ACCOUNT_ID = 'aws_account_id'
     # Same deal as the EnvProvider above.  Botocore originally supported
     # aws_security_token, but the SDKs are standardizing on aws_session_token
     # so we support both.
     TOKENS = ['aws_security_token', 'aws_session_token']
+    ACCOUNT_ID = 'aws_account_id'
 
     def __init__(self, creds_filename, profile_name=None, ini_parser=None):
         self._creds_filename = creds_filename
@@ -1354,6 +1354,7 @@ class ConfigProvider(CredentialProvider):
     # aws_security_token, but the SDKs are standardizing on aws_session_token
     # so we support both.
     TOKENS = ['aws_security_token', 'aws_session_token']
+    ACCOUNT_ID = 'aws_account_id'
 
     def __init__(self, config_filename, profile_name, config_parser=None):
         """
@@ -1390,8 +1391,13 @@ class ConfigProvider(CredentialProvider):
                     profile_config, self.ACCESS_KEY, self.SECRET_KEY
                 )
                 token = self._get_session_token(profile_config)
+                account_id = self._get_account_id(profile_config)
                 return Credentials(
-                    access_key, secret_key, token, method=self.METHOD
+                    access_key,
+                    secret_key,
+                    token,
+                    method=self.METHOD,
+                    account_id=account_id,
                 )
         else:
             return None
@@ -1400,6 +1406,9 @@ class ConfigProvider(CredentialProvider):
         for token_name in self.TOKENS:
             if token_name in profile_config:
                 return profile_config[token_name]
+
+    def _get_account_id(self, config):
+        return config.get(self.ACCOUNT_ID)
 
 
 class BotoProvider(CredentialProvider):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1293,6 +1293,7 @@ class SharedCredentialProvider(CredentialProvider):
 
     ACCESS_KEY = 'aws_access_key_id'
     SECRET_KEY = 'aws_secret_access_key'
+    ACCOUNT_ID = 'aws_account_id'
     # Same deal as the EnvProvider above.  Botocore originally supported
     # aws_security_token, but the SDKs are standardizing on aws_session_token
     # so we support both.
@@ -1323,14 +1324,22 @@ class SharedCredentialProvider(CredentialProvider):
                     config, self.ACCESS_KEY, self.SECRET_KEY
                 )
                 token = self._get_session_token(config)
+                account_id = self._get_account_id(config)
                 return Credentials(
-                    access_key, secret_key, token, method=self.METHOD
+                    access_key,
+                    secret_key,
+                    token,
+                    method=self.METHOD,
+                    account_id=account_id,
                 )
 
     def _get_session_token(self, config):
         for token_envvar in self.TOKENS:
             if token_envvar in config:
                 return config[token_envvar]
+
+    def _get_account_id(self, config):
+        return config.get(self.ACCOUNT_ID)
 
 
 class ConfigProvider(CredentialProvider):

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -479,7 +479,9 @@ class Session:
         """
         self._client_config = client_config
 
-    def set_credentials(self, access_key, secret_key, token=None):
+    def set_credentials(
+        self, access_key, secret_key, token=None, account_id=None
+    ):
         """
         Manually create credentials for this session.  If you would
         prefer to use botocore without a config file, environment variables,
@@ -495,9 +497,12 @@ class Session:
         :type token: str
         :param token: An option session token used by STS session
             credentials.
+
+        :type account_id: str
+        :param account_id: An optional account ID part of the credentials.
         """
         self._credentials = botocore.credentials.Credentials(
-            access_key, secret_key, token
+            access_key, secret_key, token, account_id=account_id
         )
 
     def get_credentials(self):
@@ -840,6 +845,7 @@ class Session:
         aws_access_key_id=None,
         aws_secret_access_key=None,
         aws_session_token=None,
+        aws_account_id=None,
         config=None,
     ):
         """Create a botocore client.
@@ -898,6 +904,13 @@ class Session:
         :param aws_session_token: The session token to use when creating
             the client.  Same semantics as aws_access_key_id above.
 
+        :type aws_account_id: string
+        :param aws_account_id: The account id to use when creating
+            the client.  This is entirely optional, and if not provided,
+            the credentials configured for the session will automatically
+            be used.  You only need to provide this argument if you want
+            to override the credentials used for this specific client.
+
         :type config: botocore.client.Config
         :param config: Advanced client configuration options. If a value
             is specified in the client config, its value will take precedence
@@ -945,6 +958,7 @@ class Session:
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,
                 token=aws_session_token,
+                account_id=aws_account_id,
             )
         elif self._missing_cred_vars(aws_access_key_id, aws_secret_access_key):
             raise PartialCredentialsError(

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -970,7 +970,7 @@ class Session:
             ):
                 logger.debug(
                     f"Ignoring the following credential-related values which were set without "
-                    f"an access key id and secret key on the client: {ignored_credentials}"
+                    f"an access key id and secret key on the session or client: {ignored_credentials}"
                 )
             credentials = self.get_credentials()
         auth_token = self.get_auth_token()

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -845,8 +845,8 @@ class Session:
         aws_access_key_id=None,
         aws_secret_access_key=None,
         aws_session_token=None,
-        aws_account_id=None,
         config=None,
+        aws_account_id=None,
     ):
         """Create a botocore client.
 
@@ -904,13 +904,6 @@ class Session:
         :param aws_session_token: The session token to use when creating
             the client.  Same semantics as aws_access_key_id above.
 
-        :type aws_account_id: string
-        :param aws_account_id: The account id to use when creating
-            the client.  This is entirely optional, and if not provided,
-            the credentials configured for the session will automatically
-            be used.  You only need to provide this argument if you want
-            to override the credentials used for this specific client.
-
         :type config: botocore.client.Config
         :param config: Advanced client configuration options. If a value
             is specified in the client config, its value will take precedence
@@ -919,6 +912,13 @@ class Session:
             object is set on the session, the config object used when creating
             the client will be the result of calling ``merge()`` on the
             default config with the config provided to this call.
+
+        :type aws_account_id: string
+        :param aws_account_id: The account id to use when creating
+            the client.  This is entirely optional, and if not provided,
+            the credentials configured for the session will automatically
+            be used.  You only need to provide this argument if you want
+            to override the credentials used for this specific client.
 
         :rtype: botocore.client.BaseClient
         :return: A botocore client instance

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -72,7 +72,10 @@ class TestCredentialPrecedence(BaseEnvVar):
         )
 
         credentials_cls.assert_called_with(
-            access_key='code', secret_key='code-secret', token=mock.ANY
+            access_key='code',
+            secret_key='code-secret',
+            token=mock.ANY,
+            account_id=mock.ANY,
         )
 
     def test_profile_env_vs_code(self):
@@ -97,7 +100,10 @@ class TestCredentialPrecedence(BaseEnvVar):
         )
 
         credentials_cls.assert_called_with(
-            access_key='code', secret_key='code-secret', token=mock.ANY
+            access_key='code',
+            secret_key='code-secret',
+            token=mock.ANY,
+            account_id=mock.ANY,
         )
 
     def test_access_secret_env_vs_profile_code(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1512,6 +1512,25 @@ class TestConfigFileProvider(BaseEnvVar):
         with self.assertRaises(botocore.exceptions.PartialCredentialsError):
             provider.load()
 
+    def test_config_file_with_account_id(self):
+        profile_config = {
+            'aws_access_key_id': 'foo',
+            'aws_secret_access_key': 'bar',
+            'aws_session_token': 'baz',
+            'aws_account_id': 'bin',
+        }
+        parsed = {'profiles': {'default': profile_config}}
+        parser = mock.Mock()
+        parser.return_value = parsed
+        provider = credentials.ConfigProvider('cli.cfg', 'default', parser)
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'config-file')
+        self.assertEqual(creds.account_id, 'bin')
+
 
 class TestBotoProvider(BaseEnvVar):
     def setUp(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1428,6 +1428,28 @@ class TestSharedCredentialsProvider(BaseEnvVar):
         creds = provider.load()
         self.assertIsNone(creds)
 
+    def test_credentials_file_exists_with_account_id(self):
+        self.ini_parser.return_value = {
+            'default': {
+                'aws_access_key_id': 'foo',
+                'aws_secret_access_key': 'bar',
+                'aws_session_token': 'baz',
+                'aws_account_id': 'bin',
+            }
+        }
+        provider = credentials.SharedCredentialProvider(
+            creds_filename='~/.aws/creds',
+            profile_name='default',
+            ini_parser=self.ini_parser,
+        )
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'shared-credentials-file')
+        self.assertEqual(creds.account_id, 'bin')
+
 
 class TestConfigFileProvider(BaseEnvVar):
     def setUp(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -781,6 +781,26 @@ class TestCreateClient(BaseSessionTest):
             ]
             self.assertEqual(call_kwargs['api_version'], override_api_version)
 
+    @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_with_credentials(self, client_creator):
+        self.session.create_client(
+            'sts',
+            'us-west-2',
+            aws_access_key_id='foo',
+            aws_secret_access_key='bar',
+            aws_session_token='baz',
+            aws_account_id='bin',
+        )
+        credentials = (
+            client_creator.return_value.create_client.call_args.kwargs[
+                'credentials'
+            ]
+        )
+        self.assertEqual(credentials.access_key, 'foo')
+        self.assertEqual(credentials.secret_key, 'bar')
+        self.assertEqual(credentials.token, 'baz')
+        self.assertEqual(credentials.account_id, 'bin')
+
 
 class TestSessionComponent(BaseSessionTest):
     def test_internal_component(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -801,6 +801,26 @@ class TestCreateClient(BaseSessionTest):
         self.assertEqual(credentials.token, 'baz')
         self.assertEqual(credentials.account_id, 'bin')
 
+    @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_with_ignored_credentials(self, client_creator):
+        with self.assertLogs('botocore.session', level='DEBUG') as log:
+            self.session.create_client(
+                'sts',
+                'us-west-2',
+                aws_account_id='foo',
+            )
+            credentials = (
+                client_creator.return_value.create_client.call_args.kwargs[
+                    'credentials'
+                ]
+            )
+            self.assertIn(
+                'Ignoring the following credential-related values',
+                log.output[0],
+            )
+            self.assertIn('aws_account_id', log.output[0])
+            self.assertEqual(credentials.account_id, None)
+
 
 class TestSessionComponent(BaseSessionTest):
     def test_internal_component(self):


### PR DESCRIPTION
This PR introduces account ID to `SharedCredentialProvider` and `ConfigProvider`. The update allows users to specify an `aws_account_id` variable either in the shared credentials file, config file, or during client creation. The account ID will then be associated with the credentials when they are loaded.