### PR TITLE
Upgrade ruff, fix issues, use ruff for import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,6 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: 'https://github.com/PyCQA/isort'
-    rev: 5.12.0
-    hooks:
-      - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.9.4
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -26,6 +26,7 @@ from operator import itemgetter
 
 from botocore.compat import (
     HAS_CRT,
+    MD5_AVAILABLE,  # noqa: F401 -- keep imported for backwards compatibility
     HTTPHeaders,
     encodebytes,
     ensure_unicode,
@@ -46,10 +47,6 @@ from botocore.utils import (
     normalize_url_path,
     percent_encode_sequence,
 )
-
-# Imports for backwards compatibility
-from botocore.compat import MD5_AVAILABLE  # noqa
-
 
 logger = logging.getLogger(__name__)
 

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -88,7 +88,7 @@ def _host_from_url(url):
     }
     if url_parts.port is not None:
         if url_parts.port != default_ports.get(url_parts.scheme):
-            host = '%s:%d' % (host, url_parts.port)
+            host = f'{host}:{url_parts.port}'
     return host
 
 

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -12,7 +12,11 @@
 # language governing permissions and limitations under the License.
 import logging
 
-from botocore import waiter, xform_name
+from botocore import (
+    UNSIGNED,  # noqa: F401 -- keep imported for backwards compatibility
+    waiter,
+    xform_name,
+)
 from botocore.args import ClientArgsCreator
 from botocore.auth import AUTH_TYPE_MAPS, resolve_auth_type
 from botocore.awsrequest import prepare_request_dict
@@ -26,6 +30,7 @@ from botocore.discovery import (
 )
 from botocore.docs.docstring import ClientMethodDocstring, PaginatorDocstring
 from botocore.exceptions import (
+    ClientError,  # noqa: F401 -- keep imported for backwards compatibility
     DataNotFoundError,
     InvalidEndpointDiscoveryConfigurationError,
     OperationNotPageableError,
@@ -45,25 +50,17 @@ from botocore.useragent import UserAgentString
 from botocore.utils import (
     CachedProperty,
     EventbridgeSignerSetter,
+    S3ArnParamHandler,  # noqa: F401 -- keep imported for backwards compatibility
+    S3ControlArnParamHandler,  # noqa: F401 -- keep imported for backwards compatibility
     S3ControlArnParamHandlerv2,
+    S3ControlEndpointSetter,  # noqa: F401 -- keep imported for backwards compatibility
+    S3EndpointSetter,  # noqa: F401 -- keep imported for backwards compatibility
     S3ExpressIdentityResolver,
+    S3RegionRedirector,  # noqa: F401 -- keep imported for backwards compatibility
     S3RegionRedirectorv2,
     ensure_boolean,
     get_service_module_name,
 )
-
-# Keep these imported.  There's pre-existing code that uses:
-# "from botocore.client import UNSIGNED"
-# "from botocore.client import ClientError"
-# etc.
-from botocore.exceptions import ClientError  # noqa
-from botocore.utils import S3ArnParamHandler  # noqa
-from botocore.utils import S3ControlArnParamHandler  # noqa
-from botocore.utils import S3ControlEndpointSetter  # noqa
-from botocore.utils import S3EndpointSetter  # noqa
-from botocore.utils import S3RegionRedirector  # noqa
-from botocore import UNSIGNED  # noqa
-
 
 _LEGACY_SIGNATURE_VERSIONS = frozenset(
     (

--- a/botocore/docs/params.py
+++ b/botocore/docs/params.py
@@ -189,8 +189,7 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
                     [f'``{key}``' for key in shape.members.keys()]
                 )
                 unknown_code_example = (
-                    '\'SDK_UNKNOWN_MEMBER\': '
-                    '{\'name\': \'UnknownMemberName\'}'
+                    '\'SDK_UNKNOWN_MEMBER\': {\'name\': \'UnknownMemberName\'}'
                 )
                 tagged_union_docs.write(note % (tagged_union_members_str))
                 example = section.add_new_section('param-unknown-example')

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -351,7 +351,7 @@ class ValidationError(BotoCoreError):
     :ivar type_name: The name of the underlying type.
     """
 
-    fmt = "Invalid value ('{value}') for param {param} " "of type {type_name} "
+    fmt = "Invalid value ('{value}') for param {param} of type {type_name} "
 
 
 class ParamValidationError(BotoCoreError):
@@ -371,8 +371,7 @@ class UnknownKeyError(ValidationError):
     """
 
     fmt = (
-        "Unknown key '{value}' for param '{param}'.  Must be one "
-        "of: {choices}"
+        "Unknown key '{value}' for param '{param}'.  Must be one of: {choices}"
     )
 
 
@@ -482,9 +481,7 @@ class WaiterError(BotoCoreError):
 class IncompleteReadError(BotoCoreError):
     """HTTP response did not return expected number of bytes."""
 
-    fmt = (
-        '{actual_bytes} read, but total bytes ' 'expected is {expected_bytes}.'
-    )
+    fmt = '{actual_bytes} read, but total bytes expected is {expected_bytes}.'
 
 
 class InvalidExpressionError(BotoCoreError):

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -27,8 +27,13 @@ from io import BytesIO
 
 import botocore
 import botocore.auth
-from botocore import utils
+from botocore import (
+    retryhandler,  # noqa: F401 -- keep imported for backwards compatibility
+    translate,  # noqa: F401 -- keep imported for backwards compatibility
+    utils,
+)
 from botocore.compat import (
+    MD5_AVAILABLE,  # noqa: F401 -- keep imported for backwards compatibility
     ETree,
     OrderedDict,
     XMLParseError,
@@ -49,6 +54,7 @@ from botocore.docs.utils import (
 from botocore.endpoint_provider import VALID_HOST_LABEL_RE
 from botocore.exceptions import (
     AliasConflictParameterError,
+    MissingServiceIdError,  # noqa: F401 -- keep imported for backwards compatibility
     ParamValidationError,
     UnsupportedTLSVersionWarning,
 )
@@ -61,20 +67,13 @@ from botocore.signers import (
 )
 from botocore.utils import (
     SAFE_CHARS,
+    SERVICE_NAME_ALIASES,  # noqa: F401 -- keep imported for backwards compatibility
     ArnParser,
+    hyphenize_service_id,  # noqa: F401 -- keep imported for backwards compatibility
+    is_global_accesspoint,  # noqa: F401 -- keep imported for backwards compatibility
     percent_encode,
     switch_host_with_param,
 )
-
-# Keep these imported.  There's pre-existing code that uses them.
-from botocore import retryhandler  # noqa
-from botocore import translate  # noqa
-from botocore.compat import MD5_AVAILABLE  # noqa
-from botocore.exceptions import MissingServiceIdError  # noqa
-from botocore.utils import hyphenize_service_id  # noqa
-from botocore.utils import is_global_accesspoint  # noqa
-from botocore.utils import SERVICE_NAME_ALIASES  # noqa
-
 
 logger = logging.getLogger(__name__)
 

--- a/botocore/monitoring.py
+++ b/botocore/monitoring.py
@@ -535,7 +535,7 @@ class CSMSerializer:
     def _truncate(self, text, max_length):
         if len(text) > max_length:
             logger.debug(
-                'Truncating following value to maximum length of ' '%s: %s',
+                'Truncating following value to maximum length of %s: %s',
                 text,
                 max_length,
             )

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -321,8 +321,7 @@ class PageIterator:
                     and previous_next_token == next_token
                 ):
                     message = (
-                        f"The same next token was received "
-                        f"twice: {next_token}"
+                        f"The same next token was received twice: {next_token}"
                     )
                     raise PaginationError(message=message)
                 self._inject_token_into_kwargs(current_kwargs, next_token)

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -18,19 +18,22 @@ from io import IOBase
 from urllib3.exceptions import ProtocolError as URLLib3ProtocolError
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 
-from botocore import parsers
-from botocore.compat import set_socket_timeout
+from botocore import (
+    ScalarTypes,  # noqa: F401 -- keep imported for backwards compatibility
+    parsers,
+)
+from botocore.compat import (
+    XMLParseError,  # noqa: F401 -- keep imported for backwards compatibility
+    set_socket_timeout,
+)
 from botocore.exceptions import (
     IncompleteReadError,
     ReadTimeoutError,
     ResponseStreamingError,
 )
-
-# Keep these imported.  There's pre-existing code that uses them.
-from botocore import ScalarTypes  # noqa
-from botocore.compat import XMLParseError  # noqa
-from botocore.hooks import first_non_none_response  # noqa
-
+from botocore.hooks import (
+    first_non_none_response,  # noqa: F401 -- keep imported for backwards compatibility
+)
 
 logger = logging.getLogger(__name__)
 

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -38,7 +38,10 @@ from botocore import (
     translate,
     waiter,
 )
-from botocore.compat import HAS_CRT, MutableMapping
+from botocore.compat import (
+    HAS_CRT,  # noqa: F401 -- keep imported for backwards compatibility
+    MutableMapping,
+)
 from botocore.configprovider import (
     BOTOCORE_DEFAUT_SESSION_VARIABLES,
     ConfigChainFactory,
@@ -71,9 +74,6 @@ from botocore.utils import (
     IMDSRegionProvider,
     validate_region_name,
 )
-
-from botocore.compat import HAS_CRT  # noqa
-
 
 logger = logging.getLogger(__name__)
 

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -25,10 +25,11 @@ from botocore.exceptions import (
     UnknownSignatureVersionError,
     UnsupportedSignatureVersionError,
 )
-from botocore.utils import ArnParser, datetime2timestamp
-
-# Keep these imported.  There's pre-existing code that uses them.
-from botocore.utils import fix_s3_host  # noqa
+from botocore.utils import (
+    ArnParser,
+    datetime2timestamp,
+    fix_s3_host,  # noqa: F401 -- keep imported for backwards compatibility
+)
 
 
 class RequestSigner:

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -37,21 +37,19 @@ from urllib3.exceptions import LocationParseError
 import botocore
 import botocore.awsrequest
 import botocore.httpsession
-
-# IP Regexes retained for backwards compatibility
-from botocore.compat import HEX_PAT  # noqa: F401
-from botocore.compat import IPV4_PAT  # noqa: F401
-from botocore.compat import IPV6_ADDRZ_PAT  # noqa: F401
-from botocore.compat import IPV6_PAT  # noqa: F401
-from botocore.compat import LS32_PAT  # noqa: F401
-from botocore.compat import UNRESERVED_PAT  # noqa: F401
-from botocore.compat import ZONE_ID_PAT  # noqa: F401
 from botocore.compat import (
     HAS_CRT,
+    HEX_PAT,  # noqa: F401 -- IP Regexes retained for backwards compatibility
+    IPV4_PAT,  # noqa: F401 -- IP Regexes retained for backwards compatibility
     IPV4_RE,
+    IPV6_ADDRZ_PAT,  # noqa: F401 -- IP Regexes retained for backwards compatibility
     IPV6_ADDRZ_RE,
+    IPV6_PAT,  # noqa: F401 -- IP Regexes retained for backwards compatibility
+    LS32_PAT,  # noqa: F401 -- IP Regexes retained for backwards compatibility
     MD5_AVAILABLE,
+    UNRESERVED_PAT,  # noqa: F401 -- IP Regexes retained for backwards compatibility
     UNSAFE_URL_CHARS,
+    ZONE_ID_PAT,  # noqa: F401 -- IP Regexes retained for backwards compatibility
     OrderedDict,
     get_md5,
     get_tzinfo_options,

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -681,7 +681,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
                     f"Attempting credential expiration extension due to a "
                     f"credential service availability issue. A refresh of "
                     f"these credentials will be attempted again within "
-                    f"the next {refresh_interval_with_jitter/60:.0f} minutes."
+                    f"the next {refresh_interval_with_jitter / 60:.0f} minutes."
                 )
         except ValueError:
             logger.debug(
@@ -3532,8 +3532,7 @@ class JSONFileCache:
             file_content = self._dumps(value)
         except (TypeError, ValueError):
             raise ValueError(
-                f"Value cannot be cached, must be "
-                f"JSON serializable: {value}"
+                f"Value cannot be cached, must be JSON serializable: {value}"
             )
         if not os.path.isdir(self._working_dir):
             os.makedirs(self._working_dir)

--- a/botocore/validate.py
+++ b/botocore/validate.py
@@ -232,7 +232,7 @@ class ParamValidator:
         elif isinstance(params, list):
             for index, entity in enumerate(params):
                 self._validate_document(
-                    entity, shape, errors, '%s[%d]' % (name, index)
+                    entity, shape, errors, f'{name}[{index}]'
                 )
         elif not isinstance(params, ((str,), int, bool, float)):
             valid_types = (str, int, bool, float, list, dict)

--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -366,7 +366,7 @@ class Waiter:
                     )
             if current_state == 'success':
                 logger.debug(
-                    "Waiting complete, waiter matched the " "success state."
+                    "Waiting complete, waiter matched the success state."
                 )
                 return
             if current_state == 'failure':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,6 @@ markers = [
     "validates_models: marks tests as one which validates service models",
 ]
 
-[tool.isort]
-profile = "black"
-line_length = 79
-honor_noqa = true
-src_paths = ["botocore", "tests"]
-
 [tool.ruff]
 exclude = [
     ".bzr",
@@ -60,7 +54,7 @@ target-version = "py38"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "UP"]
+select = ["E4", "E7", "E9", "F", "UP", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,12 @@ src_paths = ["botocore", "tests"]
 [tool.ruff]
 exclude = [
     ".bzr",
+    ".changes", # from .pre-commit-config.yaml
     ".direnv",
     ".eggs",
     ".git",
     ".git-rewrite",
+    ".github", # from .pre-commit-config.yaml
     ".hg",
     ".ipynb_checkpoints",
     ".mypy_cache",
@@ -32,11 +34,19 @@ exclude = [
     ".vscode",
     "__pypackages__",
     "_build",
+    "botocore/compat.py", # from .pre-commit-config.yaml
+    "botocore/data", # from .pre-commit-config.yaml
+    "botocore/vendored", # from .pre-commit-config.yaml
     "buck-out",
     "build",
     "dist",
+    "docs/", # from .pre-commit-config.yaml
     "node_modules",
     "site-packages",
+    "tests/functional/endpoint-rules", # from .pre-commit-config.yaml
+    "tests/unit/auth/aws4_testsuite", # from .pre-commit-config.yaml
+    "tests/unit/data/endpoints/", # from .pre-commit-config.yaml
+    "tests/unit/response_parsing/xml", # from .pre-commit-config.yaml
     "venv",
 ]
 

--- a/scripts/get-model-filename
+++ b/scripts/get-model-filename
@@ -162,7 +162,7 @@ def main():
         return 0
     if len(args) != 1:
         sys.stderr.write(
-            "Must provide the filename of the JSON model " "as an argument.\n"
+            "Must provide the filename of the JSON model as an argument.\n"
         )
         return 1
     source_filename = args[0]

--- a/tests/functional/test_cognito_idp.py
+++ b/tests/functional/test_cognito_idp.py
@@ -89,6 +89,6 @@ def test_unsigned_operations(operation_name, parameters):
             operation(**parameters)
             request = http_stubber.requests[0]
 
-        assert (
-            'authorization' not in request.headers
-        ), 'authorization header found in unsigned operation'
+        assert 'authorization' not in request.headers, (
+            'authorization header found in unsigned operation'
+        )

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -811,7 +811,7 @@ class TestAssumeRoleWithWebIdentity(BaseAssumeRoleTest):
         self.assert_session_credentials(expected_params, profile='A')
 
     def test_assume_role_env_vars(self):
-        config = '[profile B]\n' 'region = us-west-2\n'
+        config = '[profile B]\nregion = us-west-2\n'
         self.write_config(config)
         self.environ['AWS_ROLE_ARN'] = 'arn:aws:iam::123456789:role/RoleB'
         self.environ['AWS_WEB_IDENTITY_TOKEN_FILE'] = self.token_file
@@ -862,7 +862,7 @@ class TestProcessProvider(unittest.TestCase):
         self.environ_patch.stop()
 
     def test_credential_process(self):
-        config = '[profile processcreds]\n' 'credential_process = %s\n'
+        config = '[profile processcreds]\ncredential_process = %s\n'
         config = config % self.credential_process
         with temporary_file('w') as f:
             f.write(config)
@@ -875,8 +875,7 @@ class TestProcessProvider(unittest.TestCase):
 
     def test_credential_process_returns_error(self):
         config = (
-            '[profile processcreds]\n'
-            'credential_process = %s --raise-error\n'
+            '[profile processcreds]\ncredential_process = %s --raise-error\n'
         )
         config = config % self.credential_process
         with temporary_file('w') as f:

--- a/tests/functional/test_discovery.py
+++ b/tests/functional/test_discovery.py
@@ -56,9 +56,7 @@ class TestEndpointDiscovery(FunctionalSessionTest):
         stubber.add_response(status=200, body=b'{}')
 
     def set_endpoint_discovery_config_file(self, fileobj, config_val):
-        fileobj.write(
-            '[default]\n' f'endpoint_discovery_enabled={config_val}\n'
-        )
+        fileobj.write(f'[default]\nendpoint_discovery_enabled={config_val}\n')
         fileobj.flush()
         self.environ['AWS_CONFIG_FILE'] = fileobj.name
 

--- a/tests/functional/test_endpoint_rulesets.py
+++ b/tests/functional/test_endpoint_rulesets.py
@@ -266,9 +266,9 @@ def test_end_to_end_test_cases_yielding_endpoints(
             pass
         assert len(http_stubber.requests) > 0
         actual_url = http_stubber.requests[0].url
-        assert actual_url.startswith(
-            expected_endpoint['url']
-        ), f"{actual_url} does not start with {expected_endpoint['url']}"
+        assert actual_url.startswith(expected_endpoint['url']), (
+            f"{actual_url} does not start with {expected_endpoint['url']}"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_response_shadowing.py
+++ b/tests/functional/test_response_shadowing.py
@@ -30,9 +30,9 @@ def _assert_not_shadowed(key, shape):
     if not shape:
         return
 
-    assert (
-        key not in shape.members
-    ), f'Found shape "{shape.name}" that shadows the botocore response key "{key}"'
+    assert key not in shape.members, (
+        f'Found shape "{shape.name}" that shadows the botocore response key "{key}"'
+    )
 
 
 @pytest.mark.parametrize("operation_output_shape", _all_operations())

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -132,7 +132,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_client_s3_dualstack_handles_uppercase_true(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    use_dualstack_endpoint = True"
+                f, "[default]\ns3 = \n    use_dualstack_endpoint = True"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -142,7 +142,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_client_s3_dualstack_handles_lowercase_true(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    use_dualstack_endpoint = true"
+                f, "[default]\ns3 = \n    use_dualstack_endpoint = true"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -152,7 +152,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_client_s3_accelerate_handles_uppercase_true(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    use_accelerate_endpoint = True"
+                f, "[default]\ns3 = \n    use_accelerate_endpoint = True"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -162,7 +162,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_client_s3_accelerate_handles_lowercase_true(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    use_accelerate_endpoint = true"
+                f, "[default]\ns3 = \n    use_accelerate_endpoint = true"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -172,7 +172,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_client_payload_signing_enabled_handles_uppercase_true(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    payload_signing_enabled = True"
+                f, "[default]\ns3 = \n    payload_signing_enabled = True"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -182,7 +182,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_client_payload_signing_enabled_handles_lowercase_true(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    payload_signing_enabled = true"
+                f, "[default]\ns3 = \n    payload_signing_enabled = true"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -192,7 +192,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_includes_unmodeled_s3_config_vars(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    unmodeled = unmodeled_val"
+                f, "[default]\ns3 = \n    unmodeled = unmodeled_val"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -229,7 +229,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
 
     def test_use_arn_region_config_var(self):
         with temporary_file("w") as f:
-            self.set_config_file(f, "[default]\n" "s3_use_arn_region = true")
+            self.set_config_file(f, "[default]\ns3_use_arn_region = true")
             client = self.create_s3_client()
             self.assertEqual(
                 client.meta.config.s3,
@@ -241,7 +241,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_use_arn_region_nested_config_var(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    use_arn_region = true"
+                f, "[default]\ns3 = \n    use_arn_region = true"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -265,7 +265,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
         self.environ["AWS_S3_USE_ARN_REGION"] = "false"
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    use_arn_region = true"
+                f, "[default]\ns3 = \n    use_arn_region = true"
             )
             client = self.create_s3_client()
         self.assertEqual(
@@ -290,7 +290,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_client_config_use_arn_region_overrides_config_var(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3 = \n" "    use_arn_region = true"
+                f, "[default]\ns3 = \n    use_arn_region = true"
             )
             client = self.create_s3_client(
                 config=Config(s3={"use_arn_region": False})
@@ -315,7 +315,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
     def test_us_east_1_regional_config_var(self):
         with temporary_file("w") as f:
             self.set_config_file(
-                f, "[default]\n" "s3_us_east_1_regional_endpoint = regional"
+                f, "[default]\ns3_us_east_1_regional_endpoint = regional"
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -329,9 +329,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
         with temporary_file("w") as f:
             self.set_config_file(
                 f,
-                "[default]\n"
-                "s3 = \n"
-                "    us_east_1_regional_endpoint = regional",
+                "[default]\ns3 = \n    us_east_1_regional_endpoint = regional",
             )
             client = self.create_s3_client()
             self.assertEqual(
@@ -346,9 +344,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
         with temporary_file("w") as f:
             self.set_config_file(
                 f,
-                "[default]\n"
-                "s3 = \n"
-                "    us_east_1_regional_endpoint = legacy",
+                "[default]\ns3 = \n    us_east_1_regional_endpoint = legacy",
             )
             client = self.create_s3_client()
         self.assertEqual(
@@ -374,9 +370,7 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
         with temporary_file("w") as f:
             self.set_config_file(
                 f,
-                "[default]\n"
-                "s3 = \n"
-                "    us_east_1_regional_endpoint = legacy",
+                "[default]\ns3 = \n    us_east_1_regional_endpoint = legacy",
             )
             client = self.create_s3_client(
                 config=Config(s3={"us_east_1_regional_endpoint": "regional"})
@@ -1105,7 +1099,7 @@ class TestAccesspointArn(BaseS3ClientConfigurationTest):
         self.client.list_objects(Bucket=s3_accesspoint_arn)
         request = self.http_stubber.requests[0]
         expected_endpoint = (
-            "myendpoint-123456789012.s3-accesspoint." "us-east-1.amazonaws.com"
+            "myendpoint-123456789012.s3-accesspoint.us-east-1.amazonaws.com"
         )
         self.assert_endpoint(request, expected_endpoint)
 
@@ -1119,7 +1113,7 @@ class TestAccesspointArn(BaseS3ClientConfigurationTest):
         self.client.list_objects(Bucket=s3_accesspoint_arn)
         request = self.http_stubber.requests[0]
         expected_endpoint = (
-            "myendpoint-123456789012.s3-accesspoint." "us-east-1.amazonaws.com"
+            "myendpoint-123456789012.s3-accesspoint.us-east-1.amazonaws.com"
         )
         self.assert_endpoint(request, expected_endpoint)
 
@@ -1463,8 +1457,7 @@ class TestWriteGetObjectResponse(BaseS3ClientConfigurationTest):
             self.assert_signing_name(request, "s3-object-lambda")
             self.assert_signing_region(request, region)
             expected_endpoint = (
-                "endpoint-io.a1c1d5c7.s3-object-lambda."
-                f"{region}.amazonaws.com"
+                f"endpoint-io.a1c1d5c7.s3-object-lambda.{region}.amazonaws.com"
             )
             self.assert_endpoint(request, expected_endpoint)
 
@@ -1798,12 +1791,12 @@ class TestRegionRedirect(BaseS3OperationTest):
         self.assertEqual(len(self.http_stubber.requests), 2)
 
         initial_url = (
-            "https://s3.us-west-2.amazonaws.com/foo" "?encoding-type=url"
+            "https://s3.us-west-2.amazonaws.com/foo?encoding-type=url"
         )
         self.assertEqual(self.http_stubber.requests[0].url, initial_url)
 
         fixed_url = (
-            "https://s3.eu-central-1.amazonaws.com/foo" "?encoding-type=url"
+            "https://s3.eu-central-1.amazonaws.com/foo?encoding-type=url"
         )
         self.assertEqual(self.http_stubber.requests[1].url, fixed_url)
 
@@ -1825,12 +1818,12 @@ class TestRegionRedirect(BaseS3OperationTest):
 
         self.assertEqual(len(self.http_stubber.requests), 3)
         initial_url = (
-            "https://s3.us-west-2.amazonaws.com/foo" "?encoding-type=url"
+            "https://s3.us-west-2.amazonaws.com/foo?encoding-type=url"
         )
         self.assertEqual(self.http_stubber.requests[0].url, initial_url)
 
         fixed_url = (
-            "https://s3.eu-central-1.amazonaws.com/foo" "?encoding-type=url"
+            "https://s3.eu-central-1.amazonaws.com/foo?encoding-type=url"
         )
         self.assertEqual(self.http_stubber.requests[1].url, fixed_url)
         self.assertEqual(self.http_stubber.requests[2].url, fixed_url)
@@ -1849,13 +1842,12 @@ class TestRegionRedirect(BaseS3OperationTest):
 
             self.assertEqual(len(http_stubber.requests), 2)
             initial_url = (
-                "https://foo.s3.us-west-2.amazonaws.com/" "?encoding-type=url"
+                "https://foo.s3.us-west-2.amazonaws.com/?encoding-type=url"
             )
             self.assertEqual(http_stubber.requests[0].url, initial_url)
 
             fixed_url = (
-                "https://foo.s3.eu-central-1.amazonaws.com/"
-                "?encoding-type=url"
+                "https://foo.s3.eu-central-1.amazonaws.com/?encoding-type=url"
             )
             self.assertEqual(http_stubber.requests[1].url, fixed_url)
 
@@ -2909,8 +2901,7 @@ def _s3_addressing_test_cases():
         key="key",
         # More than two extra parts is not allowed.
         customer_provided_endpoint=(
-            "https://s3-accelerate.dualstack.dualstack.dualstack"
-            ".amazonaws.com"
+            "https://s3-accelerate.dualstack.dualstack.dualstack.amazonaws.com"
         ),
         expected_url=(
             "https://s3-accelerate.dualstack.dualstack.dualstack.amazonaws.com"
@@ -3335,8 +3326,7 @@ def _s3_addressing_test_cases():
     )
 
     s3_object_lambda_arn = (
-        "arn:aws:s3-object-lambda:us-east-1:"
-        "123456789012:accesspoint:mybanner"
+        "arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint:mybanner"
     )
     yield dict(
         region="aws-global",

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -67,7 +67,7 @@ class TestSTSEndpoints(BaseSessionTest):
         )
 
     def set_sts_regional_for_config_file(self, fileobj, config_val):
-        fileobj.write('[default]\n' f'sts_regional_endpoints={config_val}\n')
+        fileobj.write(f'[default]\nsts_regional_endpoints={config_val}\n')
         fileobj.flush()
         self.environ['AWS_CONFIG_FILE'] = fileobj.name
 

--- a/tests/functional/test_waiter_config.py
+++ b/tests/functional/test_waiter_config.py
@@ -118,7 +118,7 @@ def _lint_single_waiter(client, waiter_name, service_model):
     # Needs to reference an existing operation name.
     if operation_name not in service_model.operation_names:
         raise AssertionError(
-            "Waiter config references unknown " f"operation: {operation_name}"
+            f"Waiter config references unknown operation: {operation_name}"
         )
     # Needs to have at least one acceptor.
     if not waiter.config.acceptors:
@@ -146,9 +146,9 @@ def _validate_acceptor(acceptor, op_model, waiter_name):
         # The JMESPath expression should have the potential to match something
         # in the response shape.
         output_shape = op_model.output_shape
-        assert (
-            output_shape is not None
-        ), f"Waiter '{waiter_name}' has JMESPath expression with no output shape: {op_model}"
+        assert output_shape is not None, (
+            f"Waiter '{waiter_name}' has JMESPath expression with no output shape: {op_model}"
+        )
         # We want to check if the JMESPath expression makes sense.
         # To do this, we'll generate sample output and evaluate the
         # JMESPath expression against the output.  We'll then

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -713,8 +713,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
             presigned_url.startswith(
                 f'https://{self.bucket_name}.s3.amazonaws.com/{self.key}'
             ),
-            "Host was suppose to use DNS style, instead "
-            f"got: {presigned_url}",
+            f"Host was suppose to use DNS style, instead got: {presigned_url}",
         )
         # Try to retrieve the object using the presigned url.
         self.assertEqual(http_get(presigned_url).data, b'foo')
@@ -782,7 +781,7 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
             post_args['url'].startswith(
                 f'https://{self.bucket_name}.s3.amazonaws.com'
             ),
-            "Host was suppose to use DNS style, instead " "got: {}".format(
+            "Host was suppose to use DNS style, instead got: {}".format(
                 post_args['url']
             ),
         )
@@ -850,8 +849,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
             presigned_url.startswith(
                 f'https://{self.bucket_name}.s3.amazonaws.com/{self.key}'
             ),
-            "Host was suppose to use DNS style, instead "
-            f"got: {presigned_url}",
+            f"Host was suppose to use DNS style, instead got: {presigned_url}",
         )
         # Try to retrieve the object using the presigned url.
         self.assertEqual(http_get(presigned_url).data, b'foo')
@@ -911,7 +909,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
             post_args['url'].startswith(
                 f'https://{self.bucket_name}.s3.amazonaws.com'
             ),
-            "Host was suppose to use DNS style, instead " "got: {}".format(
+            "Host was suppose to use DNS style, instead got: {}".format(
                 post_args['url']
             ),
         )
@@ -948,7 +946,7 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
             post_args['url'].startswith(
                 f'https://{self.bucket_name}.s3.amazonaws.com/'
             ),
-            "Host was suppose to use DNS style, instead " "got: {}".format(
+            "Host was suppose to use DNS style, instead got: {}".format(
                 post_args['url']
             ),
         )

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -818,7 +818,7 @@ class TestSigV4Presign(BasePresignTest):
             {
                 'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
                 'X-Amz-Credential': (
-                    'access_key/20140101/myregion/' 'myservice/aws4_request'
+                    'access_key/20140101/myregion/myservice/aws4_request'
                 ),
                 'X-Amz-Date': '20140101T000000Z',
                 'X-Amz-Expires': '60',
@@ -911,7 +911,7 @@ class TestSigV4Presign(BasePresignTest):
             {
                 'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
                 'X-Amz-Credential': (
-                    'access_key/20140101/myregion/' 'myservice/aws4_request'
+                    'access_key/20140101/myregion/myservice/aws4_request'
                 ),
                 'X-Amz-Date': '20140101T000000Z',
                 'X-Amz-Expires': '60',

--- a/tests/unit/docs/bcdoc/test_style.py
+++ b/tests/unit/docs/bcdoc/test_style.py
@@ -172,10 +172,7 @@ class TestStyle(unittest.TestCase):
         style.hidden_tocitem('bar')
         self.assertEqual(
             style.doc.getvalue(),
-            (
-                b'\n.. toctree::\n  :maxdepth: 1'
-                b'\n  :hidden:\n\n  foo\n  bar\n'
-            ),
+            (b'\n.. toctree::\n  :maxdepth: 1\n  :hidden:\n\n  foo\n  bar\n'),
         )
 
     def test_hidden_toctree_non_html(self):

--- a/tests/unit/docs/test_docstring.py
+++ b/tests/unit/docs/test_docstring.py
@@ -75,7 +75,7 @@ class TestLazyLoadedDocstring(unittest.TestCase):
 class TestClientMethodDocstring(unittest.TestCase):
     def test_use_correct_docstring_writer(self):
         with mock.patch(
-            'botocore.docs.docstring' '.document_model_driven_method'
+            'botocore.docs.docstring.document_model_driven_method'
         ) as mock_writer:
             docstring = ClientMethodDocstring()
             str(docstring)
@@ -85,7 +85,7 @@ class TestClientMethodDocstring(unittest.TestCase):
 class TestWaiterDocstring(unittest.TestCase):
     def test_use_correct_docstring_writer(self):
         with mock.patch(
-            'botocore.docs.docstring' '.document_wait_method'
+            'botocore.docs.docstring.document_wait_method'
         ) as mock_writer:
             docstring = WaiterDocstring()
             str(docstring)
@@ -95,7 +95,7 @@ class TestWaiterDocstring(unittest.TestCase):
 class TestPaginatorDocstring(unittest.TestCase):
     def test_use_correct_docstring_writer(self):
         with mock.patch(
-            'botocore.docs.docstring' '.document_paginate_method'
+            'botocore.docs.docstring.document_paginate_method'
         ) as mock_writer:
             docstring = PaginatorDocstring()
             str(docstring)

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -122,7 +122,7 @@ class TestConfigLoader(unittest.TestCase):
         self.assertEqual(raw_config['cloudwatch'], '\nsignature_version = v4')
         self.assertEqual(
             raw_config['s3'],
-            '\nsignature_version = s3v4' '\naddressing_style = path',
+            '\nsignature_version = s3v4\naddressing_style = path',
         )
 
     def test_nested_bad_config(self):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -48,7 +48,7 @@ def test_retry_info_added_when_present():
     error_msg = str(exceptions.ClientError(response, 'operation'))
     if '(reached max retries: 3)' not in error_msg:
         raise AssertionError(
-            "retry information not inject into error " f"message: {error_msg}"
+            f"retry information not inject into error message: {error_msg}"
         )
 
 

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -662,7 +662,7 @@ class TestAwsChunkedWrapper(unittest.TestCase):
         bytes = BytesIO(b"abcdefghijklmnopqrstuvwxyz")
         wrapper = AwsChunkedWrapper(bytes)
         body = wrapper.read()
-        expected = b"1a\r\n" b"abcdefghijklmnopqrstuvwxyz\r\n" b"0\r\n\r\n"
+        expected = b"1a\r\nabcdefghijklmnopqrstuvwxyz\r\n0\r\n\r\n"
         self.assertEqual(body, expected)
 
     def test_multi_chunk_body(self):
@@ -671,13 +671,7 @@ class TestAwsChunkedWrapper(unittest.TestCase):
         wrapper = AwsChunkedWrapper(bytes, chunk_size=10)
         body = wrapper.read()
         expected = (
-            b"a\r\n"
-            b"abcdefghij\r\n"
-            b"a\r\n"
-            b"klmnopqrst\r\n"
-            b"6\r\n"
-            b"uvwxyz\r\n"
-            b"0\r\n\r\n"
+            b"a\r\nabcdefghij\r\na\r\nklmnopqrst\r\n6\r\nuvwxyz\r\n0\r\n\r\n"
         )
         self.assertEqual(body, expected)
 
@@ -695,13 +689,7 @@ class TestAwsChunkedWrapper(unittest.TestCase):
         # always be the configured chunk_size if the read does not return that
         # much data.
         expected = (
-            b"9\r\n"
-            b"abcdefghi\r\n"
-            b"9\r\n"
-            b"jklmnopqr\r\n"
-            b"8\r\n"
-            b"stuvwxyz\r\n"
-            b"0\r\n\r\n"
+            b"9\r\nabcdefghi\r\n9\r\njklmnopqr\r\n8\r\nstuvwxyz\r\n0\r\n\r\n"
         )
         self.assertEqual(body, expected)
 
@@ -712,9 +700,7 @@ class TestAwsChunkedWrapper(unittest.TestCase):
             checksum_name="checksum",
         )
         body = wrapper.read()
-        expected = (
-            b"b\r\n" b"hello world\r\n" b"0\r\n" b"checksum:DUoRhQ==\r\n\r\n"
-        )
+        expected = b"b\r\nhello world\r\n0\r\nchecksum:DUoRhQ==\r\n\r\n"
         self.assertEqual(body, expected)
 
     def test_multi_chunk_body_with_checksum(self):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1047,7 +1047,7 @@ class TestEventStreamParsers(unittest.TestCase):
     def test_parses_event_json(self):
         self.parser = parsers.EventStreamJSONParser()
         headers = {':event-type': 'EventD'}
-        body = b'{' b'  "StringField": "abcde",' b'  "IntField": 1234' b'}'
+        body = b'{  "StringField": "abcde",  "IntField": 1234}'
         parsed = self.parse_event(headers, body)
         expected = {'EventD': {'StringField': 'abcde', 'IntField': 1234}}
         self.assertEqual(parsed, expected)
@@ -1503,8 +1503,7 @@ class TestParseErrorResponses(unittest.TestCase):
 
     def test_can_parse_rest_json_modeled_fields(self):
         body = (
-            b'{"ModeledField":"Some modeled field",'
-            b'"Message":"Some message"}'
+            b'{"ModeledField":"Some modeled field","Message":"Some message"}'
         )
         parser = parsers.RestJSONParser()
         response_dict = {

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -719,8 +719,7 @@ class TestCreateClient(BaseSessionTest):
             self.environ['FOO_CONFIG_FILE'] = f.name
             f.write('[default]\n')
             f.write(
-                'foo_api_versions =\n'
-                f'    myservice = {config_api_version}\n'
+                f'foo_api_versions =\n    myservice = {config_api_version}\n'
             )
             f.flush()
 
@@ -768,8 +767,7 @@ class TestCreateClient(BaseSessionTest):
             self.environ['FOO_CONFIG_FILE'] = f.name
             f.write('[default]\n')
             f.write(
-                'foo_api_versions =\n'
-                f'    myservice = {config_api_version}\n'
+                f'foo_api_versions =\n    myservice = {config_api_version}\n'
             )
             f.flush()
 

--- a/tests/unit/test_session_legacy.py
+++ b/tests/unit/test_session_legacy.py
@@ -731,8 +731,7 @@ class TestCreateClient(BaseSessionTest):
             self.session = create_session(session_vars=self.env_vars)
             f.write('[default]\n')
             f.write(
-                'foo_api_versions =\n'
-                f'    myservice = {config_api_version}\n'
+                f'foo_api_versions =\n    myservice = {config_api_version}\n'
             )
             f.flush()
 
@@ -782,8 +781,7 @@ class TestCreateClient(BaseSessionTest):
             self.session = create_session(session_vars=self.env_vars)
             f.write('[default]\n')
             f.write(
-                'foo_api_versions =\n'
-                f'    myservice = {config_api_version}\n'
+                f'foo_api_versions =\n    myservice = {config_api_version}\n'
             )
             f.flush()
 


### PR DESCRIPTION
This PR:

* upgrades the version of Ruff used from 0.4.8 to 0.9.4
* copies the exclude rules from `pre-commit` configuration to the Ruff configuration, to make it possible to run `ruff` outside of `pre-commit`
* reapplies `ruff format` (mechanical)
* fixes other new complaints surfaced by the new version of Ruff
* gets rid of `isort` for import sorting in favor of just ruff's `I` rule.
  * This had some manual work go into it, to keep the context of the `noqa` comments intact. 
