### PR TITLE
Add account id to STS and SSO providers

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -735,9 +735,8 @@ class CachedCredentialFetcher:
             'secret_key': creds['SecretAccessKey'],
             'token': creds['SessionToken'],
             'expiry_time': expiration,
+            'account_id': creds.get('AccountId'),
         }
-        if account_id := creds.get('AccountId'):
-            credentials['account_id'] = account_id
 
         return credentials
 
@@ -814,7 +813,7 @@ class BaseAssumeRoleCredentialFetcher(CachedCredentialFetcher):
         argument_hash = sha1(args.encode('utf-8')).hexdigest()
         return self._make_file_safe(argument_hash)
 
-    def _get_account_id(self, response):
+    def _add_account_id_to_response(self, response):
         role_arn = response.get('AssumedRoleUser', {}).get('Arn')
         if ArnParser.is_arn(role_arn):
             arn_parser = ArnParser()
@@ -884,7 +883,7 @@ class AssumeRoleCredentialFetcher(BaseAssumeRoleCredentialFetcher):
         kwargs = self._assume_role_kwargs()
         client = self._create_client()
         response = client.assume_role(**kwargs)
-        self._get_account_id(response)
+        self._add_account_id_to_response(response)
         return response
 
     def _assume_role_kwargs(self):
@@ -973,7 +972,7 @@ class AssumeRoleWithWebIdentityCredentialFetcher(
         config = Config(signature_version=UNSIGNED)
         client = self._client_creator('sts', config=config)
         response = client.assume_role_with_web_identity(**kwargs)
-        self._get_account_id(response)
+        self._add_account_id_to_response(response)
         return response
 
     def _assume_role_kwargs(self):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -44,6 +44,7 @@ from botocore.exceptions import (
 )
 from botocore.tokens import SSOTokenProvider
 from botocore.utils import (
+    ArnParser,
     ContainerMetadataFetcher,
     FileWebIdentityTokenLoader,
     InstanceMetadataFetcher,
@@ -729,12 +730,16 @@ class CachedCredentialFetcher:
 
         creds = response['Credentials']
         expiration = _serialize_if_needed(creds['Expiration'], iso=True)
-        return {
+        credentials = {
             'access_key': creds['AccessKeyId'],
             'secret_key': creds['SecretAccessKey'],
             'token': creds['SessionToken'],
             'expiry_time': expiration,
         }
+        if account_id := creds.get('AccountId'):
+            credentials['account_id'] = account_id
+
+        return credentials
 
     def _load_from_cache(self):
         if self._cache_key in self._cache:
@@ -809,6 +814,15 @@ class BaseAssumeRoleCredentialFetcher(CachedCredentialFetcher):
         argument_hash = sha1(args.encode('utf-8')).hexdigest()
         return self._make_file_safe(argument_hash)
 
+    def _get_account_id(self, response):
+        role_arn = response.get('AssumedRoleUser', {}).get('Arn')
+        if ArnParser.is_arn(role_arn):
+            arn_parser = ArnParser()
+            account_id = arn_parser.parse_arn(role_arn)['account']
+            response['Credentials']['AccountId'] = account_id
+        else:
+            logger.debug(f"Unable to extract account ID from Arn: {role_arn}")
+
 
 class AssumeRoleCredentialFetcher(BaseAssumeRoleCredentialFetcher):
     def __init__(
@@ -869,7 +883,9 @@ class AssumeRoleCredentialFetcher(BaseAssumeRoleCredentialFetcher):
         """Get credentials by calling assume role."""
         kwargs = self._assume_role_kwargs()
         client = self._create_client()
-        return client.assume_role(**kwargs)
+        response = client.assume_role(**kwargs)
+        self._get_account_id(response)
+        return response
 
     def _assume_role_kwargs(self):
         """Get the arguments for assume role based on current configuration."""
@@ -956,7 +972,9 @@ class AssumeRoleWithWebIdentityCredentialFetcher(
         # the token, explicitly configure the client to not sign requests.
         config = Config(signature_version=UNSIGNED)
         client = self._client_creator('sts', config=config)
-        return client.assume_role_with_web_identity(**kwargs)
+        response = client.assume_role_with_web_identity(**kwargs)
+        self._get_account_id(response)
+        return response
 
     def _assume_role_kwargs(self):
         """Get the arguments for assume role based on current configuration."""
@@ -1748,8 +1766,8 @@ class AssumeRoleProvider(CredentialProvider):
         ):
             # This is only here for backwards compatibility. If this provider
             # isn't given a profile provider builder we still want to be able
-            # handle the basic static credential case as we would before the
-            # provile provider builder parameter was added.
+            # to handle the basic static credential case as we would before the
+            # profile provider builder parameter was added.
             return self._resolve_static_credentials_from_profile(profile)
         elif self._has_static_credentials(
             profile
@@ -2245,6 +2263,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
                 'SecretAccessKey': credentials['secretAccessKey'],
                 'SessionToken': credentials['sessionToken'],
                 'Expiration': self._parse_timestamp(credentials['expiration']),
+                'AccountId': self._account_id,
             },
         }
         return credentials

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -11,6 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import logging
 import os
 import shutil
 import subprocess
@@ -30,6 +31,7 @@ from botocore.configprovider import ConfigValueStore
 from botocore.credentials import (
     AssumeRoleProvider,
     AssumeRoleWithWebIdentityProvider,
+    BaseAssumeRoleCredentialFetcher,
     ConfigProvider,
     CredentialProvider,
     Credentials,
@@ -696,6 +698,52 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         ]
         self.assertEqual(calls, expected_calls)
 
+    def test_account_id_with_valid_arn(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+                'AccountId': '123456789012',
+            },
+            'AssumedRoleUser': {
+                'AssumedRoleId': 'myroleid',
+                'Arn': 'arn:aws:iam::123456789012:role/RoleA',
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        refresher = credentials.AssumeRoleCredentialFetcher(
+            client_creator, self.source_creds, self.role_arn
+        )
+        expected_response = self.get_expected_creds_from_response(response)
+        expected_response['account_id'] = '123456789012'
+        response = refresher.fetch_credentials()
+        self.assertIn('account_id', response)
+        self.assertEqual(response, expected_response)
+
+    def test_account_id_with_invalid_arn(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+            'AssumedRoleUser': {
+                'AssumedRoleId': 'myroleid',
+                'Arn': 'invalid-arn',
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        refresher = credentials.AssumeRoleCredentialFetcher(
+            client_creator, self.source_creds, self.role_arn
+        )
+        expected_response = self.get_expected_creds_from_response(response)
+        response = refresher.fetch_credentials()
+        self.assertNotIn('account_id', response)
+        self.assertEqual(response, expected_response)
+
 
 class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
     def setUp(self):
@@ -802,6 +850,54 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
         response = refresher.fetch_credentials()
 
         self.assertEqual(response, expected)
+
+    def test_account_id_with_valid_arn(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+                'AccountId': '123456789012',
+            },
+            'AssumedRoleUser': {
+                'AssumedRoleId': 'myroleid',
+                'Arn': 'arn:aws:iam::123456789012:role/RoleA',
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        refresher = credentials.AssumeRoleWithWebIdentityCredentialFetcher(
+            client_creator, self.load_token, self.role_arn
+        )
+        expected_response = self.get_expected_creds_from_response(response)
+        expected_response['account_id'] = '123456789012'
+        response = refresher.fetch_credentials()
+        self.assertIn('account_id', response)
+        self.assertEqual(response, expected_response)
+
+    def test_account_id_with_invalid_arn(self):
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+            'AssumedRoleUser': {
+                'AssumedRoleId': 'myroleid',
+                'Arn': 'invalid-arn',
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        refresher = credentials.AssumeRoleWithWebIdentityCredentialFetcher(
+            client_creator,
+            self.load_token,
+            self.role_arn,
+        )
+        expected_response = self.get_expected_creds_from_response(response)
+        response = refresher.fetch_credentials()
+        self.assertNotIn('account_id', response)
+        self.assertEqual(response, expected_response)
 
 
 class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
@@ -3750,6 +3846,7 @@ class TestSSOCredentialFetcher(unittest.TestCase):
                 'SecretAccessKey': 'bar',
                 'SessionToken': 'baz',
                 'Expiration': '2008-09-23T12:43:20Z',
+                'AccountId': '1234567890',
             },
         }
         self.assertEqual(self.cache[cache_key], expected_cached_credentials)
@@ -3883,6 +3980,15 @@ class TestSSOProvider(unittest.TestCase):
         with self.assertRaises(botocore.exceptions.InvalidConfigError):
             self.provider.load()
 
+    def test_load_sso_credentials_with_account_id(self):
+        self._add_get_role_credentials_response()
+        with self.stubber:
+            credentials = self.provider.load()
+            self.assertEqual(credentials.access_key, 'foo')
+            self.assertEqual(credentials.secret_key, 'bar')
+            self.assertEqual(credentials.token, 'baz')
+            self.assertEqual(credentials.account_id, '1234567890')
+
 
 @pytest.mark.parametrize(
     "account_id, expected", [("123456789012", "123456789012"), (None, None)]
@@ -3894,3 +4000,40 @@ def test_get_deferred_property_account_id(account_id, expected):
     deferred_account_id = creds.get_deferred_property('account_id')
     assert callable(deferred_account_id)
     assert deferred_account_id() == expected
+
+
+@pytest.fixture
+def mock_base_assume_role_credential_fetcher():
+    return BaseAssumeRoleCredentialFetcher(
+        client_creator=mock.Mock(),
+        role_arn='arn:aws:iam::123456789012:role/RoleA',
+    )
+
+
+def test_get_account_id_valid_arn(mock_base_assume_role_credential_fetcher):
+    response = {
+        'Credentials': {},
+        'AssumedRoleUser': {
+            'AssumedRoleId': 'myroleid',
+            'Arn': 'arn:aws:iam::123456789012:role/RoleA',
+        },
+    }
+    mock_base_assume_role_credential_fetcher._get_account_id(response)
+    assert 'AccountId' in response['Credentials']
+    assert response['Credentials']['AccountId'] == '123456789012'
+
+
+def test_get_account_id_invalid_arn(
+    mock_base_assume_role_credential_fetcher, caplog
+):
+    response = {
+        'Credentials': {},
+        'AssumedRoleUser': {
+            'AssumedRoleId': 'myroleid',
+            'Arn': 'invalid-arn',
+        },
+    }
+    with caplog.at_level(logging.DEBUG):
+        mock_base_assume_role_credential_fetcher._get_account_id(response)
+    assert 'AccountId' not in response['Credentials']
+    assert 'Unable to extract account ID from Arn' in caplog.text


### PR DESCRIPTION
This PR adds support to source an account ID from `AssumeRoleProvider`, `AssumeRoleWithWebIdentityProvider`, and `SSOProvider`. The account ID will be resolved after receiving  a successful response from a given provider and then be associated with the credentials object.