### PR TITLE
User agent 2.1: Track client features

### DIFF
--- a/.changes/next-release/enhancement-useragent-89566.json
+++ b/.changes/next-release/enhancement-useragent-89566.json
@@ -1,5 +1,5 @@
 {
-  "type": "feature",
+  "type": "enhancement",
   "category": "useragent",
   "description": "Update user agent string to include client feature use."
 }

--- a/.changes/next-release/feature-useragent-5816.json
+++ b/.changes/next-release/feature-useragent-5816.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "useragent",
+  "description": "Update user agent string to include client feature use."
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -29,7 +29,7 @@ from botocore.endpoint import EndpointCreator
 from botocore.regions import EndpointResolverBuiltins as EPRBuiltins
 from botocore.regions import EndpointRulesetResolver
 from botocore.signers import RequestSigner
-from botocore.useragent import UserAgentString
+from botocore.useragent import UserAgentString, register_feature_id
 from botocore.utils import ensure_boolean, is_s3_accelerate_url
 
 logger = logging.getLogger(__name__)
@@ -225,6 +225,8 @@ class ClientArgsCreator:
             client_config=client_config,
             endpoint_url=endpoint_url,
         )
+        if configured_endpoint_url is not None:
+            register_feature_id('ENDPOINT_OVERRIDE')
 
         endpoint_config = self._compute_endpoint_config(
             service_name=service_name,

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -18,6 +18,7 @@ from botocore.auth import AUTH_TYPE_MAPS, resolve_auth_type
 from botocore.awsrequest import prepare_request_dict
 from botocore.compress import maybe_compress_request
 from botocore.config import Config
+from botocore.context import with_current_context
 from botocore.credentials import RefreshableCredentials
 from botocore.discovery import (
     EndpointDiscoveryHandler,
@@ -933,11 +934,18 @@ class BaseClient:
         self.meta.events.register(
             f"request-created.{service_id}", self._request_signer.handler
         )
+        # Rebuild user agent string right before request is sent
+        # to ensure all registered features are included.
+        self.meta.events.register_last(
+            f"request-created.{service_id}",
+            self._rebuild_and_replace_user_agent,
+        )
 
     @property
     def _service_model(self):
         return self.meta.service_model
 
+    @with_current_context()
     def _make_api_call(self, operation_name, api_params):
         operation_model = self._service_model.operation_model(operation_name)
         service_name = self._service_model.service_name
@@ -1298,6 +1306,12 @@ class BaseClient:
         removal, in any botocore release.
         """
         return self._request_signer._credentials
+
+    def _rebuild_and_replace_user_agent(
+        self, operation_name, request, **kwargs
+    ):
+        ua_string = self._user_agent_creator.to_string()
+        request.headers.replace_header('User-Agent', ua_string)
 
 
 class ClientMeta:

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -1311,7 +1311,6 @@ class BaseClient:
         self, operation_name, request, **kwargs
     ):
         ua_string = self._user_agent_creator.to_string()
-        print(ua_string)
         request.headers.replace_header('User-Agent', ua_string)
 
 

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -938,7 +938,7 @@ class BaseClient:
         # to ensure all registered features are included.
         self.meta.events.register_last(
             f"request-created.{service_id}",
-            self._rebuild_and_replace_user_agent,
+            self._user_agent_creator._rebuild_and_replace_user_agent,
         )
 
     @property
@@ -1306,12 +1306,6 @@ class BaseClient:
         removal, in any botocore release.
         """
         return self._request_signer._credentials
-
-    def _rebuild_and_replace_user_agent(
-        self, operation_name, request, **kwargs
-    ):
-        ua_string = self._user_agent_creator.to_string()
-        request.headers.replace_header('User-Agent', ua_string)
 
 
 class ClientMeta:

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -938,7 +938,7 @@ class BaseClient:
         # to ensure all registered features are included.
         self.meta.events.register_last(
             f"request-created.{service_id}",
-            self._user_agent_creator._rebuild_and_replace_user_agent,
+            self._user_agent_creator.rebuild_and_replace_user_agent_handler,
         )
 
     @property

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -1311,6 +1311,7 @@ class BaseClient:
         self, operation_name, request, **kwargs
     ):
         ua_string = self._user_agent_creator.to_string()
+        print(ua_string)
         request.headers.replace_header('User-Agent', ua_string)
 
 

--- a/botocore/context.py
+++ b/botocore/context.py
@@ -58,6 +58,15 @@ def set_context(ctx):
     return token
 
 
+def reset_token(token):
+    """Reset the current ``_context`` context variable.
+
+    :type token: contextvars.Token
+    :param token: Token object to reset the context variable.
+    """
+    _context.reset(token)
+
+
 @contextmanager
 def start_as_current_context(ctx=None):
     """
@@ -86,7 +95,7 @@ def start_as_current_context(ctx=None):
     try:
         yield
     finally:
-        _context.reset(token)
+        reset_token(token)
 
 
 def with_current_context(hook=None):

--- a/botocore/context.py
+++ b/botocore/context.py
@@ -26,7 +26,7 @@ from typing import Set
 @dataclass
 class ClientContext:
     """
-    Encapsulation of objects tracked within the ``__context`` context variable.
+    Encapsulation of objects tracked within the ``_context`` context variable.
 
     ``features`` is a set responsible for storing features used during
     preparation of an AWS request. ``botocore.useragent.register_feature_id``

--- a/botocore/context.py
+++ b/botocore/context.py
@@ -58,7 +58,7 @@ def set_context(ctx):
     return token
 
 
-def reset_token(token):
+def reset_context(token):
     """Reset the current ``_context`` context variable.
 
     :type token: contextvars.Token
@@ -95,7 +95,7 @@ def start_as_current_context(ctx=None):
     try:
         yield
     finally:
-        reset_token(token)
+        reset_context(token)
 
 
 def with_current_context(hook=None):

--- a/botocore/context.py
+++ b/botocore/context.py
@@ -1,0 +1,119 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+NOTE: All classes and functions in this module are considered private and are
+subject to abrupt breaking changes. Please do not use them directly.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from copy import deepcopy
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Set
+
+
+@dataclass
+class ClientContext:
+    """
+    Encapsulation of objects tracked within the ``__context`` context variable.
+
+    ``features`` is a set responsible for storing features used during
+    preparation of an AWS request. ``botocore.useragent.register_feature_id``
+    is used to add to this set.
+    """
+
+    features: Set[str] = field(default_factory=set)
+
+
+_context = ContextVar("_context")
+
+
+def get_context():
+    """Get the current ``_context`` context variable if set, else None."""
+    return _context.get(None)
+
+
+def set_context(ctx):
+    """Set the current ``_context`` context variable.
+
+    :type ctx: ClientContext
+    :param ctx: Client context object to set as the current context variable.
+
+    :rtype: contextvars.Token
+    :returns: Token object used to revert the context variable to what it was
+        before the corresponding set.
+    """
+    token = _context.set(ctx)
+    return token
+
+
+@contextmanager
+def start_as_current_context(ctx=None):
+    """
+    Context manager that copies the passed or current context object and sets
+    it as the current context variable. If no context is found, a new
+    ``ClientContext`` object is created. It mainly ensures the context variable
+    is reset to the previous value once the executed code returns.
+
+    Example usage:
+
+        def my_feature():
+            with start_as_current_context():
+                register_feature_id('MY_FEATURE')
+                pass
+
+    :type ctx: ClientContext
+    :param ctx: The client context object to set as the new context variable.
+        If not provided, the current or a new context variable is used.
+    """
+    current = ctx or get_context()
+    if current is None:
+        new = ClientContext()
+    else:
+        new = deepcopy(current)
+    token = set_context(new)
+    try:
+        yield
+    finally:
+        _context.reset(token)
+
+
+def with_current_context(hook=None):
+    """
+    Decorator that wraps ``start_as_current_context`` and optionally invokes a
+    hook within the newly-set context. This is just syntactic sugar to avoid
+    indenting existing code under the context manager.
+
+    Example usage:
+
+        @with_current_context(partial(register_feature_id, 'MY_FEATURE'))
+        def my_feature():
+            pass
+
+    :type hook: callable
+    :param hook: A callable that will be invoked within the scope of the
+        ``start_as_current_context`` context manager.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with start_as_current_context():
+                if hook:
+                    hook()
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/botocore/crt/auth.py
+++ b/botocore/crt/auth.py
@@ -24,6 +24,7 @@ from botocore.auth import (
 )
 from botocore.compat import HTTPHeaders, awscrt, parse_qs, urlsplit, urlunsplit
 from botocore.exceptions import NoCredentialsError
+from botocore.useragent import register_feature_id
 from botocore.utils import percent_encode_sequence
 
 
@@ -248,6 +249,7 @@ class CrtSigV4AsymAuth(BaseSigner):
         self._expiration_in_seconds = None
 
     def add_auth(self, request):
+        register_feature_id("SIGV4A_SIGNING")
         if self.credentials is None:
             raise NoCredentialsError()
 

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -14,11 +14,14 @@
 import base64
 import json
 import logging
+from functools import partial
 from itertools import tee
 
 import jmespath
 
+from botocore.context import with_current_context
 from botocore.exceptions import PaginationError
+from botocore.useragent import register_feature_id
 from botocore.utils import merge_dicts, set_value_from_jmespath
 
 log = logging.getLogger(__name__)
@@ -353,6 +356,7 @@ class PageIterator:
                 # Yield result directly if it is not a list.
                 yield results
 
+    @with_current_context(partial(register_feature_id, 'PAGINATOR'))
     def _make_request(self, current_kwargs):
         return self._method(**current_kwargs)
 

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -48,6 +48,7 @@ from botocore.configprovider import (
     SmartDefaultsConfigStoreFactory,
     create_botocore_default_config_mapping,
 )
+from botocore.context import get_context, with_current_context
 from botocore.errorfactory import ClientExceptionsFactory
 from botocore.exceptions import (
     ConfigNotFound,
@@ -829,6 +830,7 @@ class Session:
     def lazy_register_component(self, name, component):
         self._components.lazy_register_component(name, component)
 
+    @with_current_context()
     def create_client(
         self,
         service_name,
@@ -981,6 +983,8 @@ class Session:
             client_name=service_name,
             config_store=config_store,
         )
+
+        user_agent_creator.set_client_features(get_context().features)
 
         client_creator = botocore.client.ClientCreator(
             loader,

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -31,8 +31,9 @@ from typing import NamedTuple, Optional
 
 from botocore import __version__ as botocore_version
 from botocore.compat import HAS_CRT
+from botocore.context import get_context
 
-_USERAGENT_ALLOWED_CHARACTERS = ascii_letters + digits + "!$%&'*+-.^_`|~"
+_USERAGENT_ALLOWED_CHARACTERS = ascii_letters + digits + "!$%&'*+-.^_`|~,"
 _USERAGENT_ALLOWED_OS_NAMES = (
     'windows',
     'linux',
@@ -49,12 +50,43 @@ _USERAGENT_PLATFORM_NAME_MAPPINGS = {'darwin': 'macos'}
 # using their existing values. Uses uppercase "B" with all other characters
 # lowercase.
 _USERAGENT_SDK_NAME = 'Botocore'
+_USERAGENT_FEATURE_MAPPINGS = {
+    'WAITER': 'B',
+    'PAGINATOR': 'C',
+    'S3_TRANSFER': 'G',
+    'ENDPOINT_OVERRIDE': 'N',
+    'SIGV4A_SIGNING': 'S',
+}
+
+
+def register_feature_id(feature_id):
+    """Adds metric value to the current context object's ``features`` set.
+
+    :type feature_id: str
+    :param feature_id: The name of the feature to register. Value must be a key
+        in the ``_USERAGENT_FEATURE_MAPPINGS`` dict.
+    """
+    ctx = get_context()
+    if ctx is None:
+        # Never register features outside the scope of a
+        # ``botocore.context.start_as_current_context`` context manager.
+        # Otherwise, the context variable won't be reset and features will
+        # bleed into all subsequent requests. Return instead of raising an
+        # exception since this function could be invoked in a public interface.
+        return
+    val = _USERAGENT_FEATURE_MAPPINGS.get(feature_id)
+    if val is None:
+        raise ValueError(
+            f"Unknown feature id: `{feature_id}`. "
+            f"Must be 1 of {', '.join(_USERAGENT_FEATURE_MAPPINGS.keys())}"
+        )
+    ctx.features.add(val)
 
 
 def sanitize_user_agent_string_component(raw_str, allow_hash):
     """Replaces all not allowed characters in the string with a dash ("-").
 
-    Allowed characters are ASCII alphanumerics and ``!$%&'*+-.^_`|~``. If
+    Allowed characters are ASCII alphanumerics and ``!$%&'*+-.^_`|~,``. If
     ``allow_hash`` is ``True``, "#"``" is also allowed.
 
     :type raw_str: str
@@ -71,12 +103,26 @@ def sanitize_user_agent_string_component(raw_str, allow_hash):
     )
 
 
+class UserAgentSizeConfig(NamedTuple):
+    """
+    Configures the max size of a built user agent string component and the
+    delimiter used to truncate the string if the size is above the max.
+    """
+
+    max_size_in_bytes: int
+    delimiter: str
+
+
 class UserAgentComponent(NamedTuple):
     """
     Component of a Botocore User-Agent header string in the standard format.
 
-    Each component consists of a prefix, a name, and a value. In the string
-    representation these are combined in the format ``prefix/name#value``.
+    Each component consists of a prefix, a name, a value, and a size_config.
+    In the string representation these are combined in the format
+    ``prefix/name#value``.
+
+    ``size_config`` configures the max size and truncation strategy for the
+    built user agent string component.
 
     This class is considered private and is subject to abrupt breaking changes.
     """
@@ -84,6 +130,7 @@ class UserAgentComponent(NamedTuple):
     prefix: str
     name: str
     value: Optional[str] = None
+    size_config: Optional[UserAgentSizeConfig] = None
 
     def to_string(self):
         """Create string like 'prefix/name#value' from a UserAgentComponent."""
@@ -94,11 +141,40 @@ class UserAgentComponent(NamedTuple):
             self.name, allow_hash=False
         )
         if self.value is None or self.value == '':
-            return f'{clean_prefix}/{clean_name}'
-        clean_value = sanitize_user_agent_string_component(
-            self.value, allow_hash=True
-        )
-        return f'{clean_prefix}/{clean_name}#{clean_value}'
+            clean_string = f'{clean_prefix}/{clean_name}'
+        else:
+            clean_value = sanitize_user_agent_string_component(
+                self.value, allow_hash=True
+            )
+            clean_string = f'{clean_prefix}/{clean_name}#{clean_value}'
+        if self.size_config is not None:
+            clean_string = self._truncate_string(
+                clean_string,
+                self.size_config.max_size_in_bytes,
+                self.size_config.delimiter,
+            )
+        return clean_string
+
+    def _truncate_string(self, string, max_size, delimiter):
+        """
+        Pop ``delimiter``-separated values until encoded string is less than or
+        equal to ``max_size``.
+        """
+        orig = string
+        encoded_string = string.encode('utf-8')
+        while len(encoded_string) > max_size:
+            parts = string.split(delimiter)
+            parts.pop()
+            string = delimiter.join(parts)
+            encoded_string = string.encode('utf-8')
+
+        if string == '':
+            raise ValueError(
+                f"User agent component `{orig}` could not be truncated to "
+                f"`{max_size}` bytes with delimiter "
+                f"`{delimiter}` without losing all contents."
+            )
+        return string
 
 
 class RawStringUserAgentComponent:
@@ -203,9 +279,9 @@ class UserAgentString:
         self._session_user_agent_extra = None
 
         self._client_config = None
-        self._uses_paginator = None
-        self._uses_waiter = None
-        self._uses_resource = None
+
+        # Component that can be set with ``set_client_features()``
+        self._client_features = None
 
     @classmethod
     def from_environment(cls):
@@ -244,6 +320,16 @@ class UserAgentString:
         self._session_user_agent_version = session_user_agent_version
         self._session_user_agent_extra = session_user_agent_extra
         return self
+
+    def set_client_features(self, features):
+        """
+        Persist client-specific features registered before or during client
+        creation.
+
+        :type features: Set[str]
+        :param features: A set of client-specific features.
+        """
+        self._client_features = features
 
     def with_client_config(self, client_config):
         """
@@ -415,12 +501,23 @@ class UserAgentString:
 
     def _build_feature_metadata(self):
         """
-        Build the features components of the User-Agent header string.
+        Build the features component of the User-Agent header string.
 
-        Botocore currently does not report any features. This may change in a
-        future version.
+        Returns a single component with prefix "m" followed by a list of
+        comma-separated metric values.
         """
-        return []
+        ctx = get_context()
+        context_features = set() if ctx is None else ctx.features
+        client_features = self._client_features or set()
+        features = client_features.union(context_features)
+        if not features:
+            return []
+        size_config = UserAgentSizeConfig(1024, ',')
+        return [
+            UserAgentComponent(
+                'm', ','.join(features), size_config=size_config
+            )
+        ]
 
     def _build_config_metadata(self):
         """

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -591,7 +591,8 @@ class UserAgentString:
         self, operation_name, request, **kwargs
     ):
         ua_string = self.to_string()
-        request.headers.replace_header('User-Agent', ua_string)
+        if request.headers.get('User-Agent'):
+            request.headers.replace_header('User-Agent', ua_string)
 
 
 def _get_crt_version():

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -587,6 +587,12 @@ class UserAgentString:
             components.append(self._client_config.user_agent_extra)
         return ' '.join(components)
 
+    def _rebuild_and_replace_user_agent(
+        self, operation_name, request, **kwargs
+    ):
+        ua_string = self.to_string()
+        request.headers.replace_header('User-Agent', ua_string)
+
 
 def _get_crt_version():
     """

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -370,7 +370,7 @@ class UserAgentString:
 
         components = [
             *self._build_sdk_metadata(),
-            RawStringUserAgentComponent('ua/2.0'),
+            RawStringUserAgentComponent('ua/2.1'),
             *self._build_os_metadata(),
             *self._build_architecture_metadata(),
             *self._build_language_metadata(),

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -23,6 +23,7 @@ configuration options:
 
 """
 
+import logging
 import os
 import platform
 from copy import copy
@@ -32,6 +33,9 @@ from typing import NamedTuple, Optional
 from botocore import __version__ as botocore_version
 from botocore.compat import HAS_CRT
 from botocore.context import get_context
+
+logger = logging.getLogger(__name__)
+
 
 _USERAGENT_ALLOWED_CHARACTERS = ascii_letters + digits + "!$%&'*+-.^_`|~,"
 _USERAGENT_ALLOWED_OS_NAMES = (
@@ -176,10 +180,11 @@ class UserAgentComponent(NamedTuple):
             string = delimiter.join(parts)
 
         if string == '':
-            raise ValueError(
+            logger.debug(
                 f"User agent component `{orig}` could not be truncated to "
                 f"`{max_size}` bytes with delimiter "
-                f"`{delimiter}` without losing all contents."
+                f"`{delimiter}` without losing all contents. "
+                f"Value will be omitted from user agent string."
             )
         return string
 
@@ -378,7 +383,9 @@ class UserAgentString:
 
         components = modify_components(components)
 
-        return ' '.join([comp.to_string() for comp in components])
+        return ' '.join(
+            [comp.to_string() for comp in components if comp.to_string()]
+        )
 
     def _build_sdk_metadata(self):
         """

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -78,13 +78,8 @@ def register_feature_id(feature_id):
         # bleed into all subsequent requests. Return instead of raising an
         # exception since this function could be invoked in a public interface.
         return
-    val = _USERAGENT_FEATURE_MAPPINGS.get(feature_id)
-    if val is None:
-        raise ValueError(
-            f"Unknown feature id: `{feature_id}`. "
-            f"Must be 1 of {', '.join(_USERAGENT_FEATURE_MAPPINGS.keys())}"
-        )
-    ctx.features.add(val)
+    if val := _USERAGENT_FEATURE_MAPPINGS.get(feature_id):
+        ctx.features.add(val)
 
 
 def sanitize_user_agent_string_component(raw_str, allow_hash):

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -587,7 +587,7 @@ class UserAgentString:
             components.append(self._client_config.user_agent_extra)
         return ' '.join(components)
 
-    def _rebuild_and_replace_user_agent(
+    def rebuild_and_replace_user_agent_handler(
         self, operation_name, request, **kwargs
     ):
         ua_string = self.to_string()

--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -12,10 +12,13 @@
 # language governing permissions and limitations under the License.
 import logging
 import time
+from functools import partial
 
 import jmespath
 
+from botocore.context import with_current_context
 from botocore.docs.docstring import WaiterDocstring
+from botocore.useragent import register_feature_id
 from botocore.utils import get_service_module_name
 
 from . import xform_name
@@ -331,6 +334,7 @@ class Waiter:
         self.name = name
         self.config = config
 
+    @with_current_context(partial(register_feature_id, 'WAITER'))
     def wait(self, **kwargs):
         acceptors = list(self.config.acceptors)
         current_state = 'waiting'

--- a/tests/functional/test_useragent.py
+++ b/tests/functional/test_useragent.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
+import time
+from concurrent import futures
 from itertools import product
 
 import pytest
@@ -193,6 +195,93 @@ def test_user_agent_appid_gets_sanitized(patched_session, caplog):
     # given string should be truncated to 50 characters
     uafields = stub_client.captured_ua_string.split(' ')
     assert 'app/1234-' in uafields
+
+
+def test_user_agent_has_registered_feature_id(patched_session):
+    client_s3 = patched_session.create_client('s3')
+    with UACapHTTPStubber(client_s3) as stub_client:
+        paginator = client_s3.get_paginator('list_buckets')
+        # The `paginate()` method registers `'PAGINATOR': 'C'`
+        for _ in paginator.paginate():
+            pass
+    uafields = stub_client.captured_ua_string.split(' ')
+    feature_field = [field for field in uafields if field.startswith('m/')][0]
+    feature_list = feature_field[2:].split(',')
+    assert 'C' in feature_list
+
+
+def test_registered_feature_ids_dont_bleed_between_requests(patched_session):
+    client_s3 = patched_session.create_client('s3')
+    with UACapHTTPStubber(client_s3) as stub_client:
+        waiter = client_s3.get_waiter('bucket_exists')
+        # The `wait()` method registers `'WAITER': 'B'`
+        waiter.wait(Bucket='mybucket')
+    uafields = stub_client.captured_ua_string.split(' ')
+    feature_field = [field for field in uafields if field.startswith('m/')][0]
+    feature_list = feature_field[2:].split(',')
+    assert 'B' in feature_list
+
+    with UACapHTTPStubber(client_s3) as stub_client:
+        paginator = client_s3.get_paginator('list_buckets')
+        # The `paginate()` method registers `'PAGINATOR': 'C'`
+        for _ in paginator.paginate():
+            pass
+    uafields = stub_client.captured_ua_string.split(' ')
+    feature_field = [field for field in uafields if field.startswith('m/')][0]
+    feature_list = feature_field[2:].split(',')
+    assert 'C' in feature_list
+    assert 'B' not in feature_list
+
+
+def test_registered_feature_ids_dont_bleed_across_threads(patched_session):
+    client_s3 = patched_session.create_client('s3')
+    # The client stubber isn't thread-safe because it mutates the client's
+    # event system. This boolean is a workaround that ensures the paginator
+    # worker's thread spawns at the same time, but does not actually execute
+    # its job until the waiter thread finishes first and resets client state.
+    waiter_done = False
+
+    def wait(client, features):
+        with UACapHTTPStubber(client) as stub_client:
+            waiter = client.get_waiter('bucket_exists')
+            # The `wait()` method registers `'WAITER': 'B'`
+            waiter.wait(Bucket='mybucket')
+        uafields = stub_client.captured_ua_string.split(' ')
+        feature_field = [
+            field for field in uafields if field.startswith('m/')
+        ][0]
+        features.extend(feature_field[2:].split(','))
+        nonlocal waiter_done
+        waiter_done = True
+
+    def paginate(client, features):
+        nonlocal waiter_done
+        while not waiter_done:
+            time.sleep(0.5)
+        with UACapHTTPStubber(client) as stub_client:
+            paginator = client.get_paginator('list_buckets')
+            # The `paginate()` method registers `'PAGINATOR': 'C'`
+            for _ in paginator.paginate():
+                pass
+        uafields = stub_client.captured_ua_string.split(' ')
+        feature_field = [
+            field for field in uafields if field.startswith('m/')
+        ][0]
+        features.extend(feature_field[2:].split(','))
+
+    waiter_features = []
+    paginator_features = []
+    with futures.ThreadPoolExecutor(max_workers=2) as executor:
+        waiter_future = executor.submit(wait, client_s3, waiter_features)
+        paginator_future = executor.submit(
+            paginate, client_s3, paginator_features
+        )
+        waiter_future.result()
+        paginator_future.result()
+    assert 'B' in waiter_features
+    assert 'C' not in waiter_features
+    assert 'C' in paginator_features
+    assert 'B' not in paginator_features
 
 
 def test_boto3_user_agent(patched_session):

--- a/tests/functional/test_useragent.py
+++ b/tests/functional/test_useragent.py
@@ -304,7 +304,7 @@ def test_boto3_user_agent(patched_session):
     )
     # The regular User-Agent header components for platform, language, ...
     # should also be present:
-    assert ' ua/2.0 ' in stub_client.captured_ua_string
+    assert ' ua/2.1 ' in stub_client.captured_ua_string
     assert ' os/' in stub_client.captured_ua_string
     assert ' lang/' in stub_client.captured_ua_string
     assert ' cfg/' in stub_client.captured_ua_string
@@ -327,7 +327,7 @@ def test_awscli_v1_user_agent(patched_session):
     )
     # The regular User-Agent header components for platform, language, ...
     # should also be present:
-    assert ' ua/2.0 ' in stub_client.captured_ua_string
+    assert ' ua/2.1 ' in stub_client.captured_ua_string
     assert ' os/' in stub_client.captured_ua_string
     assert ' lang/' in stub_client.captured_ua_string
     assert ' cfg/' in stub_client.captured_ua_string
@@ -356,7 +356,7 @@ def test_awscli_v2_user_agent(patched_session):
     )
     # The regular User-Agent header components for platform, language, ...
     # should also be present:
-    assert ' ua/2.0 ' in stub_client.captured_ua_string
+    assert ' ua/2.1 ' in stub_client.captured_ua_string
     assert ' os/' in stub_client.captured_ua_string
     assert ' lang/' in stub_client.captured_ua_string
     assert ' cfg/' in stub_client.captured_ua_string

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from botocore.context import ClientContext, _context
+
+
+@pytest.fixture
+def client_context():
+    ctx = ClientContext()
+    token = _context.set(ctx)
+    yield ctx
+    _context.reset(token)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,12 +13,12 @@
 
 import pytest
 
-from botocore.context import ClientContext, _context
+from botocore.context import ClientContext, reset_token, set_context
 
 
 @pytest.fixture
 def client_context():
     ctx = ClientContext()
-    token = _context.set(ctx)
+    token = set_context(ctx)
     yield ctx
-    _context.reset(token)
+    reset_token(token)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,7 +13,7 @@
 
 import pytest
 
-from botocore.context import ClientContext, reset_token, set_context
+from botocore.context import ClientContext, reset_context, set_context
 
 
 @pytest.fixture
@@ -21,4 +21,4 @@ def client_context():
     ctx = ClientContext()
     token = set_context(ctx)
     yield ctx
-    reset_token(token)
+    reset_context(token)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from botocore.context import (
+    ClientContext,
+    get_context,
+    set_context,
+    start_as_current_context,
+    with_current_context,
+)
+
+
+@pytest.fixture
+def custom_context():
+    ctx = ClientContext()
+    ctx.features.add('CUSTOM')
+    return ctx
+
+
+class TestContext:
+    def test_get_context_returns_none(self):
+        ctx = get_context()
+        assert ctx is None
+
+    def test_get_context_returns_current(self, client_context):
+        ctx = get_context()
+        assert ctx == client_context
+
+    def test_set_context(self, custom_context):
+        set_context(custom_context)
+        ctx = get_context()
+        assert ctx == custom_context
+
+    def test_start_as_current_context(self):
+        with start_as_current_context():
+            ctx = get_context()
+            ctx.features.add('FOO')
+            assert ctx.features == {'FOO'}
+        ctx = get_context()
+        assert ctx is None
+
+    def test_nested_start_as_current_context(self):
+        with start_as_current_context():
+            ctx = get_context()
+            ctx.features.add('FOO')
+            with start_as_current_context():
+                ctx = get_context()
+                ctx.features.add('BAR')
+                assert ctx.features == {'FOO', 'BAR'}
+            ctx = get_context()
+            assert ctx.features == {'FOO'}
+        ctx = get_context()
+        assert ctx is None
+
+    def test_start_as_current_context_with_param(self, custom_context):
+        with start_as_current_context(custom_context):
+            ctx = get_context()
+            assert ctx.features == {'CUSTOM'}
+
+    def test_with_current_context(self):
+        @with_current_context()
+        def do_something():
+            ctx = get_context()
+            assert ctx is not None
+
+        do_something()
+
+    def test_with_current_context_with_hook(self):
+        def register_fake():
+            ctx = get_context()
+            ctx.features.add('FOO')
+
+        @with_current_context(register_fake)
+        def do_something():
+            ctx = get_context()
+            assert ctx.features == {'FOO'}
+
+        do_something()

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -16,6 +16,7 @@ import pytest
 from botocore.context import (
     ClientContext,
     get_context,
+    reset_token,
     set_context,
     start_as_current_context,
     with_current_context,
@@ -39,9 +40,10 @@ class TestContext:
         assert ctx == client_context
 
     def test_set_context(self, custom_context):
-        set_context(custom_context)
+        token = set_context(custom_context)
         ctx = get_context()
         assert ctx == custom_context
+        reset_token(token)
 
     def test_start_as_current_context(self):
         with start_as_current_context():

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -16,7 +16,7 @@ import pytest
 from botocore.context import (
     ClientContext,
     get_context,
-    reset_token,
+    reset_context,
     set_context,
     start_as_current_context,
     with_current_context,
@@ -43,7 +43,7 @@ class TestContext:
         token = set_context(custom_context)
         ctx = get_context()
         assert ctx == custom_context
-        reset_token(token)
+        reset_context(token)
 
     def test_start_as_current_context(self):
         with start_as_current_context():

--- a/tests/unit/test_useragent.py
+++ b/tests/unit/test_useragent.py
@@ -217,10 +217,10 @@ def test_register_feature_id(client_context):
     assert ctx.features == {'B'}
 
 
-def test_register_unknown_feature_id_raises(client_context):
-    with pytest.raises(ValueError) as excinfo:
-        register_feature_id('MY_FEATURE')
-    assert "Unknown feature id" in str(excinfo.value)
+def test_register_unknown_feature_id_skips(client_context):
+    register_feature_id('MY_FEATURE')
+    ctx = get_context()
+    assert ctx.features == set()
 
 
 def test_user_agent_truncated_string():

--- a/tests/unit/test_useragent.py
+++ b/tests/unit/test_useragent.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import logging
 import platform
 
 import pytest
@@ -232,16 +233,16 @@ def test_user_agent_truncated_string():
     assert component.to_string() == 'm/A'
 
 
-def test_user_agent_empty_truncated_string_raises():
+def test_user_agent_empty_truncated_string_logs(caplog):
+    caplog.set_level(logging.DEBUG)
     size_config = UserAgentComponentSizeConfig(1, ',')
     component = UserAgentComponent(
         'm',
         'A,B,C',
         size_config=size_config,
     )
-    with pytest.raises(ValueError) as excinfo:
-        component.to_string()
-    assert "could not be truncated" in str(excinfo.value)
+    assert component.to_string() == ''
+    assert 'could not be truncated' in caplog.text
 
 
 def test_non_positive_user_agent_component_size_config_raises():

--- a/tests/unit/test_useragent.py
+++ b/tests/unit/test_useragent.py
@@ -20,7 +20,7 @@ from botocore.config import Config
 from botocore.context import get_context
 from botocore.useragent import (
     UserAgentComponent,
-    UserAgentSizeConfig,
+    UserAgentComponentSizeConfig,
     UserAgentString,
     register_feature_id,
     sanitize_user_agent_string_component,
@@ -223,7 +223,7 @@ def test_register_unknown_feature_id_raises(client_context):
 
 
 def test_user_agent_truncated_string():
-    size_config = UserAgentSizeConfig(4, ',')
+    size_config = UserAgentComponentSizeConfig(4, ',')
     component = UserAgentComponent(
         'm',
         'A,BCD',
@@ -233,7 +233,7 @@ def test_user_agent_truncated_string():
 
 
 def test_user_agent_empty_truncated_string_raises():
-    size_config = UserAgentSizeConfig(1, ',')
+    size_config = UserAgentComponentSizeConfig(1, ',')
     component = UserAgentComponent(
         'm',
         'A,B,C',
@@ -242,3 +242,12 @@ def test_user_agent_empty_truncated_string_raises():
     with pytest.raises(ValueError) as excinfo:
         component.to_string()
     assert "could not be truncated" in str(excinfo.value)
+
+
+def test_non_positive_user_agent_component_size_config_raises():
+    with pytest.raises(ValueError) as excinfo:
+        UserAgentComponentSizeConfig(0, ',')
+    assert 'Invalid `max_size_in_bytes`' in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        UserAgentComponentSizeConfig(-1, ',')
+    assert 'Invalid `max_size_in_bytes`' in str(excinfo.value)

--- a/tests/unit/test_useragent.py
+++ b/tests/unit/test_useragent.py
@@ -84,7 +84,7 @@ def test_basic_user_agent_string():
     expected = (
         f'Botocore/{botocore_version} '
         'md/awscrt#Unknown '
-        'ua/2.0 '
+        'ua/2.1 '
         'os/linux#1.2.3-foo '
         'md/arch#x86_64 '
         'lang/python#3.8.20 '
@@ -112,7 +112,7 @@ def test_shared_test_case():
     actual = uas.to_string().split(' ')
     expected_in_exact_order = [
         f"Botocore/{botocore_version}",
-        "ua/2.0",
+        "ua/2.1",
         "os/linux#5.4.228-131.415.AMZN2.X86_64",
         "lang/python#4.3.2",
         "exec-env/lambda",
@@ -144,7 +144,7 @@ def test_user_agent_string_with_missing_information():
         crt_version=None,
     ).with_client_config(Config())
     actual = uas.to_string()
-    assert actual == f'Botocore/{botocore_version} ua/2.0 os/other lang/python'
+    assert actual == f'Botocore/{botocore_version} ua/2.1 os/other lang/python'
 
 
 def test_from_environment(monkeypatch):


### PR DESCRIPTION
#### Description
This PR implements scaffolding for tracking client feature usage in the user agent header. Features that we track are defined in `botocore.useragent._USERAGENT_FEATURE_MAPPINGS`. Whenever a trackable feature is used, its associated metric id is stored. When the user agent string is built, it retrieves all registered features and creates a comma-separated string with the `m/` prefix. For example, if a request is made using SigV4A signing, the user agent string may look like the following:
```
Boto3/1.36.13 md/Botocore#1.36.13 md/awscrt#0.23.8 ua/2.0 os/macos#24.2.0 md/arch#arm64 lang/python#3.11.10 md/pyimpl#CPython m/S cfg/retry-mode#legacy Botocore/1.36.13
```
Note the `m/S` component.

#### Design
I prioritized an approach that tries to minimize invasiveness to the current codebase. Specifically, I wanted to avoid having to plumb some `features` variable to every method that registers a function, mainly so we wouldn't need to update the function signature of potentially all methods. This would also require higher level packages (Boto3, S3Transfer, AWS CLI) to plumb features they register.

#### Initial features to track
There are 5 features tracked to start:
- `WAITER`: An operation called using a waiter.
- `PAGINATOR`: An operation called using a paginator.
- `S3_TRANSFER`: An operation called using the S3 Transfer Manager.
- `ENDPOINT_OVERRIDE`: An operation called using a user provided endpoint URL.
- `SIGV4A_SIGNING`: An operation called using sigv4a signing.

S3Transfer usage will need to be registered in `boto3` and will require a small update to `s3transfer`(to pass context from parent to child threads).
- S3Transfer: https://github.com/boto/s3transfer/pull/335
- Boto3: https://github.com/boto/boto3/pull/4441

#### Caveats
- Features are tracked in a set. Since sets don't preserve order in which elements were added, if the feature metadata string exceeds 1KB and it's truncated, the truncation strategy won't be true LIFO. I thought this was an acceptable tradeoff since we're nowhere near the limit and we can explore storage solutions or even metric collection strategy in the future if this becomes a real issue.
- Some features are "cacheable". For example, if a Session object is creating a new Client and there are cached credentials, it will skip invoking the method that registers the relevant credentials feature. This PR doesn't prescribe a single way to deal with cacheable features since the way feature values are cached and gotten can vary. For cached credentials, I imagine we would inspect the `METHOD` attributes to determine the correct feature to register.