### PR TITLE
Remove usage of __file__ from botocore now that Python 3.8 is dropped

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -12,8 +12,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import importlib.resources
 import logging
-import os
 import re
 
 __version__ = '1.38.10'
@@ -113,7 +113,7 @@ _xform_cache = {
 }
 ScalarTypes = ('string', 'integer', 'boolean', 'timestamp', 'float', 'double')
 
-BOTOCORE_ROOT = os.path.dirname(os.path.abspath(__file__))
+BOTOCORE_ROOT = str(importlib.resources.files('botocore'))
 
 
 # Used to specify anonymous (unsigned) request signature

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -1,3 +1,4 @@
+import importlib.resources
 import logging
 import os
 import os.path
@@ -79,7 +80,7 @@ filter_ssl_warnings()
 logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 60
 MAX_POOL_CONNECTIONS = 10
-DEFAULT_CA_BUNDLE = os.path.join(os.path.dirname(__file__), 'cacert.pem')
+DEFAULT_CA_BUNDLE = str(importlib.resources.files('botocore') / 'cacert.pem')
 
 try:
     from certifi import where


### PR DESCRIPTION
This is an initial pass at moving us to importlib.resources instead of `__file__` references. We won't be touching the tests in this iteration as the intention is to allow the core library code to run with tools like `zipapp` and `PyOxidizer`. We'll also be adding a similar PR in boto3 once we've validated this approach.

The goal here is to provide the same strings as we did previously, but derive them through importlib. Some additional testing will be needed for different installation methods.