### PR TITLE
Add account id to process credentials provider

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1034,6 +1034,7 @@ class ProcessProvider(CredentialProvider):
             secret_key=creds_dict['secret_key'],
             token=creds_dict.get('token'),
             method=self.METHOD,
+            account_id=creds_dict.get('account_id'),
         )
 
     def _retrieve_credentials_using(self, credential_process):
@@ -1064,6 +1065,7 @@ class ProcessProvider(CredentialProvider):
                 'secret_key': parsed['SecretAccessKey'],
                 'token': parsed.get('SessionToken'),
                 'expiry_time': parsed.get('Expiration'),
+                'account_id': self._get_account_id(parsed),
             }
         except KeyError as e:
             raise CredentialRetrievalError(
@@ -1073,12 +1075,20 @@ class ProcessProvider(CredentialProvider):
 
     @property
     def _credential_process(self):
+        return self.profile_config.get('credential_process')
+
+    @property
+    def profile_config(self):
         if self._loaded_config is None:
             self._loaded_config = self._load_config()
         profile_config = self._loaded_config.get('profiles', {}).get(
             self._profile_name, {}
         )
-        return profile_config.get('credential_process')
+        return profile_config
+
+    def _get_account_id(self, parsed):
+        account_id = parsed.get('AccountId')
+        return account_id or self.profile_config.get('aws_account_id')
 
 
 class InstanceMetadataProvider(CredentialProvider):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3546,6 +3546,56 @@ class TestProcessProvider(BaseEnvVar):
         self.assertIsNone(creds.token)
         self.assertEqual(creds.method, 'custom-process')
 
+    def test_can_retrieve_account_id(self):
+        self.loaded_config['profiles'] = {
+            'default': {'credential_process': 'my-process'}
+        }
+        self._set_process_return_value(
+            {
+                'Version': 1,
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': '2999-01-01T00:00:00Z',
+                'AccountId': '123456789012',
+            }
+        )
+
+        provider = self.create_process_provider()
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'custom-process')
+        self.assertEqual(creds.account_id, '123456789012')
+
+    def test_can_retrieve_account_id_via_profile_config(self):
+        self.loaded_config['profiles'] = {
+            'default': {
+                'credential_process': 'my-process',
+                'aws_account_id': '123456789012',
+            }
+        }
+        self._set_process_return_value(
+            {
+                'Version': 1,
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': '2999-01-01T00:00:00Z',
+            }
+        )
+
+        provider = self.create_process_provider()
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'custom-process')
+        self.assertEqual(creds.account_id, '123456789012')
+
 
 class TestProfileProviderBuilder(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR adds support to source an account ID from `ProcessProvider`. We attempt to parse account ID from the external process JSON output using the key `AccountId` or resolve the value of the profile property `aws_account_id` and store it to be associated with the credentials object.