### PR TITLE
Remove legacy reference to Requests

### DIFF
--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -42,10 +42,9 @@ MAX_POOL_CONNECTIONS = 10
 def convert_to_response_dict(http_response, operation_model):
     """Convert an HTTP response object to a request dict.
 
-    This converts the requests library's HTTP response object to
-    a dictionary.
+    This converts the HTTP response object to a dictionary.
 
-    :type http_response: botocore.vendored.requests.model.Response
+    :type http_response: botocore.awsrequest.AWSResponse
     :param http_response: The HTTP response from an AWS service request.
 
     :rtype: dict


### PR DESCRIPTION
Fixes the typing information on `convert_to_response_dict` from prior to us dropping Requests as the default HTTP client.