### PR TITLE
Corrected typo without breaking backwards compatibility

### DIFF
--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -218,14 +218,16 @@ def _warn_misspelling_deprecated():
 
     Use of BOTOCORE_DEFAUT_SESSION_VARIABLES remains functional due to pass by reference nature of dictionaries.
     """
-    # Grab the stack
-    for frame in inspect.stack():
+    # Grab the stack and go through frames in reverse order (imports are likely low on the stack)
+    for frame in inspect.stack()[::-1]:
         if frame.code_context:
             # Do a basic regex match on each line
             for line in frame.code_context:
                 # If a named import is being used, warn the user of deprecation
                 if re.match(_BOTOCORE_DEFAUT_SESSION_VARIABLES_TEST_PATTERN, line):
                     logging.warning("BOTOCORE_DEFAUT_SESSION_VARIABLES as a named import is deprecated and will be removed in a future release. Use BOTOCORE_DEFAULT_SESSION_VARIABLES instead.")
+                    # Don't inspect rest of stack and return
+                    return BOTOCORE_DEFAULT_SESSION_VARIABLES
     # Return the value with the correct name; remains mutable via pass by reference
     return BOTOCORE_DEFAULT_SESSION_VARIABLES
 

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -214,7 +214,6 @@ def _warn_misspelling_deprecated():
     Will not warn on:
 
     - Module imports: import botocore.configprovider
-    - Imports done via python shell since import statement will not be on the stack in a shell context.
 
     Use of BOTOCORE_DEFAUT_SESSION_VARIABLES remains functional due to pass by reference nature of dictionaries.
     """

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -40,7 +40,7 @@ from botocore import (
 )
 from botocore.compat import HAS_CRT, MutableMapping
 from botocore.configprovider import (
-    BOTOCORE_DEFAUT_SESSION_VARIABLES,
+    BOTOCORE_DEFAULT_SESSION_VARIABLES,
     ConfigChainFactory,
     ConfiguredEndpointProvider,
     ConfigValueStore,
@@ -89,7 +89,7 @@ class Session:
     :ivar profile: The current profile.
     """
 
-    SESSION_VARIABLES = copy.copy(BOTOCORE_DEFAUT_SESSION_VARIABLES)
+    SESSION_VARIABLES = copy.copy(BOTOCORE_DEFAULT_SESSION_VARIABLES)
 
     #: The default format string to use when configuring the botocore logger.
     LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'


### PR DESCRIPTION
I noticed the note about the misspelled variable in #3029 which was mentioned in #2361 and #1861. The concerns about breaking backwards compatibility were important and actually sparked interest if this was resolvable. I sought to solve this issue while meeting the following requirements:

1. Does not introduce a breaking change
2. Informs the user via a warning of the deprecation ONLY if used in a named import
3. Does not make promises about when the old name will be removed; just mentions future release
4. Does not warn the user on general module imports

I used a mix of `inspect` functionality and very basic regex to achieve the above to the best of my understanding pending your review.

Python 3.8-3.12 local test using tox below; had a residual 3.13 environment that made me have to run it separately:
![image](https://github.com/user-attachments/assets/5abc85e6-b16e-4dae-953d-ff6d096ceb2f)

Python 3.13 test run separately after cleaning the 3.13 environment:
![image](https://github.com/user-attachments/assets/dc6c6c60-44eb-41dd-88bf-098f4acb79af)

Ran `pre-commit` per the Contribution guide but it seemed to skip all the tests for some reason:

![image](https://github.com/user-attachments/assets/23614e09-046f-455f-ae76-1400affd2f96)

Also ran `ruff` independently on edited files:
![image](https://github.com/user-attachments/assets/bc8b7f6f-a66e-4d0e-9373-f2a91626838a)

Ran `isort` and neither file edited was modified, so that's good as well.
![image](https://github.com/user-attachments/assets/37d987b2-62b8-4eb2-963b-1f98b0102d0c)

Below is the final result in terms of user experience if they attempt a module or named import:

![image](https://github.com/user-attachments/assets/556bc4a3-5a2b-42b6-b479-9eb5d35fe5b5)

May be a bit trivial, but below shows imports of the old variable name have changes reflected in the corrected one via pass by reference convention:

![image](https://github.com/user-attachments/assets/72776f8c-a1a4-4a43-b5f5-1e876bc59ff1)


Standing by for any questions, comments, recommendations or direction.
