### PR TITLE
Add string type check before parsing the response code value

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -1316,12 +1316,11 @@ class RestJSONParser(BaseRestParser, BaseJSONParser):
             code = response['headers']['x-amzn-errortype']
         elif 'code' in body or 'Code' in body:
             code = body.get('code', body.get('Code', ''))
-        if code is not None:
-            if ':' in code:
-                code = code.split(':', 1)[0]
-            if '#' in code:
-                code = code.rsplit('#', 1)[1]
-            error['Error']['Code'] = code
+        if code is None:
+            return
+        if isinstance(code, str):
+            code = code.split(':', 1)[0].rsplit('#', 1)[-1]
+        error['Error']['Code'] = code
 
     def _handle_boolean(self, shape, value):
         return ensure_boolean(value)


### PR DESCRIPTION
This PR addresses an bug introduced in https://github.com/boto/botocore/pull/3247.

It's possible for the code in the response body to be an integer.  We're currently attempting to parse the code as a string which may result in an error similar to the one below:

```python
TypeError: argument of type 'int' is not iterable
```

This PR adds a check to ensure the error code is a string before attempting to split it by the `:` and `#` characters.