### PR TITLE
Account ID Based Endpoint Routing

### DIFF
--- a/.changes/next-release/feature-Endpoints-14344.json
+++ b/.changes/next-release/feature-Endpoints-14344.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Endpoints",
+  "description": "Generate and use AWS-account-based endpoints for compatible services when the account ID is available. At launch, DynamoDB is the first and only compatible service. The new endpoint URL pattern will be ``https://<account-id>.ddb.<region>.amazonaws.com``. Additional services may be added in the future. See the documentation for details: https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html"
+}

--- a/botocore/config.py
+++ b/botocore/config.py
@@ -266,6 +266,19 @@ class Config:
           supported and the ``requestValidationModeMember`` member is set to ``ENABLED``.
 
         Defaults to None.
+
+    :type account_id_endpoint_mode: str
+    :param account_id_endpoint_mode: The value used to determine the client's
+        behavior for account ID based endpoint routing. Valid values are:
+
+        * ``preferred`` - The endpoint should include account ID if available.
+        * ``disabled`` - A resolved endpoint does not include account ID.
+        * ``required`` - The endpoint must include account ID. If the account ID
+          isn't available, an exception will be raised.
+
+        If a value is not provided, the client will default to ``preferred``.
+
+        Defaults to None.
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -297,6 +310,7 @@ class Config:
             ('sigv4a_signing_region_set', None),
             ('request_checksum_calculation', None),
             ('response_checksum_validation', None),
+            ('account_id_endpoint_mode', None),
         ]
     )
 

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -180,6 +180,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         "when_supported",
         None,
     ),
+    'account_id_endpoint_mode': (
+        'account_id_endpoint_mode',
+        'AWS_ACCOUNT_ID_ENDPOINT_MODE',
+        'preferred',
+        None,
+    ),
 }
 
 # Evaluate AWS_STS_REGIONAL_ENDPOINTS settings

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1307,6 +1307,7 @@ class SharedCredentialProvider(CredentialProvider):
     # aws_security_token, but the SDKs are standardizing on aws_session_token
     # so we support both.
     TOKENS = ['aws_security_token', 'aws_session_token']
+    ACCOUNT_ID = 'aws_account_id'
 
     def __init__(self, creds_filename, profile_name=None, ini_parser=None):
         self._creds_filename = creds_filename
@@ -1333,14 +1334,22 @@ class SharedCredentialProvider(CredentialProvider):
                     config, self.ACCESS_KEY, self.SECRET_KEY
                 )
                 token = self._get_session_token(config)
+                account_id = self._get_account_id(config)
                 return Credentials(
-                    access_key, secret_key, token, method=self.METHOD
+                    access_key,
+                    secret_key,
+                    token,
+                    method=self.METHOD,
+                    account_id=account_id,
                 )
 
     def _get_session_token(self, config):
         for token_envvar in self.TOKENS:
             if token_envvar in config:
                 return config[token_envvar]
+
+    def _get_account_id(self, config):
+        return config.get(self.ACCOUNT_ID)
 
 
 class ConfigProvider(CredentialProvider):
@@ -1355,6 +1364,7 @@ class ConfigProvider(CredentialProvider):
     # aws_security_token, but the SDKs are standardizing on aws_session_token
     # so we support both.
     TOKENS = ['aws_security_token', 'aws_session_token']
+    ACCOUNT_ID = 'aws_account_id'
 
     def __init__(self, config_filename, profile_name, config_parser=None):
         """
@@ -1391,8 +1401,13 @@ class ConfigProvider(CredentialProvider):
                     profile_config, self.ACCESS_KEY, self.SECRET_KEY
                 )
                 token = self._get_session_token(profile_config)
+                account_id = self._get_account_id(profile_config)
                 return Credentials(
-                    access_key, secret_key, token, method=self.METHOD
+                    access_key,
+                    secret_key,
+                    token,
+                    method=self.METHOD,
+                    account_id=account_id,
                 )
         else:
             return None
@@ -1401,6 +1416,9 @@ class ConfigProvider(CredentialProvider):
         for token_name in self.TOKENS:
             if token_name in profile_config:
                 return profile_config[token_name]
+
+    def _get_account_id(self, config):
+        return config.get(self.ACCOUNT_ID)
 
 
 class BotoProvider(CredentialProvider):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1034,6 +1034,7 @@ class ProcessProvider(CredentialProvider):
             secret_key=creds_dict['secret_key'],
             token=creds_dict.get('token'),
             method=self.METHOD,
+            account_id=creds_dict.get('account_id'),
         )
 
     def _retrieve_credentials_using(self, credential_process):
@@ -1064,6 +1065,7 @@ class ProcessProvider(CredentialProvider):
                 'secret_key': parsed['SecretAccessKey'],
                 'token': parsed.get('SessionToken'),
                 'expiry_time': parsed.get('Expiration'),
+                'account_id': self._get_account_id(parsed),
             }
         except KeyError as e:
             raise CredentialRetrievalError(
@@ -1073,12 +1075,20 @@ class ProcessProvider(CredentialProvider):
 
     @property
     def _credential_process(self):
+        return self.profile_config.get('credential_process')
+
+    @property
+    def profile_config(self):
         if self._loaded_config is None:
             self._loaded_config = self._load_config()
         profile_config = self._loaded_config.get('profiles', {}).get(
             self._profile_name, {}
         )
-        return profile_config.get('credential_process')
+        return profile_config
+
+    def _get_account_id(self, parsed):
+        account_id = parsed.get('AccountId')
+        return account_id or self.profile_config.get('aws_account_id')
 
 
 class InstanceMetadataProvider(CredentialProvider):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1979,6 +1979,7 @@ class ContainerProvider(CredentialProvider):
             method=self.METHOD,
             expiry_time=_parse_if_needed(creds['expiry_time']),
             refresh_using=fetcher,
+            account_id=creds.get('account_id'),
         )
 
     def _build_headers(self):
@@ -2016,6 +2017,7 @@ class ContainerProvider(CredentialProvider):
                 'secret_key': response['SecretAccessKey'],
                 'token': response['Token'],
                 'expiry_time': response['Expiration'],
+                'account_id': response.get('AccountId'),
             }
 
         return fetch_creds

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -344,6 +344,12 @@ class Credentials:
             self.access_key, self.secret_key, self.token, self.account_id
         )
 
+    def get_deferred_property(self, property_name):
+        def get_property():
+            return getattr(self, property_name, None)
+
+        return get_property
+
 
 class RefreshableCredentials(Credentials):
     """

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -432,10 +432,10 @@ class EndpointResolverBuiltins(str, Enum):
     # Whether the UseDualStackEndpoint configuration option has been enabled
     # for the SDK client (bool)
     AWS_USE_DUALSTACK = "AWS::UseDualStack"
-    # Whether the global endpoint should be used with STS, rather the the
+    # Whether the global endpoint should be used with STS, rather than the
     # regional endpoint for us-east-1 (bool)
     AWS_STS_USE_GLOBAL_ENDPOINT = "AWS::STS::UseGlobalEndpoint"
-    # Whether the global endpoint should be used with S3, rather then the
+    # Whether the global endpoint should be used with S3, rather than the
     # regional endpoint for us-east-1 (bool)
     AWS_S3_USE_GLOBAL_ENDPOINT = "AWS::S3::UseGlobalEndpoint"
     # Whether S3 Transfer Acceleration has been requested (bool)
@@ -452,8 +452,9 @@ class EndpointResolverBuiltins(str, Enum):
     AWS_S3_DISABLE_MRAP = "AWS::S3::DisableMultiRegionAccessPoints"
     # Whether a custom endpoint has been configured (str)
     SDK_ENDPOINT = "SDK::Endpoint"
-    # Currently not implemented:
+    # An AWS account ID that can be optionally configured for the SDK client (str)
     ACCOUNT_ID = "AWS::Auth::AccountId"
+    # Whether an endpoint should include an account ID (str)
     ACCOUNT_ID_ENDPOINT_MODE = "AWS::Auth::AccountIdEndpointMode"
 
 
@@ -620,7 +621,10 @@ class EndpointRulesetResolver:
     def _resolve_param_as_builtin(self, builtin_name, builtins):
         if builtin_name not in EndpointResolverBuiltins.__members__.values():
             raise UnknownEndpointResolutionBuiltInName(name=builtin_name)
-        return builtins.get(builtin_name)
+        builtin = builtins.get(builtin_name)
+        if callable(builtin):
+            return builtin()
+        return builtin
 
     @instance_cache
     def _get_static_context_params(self, operation_model):

--- a/tests/functional/test_account_id_endpoints.py
+++ b/tests/functional/test_account_id_endpoints.py
@@ -1,0 +1,198 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from botocore.config import Config
+from botocore.exceptions import EndpointResolutionError
+from tests import ClientHTTPStubber, patch_load_service_model
+
+FAKE_RULESET = {
+    "version": "1.0",
+    "parameters": {
+        "AccountId": {
+            "type": "String",
+            "builtIn": "AWS::Auth::AccountId",
+            "documentation": "The AWS account ID used for the request, eg. `123456789012`.",
+        },
+        "AccountIdEndpointMode": {
+            "type": "String",
+            "builtIn": "AWS::Auth::AccountIdEndpointMode",
+            "documentation": "The behavior for account ID based endpoint routing, eg. `preferred`.",
+        },
+    },
+    "rules": [
+        {
+            "documentation": "Template account ID into the URI when account ID is set and AccountIdEndpointMode is "
+            "set to preferred.",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "AccountId"}]},
+                {"fn": "isSet", "argv": [{"ref": "AccountIdEndpointMode"}]},
+                {
+                    "fn": "stringEquals",
+                    "argv": [{"ref": "AccountIdEndpointMode"}, "preferred"],
+                },
+            ],
+            "endpoint": {
+                "url": "https://{AccountId}.otherservice.us-west-2.amazonaws.com"
+            },
+            "type": "endpoint",
+        },
+        {
+            "documentation": "Do not template account ID into the URI when AccountIdEndpointMode is set to disabled.",
+            "conditions": [
+                {"fn": "isSet", "argv": [{"ref": "AccountId"}]},
+                {"fn": "isSet", "argv": [{"ref": "AccountIdEndpointMode"}]},
+                {
+                    "fn": "stringEquals",
+                    "argv": [{"ref": "AccountIdEndpointMode"}, "disabled"],
+                },
+            ],
+            "endpoint": {
+                "url": "https://otherservice.us-west-2.amazonaws.com/"
+            },
+            "type": "endpoint",
+        },
+        {
+            "documentation": "Raise an error when account ID is unset but AccountIdEndpointMode is set to required.",
+            "conditions": [
+                {
+                    "fn": "not",
+                    "argv": [{"fn": "isSet", "argv": [{"ref": "AccountId"}]}],
+                },
+                {"fn": "isSet", "argv": [{"ref": "AccountIdEndpointMode"}]},
+                {
+                    "fn": "stringEquals",
+                    "argv": [{"ref": "AccountIdEndpointMode"}, "required"],
+                },
+            ],
+            "error": "AccountIdEndpointMode is required but no AccountID was provided",
+            "type": "error",
+        },
+    ],
+}
+
+FAKE_SERVICE_MODEL = {
+    "version": "2.0",
+    "documentation": "",
+    "metadata": {
+        "apiVersion": "2020-02-02",
+        "endpointPrefix": "otherservice",
+        "protocol": "rest-xml",
+        "serviceFullName": "Other Service",
+        "serviceId": "Other Service",
+        "signatureVersion": "v4",
+        "signingName": "otherservice",
+        "uid": "otherservice-2020-02-02",
+    },
+    "operations": {
+        "MockOperation": {
+            "name": "MockOperation",
+            "http": {"method": "GET", "requestUri": "/"},
+            "input": {"shape": "MockOperationRequest"},
+            "documentation": "",
+        },
+    },
+    "shapes": {
+        "MockOpParam": {
+            "type": "string",
+        },
+        "MockOperationRequest": {
+            "type": "structure",
+            "required": ["MockOpParam"],
+            "members": {
+                "MockOpParam": {
+                    "shape": "MockOpParam",
+                    "documentation": "",
+                    "location": "uri",
+                    "locationName": "param",
+                },
+            },
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "account_id_endpoint_mode, expected_endpoint, expected_error, account_id_in_url",
+    [
+        # Test case for 'preferred' mode: Account ID is in the URL
+        (
+            'preferred',
+            'https://123456789012.otherservice.us-west-2.amazonaws.com/',
+            None,
+            True,
+        ),
+        # Test case for 'disabled' mode: Account ID is not in the URL
+        (
+            'disabled',
+            'https://otherservice.us-west-2.amazonaws.com/',
+            None,
+            False,
+        ),
+        # Test case for 'required' mode: Error is raised due to missing Account ID
+        (
+            'required',
+            None,
+            'AccountIdEndpointMode is required but no AccountID was provided',
+            False,
+        ),
+    ],
+)
+def test_account_id_endpoint_resolution(
+    account_id_endpoint_mode,
+    expected_endpoint,
+    expected_error,
+    account_id_in_url,
+    patched_session,
+    monkeypatch,
+):
+    account_id = '123456789012'
+    patch_load_service_model(
+        patched_session, monkeypatch, FAKE_SERVICE_MODEL, FAKE_RULESET
+    )
+
+    if account_id_endpoint_mode != 'required':
+        monkeypatch.setenv('AWS_ACCOUNT_ID', account_id)
+
+    client = patched_session.create_client(
+        'otherservice',
+        region_name='us-west-2',
+        config=Config(account_id_endpoint_mode=account_id_endpoint_mode),
+    )
+
+    # If we expect an error, assert that the error is raised
+    if expected_error:
+        with pytest.raises(EndpointResolutionError) as exc_info:
+            with ClientHTTPStubber(client, strict=True) as http_stubber:
+                http_stubber.add_response()
+                client.mock_operation(MockOpParam='mock-op-param-value')
+        assert str(exc_info.value) == expected_error
+    else:
+        # If no error is expected, verify the endpoint resolution
+        with ClientHTTPStubber(client, strict=True) as http_stubber:
+            http_stubber.add_response(status=200, body=b'{}')
+            client.mock_operation(MockOpParam='mock-op-param-value')
+            request = http_stubber.requests[0]
+
+            if account_id_in_url:
+                assert (
+                    account_id in request.url
+                ), f"Account ID should be in the URL, but it's not: {request.url}"
+            else:
+                assert (
+                    account_id not in request.url
+                ), f"Account ID should not be in the URL, but it is: {request.url}"
+            assert (
+                request.url == expected_endpoint
+            ), f"Expected endpoint '{expected_endpoint}', but got: {request.url}"

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -72,7 +72,10 @@ class TestCredentialPrecedence(BaseEnvVar):
         )
 
         credentials_cls.assert_called_with(
-            access_key='code', secret_key='code-secret', token=mock.ANY
+            access_key='code',
+            secret_key='code-secret',
+            token=mock.ANY,
+            account_id=mock.ANY,
         )
 
     def test_profile_env_vs_code(self):
@@ -97,7 +100,10 @@ class TestCredentialPrecedence(BaseEnvVar):
         )
 
         credentials_cls.assert_called_with(
-            access_key='code', secret_key='code-secret', token=mock.ANY
+            access_key='code',
+            secret_key='code-secret',
+            token=mock.ANY,
+            account_id=mock.ANY,
         )
 
     def test_access_secret_env_vs_profile_code(self):

--- a/tests/unit/data/endpoints/test-cases/account-id.json
+++ b/tests/unit/data/endpoints/test-cases/account-id.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "Test case for basic AccountID templating",
+      "params": {
+        "AccountId": "123456789001",
+        "AccountIdEndpointMode": "preferred"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://123456789001.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "Test case where AccountID is set but AccountIdEndpointMode is set to disabled",
+      "params": {
+        "AccountId": "123456789001",
+        "AccountIdEndpointMode": "disabled"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "Test case where AccountID is unset but AccountIdEndpointMode is set to required",
+      "params": {
+        "AccountIdEndpointMode": "required"
+      },
+      "expect": {
+        "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded"
+      }
+    },
+    {
+      "documentation": "Test case where AccountID and AccountIdEndpointMode are unset",
+      "params": {},
+      "expect": {
+        "endpoint": {
+          "url": "https://amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/data/endpoints/valid-rules/account-id.json
+++ b/tests/unit/data/endpoints/valid-rules/account-id.json
@@ -1,0 +1,130 @@
+{
+  "version": "1.0",
+  "parameters": {
+    "AccountId": {
+      "type": "String",
+      "builtIn": "AWS::Auth::AccountId",
+      "documentation": "The AWS account ID used in the endpoint for a request, eg. `123456789012`."
+    },
+    "AccountIdEndpointMode": {
+      "type": "String",
+      "builtIn": "AWS::Auth::AccountIdEndpointMode",
+      "documentation": "The behavior for account ID based endpoint routing, eg. `preferred`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template account ID into the URI when account ID is set and AccountIdEndpointMode is set to preferred.",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            },
+            "preferred"
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{AccountId}.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Do not template account ID into the URI when AccountIdEndpointMode is set to disabled.",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            },
+            "disabled"
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Raise an error when account ID is unset but AccountIdEndpointMode is set to required.",
+      "conditions": [
+        {
+          "fn": "not",
+          "argv": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "AccountId"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            {
+              "ref": "AccountIdEndpointMode"
+            },
+            "required"
+          ]
+        }
+      ],
+      "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded",
+      "type": "error"
+    },
+    {
+      "documentation": "Fallback when AccountID and AccountIdEndpointMode are unset",
+      "conditions": [],
+      "endpoint": {
+        "url": "https://amazonaws.com"
+      },
+      "type": "endpoint"
+    }
+  ]
+}

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -13,11 +13,12 @@
 # language governing permissions and limitations under the License.
 import socket
 
-from botocore import args, exceptions
+from botocore import UNSIGNED, args, exceptions
 from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
 from botocore.client import ClientEndpointBridge
 from botocore.config import Config
 from botocore.configprovider import ConfigValueStore
+from botocore.credentials import Credentials
 from botocore.exceptions import UnsupportedServiceProtocolsError
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel
@@ -718,6 +719,45 @@ class TestCreateClientArgs(unittest.TestCase):
         ):
             self.call_compute_client_args()
 
+    def test_account_id_endpoint_mode_set_on_config_store(self):
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'preferred'
+        )
+        config = self.call_get_client_args()['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'preferred')
+
+    def test_account_id_endpoint_mode_set_on_client_config(self):
+        config = self.call_get_client_args(
+            client_config=Config(account_id_endpoint_mode='required')
+        )['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'required')
+
+    def test_account_id_endpoint_mode_client_config_overrides_config_store(
+        self,
+    ):
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'preferred'
+        )
+        config = self.call_get_client_args(
+            client_config=Config(account_id_endpoint_mode='disabled')
+        )['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'disabled')
+
+    def test_account_id_endpoint_mode_bad_value(self):
+        with self.assertRaises(exceptions.InvalidConfigError):
+            config = Config(account_id_endpoint_mode='foo')
+            self.call_get_client_args(client_config=config)
+        self.config_store.set_config_variable(
+            'account_id_endpoint_mode', 'foo'
+        )
+        with self.assertRaises(exceptions.InvalidConfigError):
+            self.call_get_client_args()
+
+    def test_account_id_endpoint_mode_disabled_on_unsigned_request(self):
+        self._set_endpoint_bridge_resolve(signature_version=UNSIGNED)
+        config = self.call_get_client_args()['client_config']
+        self.assertEqual(config.account_id_endpoint_mode, 'disabled')
+
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):
@@ -761,6 +801,8 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             'endpoint_bridge': self.bridge,
             'client_endpoint_url': None,
             'legacy_endpoint_url': 'https://my.legacy.endpoint.com',
+            'credentials': None,
+            'account_id_endpoint_mode': 'preferred',
         }
         kwargs = {**defaults, **overrides}
         return self.args_create.compute_endpoint_resolver_builtin_defaults(
@@ -783,6 +825,8 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             bins['AWS::S3::DisableMultiRegionAccessPoints'], False
         )
         self.assertEqual(bins['SDK::Endpoint'], None)
+        self.assertEqual(bins['AWS::Auth::AccountId'], None)
+        self.assertEqual(bins['AWS::Auth::AccountIdEndpointMode'], 'preferred')
 
     def test_aws_region(self):
         bins = self.call_compute_endpoint_resolver_builtin_defaults(
@@ -946,6 +990,20 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             legacy_endpoint_url='https://my.legacy.endpoint.com',
         )
         self.assertEqual(bins['SDK::Endpoint'], None)
+
+    def test_account_id_set_with_credentials(self):
+        bins = self.call_compute_endpoint_resolver_builtin_defaults(
+            credentials=Credentials(
+                access_key='foo', secret_key='bar', account_id='baz'
+            )
+        )
+        self.assertEqual(bins['AWS::Auth::AccountId'](), 'baz')
+
+    def test_account_id_endpoint_mode_set_to_disabled(self):
+        bins = self.call_compute_endpoint_resolver_builtin_defaults(
+            account_id_endpoint_mode='disabled'
+        )
+        self.assertEqual(bins['AWS::Auth::AccountIdEndpointMode'], 'disabled')
 
 
 class TestProtocolPriorityList:

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3572,6 +3572,56 @@ class TestProcessProvider(BaseEnvVar):
         self.assertIsNone(creds.token)
         self.assertEqual(creds.method, 'custom-process')
 
+    def test_can_retrieve_account_id(self):
+        self.loaded_config['profiles'] = {
+            'default': {'credential_process': 'my-process'}
+        }
+        self._set_process_return_value(
+            {
+                'Version': 1,
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': '2999-01-01T00:00:00Z',
+                'AccountId': '123456789012',
+            }
+        )
+
+        provider = self.create_process_provider()
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'custom-process')
+        self.assertEqual(creds.account_id, '123456789012')
+
+    def test_can_retrieve_account_id_via_profile_config(self):
+        self.loaded_config['profiles'] = {
+            'default': {
+                'credential_process': 'my-process',
+                'aws_account_id': '123456789012',
+            }
+        }
+        self._set_process_return_value(
+            {
+                'Version': 1,
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': '2999-01-01T00:00:00Z',
+            }
+        )
+
+        provider = self.create_process_provider()
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'custom-process')
+        self.assertEqual(creds.account_id, '123456789012')
+
 
 class TestProfileProviderBuilder(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3882,3 +3882,15 @@ class TestSSOProvider(unittest.TestCase):
         # If any required configuration is missing we should get an error
         with self.assertRaises(botocore.exceptions.InvalidConfigError):
             self.provider.load()
+
+
+@pytest.mark.parametrize(
+    "account_id, expected", [("123456789012", "123456789012"), (None, None)]
+)
+def test_get_deferred_property_account_id(account_id, expected):
+    creds = Credentials(
+        access_key='foo', secret_key='bar', token='baz', account_id=account_id
+    )
+    deferred_account_id = creds.get_deferred_property('account_id')
+    assert callable(deferred_account_id)
+    assert deferred_account_id() == expected

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1428,6 +1428,28 @@ class TestSharedCredentialsProvider(BaseEnvVar):
         creds = provider.load()
         self.assertIsNone(creds)
 
+    def test_credentials_file_exists_with_account_id(self):
+        self.ini_parser.return_value = {
+            'default': {
+                'aws_access_key_id': 'foo',
+                'aws_secret_access_key': 'bar',
+                'aws_session_token': 'baz',
+                'aws_account_id': 'bin',
+            }
+        }
+        provider = credentials.SharedCredentialProvider(
+            creds_filename='~/.aws/creds',
+            profile_name='default',
+            ini_parser=self.ini_parser,
+        )
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'shared-credentials-file')
+        self.assertEqual(creds.account_id, 'bin')
+
 
 class TestConfigFileProvider(BaseEnvVar):
     def setUp(self):
@@ -1489,6 +1511,25 @@ class TestConfigFileProvider(BaseEnvVar):
         provider = credentials.ConfigProvider('cli.cfg', 'default', parser)
         with self.assertRaises(botocore.exceptions.PartialCredentialsError):
             provider.load()
+
+    def test_config_file_with_account_id(self):
+        profile_config = {
+            'aws_access_key_id': 'foo',
+            'aws_secret_access_key': 'bar',
+            'aws_session_token': 'baz',
+            'aws_account_id': 'bin',
+        }
+        parsed = {'profiles': {'default': profile_config}}
+        parser = mock.Mock()
+        parser.return_value = parsed
+        provider = credentials.ConfigProvider('cli.cfg', 'default', parser)
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.method, 'config-file')
+        self.assertEqual(creds.account_id, 'bin')
 
 
 class TestBotoProvider(BaseEnvVar):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1020,6 +1020,20 @@ class TestEnvVar(BaseEnvVar):
         self.assertEqual(creds.token, 'baz')
         self.assertEqual(creds.method, 'env')
 
+    def test_envvars_found_with_account_id(self):
+        environ = {
+            'AWS_ACCESS_KEY_ID': 'foo',
+            'AWS_SECRET_ACCESS_KEY': 'bar',
+            'AWS_ACCOUNT_ID': 'baz',
+        }
+        provider = credentials.EnvProvider(environ)
+        creds = provider.load()
+        self.assertIsNotNone(creds)
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.account_id, 'baz')
+        self.assertEqual(creds.method, 'env')
+
     def test_envvars_not_found(self):
         provider = credentials.EnvProvider(environ={})
         creds = provider.load()
@@ -1126,6 +1140,22 @@ class TestEnvVar(BaseEnvVar):
         )
         with self.assertRaisesRegex(RuntimeError, error_message):
             creds.get_frozen_credentials()
+
+    def test_can_override_account_id_env_var_mapping(self):
+        environ = {
+            'AWS_ACCESS_KEY_ID': 'foo',
+            'AWS_SECRET_ACCESS_KEY': 'bar',
+            'AWS_SESSION_TOKEN': 'baz',
+            'FOO_ACCOUNT_ID': 'bin',
+        }
+        provider = credentials.EnvProvider(
+            environ, {'account_id': 'FOO_ACCOUNT_ID'}
+        )
+        creds = provider.load()
+        self.assertEqual(creds.access_key, 'foo')
+        self.assertEqual(creds.secret_key, 'bar')
+        self.assertEqual(creds.token, 'baz')
+        self.assertEqual(creds.account_id, 'bin')
 
     def test_partial_creds_is_an_error(self):
         # If the user provides an access key, they must also

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -137,6 +137,7 @@ def endpoint_rule():
 
 def ruleset_testcases():
     filenames = [
+        "account-id",
         "array-index",
         "aws-region",
         "default-values",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -781,6 +781,46 @@ class TestCreateClient(BaseSessionTest):
             ]
             self.assertEqual(call_kwargs['api_version'], override_api_version)
 
+    @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_with_credentials(self, client_creator):
+        self.session.create_client(
+            'sts',
+            'us-west-2',
+            aws_access_key_id='foo',
+            aws_secret_access_key='bar',
+            aws_session_token='baz',
+            aws_account_id='bin',
+        )
+        credentials = (
+            client_creator.return_value.create_client.call_args.kwargs[
+                'credentials'
+            ]
+        )
+        self.assertEqual(credentials.access_key, 'foo')
+        self.assertEqual(credentials.secret_key, 'bar')
+        self.assertEqual(credentials.token, 'baz')
+        self.assertEqual(credentials.account_id, 'bin')
+
+    @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_with_ignored_credentials(self, client_creator):
+        with self.assertLogs('botocore.session', level='DEBUG') as log:
+            self.session.create_client(
+                'sts',
+                'us-west-2',
+                aws_account_id='foo',
+            )
+            credentials = (
+                client_creator.return_value.create_client.call_args.kwargs[
+                    'credentials'
+                ]
+            )
+            self.assertIn(
+                'Ignoring the following credential-related values',
+                log.output[0],
+            )
+            self.assertIn('aws_account_id', log.output[0])
+            self.assertEqual(credentials.account_id, None)
+
 
 class TestSessionComponent(BaseSessionTest):
     def test_internal_component(self):


### PR DESCRIPTION
This PR adds support for account id-based endpoint routing which improves performance and scalability by using your AWS account ID to streamline request routing for services that support this feature. When using the SDK with a compatible credential provider and service, it will automatically construct an account ID-based endpoint instead of a regional endpoint that follows this format:
```
https://<account-id>.service.<region>.amazonaws.com
```
The following credential providers are supported:
* Environment variables
* Assume role provider
* Assume role with web identity provider
* AWS IAM Identity Center credential provider
* Static credentials providers
  * Client creation `session.create_client()`
  * Shared credential file (`~/.aws/credentials`)
  * AWS config file (`~/.aws/config`)
* Container credential provider

### Modifications
* Implementing `AccountId` and `AccountIdEndpointMode` as built-in endpoint parameters. 
* Adding support for resolving `account_id` from supported identity resolvers.
* Adding the setting `account_id_endpoint_mode` which can be configured in the credential/config file, env vars, and at the client level. This is a setting that can be used to turn off account ID-based endpoint routing if necessary.
  * The SDK will enable account-id based endpoint routing by default.
  
 ### References
* AWS SDKs and Tools Reference Guide: [Account-based endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html)
