### PR TITLE
SSOTokenLoader expiration check

### DIFF
--- a/.changes/next-release/enhancement-sso-48422.json
+++ b/.changes/next-release/enhancement-sso-48422.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``sso``",
+  "description": "Updates legacy token auth flow to check if cached legacy tokens are expired according to the local clock. If expired, it will raise an ``UnauthorizedSSOTokenError`` instead of sending an expired token to Identity Center's ``GetRoleCredentials`` API."
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -22,8 +22,8 @@ import time
 from collections import namedtuple
 from copy import deepcopy
 from hashlib import sha1
-import dateutil.parser
 
+import dateutil.parser
 from dateutil.parser import parse
 from dateutil.tz import tzlocal, tzutc
 

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -22,6 +22,7 @@ import time
 from collections import namedtuple
 from copy import deepcopy
 from hashlib import sha1
+import dateutil.parser
 
 from dateutil.parser import parse
 from dateutil.tz import tzlocal, tzutc
@@ -2192,6 +2193,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         expiry_window_seconds=None,
         token_provider=None,
         sso_session_name=None,
+        time_fetcher=_local_now,
     ):
         self._client_creator = client_creator
         self._sso_region = sso_region
@@ -2201,6 +2203,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         self._token_loader = token_loader
         self._token_provider = token_provider
         self._sso_session_name = sso_session_name
+        self._time_fetcher = time_fetcher
         super().__init__(cache, expiry_window_seconds)
 
     def _create_cache_key(self):
@@ -2242,7 +2245,16 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
             initial_token_data = self._token_provider.load_token()
             token = initial_token_data.get_frozen_token().token
         else:
-            token = self._token_loader(self._start_url)['accessToken']
+            token_dict = self._token_loader(self._start_url)
+            token = token_dict['accessToken']
+
+            # raise an UnauthorizedSSOTokenError if the loaded legacy token
+            # is expired to save a call to GetRoleCredentials with an
+            # expired token.
+            expiration = dateutil.parser.parse(token_dict['expiresAt'])
+            remaining = total_seconds(expiration - self._time_fetcher())
+            if remaining <= 0:
+                raise UnauthorizedSSOTokenError()
 
         kwargs = {
             'roleName': self._role_name,

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -576,7 +576,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
         token_cache_key = 'f395038c92f1828cbb3991d2d6152d326b895606'
         cached_token = {
             'accessToken': 'a.token',
-            'expiresAt': self.some_future_time(),
+            'expiresAt': self.some_future_time().strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
         temp_cache = JSONFileCache(self.tempdir)
         temp_cache[token_cache_key] = cached_token

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -576,7 +576,9 @@ class TestAssumeRole(BaseAssumeRoleTest):
         token_cache_key = 'f395038c92f1828cbb3991d2d6152d326b895606'
         cached_token = {
             'accessToken': 'a.token',
-            'expiresAt': self.some_future_time().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'expiresAt': self.some_future_time().strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
         }
         temp_cache = JSONFileCache(self.tempdir)
         temp_cache[token_cache_key] = cached_token

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3795,11 +3795,13 @@ class TestSSOCredentialFetcher(unittest.TestCase):
         self.account_id = '1234567890'
         self.access_token = {
             'accessToken': 'some.sso.token',
+            'expiresAt': '2018-10-18T22:26:40Z',
         }
         # This is just an arbitrary point in time we can pin to
         self.now = datetime(2008, 9, 23, 12, 26, 40, tzinfo=tzutc())
         # The SSO endpoint uses ms whereas the OIDC endpoint uses seconds
         self.now_timestamp = 1222172800000
+        self.mock_time_fetcher = mock.Mock(return_value=self.now)
 
         self.loader = mock.Mock(spec=SSOTokenLoader)
         self.loader.return_value = self.access_token
@@ -3811,6 +3813,7 @@ class TestSSOCredentialFetcher(unittest.TestCase):
             self.mock_session.create_client,
             token_loader=self.loader,
             cache=self.cache,
+            time_fetcher=self.mock_time_fetcher,
         )
 
     def test_can_fetch_credentials(self):
@@ -3865,6 +3868,22 @@ class TestSSOCredentialFetcher(unittest.TestCase):
         with self.assertRaises(botocore.exceptions.UnauthorizedSSOTokenError):
             with self.stubber:
                 self.fetcher.fetch_credentials()
+
+    def test_expired_legacy_token_has_expected_behavior(self):
+        # Mock the current time to be in the future after the access token has expired
+        now = datetime(2018, 10, 19, 12, 26, 40, tzinfo=tzutc())
+        mock_client = mock.Mock()
+        create_mock_client = mock.Mock(return_value=mock_client)
+        fetcher = SSOCredentialFetcher(
+            self.start_url, self.sso_region, self.role_name, self.account_id,
+            create_mock_client, token_loader=self.loader,
+            cache=self.cache, time_fetcher=mock.Mock(return_value=now)
+        )
+        # since the cached token is expired, an UnauthorizedSSOTokenError should be
+        # raised and GetRoleCredentials should not be called.
+        with self.assertRaises(botocore.exceptions.UnauthorizedSSOTokenError):
+            fetcher.fetch_credentials()
+        self.assertFalse(mock_client.get_role_credentials.called)
 
 
 class TestSSOProvider(unittest.TestCase):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -3875,9 +3875,14 @@ class TestSSOCredentialFetcher(unittest.TestCase):
         mock_client = mock.Mock()
         create_mock_client = mock.Mock(return_value=mock_client)
         fetcher = SSOCredentialFetcher(
-            self.start_url, self.sso_region, self.role_name, self.account_id,
-            create_mock_client, token_loader=self.loader,
-            cache=self.cache, time_fetcher=mock.Mock(return_value=now)
+            self.start_url,
+            self.sso_region,
+            self.role_name,
+            self.account_id,
+            create_mock_client,
+            token_loader=self.loader,
+            cache=self.cache,
+            time_fetcher=mock.Mock(return_value=now),
         )
         # since the cached token is expired, an UnauthorizedSSOTokenError should be
         # raised and GetRoleCredentials should not be called.


### PR DESCRIPTION
# Context

This is a port of https://github.com/aws/aws-cli/pull/9356

# Changes

- Updated `SSOCredentialFetcher` to check if the cached legacy token is expired according to the local clock. If expired, it will raise an `UnauthorizedSSOTokenError` instead of sending an expired token to Identity Center's `GetRoleCredentials` API.
- Added a unit test to verify when an expired token is cached, that GetRoleCredentials is not called and `UnauthorizedSSOTokenError` is raised.

# Tests

- Ran all test suites (unit, functional, integration, etc.) and CI.

## boto3

- The following script was used in boto3 to test the code.

```python
import logging
import boto3

from boto3 import client, set_stream_logger

boto3.setup_default_session(profile_name='SSO-PROFILE-NAME')
client = client('s3')
set_stream_logger('', logging.DEBUG)

response = client.list_objects_v2(
    Bucket='BUCKET-NAME',
)
```

**Stacktrace from script built against this branch**

```
Traceback (most recent call last):
  File "/Users/aemous/GitHub/boto3/py312/src/botocore/botocore/credentials.py", line 568, in _protected_refresh
    metadata = self._refresh_using()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/boto3/py312/src/botocore/botocore/credentials.py", line 717, in fetch_credentials
    return self._get_cached_credentials()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/boto3/py312/src/botocore/botocore/credentials.py", line 727, in _get_cached_credentials
    response = self._get_credentials()
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/boto3/py312/src/botocore/botocore/credentials.py", line 2257, in _get_credentials
    raise UnauthorizedSSOTokenError()
```

**Stacktrace from script built against `develop`**

```
Traceback (most recent call last):
  File "/Users/aemous/GitHub/boto3/py312/lib/python3.12/site-packages/botocore/credentials.py", line 2253, in _get_credentials
    response = client.get_role_credentials(**kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/boto3/py312/lib/python3.12/site-packages/botocore/client.py", line 570, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/boto3/py312/lib/python3.12/site-packages/botocore/context.py", line 124, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/boto3/py312/lib/python3.12/site-packages/botocore/client.py", line 1031, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.UnauthorizedException: An error occurred (UnauthorizedException) when calling the GetRoleCredentials operation: Session token not found or invalid
```

Notice the latter exception is raised due to a returned `UnauthorizedException` from making an API call to `GetRoleCredentials`, while this is not the case in the former stacktrace.

## AWS CLI v1

- The following manual workflow was completed in AWS CLI v1 to test the code.
  1. Login to a user account using the legacy flow via `aws sso login`.
  2. Let the cached token expire.
  3. Ran a command using the SSO profile (e.g. `aws s3 ls --profile SSOProfile --debug`)
  4. Verified an `UnauthorizedSSOTokenError` was raised, and checked the stacktrace (pasted below) to verify this exception was raised _without_  `GetRoleCredentials` being called.

**Stacktrace from manual workflow on AWS CLI v1 built against this branch**

```
Traceback (most recent call last):
  File "/Users/aemous/.local/lib/aws/lib/python3.8/site-packages/botocore/credentials.py", line 568, in _protected_refresh
    metadata = self._refresh_using()
  File "/Users/aemous/.local/lib/aws/lib/python3.8/site-packages/botocore/credentials.py", line 717, in fetch_credentials
    return self._get_cached_credentials()
  File "/Users/aemous/.local/lib/aws/lib/python3.8/site-packages/botocore/credentials.py", line 727, in _get_cached_credentials
    response = self._get_credentials()
  File "/Users/aemous/.local/lib/aws/lib/python3.8/site-packages/botocore/credentials.py", line 2257, in _get_credentials
    raise UnauthorizedSSOTokenError()
botocore.exceptions.UnauthorizedSSOTokenError: The SSO session associated with this profile has expired or is otherwise invalid. To refresh this SSO session run aws sso login with the corresponding profile.
```

**Stacktrace from manual workflow on AWS CLI v1 built against `develop`**

```
Traceback (most recent call last):
  File "/usr/local/aws/lib/python3.9/site-packages/botocore/credentials.py", line 2253, in _get_credentials
    response = client.get_role_credentials(**kwargs)
  File "/usr/local/aws/lib/python3.9/site-packages/botocore/client.py", line 570, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/aws/lib/python3.9/site-packages/botocore/context.py", line 124, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/aws/lib/python3.9/site-packages/botocore/client.py", line 1031, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.UnauthorizedException: An error occurred (UnauthorizedException) when calling the GetRoleCredentials operation: Session token not found or invalid
```

Notice the latter exception is raised due to a returned `UnauthorizedException` from making an API call to `GetRoleCredentials`, while this is not the case in the former stacktrace.