### PR TITLE
Add SigV4 note to generate_presigned_post documentation

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -848,7 +848,7 @@ def generate_presigned_post(
         For more details, see:
         `AWS Signature Version 4 <https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html>`_.
 
-        
+
     :type Bucket: string
     :param Bucket: The name of the bucket to presign the post to. Note that
         bucket related conditions should not be included in the

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -838,11 +838,11 @@ def generate_presigned_post(
 
     .. note::
 
-        Amazon S3 supports Signature Version 4, a protocol for authenticating 
-        inbound API requests to AWS services, in all AWS Regions. At this time, 
-        AWS Regions created before January 30, 2014, will continue to support 
-        the previous protocol, Signature Version 2. Any new Regions after January 30, 
-        2014, will support only Signature Version 4 and therefore all requests to 
+        Amazon S3 supports Signature Version 4, a protocol for authenticating
+        inbound API requests to AWS services, in all AWS Regions. At this time,
+        AWS Regions created before January 30, 2014, will continue to support
+        the previous protocol, Signature Version 2. Any new Regions after January 30,
+        2014, will support only Signature Version 4 and therefore all requests to
         those Regions must be made with Signature Version 4.
 
         For more details, see:

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -836,6 +836,19 @@ def generate_presigned_post(
 ):
     """Builds the url and the form fields used for a presigned s3 post
 
+    .. note::
+
+        Amazon S3 supports Signature Version 4, a protocol for authenticating 
+        inbound API requests to AWS services, in all AWS Regions. At this time, 
+        AWS Regions created before January 30, 2014, will continue to support 
+        the previous protocol, Signature Version 2. Any new Regions after January 30, 
+        2014, will support only Signature Version 4 and therefore all requests to 
+        those Regions must be made with Signature Version 4.
+
+        For more details, see:
+        `AWS Signature Version 4 <https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html>`_.
+
+        
     :type Bucket: string
     :param Bucket: The name of the bucket to presign the post to. Note that
         bucket related conditions should not be included in the


### PR DESCRIPTION
## Issue
https://github.com/boto/boto3/issues/4351 
Title: (short issue description)generate_presigned_post documentation should provide a link to S3 doc explaining regional default variation in response #4351

## Summary
This PR adds a documentation note to `generate_presigned_post` in `signers.py`, explaining the difference 
between Signature Version 2 (SigV2) and Signature Version 4 (SigV4). As suggested on Issue 4351, it would be feasible if the information from the S3 API Documentation https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html would be included to the Boto3 Doc: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/generate_presigned_post.html#generate-presigned-post 


## Changes
- Added a `.. note::` section in `signers.py` docstring.
- Included a link to AWS's official SigV4 documentation and its note.

## Testing
- Ran `make html` in `docs/` to verify the doc renders correctly.
