### PR TITLE
Replace bespoke NullHandler with Python's implementation

### DIFF
--- a/botocore/__init__.py
+++ b/botocore/__init__.py
@@ -15,13 +15,9 @@
 import logging
 import os
 import re
+from logging import NullHandler
 
 __version__ = '1.39.0'
-
-
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
 
 
 # Configure default logger to do nothing


### PR DESCRIPTION
[NullHandler](https://github.com/python/cpython/blob/c44070b2d51d59f608577b1f6c55c0168d8e416b/Lib/logging/__init__.py#L2265-L2285) was added in Python 3.1 which does effectively the same thing our current custom one does. They both inherit from the same parent `logging.Handler` class so it should be safe to replace all usages of this. There will be follow up PRs for Boto3 and S3transfer as well.

https://github.com/boto/s3transfer/pull/351
https://github.com/boto/boto3/pull/4231