### PR TITLE
Protocols trait support

### DIFF
--- a/.changes/next-release/enhancement-Protocols-98789.json
+++ b/.changes/next-release/enhancement-Protocols-98789.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Protocols",
+  "description": "This version of botocore adds support for using a priority ordered list of protocols to determine which protocol to use for a service"
+}

--- a/.changes/next-release/enhancement-Protocols-98789.json
+++ b/.changes/next-release/enhancement-Protocols-98789.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
   "category": "Protocols",
-  "description": "This version of botocore adds support for using a priority ordered list of protocols to determine which protocol to use for a service"
+  "description": "Added support for multiple protocols within a service based on performance priority."
 }

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -820,8 +820,8 @@ class ClientArgsCreator:
 
     def _resolve_protocol(self, service_model):
         # We need to ensure `protocols` exists in the metadata before attempting to
-        #  access it directly since referencing service_model.protocols directly will
-        #  raise an UndefinedModelAttributeError if protocols is not defined
+        # access it directly since referencing service_model.protocols directly will
+        # raise an UndefinedModelAttributeError if protocols is not defined
         if service_model.metadata.get('protocols'):
             for protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS:
                 if protocol in service_model.protocols:

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -819,7 +819,8 @@ class ClientArgsCreator:
         )
 
     def _compute_protocol(self, service_model):
-        # If we don't have a protocols trait, fall back to the legacy protocol trait
+        # If a service does not have a `protocols trait`, fall back to the legacy
+        # `protocol` trait
         if 'protocols' not in service_model.metadata:
             return service_model.metadata['protocol']
         for protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS:

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -822,7 +822,6 @@ class ClientArgsCreator:
         # If we don't have a protocols trait, fall back to the legacy protocol trait
         if 'protocols' not in service_model.metadata:
             return service_model.metadata['protocol']
-
         for protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS:
             if protocol in service_model.protocols:
                 return protocol

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -70,14 +70,12 @@ VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG = (
     "when_required",
 )
 
-PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = list(
-    (
-        'json',
-        'rest-json',
-        'rest-xml',
-        'query',
-        'ec2',
-    )
+PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = (
+    'json',
+    'rest-json',
+    'rest-xml',
+    'query',
+    'ec2',
 )
 
 

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -70,6 +70,16 @@ VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG = (
     "when_required",
 )
 
+PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = list(
+    (
+        'json',
+        'rest-json',
+        'rest-xml',
+        'query',
+        'ec2',
+    )
+)
+
 
 class ClientArgsCreator:
     def __init__(
@@ -210,7 +220,7 @@ class ClientArgsCreator:
         scoped_config,
     ):
         service_name = service_model.endpoint_prefix
-        protocol = service_model.metadata['protocol']
+        protocol = self._compute_protocol(service_model)
         parameter_validation = True
         if client_config and not client_config.parameter_validation:
             parameter_validation = False
@@ -808,6 +818,20 @@ class ClientArgsCreator:
             config_kwargs,
             config_key="response_checksum_validation",
             valid_options=VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG,
+        )
+
+    def _compute_protocol(self, service_model):
+        # If we don't have a protocols trait, fall back to the legacy protocol trait
+        if 'protocols' not in service_model.metadata:
+            return service_model.metadata['protocol']
+
+        for protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS:
+            if protocol in service_model.protocols:
+                return protocol
+        raise botocore.exceptions.NoSupportedProtocolError(
+            botocore_supported_protocols=PRIORITY_ORDERED_SUPPORTED_PROTOCOLS,
+            service_supported_protocols=service_model.protocols,
+            service=service_model.service_name,
         )
 
     def _handle_checksum_config(

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -218,7 +218,7 @@ class ClientArgsCreator:
         scoped_config,
     ):
         service_name = service_model.endpoint_prefix
-        protocol = self._compute_protocol(service_model)
+        protocol = self._resolve_protocol(service_model)
         parameter_validation = True
         if client_config and not client_config.parameter_validation:
             parameter_validation = False
@@ -818,7 +818,7 @@ class ClientArgsCreator:
             valid_options=VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG,
         )
 
-    def _compute_protocol(self, service_model):
+    def _resolve_protocol(self, service_model):
         # If a service does not have a `protocols trait`, fall back to the legacy
         # `protocol` trait
         if 'protocols' not in service_model.metadata:

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -819,7 +819,7 @@ class ClientArgsCreator:
         )
 
     def _resolve_protocol(self, service_model):
-        # If a service does not have a `protocols trait`, fall back to the legacy
+        # If a service does not have a `protocols` trait, fall back to the legacy
         # `protocol` trait
         if 'protocols' not in service_model.metadata:
             return service_model.metadata['protocol']

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -825,7 +825,7 @@ class InvalidChecksumConfigError(BotoCoreError):
     )
 
 
-class NoSupportedProtocolError(BotoCoreError):
+class UnsupportedServiceProtocolsError(BotoCoreError):
     """Error when a service does not use any protocol supported by botocore."""
 
     fmt = (

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -826,7 +826,7 @@ class InvalidChecksumConfigError(BotoCoreError):
 
 
 class NoSupportedProtocolError(BotoCoreError):
-    """Error when a service does not use any protocol we support."""
+    """Error when a service does not use any protocol supported by botocore."""
 
     fmt = (
         'Botocore supports {botocore_supported_protocols}, but service {service} only '

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -823,3 +823,12 @@ class InvalidChecksumConfigError(BotoCoreError):
         'Unsupported configuration value for {config_key}. '
         'Expected one of {valid_options} but got {config_value}.'
     )
+
+
+class NoSupportedProtocolError(BotoCoreError):
+    """Error when a service does not use any protocol we support."""
+
+    fmt = (
+        'Botocore supports {botocore_supported_protocols}, but service {service} only '
+        'supports {service_supported_protocols}.'
+    )

--- a/botocore/model.py
+++ b/botocore/model.py
@@ -423,6 +423,10 @@ class ServiceModel:
         return self._get_metadata_property('protocol')
 
     @CachedProperty
+    def protocols(self):
+        return self._get_metadata_property('protocols')
+
+    @CachedProperty
     def endpoint_prefix(self):
         return self._get_metadata_property('endpointPrefix')
 

--- a/tests/functional/test_supported_protocols.py
+++ b/tests/functional/test_supported_protocols.py
@@ -17,12 +17,12 @@ from botocore.loaders import Loader
 from botocore.session import get_session
 
 
-def _get_services_models_by_protocols_trait(get_models_with_protocols_trait):
+def _get_services_models_by_protocols_trait(has_protocol_trait):
     session = get_session()
     service_list = Loader().list_available_services('service-2')
     for service in service_list:
         service_model = session.get_service_model(service)
-        if ('protocols' in service_model.metadata) == get_models_with_protocols_trait:
+        if ('protocols' in service_model.metadata) == has_protocol_trait:
             yield service_model
 
 

--- a/tests/functional/test_supported_protocols.py
+++ b/tests/functional/test_supported_protocols.py
@@ -1,0 +1,56 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import pytest
+
+from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
+from botocore.session import get_session
+
+
+def _all_test_cases():
+    session = get_session()
+    loader = session.get_component('data_loader')
+
+    services = loader.list_available_services('service-2')
+    services_models_with_protocols = []
+    services_models_without_protocols = []
+
+    for service in services:
+        service_model = session.get_service_model(service)
+        if 'protocols' in service_model.metadata:
+            services_models_with_protocols.append(service_model)
+        else:
+            services_models_without_protocols.append(service_model)
+    return (services_models_with_protocols, services_models_without_protocols)
+
+
+SERVICE_MODELS_WITH_PROTOCOLS, SERVICE_MODELS_WITHOUT_PROTOCOLS = (
+    _all_test_cases()
+)
+
+
+@pytest.mark.validates_models
+@pytest.mark.parametrize("service", SERVICE_MODELS_WITH_PROTOCOLS)
+def test_services_with_protocols_trait_have_supported_protocol(service):
+    service_supported_protocols = service.protocols
+    message = f"No protocols supported for service {service.service_name}"
+    assert any(
+        protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
+        for protocol in service_supported_protocols
+    ), message
+
+
+@pytest.mark.validates_models
+@pytest.mark.parametrize("service", SERVICE_MODELS_WITHOUT_PROTOCOLS)
+def test_services_without_protocols_trait_have_supported_protocol(service):
+    message = f"No protocols supported for service {service.service_name}"
+    assert service.protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS, message

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -71,6 +71,7 @@ class TestCreateClientArgs(unittest.TestCase):
         service_model.protocols = ['query']
         service_model.metadata = {
             'serviceFullName': 'MyService',
+            'protocol': 'query',
             'protocols': ['query'],
         }
         service_model.operation_names = []
@@ -951,9 +952,15 @@ class TestProtocolPriorityList:
     def test_all_parsers_accounted_for(self):
         assert set(PRIORITY_ORDERED_SUPPORTED_PROTOCOLS) == set(
             PROTOCOL_PARSERS.keys()
+        ), (
+            "The map of protocol names to parsers is out of sync with the priority "
+            "ordered list of protocols supported by botocore"
         )
 
     def test_all_serializers_accounted_for(self):
         assert set(PRIORITY_ORDERED_SUPPORTED_PROTOCOLS) == set(
             SERIALIZERS.keys()
+        ), (
+            "The map of protocol names to serializers is out of sync with the "
+            "priority ordered list of protocols supported by botocore"
         )

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -18,7 +18,7 @@ from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
 from botocore.client import ClientEndpointBridge
 from botocore.config import Config
 from botocore.configprovider import ConfigValueStore
-from botocore.exceptions import NoSupportedProtocolError
+from botocore.exceptions import UnsupportedServiceProtocolsError
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel
 from botocore.parsers import PROTOCOL_PARSERS
@@ -67,10 +67,10 @@ class TestCreateClientArgs(unittest.TestCase):
         service_model = mock.Mock(ServiceModel)
         service_model.service_name = service_name
         service_model.endpoint_prefix = service_name
+        service_model.protocol = 'query'
         service_model.protocols = ['query']
         service_model.metadata = {
             'serviceFullName': 'MyService',
-            'protocol': 'query',
             'protocols': ['query'],
         }
         service_model.operation_names = []
@@ -713,7 +713,7 @@ class TestCreateClientArgs(unittest.TestCase):
     def test_protocol_raises_error_for_unsupported_protocol(self):
         self.service_model.protocols = ['wrongprotocol']
         with self.assertRaisesRegex(
-            NoSupportedProtocolError, self.service_model.service_name
+            UnsupportedServiceProtocolsError, self.service_model.service_name
         ):
             self.call_compute_client_args()
 

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -14,12 +14,15 @@
 import socket
 
 from botocore import args, exceptions
+from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
 from botocore.client import ClientEndpointBridge
 from botocore.config import Config
 from botocore.configprovider import ConfigValueStore
 from botocore.exceptions import NoSupportedProtocolError
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel
+from botocore.parsers import PROTOCOL_PARSERS
+from botocore.serialize import SERIALIZERS
 from botocore.useragent import UserAgentString
 from tests import get_botocore_default_config_mapping, mock, unittest
 
@@ -940,3 +943,15 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             legacy_endpoint_url='https://my.legacy.endpoint.com',
         )
         self.assertEqual(bins['SDK::Endpoint'], None)
+
+
+class TestProtocolPriorityList:
+    def test_all_parsers_accounted_for(self):
+        assert set(PRIORITY_ORDERED_SUPPORTED_PROTOCOLS) == set(
+            PROTOCOL_PARSERS.keys()
+        )
+
+    def test_all_serializers_accounted_for(self):
+        assert set(PRIORITY_ORDERED_SUPPORTED_PROTOCOLS) == set(
+            SERIALIZERS.keys()
+        )

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -699,6 +699,8 @@ class TestCreateClientArgs(unittest.TestCase):
             self.call_get_client_args()
 
     def test_protocol_resolution_without_protocols_trait(self):
+        del self.service_model.protocols
+        del self.service_model.metadata['protocols']
         client_args = self.call_compute_client_args()
         self.assertEqual(client_args['protocol'], 'query')
 


### PR DESCRIPTION
This PR adds support for the new `protocols` trait, which allows a service to list a number of protocols it supports; botocore will automatically choose the highest priority supported protocol and use that to make requests to the service.