### PR TITLE
fix: updated closed-issue-message version

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -12,7 +12,7 @@ jobs:
         permissions:
             issues: write
         steps:
-        - uses: aws-actions/closed-issue-message@37548691e7cc75ba58f85c9f873f9eee43590449
+        - uses: aws-actions/closed-issue-message@v2
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@119dcadf8036efef52409d94132c9441c346285c
+    - uses: aws-actions/stale-issue-cleanup@v7.0.1
       with:
         issue-types: issues
         stale-issue-message: Greetings! It looks like this issue hasn’t been 


### PR DESCRIPTION
A new version of the closed-issue-message action has been released. The workflow file has been updated to use this new version, which should fix failing workflows.