### PR TITLE
Restrict CRC64NVME support based on CRT version

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -296,6 +296,21 @@ except ImportError:
     HAS_CRT = False
 
 
+def has_minimum_crt_version(minimum_version):
+    """Not intended for use outside botocore."""
+    if not HAS_CRT:
+        return False
+
+    crt_version_str = awscrt.__version__
+    try:
+        crt_version_ints = map(int, crt_version_str.split("."))
+        crt_version_tuple = tuple(crt_version_ints)
+    except (TypeError, ValueError):
+        return False
+
+    return crt_version_tuple >= minimum_version
+
+
 ########################################################
 #              urllib3 compat backports                #
 ########################################################

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -25,7 +25,7 @@ import logging
 from binascii import crc32
 from hashlib import sha1, sha256
 
-from botocore.compat import HAS_CRT, urlparse
+from botocore.compat import HAS_CRT, has_minimum_crt_version, urlparse
 from botocore.exceptions import (
     AwsChunkedWrapperError,
     FlexibleChecksumError,
@@ -522,8 +522,12 @@ if HAS_CRT:
     _CRT_CHECKSUM_CLS = {
         "crc32": CrtCrc32Checksum,
         "crc32c": CrtCrc32cChecksum,
-        "crc64nvme": CrtCrc64NvmeChecksum,
     }
+
+    if has_minimum_crt_version((0, 23, 4)):
+        # CRC64NVME support wasn't officially added until 0.23.4
+        _CRT_CHECKSUM_CLS["crc64nvme"] = CrtCrc64NvmeChecksum
+
     _CHECKSUM_CLS.update(_CRT_CHECKSUM_CLS)
     # Validate this list isn't out of sync with _CRT_CHECKSUM_CLS keys
     assert all(


### PR DESCRIPTION
Some platforms automatically include a copy of the CRT in the environment, unbeknownst to the end user. In these cases, when the default checksum CRC64NVME is added to object uploaded through the console, boto3 will fail trying to validate the returned checksum.

This patch moves CRC64NVME out of the hot path for validation and will only attempt to process the received checksum when it's supported by the AWS CRT version on the machine. 