### PR TITLE
Catch AttributeError when broken version of PyOpenSSL installed

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -45,7 +45,7 @@ try:
         from urllib3.contrib.pyopenssl import (
             orig_util_SSLContext as SSLContext,
         )
-except ImportError:
+except (AttributeError, ImportError):
     from urllib3.util.ssl_ import SSLContext
 
 try:


### PR DESCRIPTION
This PR is an attempt to minimize noise from end-users installing broken copies of PyOpenSSL on their system. If the module can't be imported, we can have confidence that the patching isn't being done to the base SSLContext. This should address unnecessary impact like what's seen in boto/boto3#3585.