### PR TITLE
Use usedforsecurity=False for md5

### DIFF
--- a/botocore/compat.py
+++ b/botocore/compat.py
@@ -148,7 +148,7 @@ def total_seconds(delta):
 # Checks to see if md5 is available on this system. A given system might not
 # have access to it for various reasons, such as FIPS mode being enabled.
 try:
-    hashlib.md5()
+    hashlib.md5(usedforsecurity=False)
     MD5_AVAILABLE = True
 except (AttributeError, ValueError):
     MD5_AVAILABLE = False

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -328,9 +328,8 @@ def _sse_md5(params, sse_member_prefix='SSECustomer'):
     key_as_bytes = params[sse_key_member]
     if isinstance(key_as_bytes, str):
         key_as_bytes = key_as_bytes.encode('utf-8')
-    key_md5_str = base64.b64encode(get_md5(key_as_bytes).digest()).decode(
-        'utf-8'
-    )
+    md5_val = get_md5(key_as_bytes, usedforsecurity=False).digest()
+    key_md5_str = base64.b64encode(md5_val).decode('utf-8')
     key_b64_encoded = base64.b64encode(key_as_bytes).decode('utf-8')
     params[sse_key_member] = key_b64_encoded
     params[sse_md5_member] = key_md5_str

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3247,14 +3247,14 @@ def calculate_md5(body, **kwargs):
 
 def _calculate_md5_from_bytes(body_bytes):
     """This function has been deprecated, but is kept for backwards compatibility."""
-    md5 = get_md5(body_bytes)
+    md5 = get_md5(body_bytes, usedforsecurity=False)
     return md5.digest()
 
 
 def _calculate_md5_from_file(fileobj):
     """This function has been deprecated, but is kept for backwards compatibility."""
     start_position = fileobj.tell()
-    md5 = get_md5()
+    md5 = get_md5(usedforsecurity=False)
     for chunk in iter(lambda: fileobj.read(1024 * 1024), b''):
         md5.update(chunk)
     fileobj.seek(start_position)


### PR DESCRIPTION
Now that we've dropped Python 3.8, we should have this available on all supported versions. We've removed large portions of our MD5 out of the library and the remaining bits are all for non-security related functionality. We can start flagging these as such for FIPS compliant environments and other deployments that restrict use.