### PR TITLE
Avoid a race condition on directory creation

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3545,7 +3545,7 @@ class JSONFileCache:
                 f"JSON serializable: {value}"
             )
         if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir)
+            os.makedirs(self._working_dir, exist_ok=True)
         with os.fdopen(
             os.open(full_key, os.O_WRONLY | os.O_CREAT, 0o600), 'w'
         ) as f:


### PR DESCRIPTION
If a command like `aws s3 cp` is spawned simultaneously (and for the first time), different processes might try to create this directory simultaneously, resulting in an unnecessary exception.

Fixes aws/aws-cli#6489