### PR TITLE
fix: convert utcnow() to now(UTC)

### DIFF
--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -422,7 +422,7 @@ class SigV4Auth(BaseSigner):
     def add_auth(self, request):
         if self.credentials is None:
             raise NoCredentialsError()
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
@@ -560,7 +560,7 @@ class S3ExpressPostAuth(S3ExpressAuth):
     REQUIRES_IDENTITY_CACHE = True
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}
@@ -819,7 +819,7 @@ class S3SigV4PostAuth(SigV4Auth):
     """
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}


### PR DESCRIPTION
# Fix deprecated `datetime.datetime.utcnow()` usage
Replace deprecated `datetime.datetime.utcnow()` calls with `datetime.datetime.now(datetime.UTC)` to resolve deprecation warnings and ensure future compatibility.

### What changed:

Updated all instances of `datetime.datetime.utcnow()` to use `datetime.datetime.now(datetime.UTC)`
This change maintains identical functionality while using the recommended timezone-aware approach

### Why:

`datetime.datetime.utcnow()` is deprecated in Python 3.12+ and scheduled for removal
The new approach explicitly uses timezone-aware datetime objects, which is the recommended best practice
Prevents deprecation warnings in logs and ensures forward compatibility

### Testing:

Verified all datetime operations continue to work as expected
No functional changes to application behavior