### PR TITLE
Updates the docs file so that the pages related to index and error are compliant of the security policy.

### DIFF
--- a/docs/source/_static/404.html
+++ b/docs/source/_static/404.html
@@ -1,34 +1,12 @@
 <!doctype html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Page Not Found</title>
-    <style>
-    * {
-        box-sizing: border-box;
-    }
-    body {
-        vertical-align: middle;
-        text-align: center;
-        line-height: 1.5;
-        font-family: "Open Sans", Helvetica, Arial, sans-serif;
-        font-size: 16px;
-        margin: 0;
-        padding: 0;
-    }
-    h1 {
-        font-size: 38px;
-        padding: 10px 10px 10px 45px;
-        margin: 20px 0 35px -45px;
-        font-weight: normal;
-    }
-    p {
-        padding: 0;
-        margin: 0 0 10px;
-    }
-    </style>
-</head>
-<body>
-    <h1>Page Not Found</h1>
-    <p>Sorry, the page you requested could not be found.</p>
+    <head>
+        <meta charset="utf-8" />
+        <title>Page Not Found</title>
+        <link rel="stylesheet" href="css/custom.css" />
+    </head>
+    <body class="error-page-style">
+        <h1>Page Not Found</h1>
+        <p>Sorry, the page you requested could not be found.</p>
+    </body>
 </html>

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -110,3 +110,41 @@ h3.admonition-title::before {
 .hidden {
     display: none;
 }
+/* Applies styling to a table and ensures the borders are collapsed */
+.styled-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+/* Use flexbox to align columns */
+.styled-table tr {
+    display: flex;
+}
+/* Ensures columns are aligned properly */
+.styled-row-col {
+    width: 33%;
+    vertical-align: top;
+    display: inline-block;
+}
+/* Applies styling to an error page */
+.error-page-style {
+    box-sizing: border-box;
+    vertical-align: middle;
+    text-align: center;
+    line-height: 1.5;
+    font-family: "Open Sans", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    margin: 0;
+    padding: 0;
+}
+
+.error-page-style h1 {
+    font-size: 38px;
+    padding: 10px 10px 10px 45px;
+    margin: 20px 0 35px -45px;
+    font-weight: normal;
+}
+
+.error-page-style p {
+    padding: 0;
+    margin: 0 0 10px;
+}

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -110,20 +110,14 @@ h3.admonition-title::before {
 .hidden {
     display: none;
 }
-/* Applies styling to a table and ensures the borders are collapsed */
-.styled-table {
+
+.max-width {
     width: 100%;
-    border-collapse: collapse;
-}
-/* Use flexbox to align columns */
-.styled-table tr {
-    display: flex;
 }
 /* Ensures columns are aligned properly */
 .styled-row-col {
     width: 33%;
     vertical-align: top;
-    display: inline-block;
 }
 /* Applies styling to an error page */
 .error-page-style {

--- a/docs/source/_templates/domainindex.html
+++ b/docs/source/_templates/domainindex.html
@@ -1,0 +1,56 @@
+{#This file is normally inherited from the version defined by our docs theme (Furo).
+However, that file includes in-line styling which isn't allowed by our website's
+Content Security Policy (CSP). To resolve this issue, we copied this file from
+Furo version "2022.12.7".#}
+
+{% extends "page.html" %}
+
+{% block htmltitle -%}
+  <title>{{ indextitle|striptags|e }} - {{ docstitle|striptags|e }}</title>
+{% endblock htmltitle -%}
+
+{% block scripts -%}
+  {{ super() }}
+  {%- if not embedded and collapse_index %}
+    <script>DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true</script>
+  {%- endif -%}
+{%- endblock scripts %}
+
+{% block content %}
+<section class="domainindex-section">
+  <h1>{{ indextitle }}</h1>
+  <div class="domainindex-jumpbox">
+    {%- for (letter, entries) in content -%}
+      <a href="#cap-{{ letter }}"><strong>{{ letter }}</strong></a>
+    {%- if not loop.last %} | {% endif -%}
+    {%- endfor -%}
+  </div>
+</section>
+
+{%- set groupid = idgen() %}
+<table class="domainindex-table">
+  {%- for letter, entries in content %}
+  <tr class="pcap">
+    <td></td><td>&#160;</td><td></td>
+  </tr>
+  <tr class="cap" id="cap-{{ letter }}">
+    <td></td><td><strong>{{ letter }}</strong></td><td></td>
+  </tr>
+  {%- for (name, grouptype, page, anchor, extra, qualifier, description) in entries %}
+  <tr{% if grouptype == 2 %} class="cg-{{ groupid.current() }}"{% endif %}>
+    <td>{% if grouptype == 1 -%}
+        <img src="{{ pathto('_static/minus.png', 1) }}" class="toggler"
+              id="toggle-{{ groupid.next() }}" class="hidden" alt="-" />
+        {%- endif %}</td>
+    <td>{% if grouptype == 2 %}&#160;&#160;&#160;{% endif %}
+        {% if page %}<a href="{{ pathto(page)|e }}#{{ anchor }}">{% endif -%}
+            <code class="xref">{{ name|e }}</code>
+            {%- if page %}</a>{% endif %}
+        {%- if extra %} <em>({{ extra|e }})</em>{% endif -%}
+    </td><td>{% if qualifier %}<strong>{{ qualifier|e }}:</strong>{% endif %}
+    <em>{{ description|e }}</em></td>
+  </tr>
+  {%- endfor %}
+  {%- endfor %}
+</table>
+{% endblock content %}

--- a/docs/source/_templates/genindex.html
+++ b/docs/source/_templates/genindex.html
@@ -1,61 +1,58 @@
-{#This file is normally inherited from the version defined by our docs theme (Furo).
-However, that file includes in-line styling which isn't allowed by our website's
-Content Security Policy (CSP). To resolve this issue, we copied this file from
-Furo version "2022.12.7".#}
+{% extends "page.html" %}
 
-{% extends "page.html" %} {% block htmltitle -%}
+{% block htmltitle -%}
+  <title>{{ _("Index") }} - {{ docstitle|striptags|e }}</title>
+{% endblock htmltitle -%}
 
-<title>{{ _("Index") }} - {{ docstitle|striptags|e }}</title>
-{% endblock htmltitle -%} 
+{% macro indexentries(firstname, links) %}
+  {%- if links -%}
+    <a href="{{ links[0][1] }}">
+    {%- if links[0][0] %}<strong>{% endif -%}
+    {{ firstname|e }}
+    {%- if links[0][0] %}</strong>{% endif -%}
+    </a>
 
-{% macro indexentries(firstname, links) %} {%- if
-links -%}
-<a href="{{ links[0][1] }}">
-  {%- if links[0][0] %}<strong
-    >{% endif -%} {{ firstname|e }} {%- if links[0][0] %}</strong
-  >{% endif -%}
-</a>
+    {%- for ismain, link in links[1:] -%}
+      , <a href="{{ link }}">{% if ismain %}<strong>{% endif -%}
+      [{{ loop.index }}]
+      {%- if ismain %}</strong>{% endif -%}
+      </a>
+    {%- endfor %}
+  {%- else %}
+    {{ firstname|e }}
+  {%- endif %}
+{% endmacro %}
 
-{%- for ismain, link in links[1:] -%} ,
-<a href="{{ link }}"
-  >{% if ismain %}<strong
-    >{% endif -%} [{{ loop.index }}] {%- if ismain %}</strong
-  >{% endif -%}
-</a>
-{%- endfor %} {%- else %} {{ firstname|e }} {%- endif %} {% endmacro %} {% block
-content %}
+{% block content %}
 <section class="genindex-section">
   <h1 id="index">{{ _('Index') }}</h1>
   <div class="genindex-jumpbox">
     {%- for key, dummy in genindexentries -%}
     <a href="#{{ key }}"><strong>{{ key }}</strong></a>
-    {%- if not loop.last %} | {% endif -%} {%- endfor -%}
+    {%- if not loop.last %} | {% endif -%}
+    {%- endfor -%}
   </div>
 </section>
 
 {%- for key, entries in genindexentries %}
 <section id="{{ key }}" class="genindex-section">
   <h2>{{ key }}</h2>
-  <table class="styled-table indextable genindextable">
-    <tr>
-      {%- for column in entries|slice_index(2) if column %}
-      <td class="styled-row-col">
+    <table class="max-width indextable genindextable">
+    {%- for column in entries|slice_index(2) if column %}
+    <td class="styled-row-col"><ul>
+      {%- for entryname, (links, subitems, _) in column %}
+        <li>{{ indexentries(entryname, links) }}
+        {%- if subitems %}
         <ul>
-          {%- for entryname, (links, subitems, _) in column %}
-          <li>
-            {{ indexentries(entryname, links) }} {%- if subitems %}
-            <ul>
-              {%- for subentryname, subentrylinks in subitems %}
-              <li>{{ indexentries(subentryname, subentrylinks) }}</li>
-              {%- endfor %}
-            </ul>
-            {%- endif -%}
-          </li>
-          {%- endfor %}
+        {%- for subentryname, subentrylinks in subitems %}
+          <li>{{ indexentries(subentryname, subentrylinks) }}</li>
+        {%- endfor %}
         </ul>
-      </td>
+        {%- endif -%}</li>
       {%- endfor %}
-    </tr>
-  </table>
+    </ul></td>
+    {%- endfor %}
+  </tr></table>
 </section>
-{% endfor %} {% endblock %}
+{% endfor %}
+{% endblock %}

--- a/docs/source/_templates/genindex.html
+++ b/docs/source/_templates/genindex.html
@@ -1,0 +1,57 @@
+{% extends "page.html" %} {% block htmltitle -%}
+
+<title>{{ _("Index") }} - {{ docstitle|striptags|e }}</title>
+<link rel="stylesheet" href="../_static/css/custom.css"> </head>
+{% endblock htmltitle -%} 
+
+{% macro indexentries(firstname, links) %} {%- if
+links -%}
+<a href="{{ links[0][1] }}">
+  {%- if links[0][0] %}<strong
+    >{% endif -%} {{ firstname|e }} {%- if links[0][0] %}</strong
+  >{% endif -%}
+</a>
+
+{%- for ismain, link in links[1:] -%} ,
+<a href="{{ link }}"
+  >{% if ismain %}<strong
+    >{% endif -%} [{{ loop.index }}] {%- if ismain %}</strong
+  >{% endif -%}
+</a>
+{%- endfor %} {%- else %} {{ firstname|e }} {%- endif %} {% endmacro %} {% block
+content %}
+<section class="genindex-section">
+  <h1 id="index">{{ _('Index') }}</h1>
+  <div class="genindex-jumpbox">
+    {%- for key, dummy in genindexentries -%}
+    <a href="#{{ key }}"><strong>{{ key }}</strong></a>
+    {%- if not loop.last %} | {% endif -%} {%- endfor -%}
+  </div>
+</section>
+
+{%- for key, entries in genindexentries %}
+<section id="{{ key }}" class="genindex-section">
+  <h2>{{ key }}</h2>
+  <table class="styled-table indextable genindextable">
+    <tr>
+      {%- for column in entries|slice_index(2) if column %}
+      <td class="styled-row-col">
+        <ul>
+          {%- for entryname, (links, subitems, _) in column %}
+          <li>
+            {{ indexentries(entryname, links) }} {%- if subitems %}
+            <ul>
+              {%- for subentryname, subentrylinks in subitems %}
+              <li>{{ indexentries(subentryname, subentrylinks) }}</li>
+              {%- endfor %}
+            </ul>
+            {%- endif -%}
+          </li>
+          {%- endfor %}
+        </ul>
+      </td>
+      {%- endfor %}
+    </tr>
+  </table>
+</section>
+{% endfor %} {% endblock %}

--- a/docs/source/_templates/genindex.html
+++ b/docs/source/_templates/genindex.html
@@ -1,7 +1,11 @@
+{#This file is normally inherited from the version defined by our docs theme (Furo).
+However, that file includes in-line styling which isn't allowed by our website's
+Content Security Policy (CSP). To resolve this issue, we copied this file from
+Furo version "2022.12.7".#}
+
 {% extends "page.html" %} {% block htmltitle -%}
 
 <title>{{ _("Index") }} - {{ docstitle|striptags|e }}</title>
-<link rel="stylesheet" href="../_static/css/custom.css"> </head>
 {% endblock htmltitle -%} 
 
 {% macro indexentries(firstname, links) %} {%- if


### PR DESCRIPTION
This update removes inline styles from some docs pages and transfers them to a separate CSS file. Additionally, I added genindex.html file because it uses inline scripts, and the only way to customize it is by copying it to our directory and editing it. This change has been tested in the dev environment.