### PR TITLE
Update awscrt version to 0.23.8

### DIFF
--- a/.changes/next-release/enhancement-AWSCRT-25567.json
+++ b/.changes/next-release/enhancement-AWSCRT-25567.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "AWSCRT",
+  "description": "Update awscrt version to 0.23.8"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ requires_dist =
     urllib3>=1.25.4,!=2.2.0,<3; python_version>="3.10"
 
 [options.extras_require]
-crt = awscrt==0.23.4
+crt = awscrt==0.23.8

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requires = [
 ]
 
 extras_require = {
-    'crt': ['awscrt==0.23.4'],
+    'crt': ['awscrt==0.23.8'],
 }
 
 setup(


### PR DESCRIPTION
Updates botocore's dependency on the AWS Common Runtime (CRT) to use the latest version `awscrt-0.23.8`.