### PR TITLE
Replace `utcnow()` with `now(tz=timezone.utc)`

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -422,7 +422,10 @@ class SigV4Auth(BaseSigner):
     def add_auth(self, request):
         if self.credentials is None:
             raise NoCredentialsError()
-        datetime_now = datetime.datetime.utcnow()
+
+        # TODO fix this. But make sure it still works for Python 3.8
+        datetime_now = datetime.datetime.now(tz=datetime.timezone.utc)
+
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
@@ -560,7 +563,7 @@ class S3ExpressPostAuth(S3ExpressAuth):
     REQUIRES_IDENTITY_CACHE = True
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(tz=datetime.timezone.utc)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}
@@ -819,7 +822,7 @@ class S3SigV4PostAuth(SigV4Auth):
     """
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(tz=datetime.timezone.utc)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -423,7 +423,6 @@ class SigV4Auth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        # TODO fix this. But make sure it still works for Python 3.8
         datetime_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)

--- a/botocore/crt/auth.py
+++ b/botocore/crt/auth.py
@@ -55,11 +55,7 @@ class CrtSigV4Auth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        # Use utcnow() because that's what gets mocked by tests, but set
-        # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)
@@ -253,11 +249,7 @@ class CrtSigV4AsymAuth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        # Use utcnow() because that's what gets mocked by tests, but set
-        # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -150,7 +150,7 @@ class Endpoint:
     def _calculate_ttl(
         self, response_received_timestamp, date_header, read_timeout
     ):
-        local_timestamp = datetime.datetime.utcnow()
+        local_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         date_conversion = datetime.datetime.strptime(
             date_header, "%a, %d %b %Y %H:%M:%S %Z"
         )
@@ -167,7 +167,10 @@ class Endpoint:
         has_streaming_input = retries_context.get('has_streaming_input')
         if response_date_header and not has_streaming_input:
             try:
-                response_received_timestamp = datetime.datetime.utcnow()
+                response_received_timestamp = datetime.datetime.now(
+                    tz=datetime.timezone.utc
+                )
+
                 retries_context['ttl'] = self._calculate_ttl(
                     response_received_timestamp,
                     response_date_header,

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -723,7 +723,8 @@ class S3PostPresigner:
         policy = {}
 
         # Create an expiration date for the policy
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(tz=datetime.timezone.utc)
+
         expire_date = datetime_now + datetime.timedelta(seconds=expires_in)
         policy['expiration'] = expire_date.strftime(botocore.auth.ISO8601)
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -667,7 +667,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
             )
             jitter = random.randint(120, 600)  # Between 2 to 10 minutes
             refresh_interval_with_jitter = refresh_interval + jitter
-            current_time = datetime.datetime.utcnow()
+            current_time = datetime.datetime.now(tz=datetime.timezone.utc)
             refresh_offset = datetime.timedelta(
                 seconds=refresh_interval_with_jitter
             )
@@ -681,7 +681,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
                     f"Attempting credential expiration extension due to a "
                     f"credential service availability issue. A refresh of "
                     f"these credentials will be attempted again within "
-                    f"the next {refresh_interval_with_jitter/60:.0f} minutes."
+                    f"the next {refresh_interval_with_jitter / 60:.0f} minutes."
                 )
         except ValueError:
             logger.debug(
@@ -3532,8 +3532,7 @@ class JSONFileCache:
             file_content = self._dumps(value)
         except (TypeError, ValueError):
             raise ValueError(
-                f"Value cannot be cached, must be "
-                f"JSON serializable: {value}"
+                f"Value cannot be cached, must be JSON serializable: {value}"
             )
         if not os.path.isdir(self._working_dir):
             os.makedirs(self._working_dir)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -574,12 +574,12 @@ class FreezeTime(ContextDecorator):
     :param module: reference to imported module to patch (e.g. botocore.auth.datetime)
 
     :type date: datetime.datetime
-    :param date: datetime object specifying the output for utcnow()
+    :param date: datetime object specifying the output for now()
     """
 
     def __init__(self, module, date=None):
         if date is None:
-            date = datetime.datetime.utcnow()
+            date = datetime.datetime.now(tz=datetime.timezone.utc)
         self.date = date
         self.datetime_patcher = mock.patch.object(
             module, 'datetime', mock.Mock(wraps=datetime.datetime)
@@ -587,7 +587,7 @@ class FreezeTime(ContextDecorator):
 
     def __enter__(self, *args, **kwargs):
         mock = self.datetime_patcher.start()
-        mock.utcnow.return_value = self.date
+        mock.now.return_value = self.date
 
     def __exit__(self, *args, **kwargs):
         self.datetime_patcher.stop()

--- a/tests/functional/test_ec2.py
+++ b/tests/functional/test_ec2.py
@@ -98,7 +98,7 @@ class TestCopySnapshotCustomization(BaseSessionTest):
             mock.Mock(wraps=datetime.datetime),
         )
         self.mocked_datetime = self.datetime_patch.start()
-        self.mocked_datetime.utcnow.return_value = self.now
+        self.mocked_datetime.now.return_value = self.now
 
     def tearDown(self):
         super().tearDown()

--- a/tests/functional/test_lex.py
+++ b/tests/functional/test_lex.py
@@ -34,7 +34,7 @@ class TestLex(BaseSessionTest):
         timestamp = datetime(2017, 3, 22, 0, 0)
 
         with mock.patch('botocore.auth.datetime.datetime') as _datetime:
-            _datetime.utcnow.return_value = timestamp
+            _datetime.now.return_value = timestamp
             self.http_stubber.add_response(body=b'{}')
             with self.http_stubber:
                 self.client.post_content(**params)

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -114,7 +114,7 @@ class TestRetryHeader(BaseRetryTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = datetime_patcher.start()
-        mocked_datetime.utcnow.side_effect = utcnow_side_effects
+        mocked_datetime.now.side_effect = utcnow_side_effects
 
         client = self.session.create_client(
             'dynamodb', self.region, config=client_config

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -66,9 +66,9 @@ class TestRetryHeader(BaseRetryTest):
         ]
 
         # The first, third and seventh datetime values of each
-        # utcnow_side_effects list are side_effect values for when
-        # utcnow is called in SigV4 signing.
-        utcnow_side_effects = [
+        # now_side_effects list are side_effect values for when
+        # now is called in SigV4 signing.
+        now_side_effects = [
             [
                 datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
                 datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
@@ -100,13 +100,11 @@ class TestRetryHeader(BaseRetryTest):
                 b'ttl=20190601T001020Z; attempt=3; max=3',
             ],
         ]
-        test_cases = list(
-            zip(responses, utcnow_side_effects, expected_headers)
-        )
+        test_cases = list(zip(responses, now_side_effects, expected_headers))
         return test_cases
 
     def _test_amz_sdk_request_header_with_test_case(
-        self, responses, utcnow_side_effects, expected_headers, client_config
+        self, responses, now_side_effects, expected_headers, client_config
     ):
         datetime_patcher = mock.patch.object(
             botocore.endpoint.datetime,
@@ -114,7 +112,7 @@ class TestRetryHeader(BaseRetryTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = datetime_patcher.start()
-        mocked_datetime.now.side_effect = utcnow_side_effects
+        mocked_datetime.now.side_effect = now_side_effects
 
         client = self.session.create_client(
             'dynamodb', self.region, config=client_config

--- a/tests/functional/test_s3express.py
+++ b/tests/functional/test_s3express.py
@@ -108,7 +108,7 @@ class TestS3ExpressAuth:
 class TestS3ExpressIdentityCache:
     def test_default_s3_express_cache(self, default_s3_client, mock_datetime):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
+        mock_datetime.now.return_value = DATE
 
         identity_cache = S3ExpressIdentityCache(
             default_s3_client,
@@ -126,7 +126,7 @@ class TestS3ExpressIdentityCache:
         self, default_s3_client, mock_datetime
     ):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
+        mock_datetime.now.return_value = DATE
         bucket = 'my_bucket'
 
         identity_cache = S3ExpressIdentityCache(
@@ -151,7 +151,7 @@ class TestS3ExpressIdentityCache:
         self, default_s3_client, mock_datetime
     ):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
+        mock_datetime.now.return_value = DATE
         bucket = 'my_bucket'
         other_bucket = 'other_bucket'
 
@@ -204,7 +204,7 @@ class TestS3ExpressRequests:
         )
 
     def test_create_bucket(self, default_s3_client, mock_datetime):
-        mock_datetime.utcnow.return_value = DATE
+        mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
             stubber.add_response()
@@ -228,7 +228,6 @@ class TestS3ExpressRequests:
         self._assert_standard_sigv4_signature(stubber.requests[0].headers)
 
     def test_get_object(self, default_s3_client, mock_datetime):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
@@ -250,7 +249,6 @@ class TestS3ExpressRequests:
     def test_cache_with_multiple_requests(
         self, default_s3_client, mock_datetime
     ):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
@@ -275,7 +273,6 @@ class TestS3ExpressRequests:
     def test_delete_objects_injects_correct_checksum(
         self, default_s3_client, mock_datetime
     ):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:

--- a/tests/functional/test_sts.py
+++ b/tests/functional/test_sts.py
@@ -39,7 +39,7 @@ class TestSTSPresignedUrl(BaseSessionTest):
     def test_presigned_url_contains_no_content_type(self):
         timestamp = datetime(2017, 3, 22, 0, 0)
         with mock.patch('botocore.auth.datetime.datetime') as _datetime:
-            _datetime.utcnow.return_value = timestamp
+            _datetime.now.return_value = timestamp
             url = self.client.generate_presigned_url('get_caller_identity', {})
 
         # There should be no 'content-type' in x-amz-signedheaders
@@ -67,7 +67,7 @@ class TestSTSEndpoints(BaseSessionTest):
         )
 
     def set_sts_regional_for_config_file(self, fileobj, config_val):
-        fileobj.write('[default]\n' f'sts_regional_endpoints={config_val}\n')
+        fileobj.write(f'[default]\nsts_regional_endpoints={config_val}\n')
         fileobj.flush()
         self.environ['AWS_CONFIG_FILE'] = fileobj.name
 

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -30,7 +30,7 @@ class BaseTestWithFixedDate(unittest.TestCase):
         self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
         self.datetime_patch = mock.patch('botocore.auth.datetime.datetime')
         self.datetime_mock = self.datetime_patch.start()
-        self.datetime_mock.utcnow.return_value = self.fixed_date
+        self.datetime_mock.now.return_value = self.fixed_date
         self.datetime_mock.strptime.return_value = self.fixed_date
 
     def tearDown(self):
@@ -526,7 +526,7 @@ class TestSigV4(unittest.TestCase):
         ) as mock_datetime:
             original_utcnow = datetime.datetime(2014, 1, 1, 0, 0)
 
-            mock_datetime.utcnow.return_value = original_utcnow
+            mock_datetime.now.return_value = original_utcnow
             # Go through the add_auth process once. This will attach
             # a timestamp to the request at the beginning of auth.
             auth.add_auth(request)
@@ -534,7 +534,7 @@ class TestSigV4(unittest.TestCase):
             # Ensure the date is in the Authorization header
             self.assertIn('20140101', request.headers['Authorization'])
             # Now suppose the utc time becomes the next day all of a sudden
-            mock_datetime.utcnow.return_value = datetime.datetime(
+            mock_datetime.now.return_value = datetime.datetime(
                 2014, 1, 2, 0, 0
             )
             # Smaller methods like the canonical request and string_to_sign
@@ -799,9 +799,7 @@ class TestSigV4Presign(BasePresignTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
-            2014, 1, 1, 0, 0
-        )
+        mocked_datetime.now.return_value = datetime.datetime(2014, 1, 1, 0, 0)
 
     def tearDown(self):
         self.datetime_patcher.stop()
@@ -818,7 +816,7 @@ class TestSigV4Presign(BasePresignTest):
             {
                 'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
                 'X-Amz-Credential': (
-                    'access_key/20140101/myregion/' 'myservice/aws4_request'
+                    'access_key/20140101/myregion/myservice/aws4_request'
                 ),
                 'X-Amz-Date': '20140101T000000Z',
                 'X-Amz-Expires': '60',
@@ -911,7 +909,7 @@ class TestSigV4Presign(BasePresignTest):
             {
                 'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
                 'X-Amz-Credential': (
-                    'access_key/20140101/myregion/' 'myservice/aws4_request'
+                    'access_key/20140101/myregion/myservice/aws4_request'
                 ),
                 'X-Amz-Date': '20140101T000000Z',
                 'X-Amz-Expires': '60',
@@ -1103,9 +1101,7 @@ class TestS3SigV4Post(BaseS3PresignPostTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
-            2014, 1, 1, 0, 0
-        )
+        mocked_datetime.now.return_value = datetime.datetime(2014, 1, 1, 0, 0)
 
     def tearDown(self):
         self.datetime_patcher.stop()

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -524,9 +524,9 @@ class TestSigV4(unittest.TestCase):
             'datetime',
             mock.Mock(wraps=datetime.datetime),
         ) as mock_datetime:
-            original_utcnow = datetime.datetime(2014, 1, 1, 0, 0)
+            original_now = datetime.datetime(2014, 1, 1, 0, 0)
 
-            mock_datetime.now.return_value = original_utcnow
+            mock_datetime.now.return_value = original_now
             # Go through the add_auth process once. This will attach
             # a timestamp to the request at the beginning of auth.
             auth.add_auth(request)

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -59,6 +59,7 @@ from tests import (
     temporary_file,
     unittest,
 )
+from datetime import timezone
 
 # Passed to session to keep it from finding default config file
 TESTENVVARS = {'config_file': (None, 'AWS_CONFIG_FILE', None)}
@@ -130,8 +131,7 @@ class TestRefreshableCredentials(TestCredentials):
 
     def test_refresh_needed(self):
         # The expiry time was set for 30 minutes ago, so if we
-        # say the current time is utcnow(), then we should need
-        # a refresh.
+        # say the current time is now(), then we should need a refresh
         self.mock_time.return_value = datetime.now(tzlocal())
         self.assertTrue(self.creds.refresh_needed())
         # We should refresh creds, if we try to access "access_key"
@@ -318,7 +318,9 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(tz=timezone.utc) + timedelta(
+            seconds=1000
+        )
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -798,7 +800,9 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.datetime.now(
+            tz=datetime.timezone.utc
+        ) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -963,7 +967,9 @@ class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
         mock_loader_cls.assert_called_with('/some/path/token.jwt')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(tz=datetime.timezone.utc) + timedelta(
+            seconds=1000
+        )
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         cache_key = 'c29461feeacfbed43017d20612606ff76abc073d'
@@ -2204,7 +2210,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(expiry_time, '2016-11-06T01:30:00UTC')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now() + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         self.fake_config['profiles']['development']['role_arn'] = 'myrole'
 
@@ -2233,7 +2239,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(creds.token, 'baz-cached')
 
     def test_chain_prefers_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now() + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         # The profile we will be using has a cache entry, but the profile it

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -321,7 +321,6 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         date_in_future = datetime.now(tz=timezone.utc) + timedelta(
             seconds=1000
         )
-        utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
             cache_key: {
@@ -329,7 +328,7 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
                     'AccessKeyId': 'foo-cached',
                     'SecretAccessKey': 'bar-cached',
                     'SessionToken': 'baz-cached',
-                    'Expiration': utc_timestamp,
+                    'Expiration': date_in_future.isoformat(),
                 }
             }
         }
@@ -800,10 +799,9 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.datetime.now(
-            tz=datetime.timezone.utc
-        ) + timedelta(seconds=1000)
-        utc_timestamp = date_in_future.isoformat() + 'Z'
+        date_in_future = datetime.now(tz=timezone.utc) + timedelta(
+            seconds=1000
+        )
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
             cache_key: {
@@ -811,7 +809,7 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
                     'AccessKeyId': 'foo-cached',
                     'SecretAccessKey': 'bar-cached',
                     'SessionToken': 'baz-cached',
-                    'Expiration': utc_timestamp,
+                    'Expiration': date_in_future.isoformat(),
                 }
             }
         }
@@ -967,10 +965,9 @@ class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
         mock_loader_cls.assert_called_with('/some/path/token.jwt')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.now(tz=datetime.timezone.utc) + timedelta(
+        date_in_future = datetime.now(tz=timezone.utc) + timedelta(
             seconds=1000
         )
-        utc_timestamp = date_in_future.isoformat() + 'Z'
 
         cache_key = 'c29461feeacfbed43017d20612606ff76abc073d'
         cache = {
@@ -979,7 +976,7 @@ class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
                     'AccessKeyId': 'foo-cached',
                     'SecretAccessKey': 'bar-cached',
                     'SessionToken': 'baz-cached',
-                    'Expiration': utc_timestamp,
+                    'Expiration': date_in_future.isoformat(),
                 }
             }
         }

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -696,7 +696,7 @@ class TestS3PostPresigner(BaseSignerTest):
         self.datetime_mock = self.datetime_patch.start()
         self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
         self.fixed_delta = datetime.timedelta(seconds=3600)
-        self.datetime_mock.datetime.utcnow.return_value = self.fixed_date
+        self.datetime_mock.datetime.now.return_value = self.fixed_date
         self.datetime_mock.timedelta.return_value = self.fixed_delta
 
     def tearDown(self):
@@ -1151,7 +1151,7 @@ class TestGenerateDBAuthToken(BaseSignerTest):
         clock = datetime.datetime(2016, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             result = generate_db_auth_token(
                 self.client, hostname, port, username
             )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3144,7 +3144,7 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
 
     def _get_datetime(self, dt=None, offset=None, offset_func=operator.add):
         if dt is None:
-            dt = datetime.datetime.utcnow()
+            dt = datetime.datetime.now(tz=datetime.timezone.utc)
         if offset is not None:
             dt = offset_func(dt, offset)
 


### PR DESCRIPTION
As [`utcnow()` has been deprecated](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) since Python 3.12, I replaced the occurrences with `now(tz=timezone.utc)`. This is also supported from Python 3.8 and onwards. The tests, including mocks, have also been changed.