### PR TITLE
Fix datetime deprecation warning

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -421,7 +421,7 @@ class SigV4Auth(BaseSigner):
     def add_auth(self, request):
         if self.credentials is None:
             raise NoCredentialsError()
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
@@ -559,7 +559,7 @@ class S3ExpressPostAuth(S3ExpressAuth):
     REQUIRES_IDENTITY_CACHE = True
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}
@@ -818,7 +818,7 @@ class S3SigV4PostAuth(SigV4Auth):
     """
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}

--- a/botocore/crt/auth.py
+++ b/botocore/crt/auth.py
@@ -56,7 +56,7 @@ class CrtSigV4Auth(BaseSigner):
 
         # Use utcnow() because that's what gets mocked by tests, but set
         # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
+        datetime_now = datetime.datetime.now(datetime.UTC).replace(
             tzinfo=datetime.timezone.utc
         )
 
@@ -253,7 +253,7 @@ class CrtSigV4AsymAuth(BaseSigner):
 
         # Use utcnow() because that's what gets mocked by tests, but set
         # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
+        datetime_now = datetime.datetime.now(datetime.UTC).replace(
             tzinfo=datetime.timezone.utc
         )
 

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -150,7 +150,7 @@ class Endpoint:
     def _calculate_ttl(
         self, response_received_timestamp, date_header, read_timeout
     ):
-        local_timestamp = datetime.datetime.utcnow()
+        local_timestamp = datetime.datetime.now(datetime.UTC)
         date_conversion = datetime.datetime.strptime(
             date_header, "%a, %d %b %Y %H:%M:%S %Z"
         )
@@ -167,7 +167,7 @@ class Endpoint:
         has_streaming_input = retries_context.get('has_streaming_input')
         if response_date_header and not has_streaming_input:
             try:
-                response_received_timestamp = datetime.datetime.utcnow()
+                response_received_timestamp = datetime.datetime.now(datetime.UTC)
                 retries_context['ttl'] = self._calculate_ttl(
                     response_received_timestamp,
                     response_date_header,

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -723,7 +723,7 @@ class S3PostPresigner:
         policy = {}
 
         # Create an expiration date for the policy
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         expire_date = datetime_now + datetime.timedelta(seconds=expires_in)
         policy['expiration'] = expire_date.strftime(botocore.auth.ISO8601)
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -667,7 +667,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
             )
             jitter = random.randint(120, 600)  # Between 2 to 10 minutes
             refresh_interval_with_jitter = refresh_interval + jitter
-            current_time = datetime.datetime.utcnow()
+            current_time = datetime.datetime.now(datetime.UTC)
             refresh_offset = datetime.timedelta(
                 seconds=refresh_interval_with_jitter
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -572,7 +572,7 @@ class FreezeTime(ContextDecorator):
 
     def __init__(self, module, date=None):
         if date is None:
-            date = datetime.datetime.utcnow()
+            date = datetime.datetime.now(datetime.UTC)
         self.date = date
         self.datetime_patcher = mock.patch.object(
             module, 'datetime', mock.Mock(wraps=datetime.datetime)

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -315,7 +315,7 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(datetime.UTC) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -749,7 +749,7 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(datetime.UTC) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -867,7 +867,7 @@ class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
         mock_loader_cls.assert_called_with('/some/path/token.jwt')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(datetime.UTC) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         cache_key = 'c29461feeacfbed43017d20612606ff76abc073d'
@@ -2037,7 +2037,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(expiry_time, '2016-11-06T01:30:00UTC')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(datetime.UTC) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         self.fake_config['profiles']['development']['role_arn'] = 'myrole'
 
@@ -2066,7 +2066,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(creds.token, 'baz-cached')
 
     def test_chain_prefers_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(datetime.UTC) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         # The profile we will be using has a cache entry, but the profile it

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3144,7 +3144,7 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
 
     def _get_datetime(self, dt=None, offset=None, offset_func=operator.add):
         if dt is None:
-            dt = datetime.datetime.utcnow()
+            dt = datetime.datetime.now(datetime.UTC)
         if offset is not None:
             dt = offset_func(dt, offset)
 


### PR DESCRIPTION
When running boto3 on Python 3.12 environment, there is a deprecation warning "DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)". This PR tries to address this issue.