### PR TITLE
Remove payload length cap from Event Stream messages

### DIFF
--- a/.changes/next-release/enhancement-Eventsteam-78927.json
+++ b/.changes/next-release/enhancement-Eventsteam-78927.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Eventsteam",
+  "description": "The SDK no longer validates payload size for eventstreams. This is to facilitate varying payload requirements across AWS services."
+}

--- a/botocore/eventstream.py
+++ b/botocore/eventstream.py
@@ -20,7 +20,6 @@ from botocore.exceptions import EventStreamError
 # byte length of the prelude (total_length + header_length + prelude_crc)
 _PRELUDE_LENGTH = 12
 _MAX_HEADERS_LENGTH = 128 * 1024  # 128 Kb
-_MAX_PAYLOAD_LENGTH = 16 * 1024**2  # 16 Mb
 
 
 class ParserError(Exception):
@@ -46,10 +45,14 @@ class InvalidHeadersLength(ParserError):
 
 
 class InvalidPayloadLength(ParserError):
-    """Payload length is longer than the maximum."""
+    """Payload length is longer than the maximum.
+
+    DEPRECATED: This case is no longer validated client side. Payloads
+    of varying lengths are now supported by AWS services.
+    """
 
     def __init__(self, length):
-        message = f'Payload length of {length} exceeded the maximum of {_MAX_PAYLOAD_LENGTH}'
+        message = f'Payload length of {length} exceeded the maximum of 24MB.'
         super().__init__(message)
 
 
@@ -458,9 +461,6 @@ class EventStreamBuffer:
     def _validate_prelude(self, prelude):
         if prelude.headers_length > _MAX_HEADERS_LENGTH:
             raise InvalidHeadersLength(prelude.headers_length)
-
-        if prelude.payload_length > _MAX_PAYLOAD_LENGTH:
-            raise InvalidPayloadLength(prelude.payload_length)
 
     def _parse_prelude(self):
         prelude_bytes = self._data[:_PRELUDE_LENGTH]

--- a/tests/unit/test_eventstream.py
+++ b/tests/unit/test_eventstream.py
@@ -23,7 +23,6 @@ from botocore.eventstream import (
     EventStreamHeaderParser,
     EventStreamMessage,
     InvalidHeadersLength,
-    InvalidPayloadLength,
     MessagePrelude,
     NoInitialResponseError,
 )
@@ -261,17 +260,6 @@ INVALID_HEADERS_LENGTH = (
     InvalidHeadersLength,
 )
 
-# In contrast to the CORRUPTED_PAYLOAD case, this message is otherwise
-# well-formed - the checksums match.
-INVALID_PAYLOAD_LENGTH = (
-    b"\x01\x00\x00\x11"  # total length
-    + b"\x00\x00\x00\x00"  # headers length
-    + b"\xf4\x08\x61\xc5"  # prelude crc
-    + b"0" * (16 * 1024**2 + 1)  # payload
-    + b"\x2a\xb4\xc5\xa5",  # message crc
-    InvalidPayloadLength,
-)
-
 # Tuples of encoded messages and their expected exception
 NEGATIVE_CASES = [
     CORRUPTED_LENGTH,
@@ -280,7 +268,6 @@ NEGATIVE_CASES = [
     CORRUPTED_HEADER_LENGTH,
     DUPLICATE_HEADER,
     INVALID_HEADERS_LENGTH,
-    INVALID_PAYLOAD_LENGTH,
 ]
 
 
@@ -348,7 +335,6 @@ def test_all_positive_cases():
         "corrupted-headers-length",
         "duplicate-headers",
         "invalid-headers-length",
-        "invalid-payload-length",
     ],
 )
 def test_negative_cases(encoded, exception):


### PR DESCRIPTION
In initial implementations of Event Streams, there was a 16MB payload limit for Event Stream payloads. Anything exceeding that was considered malformed. In more modern implementations, that limit has been raised with some services using 24MB. We'll be removing this client-side check going forward as it doesn't serve a practical purpose. The checksum will be used to validate the payload and size limitations will be left to the service to determine going forward.