### PR TITLE
fix: updated the node version in closed-issue-message & SHA in stale-issue-cleanup

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -12,6 +12,9 @@ jobs:
         permissions:
             issues: write
         steps:
+        - uses: actions/setup-node@v3
+          with:
+            node-version: '16'
         - uses: aws-actions/closed-issue-message@37548691e7cc75ba58f85c9f873f9eee43590449
           with:
             # These inputs are both required

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -15,7 +15,7 @@ jobs:
         - uses: actions/setup-node@v3
           with:
             node-version: '16'
-        - uses: aws-actions/closed-issue-message@37548691e7cc75ba58f85c9f873f9eee43590449
+        - uses: aws-actions/closed-issue-message@0b50d3fb9d583aabd14e88ec0639b4f6e67d882f
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The closed-issue-message action would fail as it was being used with an older version of node. The workflow has been updated to use v16 which fixes the action. The stale-issue-cleanup action has been updated with the latest SHA which now prevents it from breaking. 