### PR TITLE
Track RPC v2 CBOR feature

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -229,8 +229,6 @@ class ClientArgsCreator:
     ):
         service_name = service_model.endpoint_prefix
         protocol = self._resolve_protocol(service_model)
-        if protocol == 'smithy-rpc-v2-cbor':
-            register_feature_id('PROTOCOL_RPC_V2_CBOR')
         parameter_validation = True
         if client_config and not client_config.parameter_validation:
             parameter_validation = False

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -229,6 +229,8 @@ class ClientArgsCreator:
     ):
         service_name = service_model.endpoint_prefix
         protocol = self._resolve_protocol(service_model)
+        if protocol == 'smithy-rpc-v2-cbor':
+            register_feature_id('PROTOCOL_RPC_V2_CBOR')
         parameter_validation = True
         if client_config and not client_config.parameter_validation:
             parameter_validation = False

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -1179,13 +1179,16 @@ class RestXMLSerializer(BaseRestSerializer):
 class RpcV2CBORSerializer(BaseRpcV2Serializer, CBORSerializer):
     TIMESTAMP_FORMAT = 'unixtimestamp'
 
+    def serialize_to_request(self, parameters, operation_model):
+        register_feature_id('PROTOCOL_RPC_V2_CBOR')
+        return super().serialize_to_request(parameters, operation_model)
+
     def _serialize_body_params(self, parameters, input_shape):
         body = bytearray()
         self._serialize_data_item(body, parameters, input_shape)
         return bytes(body)
 
     def _serialize_headers(self, serialized, operation_model):
-        register_feature_id('PROTOCOL_RPC_V2_CBOR')
         serialized['headers']['smithy-protocol'] = 'rpc-v2-cbor'
 
         if operation_model.has_event_stream_output:

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -50,6 +50,7 @@ from xml.etree import ElementTree
 from botocore import validate
 from botocore.compat import formatdate
 from botocore.exceptions import ParamValidationError
+from botocore.useragent import register_feature_id
 from botocore.utils import (
     has_header,
     is_json_value_header,
@@ -1184,6 +1185,7 @@ class RpcV2CBORSerializer(BaseRpcV2Serializer, CBORSerializer):
         return bytes(body)
 
     def _serialize_headers(self, serialized, operation_model):
+        register_feature_id('PROTOCOL_RPC_V2_CBOR')
         serialized['headers']['smithy-protocol'] = 'rpc-v2-cbor'
 
         if operation_model.has_event_stream_output:

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -58,6 +58,7 @@ _USERAGENT_FEATURE_MAPPINGS = {
     'WAITER': 'B',
     'PAGINATOR': 'C',
     'S3_TRANSFER': 'G',
+    'PROTOCOL_RPC_V2_CBOR': 'M',
     'ENDPOINT_OVERRIDE': 'N',
     'SIGV4A_SIGNING': 'S',
 }

--- a/tests/functional/test_rpc_v2_cbor.py
+++ b/tests/functional/test_rpc_v2_cbor.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from tests import ClientHTTPStubber, patch_load_service_model
+from tests.functional.test_useragent import (
+    get_captured_ua_strings,
+    parse_registered_feature_ids,
+)
+
+MOCK_SERVICE_MODEL = {
+    "version": "1.0",
+    "documentation": "",
+    "metadata": {
+        "apiVersion": "2020-02-02",
+        "endpointPrefix": "mockservice",
+        "protocols": ["smithy-rpc-v2-cbor"],
+        "protocol": "smithy-rpc-v2-cbor",
+        "serviceFullName": "Mock Service",
+        "serviceId": "mockservice",
+        "signatureVersion": "v4",
+        "signingName": "mockservice",
+        "targetPrefix": "mockservice",
+        "uid": "mockservice-2020-02-02",
+    },
+    "operations": {
+        "MockOperation": {
+            "name": "MockOperation",
+            "http": {"method": "GET", "requestUri": "/"},
+            "input": {"shape": "MockOperationRequest"},
+            "documentation": "",
+        },
+    },
+    "shapes": {
+        "MockOpParam": {
+            "type": "string",
+        },
+        "MockOperationRequest": {
+            "type": "structure",
+            "required": ["MockOpParam"],
+            "members": {
+                "MockOpParam": {
+                    "shape": "MockOpParam",
+                    "documentation": "",
+                    "location": "uri",
+                    "locationName": "param",
+                },
+            },
+        },
+    },
+}
+
+MOCK_RULESET = {
+    "version": "1.0",
+    "parameters": {},
+    "rules": [
+        {
+            "conditions": [],
+            "endpoint": {
+                "url": "https://mockservice.us-west-2.amazonaws.com/"
+            },
+            "type": "endpoint",
+        },
+    ],
+}
+
+
+def test_user_agent_has_cbor_feature_id(patched_session, monkeypatch):
+    patch_load_service_model(
+        patched_session, monkeypatch, MOCK_SERVICE_MODEL, MOCK_RULESET
+    )
+    client = patched_session.create_client(
+        'mockservice', region_name='us-west-2'
+    )
+    with ClientHTTPStubber(client) as stub_client:
+        stub_client.add_response()
+        # The mock CBOR operation registers `'PROTOCOL_RPC_V2_CBOR': 'M'`
+        client.mock_operation(MockOpParam='mock-op-param-value')
+    ua_string = get_captured_ua_strings(stub_client)[0]
+    feature_list = parse_registered_feature_ids(ua_string)
+    assert 'M' in feature_list


### PR DESCRIPTION
Description

This PR adds support for tracking usage of the `PROTOCOL_RPC_V2_CBOR` feature.

User agent strings can now include an 'M' in the `m/` metrics field when an operation is called using the Smithy RPC v2 CBOR protocol. 

User agent string example:
```
Boto3/1.37.9 md/Botocore#1.37.9 ua/2.1 os/macos#24.3.0 md/arch#arm64 lang/python#3.12.8 md/pyimpl#CPython m/M cfg/retry-mode#legacy Botocore/1.37.9
```

See #3389 for more details on client feature tracking.