### PR TITLE
Prefer signature version from service models over endpoints.json

### DIFF
--- a/.changes/next-release/bugfix-endpoints-38893.json
+++ b/.changes/next-release/bugfix-endpoints-38893.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``endpoints``",
+  "description": "Prefer signature version from service models over endpoints.json."
+}

--- a/tests/functional/test_endpoint_rulesets.py
+++ b/tests/functional/test_endpoint_rulesets.py
@@ -55,7 +55,7 @@ def get_endpoint_tests_for_service(service_name):
     if not file_path.is_file():
         raise FileNotFoundError(
             f'Cannot find endpoint tests file for "{service_name}" at '
-            'path {file_path}'
+            f'path {file_path}'
         )
     with file_path.open('r') as f:
         return json.load(f)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2263,6 +2263,18 @@ class TestClientEndpointBridge(unittest.TestCase):
         with self.assertRaises(UnknownSignatureVersionError):
             bridge.resolve('test', 'us-west-2')
 
+    def test_prefers_signature_version_from_service_model(self):
+        resolver = mock.Mock()
+        resolver.construct_endpoint.return_value = {
+            'partition': 'aws',
+            'hostname': 'test',
+            'endpointName': 'us-west-2',
+            'signatureVersions': ['v2'],
+        }
+        bridge = ClientEndpointBridge(resolver, service_signature_version='v4')
+        resolved = bridge.resolve('test', 'us-west-2')
+        self.assertEqual('v4', resolved['signature_version'])
+
     def test_uses_service_name_as_signing_name(self):
         resolver = mock.Mock()
         resolver.construct_endpoint.return_value = {


### PR DESCRIPTION
### Background
An upcoming service is re-using an existing endpoint prefix that is still present in `endpoints.json` with an explicit `signatureVersions`. 

The new service is specifying a different `signatureVersion` in its service model. However botocore is still preferring the version from `endpoints.json`

https://github.com/boto/botocore/pull/2816 in 2022 last touched this area. However this logic: https://github.com/boto/botocore/blob/6f783fe339578cd7444bbd0296aade4ebdb0ce43/botocore/client.py#L836-L843

 only prefers the service model  over `endpoints.json` if the service model's signature version is _not_ in the this list:
https://github.com/boto/botocore/blob/6f783fe339578cd7444bbd0296aade4ebdb0ce43/botocore/client.py#L69-L78

My interpretation is that this allowed new services to model new signature versions such as `bearer`, but preserved our original behavior of using `endpoints.json` as the source of truth.

### Approach
Now, I removed that `_LEGACY_SIGNATURE_VERSIONS` set. We'll prefer the service model it its set, but still fall back to `endpoints.json` if not.

This required some custom handling for S3, S3Control, and Import/Export to preserve their current resolved values.

**For Reviewers**: Long term, we likely want to remove `endpoints.json` entirely. I didn't do so yet, as that `resolved` is plumbed around pretty heavily, and we do have unit tests that are guarding the current code paths. But let me know if you'd rather do so now.

### Testing
1. Added a unit test exercising the scenario that the upcoming service is hitting.
2. Ran the following both before and after this change, confirmed that there was not a diff in the output:
```
import json
import botocore.session

session = botocore.session.get_session()
signature_versions = {}
for service_name in session.get_available_services():
    client = session.create_client(service_name)
    signature_versions[service_name] = client.meta.config.signature_version

print(json.dumps(signature_versions, indent=2))
```