### PR TITLE
Add official Python 3.14 support with first release candidate

### DIFF
--- a/.changes/next-release/enhancement-Python-78496.json
+++ b/.changes/next-release/enhancement-Python-78496.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Added provisional support for the upcoming Python 3.14 release"
+}

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,6 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
 )

--- a/tests/functional/leak/test_resource_leaks.py
+++ b/tests/functional/leak/test_resource_leaks.py
@@ -22,8 +22,10 @@ class TestDoesNotLeakMemory(BaseClientDriverTest):
     # a substantial amount of time to the total test run time.
     INJECT_DUMMY_CREDS = True
     # We're making up numbers here, but let's say arbitrarily
-    # that the memory can't increase by more than 10MB.
-    MAX_GROWTH_BYTES = 12 * 1024 * 1024
+    # that the memory can't increase by more than 13MB.
+
+    # TODO: Attempt to bring this back to 10MB once Python 3.14 releases
+    MAX_GROWTH_BYTES = 13 * 1024 * 1024
 
     def test_create_single_client_memory_constant(self):
         self.cmd('create_client', 's3')


### PR DESCRIPTION
The first release candidate for Python 3.14 is tentatively scheduled for July 22nd ([ref](https://peps.python.org/pep-0745/)). We've been stable through the beta process and since we're entering feature lock, we should be good to start advertising support to enable other tools to onboard early.

This PR raises our memory threshold to 13MB (ideally temporarily) due to the mac client specifically having a larger memory footprint than before. We saw similar issues in Python 3.13 that were corrected prior to the final release. We should revisit this test once we get to that point.