### PR TITLE
Add configuration to disable host prefix injection

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -30,7 +30,7 @@ from botocore.regions import EndpointResolverBuiltins as EPRBuiltins
 from botocore.regions import EndpointRulesetResolver
 from botocore.signers import RequestSigner
 from botocore.useragent import UserAgentString
-from botocore.utils import ensure_boolean, is_s3_accelerate_url
+from botocore.utils import DEFAULT_TRUE, ensure_boolean, is_s3_accelerate_url
 
 logger = logging.getLogger(__name__)
 
@@ -293,6 +293,7 @@ class ClientArgsCreator:
         self._compute_request_compression_config(config_kwargs)
         self._compute_sigv4a_signing_region_set_config(config_kwargs)
         self._compute_checksum_config(config_kwargs)
+        self._compute_inject_host_prefix(config_kwargs)
         s3_config = self.compute_s3_config(client_config)
 
         is_s3_service = self._is_s3_service(service_name)
@@ -314,6 +315,30 @@ class ClientArgsCreator:
                 scoped_config, client_config
             ),
         }
+
+    def _compute_inject_host_prefix(self, config_kwargs):
+        # If the value isn't available, that is because the user didn't pass in a Config
+        # object. UNSET is used to differentiate between other currently allowed values,
+        #  like None.
+        inject_host_prefix = config_kwargs.get('inject_host_prefix', 'UNSET')
+
+        # A value of DEFAULT_TRUE means the user did not supply a value
+        # specifically for inject_host_prefix; a value of UNSET means the user
+        # didn't provide a Config object to the client constructor. In these
+        # cases we want to fall back to the order of precedence for resolving
+        # the value.
+        if inject_host_prefix is DEFAULT_TRUE or inject_host_prefix == 'UNSET':
+            configured_disable_host_prefix_injection = (
+                self._config_store.get_config_variable(
+                    'disable_host_prefix_injection'
+                )
+            )
+            if configured_disable_host_prefix_injection is not None:
+                config_kwargs[
+                    'inject_host_prefix'
+                ] = not configured_disable_host_prefix_injection
+            else:
+                config_kwargs['inject_host_prefix'] = True
 
     def _compute_configured_endpoint_url(self, client_config, endpoint_url):
         if endpoint_url is not None:

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -20,6 +20,7 @@ from botocore.exceptions import (
     InvalidRetryModeError,
     InvalidS3AddressingStyleError,
 )
+from botocore.utils import DEFAULT_TRUE
 
 
 class Config:
@@ -284,7 +285,7 @@ class Config:
             ('s3', None),
             ('retries', None),
             ('client_cert', None),
-            ('inject_host_prefix', True),
+            ('inject_host_prefix', DEFAULT_TRUE),
             ('endpoint_discovery_enabled', None),
             ('use_dualstack_endpoint', None),
             ('use_fips_endpoint', None),

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -180,6 +180,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         "when_supported",
         None,
     ),
+    'disable_host_prefix_injection': (
+        'disable_host_prefix_injection',
+        'AWS_DISABLE_HOST_PREFIX_INJECTION',
+        None,
+        utils.ensure_boolean,
+    ),
 }
 
 # Evaluate AWS_STS_REGIONAL_ENDPOINTS settings

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3633,3 +3633,11 @@ CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES = {
     'stepfunctions': 'sfn',
     'storagegateway': 'storage-gateway',
 }
+
+
+class DefaultTrue:
+    def __eq__(self, other):
+        return other == True  # noqa: E712
+
+
+DEFAULT_TRUE = DefaultTrue()

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -679,6 +679,32 @@ class TestCreateClientArgs(unittest.TestCase):
         with self.assertRaises(exceptions.InvalidChecksumConfigError):
             self.call_get_client_args()
 
+    def test_disable_host_prefix_injection_default_client_config(self):
+        input_config = Config()
+        client_args = self.call_get_client_args(client_config=input_config)
+        config = client_args["client_config"]
+        self.assertEqual(config.inject_host_prefix, True)
+
+    def test_disable_host_prefix_injection_config_store(self):
+        self.config_store.set_config_variable(
+            "disable_host_prefix_injection",
+            True,
+        )
+        config = self.call_get_client_args()['client_config']
+        self.assertEqual(config.inject_host_prefix, False)
+
+    def test_disable_host_prefix_injection_client_config_overrides_config_store(
+        self,
+    ):
+        self.config_store.set_config_variable(
+            "disable_host_prefix_injection",
+            True,
+        )
+        input_config = Config(inject_host_prefix=False)
+        client_args = self.call_get_client_args(client_config=input_config)
+        config = client_args['client_config']
+        self.assertEqual(config.inject_host_prefix, False)
+
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This change adds the ability to disable host prefix injection via an environment variable (`AWS_DISABLE_HOST_PREFIX_INJECTION`) or a shared configuration file parameter (`disable_host_prefix_injection`).

It changes the default for `inject_host_prefix` in the Config object to be a True-like object `DEFAULT_TRUE` (from `True`) so that the value can be differentiated from a user-set value using the standard configuration precedence order.
