### PR TITLE
fix: stale-issue-cleanup used with version instead of SHA

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@119dcadf8036efef52409d94132c9441c346285c
+    - uses: aws-actions/stale-issue-cleanup@v7.0.1
       with:
         issue-types: issues
         stale-issue-message: Greetings! It looks like this issue hasn’t been 


### PR DESCRIPTION
The action uses the latest release version tag instead of the SHA.