### PR TITLE
Fix generic error parsing to handle 4xx responses

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -300,7 +300,7 @@ class ResponseParser:
         # non sensical parsed data.
         # To prevent this case from happening we first need to check
         # whether or not this response looks like the generic response.
-        if response['status_code'] >= 500:
+        if response['status_code'] >= 400:
             if 'body' not in response or response['body'] is None:
                 return True
 


### PR DESCRIPTION
When 4XX error is returned by AWS Services, the actual 4XX error information is not returned. Instead, depending on where the error exception has happened (for example:`ResponseParserError`) `ResponseParserError` exceptions are returned to users instead of informative error messages.

This change updates `_is_generic_error_response()`is to detect generic HTML error responses for all 4xx status codes, not just 5xx. This allows botocore to handle errors gracefully and provide more informative error messages to customers.
