### PR TITLE
Add support for decimal.Decimal to the JSON serializer

### DIFF
--- a/.changes/next-release/bugfix-Serialization-35486.json
+++ b/.changes/next-release/bugfix-Serialization-35486.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Serialization",
+  "description": "Fixes a bug where instances of decimal.Decimal were unable to be passed into JSON serialization"
+}

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -41,6 +41,7 @@ and if a str/unicode type is passed in, it will be encoded as utf-8.
 import base64
 import calendar
 import datetime
+import decimal
 import json
 import math
 import re
@@ -451,6 +452,8 @@ class JSONSerializer(Serializer):
         serialized[key] = self._get_base64(value)
 
     def _serialize_type_float(self, serialized, value, shape, prefix=''):
+        if isinstance(value, decimal.Decimal):
+            value = float(value)
         serialized[prefix] = self._handle_float(value)
 
     def _serialize_type_double(self, serialized, value, shape, prefix=''):

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -14,6 +14,7 @@ spec.  This can happen for a number of reasons:
 
 import base64
 import datetime
+import decimal
 import io
 import json
 
@@ -374,6 +375,79 @@ class TestJSONTimestampSerialization(unittest.TestCase):
             ].decode('utf-8')
         )
         self.assertEqual(body['Timestamp'], 0)
+
+
+class TestJSONFloatSerialization(unittest.TestCase):
+    def setUp(self):
+        self.model = {
+            'metadata': {
+                'protocol': 'json',
+                'apiVersion': '2014-01-01',
+                'jsonVersion': '1.1',
+                'targetPrefix': 'foo',
+            },
+            'documentation': '',
+            'operations': {
+                'TestOperation': {
+                    'name': 'TestOperation',
+                    'http': {
+                        'method': 'POST',
+                        'requestUri': '/',
+                    },
+                    'input': {'shape': 'InputShape'},
+                }
+            },
+            'shapes': {
+                'InputShape': {
+                    'type': 'structure',
+                    'members': {
+                        'Double': {'shape': 'DoubleType'},
+                        'Float': {'shape': 'FloatType'},
+                    },
+                },
+                'DoubleType': {
+                    'type': 'double',
+                },
+                'FloatType': {
+                    'type': 'float',
+                },
+            },
+        }
+        self.service_model = ServiceModel(self.model)
+
+    def serialize_to_request(self, input_params):
+        request_serializer = serialize.create_serializer(
+            self.service_model.metadata['protocol']
+        )
+        return request_serializer.serialize_to_request(
+            input_params, self.service_model.operation_model('TestOperation')
+        )
+
+    def test_accepts_decimal_with_precision_above_floats(self):
+        float_string = '0.12345678901234567890'
+        float_as_float = float(
+            float_string
+        )  # This has less precision; it will be lost on serialization
+        float_as_decimal = decimal.Decimal(float_string)
+        body = json.loads(
+            self.serialize_to_request({'Float': float_as_decimal})[
+                'body'
+            ].decode('utf-8')
+        )
+        self.assertEqual(decimal.Decimal(body['Float']), float_as_float)
+
+    def test_accepts_decimal_with_precision_above_doubles(self):
+        double_string = '0.12345678901234567890'
+        double_as_float = float(
+            double_string
+        )  # This has less precision; it will be lost on serialization
+        double_as_decimal = decimal.Decimal(double_string)
+        body = json.loads(
+            self.serialize_to_request({'Double': double_as_decimal})[
+                'body'
+            ].decode('utf-8')
+        )
+        self.assertEqual(decimal.Decimal(body['Double']), double_as_float)
 
 
 class TestInstanceCreation(unittest.TestCase):


### PR DESCRIPTION
Botocore [supports](https://github.com/boto/botocore/blob/develop/botocore/validate.py#L338-L342) supplying floats or instances of [decimal.Decimal](https://docs.python.org/3/library/decimal.html#decimal.Decimal) for service inputs that are floats or doubles.  

Users passing in floats will not see an issue when encoding to JSON, but users passing in instances of `Decimal` will see an error being raised on serialization since `Decimal` objects are not JSON serializable using [Python's default JSONEncoder](https://github.com/python/cpython/blob/main/Lib/json/encoder.py#L79-L95).  While floats have less precision than `Decimal` objects, these inputs are modeled by service teams as doubles and will lose that precision on the service side anyway.  

This PR adds support `Decimal` types in JSON by casting the values to a float prior to JSON serialization

