### PR TITLE
Ignore .venv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ pip-log.txt
 .idea/
 
 # Virtualenvs
+.venv
+venv
 env
 env2
 env3


### PR DESCRIPTION
Add .venv and venv to our .gitignore file to avoid accidental inclusion.