### PR TITLE
Alias command for socialmessaging

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -62,8 +62,8 @@ _xform_cache = {
         'AssociateWhatsAppBusinessAccount',
         '-',
     ): 'associate-whatsapp-business-account',
-    ('DeleteWhatsAppMessageMedia', '_'): 'delete_whatsapp_media_message',
-    ('DeleteWhatsAppMessageMedia', '-'): 'delete-whatsapp-media-message',
+    ('DeleteWhatsAppMessageMedia', '_'): 'delete_whatsapp_message_media',
+    ('DeleteWhatsAppMessageMedia', '-'): 'delete-whatsapp-message-media',
     (
         'DisassociateWhatsAppBusinessAccount',
         '_',

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1338,6 +1338,10 @@ BUILTIN_HANDLERS = [
         ClientMethodAlias('list_hits_for_qualification_type'),
     ),
     (
+        'getattr.socialmessaging.delete_whatsapp_media_message',
+        ClientMethodAlias('delete_whatsapp_message_media'),
+    ),
+    (
         'before-parameter-build.s3.UploadPart',
         convert_body_to_file_like_object,
         REGISTER_LAST,

--- a/tests/functional/test_socialmessaging.py
+++ b/tests/functional/test_socialmessaging.py
@@ -14,6 +14,7 @@ import pytest
 
 from botocore import xform_name
 from botocore.session import get_session
+from botocore.stub import Stubber
 
 _KNOWN_REPLACEMENTS = [
     'whatsapp',
@@ -42,3 +43,23 @@ def test_known_replacements(operation, replacement):
     # name
     assert replacement in xform_name(operation, '_')
     assert replacement in xform_name(operation, '-')
+
+
+class TestSocialMessaging:
+    def test_delete_whatsapp_message_media_aliased(self):
+        session = get_session()
+        self.client = session.create_client('socialmessaging', 'us-west-2')
+        self.stubber = Stubber(self.client)
+        self.stubber.activate()
+        self.stubber.add_response('delete_whatsapp_message_media', {})
+        self.stubber.add_response('delete_whatsapp_message_media', {})
+
+        params = {
+            'mediaId': 'foo',
+            'originationPhoneNumberId': 'bar',
+        }
+
+        self.client.delete_whatsapp_media_message(**params)
+        self.client.delete_whatsapp_message_media(**params)
+
+        self.stubber.assert_no_pending_responses()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -291,7 +291,7 @@ class TestTransformName(unittest.TestCase):
         )
         self.assertEqual(
             xform_name('DeleteWhatsAppMessageMedia', '-'),
-            'delete-whatsapp-media-message',
+            'delete-whatsapp-message-media',
         )
         self.assertEqual(
             xform_name('DisassociateWhatsAppBusinessAccount', '-'),


### PR DESCRIPTION
During a previous manual customization to rename this method, there was a human error which caused the command to be named incorrectly.  This PR allows both the old name and the new name to be used in botocore and boto3.  This must be released on the same day as [the associated CLI v1 PR](https://github.com/aws/aws-cli/pull/9450).

Generating the docs shows that this now has the correctly documented name and does not show the old name:
![image](https://github.com/user-attachments/assets/843aa192-010e-493f-a79d-6dabced6d40b).