### PR TITLE
Preparing merge PR for RPCv2 CBOR

### DIFF
--- a/.changes/next-release/enhancement-Protocol-13828.json
+++ b/.changes/next-release/enhancement-Protocol-13828.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``Protocol``",
+  "description": "Adds support for the smithy-rpcv2-CBOR protocol.  Services can now opt in to using this as their preferred protocol.  For more information, see https"
+}

--- a/.changes/next-release/enhancement-Protocol-13828.json
+++ b/.changes/next-release/enhancement-Protocol-13828.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
   "category": "``Protocol``",
-  "description": "Adds support for the smithy-rpcv2-CBOR protocol.  Services can now opt in to using this as their preferred protocol.  For more information, see https"
+  "description": "Adds support for the smithy-rpcv2-cbor protocol.  If a service supports smithy-rpcv2-cbor, this protocol will automatically be used.  For more information, see https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html"
 }

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -895,7 +895,7 @@ class BaseCBORParser(ResponseParser):
             return self._parse_datetime(value)
         else:
             raise ResponseParserError(
-                f"Found CBOR tag not supported by botocore:" f" {tag}"
+                f"Found CBOR tag not supported by botocore: {tag}"
             )
 
     def _parse_datetime(self, value):

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -128,11 +128,10 @@ import os
 import re
 import struct
 
-from propcache import cached_property
-
 from botocore.compat import ETree, XMLParseError
 from botocore.eventstream import EventStream, NoInitialResponseError
 from botocore.utils import (
+    CachedProperty,
     ensure_boolean,
     is_json_value_header,
     lowercase_dict,
@@ -774,7 +773,7 @@ class BaseCBORParser(ResponseParser):
     INDEFINITE_ITEM_ADDITIONAL_INFO = 31
     BREAK_CODE = 0xFF
 
-    @cached_property
+    @CachedProperty
     def major_type_to_parsing_method_map(self):
         return {
             0: self._parse_unsigned_integer,

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -943,7 +943,7 @@ class BaseCBORParser(ResponseParser):
     # the break code, it advances past that byte and returns True so the calling
     # method knows to stop parsing that data item.
     def _handle_break_code(self, stream):
-        if int.from_bytes(stream.peek(1)[:1]) == self.BREAK_CODE:
+        if int.from_bytes(stream.peek(1)[:1], 'big') == self.BREAK_CODE:
             stream.seek(1, os.SEEK_CUR)
             return True
 

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -499,7 +499,9 @@ class CBORSerializer(Serializer):
         additional_info, num_bytes = self._get_additional_info_and_num_bytes(
             length
         )
-        initial_byte = self._get_initial_byte(self.STRING_MAJOR_TYPE, length)
+        initial_byte = self._get_initial_byte(
+            self.STRING_MAJOR_TYPE, additional_info
+        )
         if num_bytes == 0:
             serialized.extend(initial_byte + encoded)
         else:

--- a/tests/unit/cbor/test_cbor_decoding.py
+++ b/tests/unit/cbor/test_cbor_decoding.py
@@ -1,4 +1,3 @@
-import io
 import json
 import os
 import struct
@@ -27,9 +26,7 @@ IGNORE_CASES = [
     'map - {null}',
 ]
 
-TEST_DIR = os.path.join(
-    os.path.dirname(os.path.abspath(__file__))
-)
+TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 
 
 @pytest.fixture(scope="module")
@@ -38,7 +35,9 @@ def parser():
 
 
 def _get_cbor_decoding_success_tests():
-    success_test_file_name = os.path.join(TEST_DIR, 'decode-success-tests.json')
+    success_test_file_name = os.path.join(
+        TEST_DIR, 'decode-success-tests.json'
+    )
     success_test_data = json.load(open(success_test_file_name))
     for case in success_test_data:
         if case['description'] in IGNORE_CASES:


### PR DESCRIPTION
Changes included:
- Bugfix on string serialization, 
- minor PR feedback on the parsers file 
- fixing a broken import
- adds a changelog
- no longer relies on the default byte order for int.to_bytes that was introduced in 3.11
- runs pre-commit on the cbor decoding tests.

> Note, this is still into the merge PR branch.  I'll open a final PR to develop after this is merged, but at that point everything will have been approved