### PR TITLE
Reason Phrase is optional

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -224,9 +224,9 @@ class AWSConnection:
 
     def _is_100_continue_status(self, maybe_status_line):
         parts = maybe_status_line.split(None, 2)
-        # Check for HTTP/<version> 100 Continue\r\n
+        # Check for HTTP/<version> 100 (Continue)\r\n
         return (
-            len(parts) >= 3
+            len(parts) >= 2
             and parts[0].startswith(b'HTTP/')
             and parts[1] == b'100'
         )


### PR DESCRIPTION
Fix 100-continue behaviour with servers that do not send the optional reason phrase on 100-continue responses.
See https://www.rfc-editor.org/rfc/rfc9110.html#section-15.1

Fixes #3455