### PR TITLE
Add concurrency control to run-tests and run-crt-test workflows

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && github.run_id || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: '${{ matrix.os }}'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && github.run_id || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: '${{ matrix.os }}'


### PR DESCRIPTION
This PR adds concurrency control to the `run-tests` and `run-crt-test` GitHub Actions workflows.

Problem Description

Currently, when multiple commits are pushed to the same branch in succession, the `run-tests` and `run-crt-test` workflows are triggered for each push. This results in excessive use of GitHub Actions minutes as it's only necessary to run the workflows for the most recent push within a pull request.

Solution in This PR

This PR adds concurrency control to the `run-tests` and `run-crt-test` runners to cancel in-progress jobs when new commits are pushed to the same branch. Only the latest push will now trigger the workflows. However, this behavior does not apply to the `develop` and `master` branches, where all pushed commits should continue triggering `run-tests` and `run-crt-test`.
