### PR TITLE
Query compatibility bugfix

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -1067,10 +1067,9 @@ class BaseClient:
 
         if http.status_code >= 300:
             error_info = parsed_response.get("Error", {})
-            if error_code := error_info.get('ErrorCodeOverride'):
-                del error_info['ErrorCodeOverride']
-            else:
-                error_code = error_info.get("Code")
+            error_code = request_context.get(
+                'error_code_override'
+            ) or error_info.get("Code")
             error_class = self.exceptions.from_code(error_code)
             raise error_class(parsed_response, operation_name)
         else:

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -1067,9 +1067,7 @@ class BaseClient:
 
         if http.status_code >= 300:
             error_info = parsed_response.get("Error", {})
-            error_code = error_info.get("QueryErrorCode") or error_info.get(
-                "Code"
-            )
+            error_code = error_info.get("Code")
             error_class = self.exceptions.from_code(error_code)
             raise error_class(parsed_response, operation_name)
         else:

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -1067,7 +1067,10 @@ class BaseClient:
 
         if http.status_code >= 300:
             error_info = parsed_response.get("Error", {})
-            error_code = error_info.get("Code")
+            if error_code := error_info.get('ErrorCodeOverride'):
+                del error_info['ErrorCodeOverride']
+            else:
+                error_code = error_info.get("Code")
             error_class = self.exceptions.from_code(error_code)
             raise error_class(parsed_response, operation_name)
         else:

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -237,7 +237,7 @@ def set_operation_specific_signer(context, signing_name, **kwargs):
         return signature_version
 
 
-def _handle_sqs_compatible_error(parsed, http_response, **kwargs):
+def _handle_sqs_compatible_error(parsed, context, **kwargs):
     """
     Ensures backward compatibility for SQS errors.
 
@@ -252,7 +252,7 @@ def _handle_sqs_compatible_error(parsed, http_response, **kwargs):
         return
 
     if query_code := parsed_error.get("QueryErrorCode"):
-        parsed["Error"]["ErrorCodeOverride"] = query_code
+        context['error_code_override'] = query_code
 
 
 def _resolve_sigv4a_region(context):

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -241,10 +241,10 @@ def _handle_sqs_compatible_error(parsed, context, **kwargs):
     """
     Ensures backward compatibility for SQS errors.
 
-    SQS' migration from the query protocol to JSON was done prior SDKs allowing a
-    service to support multiple models.  Because of this SQS is missing the "error"
+    SQS's migration from the Query protocol to JSON was done prior to SDKs allowing a
+    service to support multiple protocols.  Because of this, SQS is missing the "error"
     key from its modeled exceptions, which is used by most query compatible services
-    to map exceptions to the proper error.  SQS instead uses the error's shape name,
+    to map error codes to the proper exception.  Instead, SQS uses the error's shape name,
     which is preserved in the QueryErrorCode key.
     """
     parsed_error = parsed.get("Error", {})

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -251,8 +251,8 @@ def _handle_sqs_compatible_error(parsed, http_response, **kwargs):
     if not parsed_error:
         return
 
-    query_code = parsed_error.get("QueryErrorCode")
-    parsed["Error"]["Code"] = query_code
+    if query_code := parsed_error.get("QueryErrorCode"):
+        parsed["Error"]["ErrorCodeOverride"] = query_code
 
 
 def _resolve_sigv4a_region(context):

--- a/tests/functional/test_query_compatibility.py
+++ b/tests/functional/test_query_compatibility.py
@@ -1,0 +1,134 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+from tests import ClientHTTPStubber, patch_load_service_model
+
+TEST_QUERY_COMPAT_SERVICE_MODEL = {
+    "version": "2.0",
+    "documentation": "This is a test service.",
+    "metadata": {
+        "apiVersion": "2023-01-01",
+        "endpointPrefix": "test",
+        "protocol": "json",
+        "protocols": ["json", "query"],
+        "jsonVersion": "1.0",
+        "serviceFullName": "Test Service",
+        "serviceId": "Test Service",
+        "signatureVersion": "v4",
+        "signingName": "testservice",
+        "targetPrefix": "testservice",
+        "uid": "testservice-2025-01-01",
+    },
+    "operations": {
+        "QueryCompatOperation": {
+            "name": "QueryCompatOperation",
+            "http": {"method": "POST", "requestUri": "/QueryCompatOperation"},
+            "input": {"shape": "SomeInput"},
+            "output": {"shape": "SomeOutput"},
+            "errors": [{"shape": "QueryError"}],
+        }
+    },
+    "shapes": {
+        "SomeInput": {
+            "type": "structure",
+        },
+        "SomeOutput": {
+            "type": "structure",
+        },
+        "QueryError": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "shape": "ErrorMessage",
+                }
+            },
+            "error": {
+                "code": "QueryErrorCode",
+                "httpStatusCode": 404,
+                "senderFault": True,
+            },
+            "exception": True,
+        },
+        "ErrorMessage": {"type": "string"},
+    },
+}
+
+TEST_QUERY_COMPAT_RULESET = {
+    "version": "1.0",
+    "parameters": {},
+    "rules": [
+        {
+            "conditions": [],
+            "type": "endpoint",
+            "endpoint": {
+                "url": "https://foo.bar",
+                "properties": {},
+                "headers": {},
+            },
+        }
+    ],
+}
+
+
+def test_generic_query_compatibility(
+    patched_session,
+    monkeypatch,
+):
+    patch_load_service_model(
+        patched_session,
+        monkeypatch,
+        TEST_QUERY_COMPAT_SERVICE_MODEL,
+        TEST_QUERY_COMPAT_RULESET,
+    )
+    client = patched_session.create_client(
+        "testservice", region_name="us-west-2"
+    )
+    with ClientHTTPStubber(client, strict=True) as http_stubber:
+        http_stubber.add_response(
+            status=400,
+            body=b'{"__type":"com.amazonaws.testService#QueryErrorType","message":"Message for query compatible error"}',
+            headers={'x-amzn-query-error': 'QueryErrorCode;Sender'},
+        )
+        try:
+            client.query_compat_operation()
+            assert False, "Expected a QueueDoesNotExist, but wasn't thrown"
+        except client.exceptions.QueryError as e:
+            assert e.response['Error']['Code'] == 'QueryErrorCode'
+            assert e.response['Error']['QueryErrorCode'] == 'QueryErrorType'
+            assert e.response['Error']['Type'] == 'Sender'
+            assert e.response['ResponseMetadata']['HTTPStatusCode'] == 400
+
+
+# SQS was the first service to migrate protocols, and has some unique behavior.
+# We need to check that we are maintaining backwards compatibility with the error code,
+# type, and query error code
+def test_sqs_query_compatibility(
+    patched_session,
+):
+    client = patched_session.create_client('sqs', region_name='us-east-1')
+    with ClientHTTPStubber(client, strict=True) as http_stubber:
+        http_stubber.add_response(
+            status=200,
+            body=b'{"__type":"com.amazonaws.sqs#QueryError","message":"The specified queue does not exist."}',
+            headers={
+                'x-amzn-query-error': 'AWS.SimpleQueueService.NonExistentQueue;Sender'
+            },
+        )
+        try:
+            client.delete_queue(QueueUrl="not-a-real-queue")
+        except client.exceptions.QueueDoesNotExist as e:
+            assert e.response['Error']['Code'] == 'QueueDoesNotExist'
+            assert e.response['Error']['QueryErrorCode'] == 'QueueDoesNotExist'
+            assert e.response['Error']['Type'] == 'Sender'
+            assert e.response['ResponseMetadata']['HTTPStatusCode'] == 400


### PR DESCRIPTION
There's a fundamental problem with our query compatibility mode, rooted in how SQS implemented protocol migration and how error handling has evolved in AWS SDKs.

### Background

The Query protocol is unique because it can model error code information within errors themselves. Other protocols (JSON, CBOR) cannot include "error" fields in exception shapes.

Error codes help map exceptions to specific error classes (e.g., cloudwatch.exceptions.ResourceNotFound).  Each modeled error has a "code" associated with it which will map to the specific class.  This code comes straight from the "code" key from the "error" fields in the json model.  If the error does not have a code, the shape name is used as a fallback.

### Historical Context
 -  SQS migrated protocols before services were able to model support for multiple protocols
 -  During this migration, SQS models lost critical information from their "error" sections
 -  This information loss was never properly addressed, leading to some persistent breaking changes

### Current State

Multi-protocol support allows services to maintain their "error" section information when they support the `query` protocol as well as other protocols.  However, our Query protocol logic is broken because of the following:

When receiving a query-compatible error header, we store the original error code in a key called `QueryErrorCode` and the header-provided query error code in a key called `Code`.

During error mapping, we [prioritize QueryErrorCode (original code) over the code from the header](https://github.com/boto/botocore/blob/e566e05467f221f81bccd2fbd1b0fa20b92c6be2/botocore/client.py#L1019-L1021).  This means we will effectively never use the error code that gets sent back from a service.

### Impact
Currently, this only affects SQS as it's the only query-compatible service, but future query-compatible services would face incorrect error mapping.

### Proposed Solution
Change error code lookup from:
```
error_code = error_info.get("QueryErrorCode") or error_info.get("Code")
```
to:
```
error_code = error_info.get("Code")
```

This will prioritize the proper code for future services.  To preserve backwards compatibility for SQS specifically, we will create an SQS specific customization that prioritizes the original code over the one sent back in the header.