### PR TITLE
Consolidate STS settings back to centralized location

### DIFF
--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -144,6 +144,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         'auto',
         None,
     ),
+    'sts_regional_endpoints': (
+        'sts_regional_endpoints',
+        'AWS_STS_REGIONAL_ENDPOINTS',
+        'legacy',
+        None,
+    ),
     'retry_mode': ('retry_mode', 'AWS_RETRY_MODE', 'legacy', None),
     'defaults_mode': ('defaults_mode', 'AWS_DEFAULTS_MODE', 'legacy', None),
     # We can't have a default here for v1 because we need to defer to
@@ -199,28 +205,6 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         None,
     ),
 }
-
-# Evaluate AWS_STS_REGIONAL_ENDPOINTS settings
-try:
-    # This is not a public interface and is subject to abrupt breaking changes.
-    # Any usage is not advised or supported in external code bases.
-    from botocore.customizations.sts import (
-        sts_default_setting as _sts_default_setting,
-    )
-except ImportError:
-    _sts_default_setting = 'legacy'
-
-_STS_DEFAULT_SETTINGS = {
-    'sts_regional_endpoints': (
-        'sts_regional_endpoints',
-        'AWS_STS_REGIONAL_ENDPOINTS',
-        _sts_default_setting,
-        None,
-    ),
-}
-BOTOCORE_DEFAUT_SESSION_VARIABLES.update(_STS_DEFAULT_SETTINGS)
-
-
 # A mapping for the s3 specific configuration vars. These are the configuration
 # vars that typically go in the s3 section of the config file. This mapping
 # follows the same schema as the previous session variable mapping.


### PR DESCRIPTION
This PR moves the abstracted STS settings back to the centralized config provider.