### PR TITLE
fix awscrt version detection

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -303,7 +303,7 @@ def has_minimum_crt_version(minimum_version):
 
     crt_version_str = awscrt.__version__
     try:
-        crt_version_ints = map(int, crt_version_str.split("."))
+        crt_version_ints = map(int, crt_version_str.strip("v").split("."))
         crt_version_tuple = tuple(crt_version_ints)
     except (TypeError, ValueError):
         return False


### PR DESCRIPTION
This PR contains a small adjustment to how the `awscrt` version is detected, such that it is compatible with the version string of `awscrt>=0.27.1`.

Fixes https://github.com/boto/botocore/issues/3468.