### PR TITLE
Restrict bedrock bearer auth by trait

### DIFF
--- a/.changes/next-release/bugfix-bedrock-37870.json
+++ b/.changes/next-release/bugfix-bedrock-37870.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``bedrock``",
+  "description": "Fixes an issue where bearer authentication was incorrectly applied to all services with the ``bedrock`` signing name. Bearer auth is now only applied if the service model also includes the ``smithy.api#httpBearerAuth`` trait."
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1386,7 +1386,10 @@ def _set_auth_scheme_preference_signer(context, signing_name, **kwargs):
     # is allowed for this service. This can override earlier resolution if the
     # config object didn't explicitly set a signature version.
     if _should_prefer_bearer_auth(
-        has_in_code_configuration, signing_name, resolved_signature_version
+        has_in_code_configuration,
+        signing_name,
+        resolved_signature_version,
+        auth_options,
     ):
         register_feature_id('BEARER_SERVICE_ENV_VARS')
         resolved_signature_version = 'bearer'
@@ -1397,9 +1400,15 @@ def _set_auth_scheme_preference_signer(context, signing_name, **kwargs):
 
 
 def _should_prefer_bearer_auth(
-    has_in_code_configuration, signing_name, resolved_signature_version
+    has_in_code_configuration,
+    signing_name,
+    resolved_signature_version,
+    auth_options,
 ):
     if signing_name not in get_bearer_auth_supported_services():
+        return False
+
+    if not auth_options or 'smithy.api#httpBearerAuth' not in auth_options:
         return False
 
     has_token = get_token_from_environment(signing_name) is not None

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -2120,7 +2120,10 @@ def test_set_auth_scheme_preference_signer(
         # Case 6: Service has 'bedrock' signing name but does not support bearer auth.
         (
             "bedrock",
-            {"signature_version": "v4"},
+            {
+                "signature_version": "v4",
+                "auth_scheme_preference": ClientConfigString("httpBearerAuth"),
+            },
             ["aws.auth#sigv4"],
             "test_token",
             None,

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -2117,6 +2117,14 @@ def test_set_auth_scheme_preference_signer(
             "test_token",
             None,
         ),
+        # Case 6: Service has 'bedrock' signing name but does not support bearer auth.
+        (
+            "bedrock",
+            {"signature_version": "v4"},
+            ["aws.auth#sigv4"],
+            "test_token",
+            None,
+        ),
     ],
 )
 def test_set_auth_scheme_preference_signer_with_bearer_token(


### PR DESCRIPTION
### Summary
This PR updates the bearer authentication logic to align with the intended behavior: bearer auth should only be applied to services that:
1. Use the SigV4 signing name `bedrock`, and
2. Have the `smithy.api#httpBearerAuth` trait in their model

Previously, bearer auth was applied to all services with the `bedrock` signing name if a token was present, including unsupported services like `bedrock-agent`, which resulted in runtime failures. This update narrows the logic to match expectations and prevents invalid auth headers from being sent.

### Changes
* Updated `_should_prefer_bearer_auth` to check both signing name and presence of `httpBearerAuth` in `auth_options`
* Added a test case to ensure unsupported `bedrock` services no longer receive bearer auth
