### PR TITLE
Move CBOR to be the highest supported protocol 

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -71,12 +71,12 @@ VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG = (
 )
 
 PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = (
+    'smithy-rpc-v2-cbor',
     'json',
     'rest-json',
     'rest-xml',
     'query',
     'ec2',
-    'smithy-rpc-v2-cbor',
 )
 
 


### PR DESCRIPTION
Quick fix of a miss on the CBOR protocol before this support gets merged today.  