### PR TITLE
Handle md5 being removed by third party CPython implementations

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -150,7 +150,7 @@ def total_seconds(delta):
 try:
     hashlib.md5()
     MD5_AVAILABLE = True
-except ValueError:
+except (AttributeError, ValueError):
     MD5_AVAILABLE = False
 
 


### PR DESCRIPTION
Some third-party vendors providing FIPS compliant versions of CPython have decided to entirely remove the `md5` function from hashlib instead of the using the existing convention of raising a `ValueError`. This patch will tolerate the removal more gracefully.