### PR TITLE
Fix logging calls to defer formatting messages until needed

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -839,7 +839,8 @@ class ClientArgsCreator:
         ):
             logger.warning(
                 'The configured value for user_agent_appid exceeds the '
-                f'maximum length of {USERAGENT_APPID_MAXLEN} characters.'
+                'maximum length of %d characters.',
+                USERAGENT_APPID_MAXLEN,
             )
         config_kwargs['user_agent_appid'] = user_agent_appid
 

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -993,7 +993,7 @@ class HmacV1Auth(BaseSigner):
         string_to_sign = self.canonical_string(
             method, split, headers, auth_path=auth_path
         )
-        logger.debug(f'StringToSign:\n{string_to_sign}')
+        logger.debug('StringToSign:\n%s', string_to_sign)
         return self.sign_string(string_to_sign)
 
     def add_auth(self, request):
@@ -1001,7 +1001,7 @@ class HmacV1Auth(BaseSigner):
             raise NoCredentialsError
         logger.debug("Calculating signature using hmacv1 auth.")
         split = urlsplit(request.url)
-        logger.debug(f'HTTP request method: {request.method}')
+        logger.debug("HTTP request method: %s", request.method)
         signature = self.get_signature(
             request.method, split, request.headers, auth_path=request.auth_path
         )
@@ -1158,7 +1158,7 @@ def resolve_auth_scheme_preference(preference_list, auth_options):
     ]
     if unsupported:
         logger.debug(
-            f"Unsupported auth schemes in preference list: {', '.join(unsupported)}"
+            "Unsupported auth schemes in preference list: %r", unsupported
         )
 
     combined = preference_list + service_supported

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -220,10 +220,11 @@ class ClientCreator:
                 else:
                     client_config = config_use_fips_endpoint
                 logger.warning(
-                    f'transforming region from {region_name} to '
-                    f'{normalized_region_name} and setting '
+                    'transforming region from %s to %s and setting '
                     'use_fips_endpoint to true. client should not '
-                    'be configured with a fips psuedo region.'
+                    'be configured with a fips psuedo region.',
+                    region_name,
+                    normalized_region_name,
                 )
                 region_name = normalized_region_name
         return region_name, client_config
@@ -786,7 +787,10 @@ class ClientEndpointBridge:
                 hostname, is_secure, ['http', 'https']
             )
         logger.debug(
-            f'Assuming an endpoint for {service_name}, {region_name}: {endpoint_url}'
+            'Assuming an endpoint for %s, %s: %s',
+            service_name,
+            region_name,
+            endpoint_url,
         )
         # We still want to allow the user to provide an explicit version.
         signature_version = self._resolve_signature_version(

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -823,7 +823,7 @@ class BaseAssumeRoleCredentialFetcher(CachedCredentialFetcher):
             account_id = arn_parser.parse_arn(role_arn)['account']
             response['Credentials']['AccountId'] = account_id
         else:
-            logger.debug(f"Unable to extract account ID from Arn: {role_arn}")
+            logger.debug("Unable to extract account ID from Arn: %s", role_arn)
 
 
 class AssumeRoleCredentialFetcher(BaseAssumeRoleCredentialFetcher):

--- a/botocore/discovery.py
+++ b/botocore/discovery.py
@@ -185,7 +185,8 @@ class EndpointDiscoveryManager:
         if not self._always_discover and not discovery_required:
             # Discovery set to only run on required operations
             logger.debug(
-                f'Optional discovery disabled. Skipping discovery for Operation: {operation}'
+                'Optional discovery disabled. Skipping discovery for Operation: %s',
+                operation,
             )
             return None
 

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -283,7 +283,9 @@ def generate_idempotent_uuid(params, model, **kwargs):
         if name not in params:
             params[name] = str(uuid.uuid4())
             logger.debug(
-                f"injecting idempotency token ({params[name]}) into param '{name}'."
+                "injecting idempotency token (%s) into param '%s'.",
+                params[name],
+                name,
             )
 
 
@@ -1215,8 +1217,9 @@ def handle_expires_header(
                 utils.parse_timestamp(expires_value)
             except (ValueError, RuntimeError):
                 logger.warning(
-                    f'Failed to parse the "Expires" member as a timestamp: {expires_value}. '
-                    f'The unparsed value is available in the response under "ExpiresString".'
+                    'Failed to parse the "Expires" member as a timestamp: %s. '
+                    'The unparsed value is available in the response under "ExpiresString".',
+                    expires_value,
                 )
                 del response_dict['headers']['Expires']
 
@@ -1280,7 +1283,8 @@ def _handle_200_error(operation_model, response_dict, **kwargs):
     ):
         response_dict['status_code'] = 500
         logger.debug(
-            f"Error found for response with 200 status code: {response_dict['body']}."
+            "Error found for response with 200 status code: %s.",
+            response_dict['body'],
         )
 
 

--- a/botocore/hooks.py
+++ b/botocore/hooks.py
@@ -480,7 +480,7 @@ class EventAliaser(BaseEventHooks):
 
             new_name = '.'.join(event_parts)
             logger.debug(
-                f"Changing event name from {event_name} to {new_name}"
+                "Changing event name from %s to %s", event_name, new_name
             )
             self._alias_name_cache[event_name] = new_name
             return new_name

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -516,8 +516,8 @@ def handle_checksum_body(http_response, response, context, operation_model):
         return
 
     logger.debug(
-        f'Skipping checksum validation. Response did not contain one of the '
-        f'following algorithms: {algorithms}.'
+        'Skipping checksum validation. Response did not contain one of the following algorithms: %s.',
+        algorithms,
     )
 
 

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -94,7 +94,7 @@ def get_cert_path(verify):
         return verify
 
     cert_path = where()
-    logger.debug(f"Certificate path: {cert_path}")
+    logger.debug("Certificate path: %s", cert_path)
 
     return cert_path
 

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -548,8 +548,8 @@ class PageIterator:
         coerce them into the new style.
         """
         log.debug(
-            "Attempting to fall back to old starting token parser. For "
-            f"token: {self._starting_token}"
+            "Attempting to fall back to old starting token parser. For token: %s",
+            self._starting_token,
         )
         if self._starting_token is None:
             return None

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -385,12 +385,11 @@ class ResponseParser:
                 for member in shape.members
             ]
             if tag not in serialized_member_names:
-                msg = (
-                    "Received a tagged union response with member "
-                    "unknown to client: %s. Please upgrade SDK for full "
-                    "response support."
+                LOG.info(
+                    "Received a tagged union response with member unknown to client: %s. "
+                    "Please upgrade SDK for full response support.",
+                    tag,
                 )
-                LOG.info(msg % tag)
                 return True
         return False
 

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -361,7 +361,8 @@ class EndpointResolver(BaseEndpointResolver):
 
         if endpoint_data.get('deprecated'):
             LOG.warning(
-                f'Client is configured with the deprecated endpoint: {endpoint_name}'
+                'Client is configured with the deprecated endpoint: %s',
+                endpoint_name,
             )
 
         service_defaults = service_data.get('defaults', {})
@@ -503,7 +504,7 @@ class EndpointRulesetResolver:
             operation_model, call_args, request_context
         )
         LOG.debug(
-            f'Calling endpoint provider with parameters: {provider_params}'
+            'Calling endpoint provider with parameters: %s', provider_params
         )
         try:
             provider_result = self._provider.resolve_endpoint(
@@ -517,7 +518,7 @@ class EndpointRulesetResolver:
                 raise
             else:
                 raise botocore_exception from ex
-        LOG.debug(f'Endpoint provider result: {provider_result.url}')
+        LOG.debug('Endpoint provider result: %s', provider_result.url)
 
         # The endpoint provider does not support non-secure transport.
         if not self._use_ssl and provider_result.url.startswith('https://'):

--- a/botocore/response.py
+++ b/botocore/response.py
@@ -77,11 +77,9 @@ class StreamingBody(IOBase):
         try:
             set_socket_timeout(self._raw_stream, timeout)
         except AttributeError:
-            logger.error(
-                "Cannot access the socket object of "
-                "a streaming response.  It's possible "
-                "the interface has changed.",
-                exc_info=True,
+            logger.exception(
+                "Cannot access the socket object of a streaming response. "
+                "It's possible the interface has changed."
             )
             raise
 

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -979,8 +979,9 @@ class Session:
                 aws_session_token, aws_account_id
             ):
                 logger.debug(
-                    f"Ignoring the following credential-related values which were set without "
-                    f"an access key id and secret key on the session or client: {ignored_credentials}"
+                    "Ignoring the following credential-related values which were set without "
+                    "an access key id and secret key on the session or client: %s",
+                    ignored_credentials,
                 )
             credentials = self.get_credentials()
         auth_token = self.get_auth_token()
@@ -1178,7 +1179,7 @@ class Session:
                 client_plugins[name] = module
             except ValueError:
                 logger.warning(
-                    f"Invalid plugin format: {plugin}. Expected 'name=module'"
+                    "Invalid plugin format: %s. Expected 'name=module'", plugin
                 )
 
         if client_plugins:

--- a/botocore/tokens.py
+++ b/botocore/tokens.py
@@ -297,7 +297,7 @@ class SSOTokenProvider:
 
         expiry = dateutil.parser.parse(token["registrationExpiresAt"])
         if total_seconds(expiry - self._now()) <= 0:
-            logger.info(f"SSO token registration expired at {expiry}")
+            logger.info("SSO token registration expired at %s", expiry)
             return None
 
         try:
@@ -309,10 +309,10 @@ class SSOTokenProvider:
     def _refresher(self):
         start_url = self._sso_config["sso_start_url"]
         session_name = self._sso_config["session_name"]
-        logger.info(f"Loading cached SSO token for {session_name}")
+        logger.info("Loading cached SSO token for %s", session_name)
         token_dict = self._token_loader(start_url, session_name=session_name)
         expiration = dateutil.parser.parse(token_dict["expiresAt"])
-        logger.debug(f"Cached SSO token expires at {expiration}")
+        logger.debug("Cached SSO token expires at %s", expiration)
 
         remaining = total_seconds(expiration - self._now())
         if remaining < self._REFRESH_WINDOW:

--- a/botocore/useragent.py
+++ b/botocore/useragent.py
@@ -195,10 +195,13 @@ class UserAgentComponent(NamedTuple):
 
         if string == '':
             logger.debug(
-                f"User agent component `{orig}` could not be truncated to "
-                f"`{max_size}` bytes with delimiter "
-                f"`{delimiter}` without losing all contents. "
-                f"Value will be omitted from user agent string."
+                "User agent component `%s` could not be truncated to "
+                "`%s` bytes with delimiter "
+                "`%s` without losing all contents. "
+                "Value will be omitted from user agent string.",
+                orig,
+                max_size,
+                delimiter,
             )
         return string
 

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -453,7 +453,7 @@ class IMDSFetcher:
         else:
             chosen_base_url = METADATA_BASE_URL
 
-        logger.debug(f"IMDS ENDPOINT: {chosen_base_url}")
+        logger.debug("IMDS ENDPOINT: %s", chosen_base_url)
         if not is_valid_uri(chosen_base_url):
             raise InvalidIMDSEndpointError(endpoint=chosen_base_url)
 
@@ -704,14 +704,15 @@ class InstanceMetadataFetcher(IMDSFetcher):
                     "%Y-%m-%dT%H:%M:%SZ"
                 )
                 logger.info(
-                    f"Attempting credential expiration extension due to a "
-                    f"credential service availability issue. A refresh of "
-                    f"these credentials will be attempted again within "
-                    f"the next {refresh_interval_with_jitter / 60:.0f} minutes."
+                    "Attempting credential expiration extension due to a "
+                    "credential service availability issue. A refresh of "
+                    "these credentials will be attempted again within "
+                    "the next %.0f minutes.",
+                    refresh_interval_with_jitter / 60,
                 )
         except ValueError:
             logger.debug(
-                f"Unable to parse expiry_time in {credentials['expiry_time']}"
+                "Unable to parse expiry_time in %s", credentials['expiry_time']
             )
 
 
@@ -1572,7 +1573,9 @@ def _get_new_endpoint(original_endpoint, new_endpoint, use_new_scheme=True):
         '',
     )
     final_endpoint = urlunsplit(final_endpoint_components)
-    logger.debug(f'Updating URI from {original_endpoint} to {final_endpoint}')
+    logger.debug(
+        'Updating URI from %s to %s', original_endpoint, final_endpoint
+    )
     return final_endpoint
 
 
@@ -1823,16 +1826,21 @@ class S3RegionRedirectorv2:
 
         if new_region is None:
             logger.debug(
-                f"S3 client configured for region {client_region} but the "
-                f"bucket {bucket} is not in that region and the proper region "
-                "could not be automatically determined."
+                "S3 client configured for region %s but the "
+                "bucket %s is not in that region and the proper region "
+                "could not be automatically determined.",
+                client_region,
+                bucket,
             )
             return
 
         logger.debug(
-            f"S3 client configured for region {client_region} but the bucket {bucket} "
-            f"is in region {new_region}; Please configure the proper region to "
-            f"avoid multiple unnecessary redirects and signing attempts."
+            "S3 client configured for region %s but the bucket %s "
+            "is in region %s; Please configure the proper region to "
+            "avoid multiple unnecessary redirects and signing attempts.",
+            client_region,
+            bucket,
+            new_region,
         )
         # Adding the new region to _cache will make construct_endpoint() to
         # use the new region as value for the AWS::Region builtin parameter.
@@ -2021,16 +2029,21 @@ class S3RegionRedirector:
 
         if new_region is None:
             logger.debug(
-                f"S3 client configured for region {client_region} but the bucket {bucket} is not "
+                "S3 client configured for region %s but the bucket %s is not "
                 "in that region and the proper region could not be "
-                "automatically determined."
+                "automatically determined.",
+                client_region,
+                bucket,
             )
             return
 
         logger.debug(
-            f"S3 client configured for region {client_region} but the bucket {bucket} is in region"
-            f" {new_region}; Please configure the proper region to avoid multiple "
-            "unnecessary redirects and signing attempts."
+            "S3 client configured for region %s but the bucket %s is in region"
+            " %s; Please configure the proper region to avoid multiple "
+            "unnecessary redirects and signing attempts.",
+            client_region,
+            bucket,
+            new_region,
         )
         endpoint = self._endpoint_resolver.resolve('s3', new_region)
         endpoint = endpoint['endpoint_url']
@@ -2449,7 +2462,7 @@ class S3EndpointSetter:
             )
         )
         logger.debug(
-            f'Updating URI from {request.url} to {accesspoint_endpoint}'
+            'Updating URI from %s to %s', request.url, accesspoint_endpoint
         )
         request.url = accesspoint_endpoint
 
@@ -2749,7 +2762,7 @@ class S3ControlEndpointSetter:
             )
         )
         logger.debug(
-            f'Updating URI from {request.url} to {arn_details_endpoint}'
+            'Updating URI from %s to %s', request.url, arn_details_endpoint
         )
         request.url = arn_details_endpoint
 
@@ -3381,7 +3394,7 @@ class SSOTokenLoader:
 
     def __call__(self, start_url, session_name=None):
         cache_key = self._generate_cache_key(start_url, session_name)
-        logger.debug(f'Checking for cached token at: {cache_key}')
+        logger.debug('Checking for cached token at: %s', cache_key)
         if cache_key not in self._cache:
             name = start_url
             if session_name is not None:
@@ -3417,7 +3430,9 @@ class EventbridgeSignerSetter:
     def set_endpoint_url(self, params, context, **kwargs):
         if 'eventbridge_endpoint' in context:
             endpoint = context['eventbridge_endpoint']
-            logger.debug(f"Rewriting URL from {params['url']} to {endpoint}")
+            logger.debug(
+                "Rewriting URL from %s to %s", params['url'], endpoint
+            )
             params['url'] = endpoint
 
     def check_for_global_endpoint(self, params, context, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,17 @@ indent-width = 4
 target-version = "py39"
 
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "I", "UP"]
+select = [
+    "E4", # pycodestyle
+    "E7", # pycodestyle
+    "E9", # pycodestyle
+    "F", # Pyflakes
+    "I", # Import sorting
+    "UP", # PyUpgrade
+    "G", # Log formatting
+]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/tests/unit/response_parsing/test_response_parsing.py
+++ b/tests/unit/response_parsing/test_response_parsing.py
@@ -93,11 +93,11 @@ def _test_parsed_response(xmlfile, operation_model, expected):
 
     if d1 != d2:
         log.debug('-' * 40)
-        log.debug("XML FILE:\n" + xmlfile)
+        log.debug("XML FILE:\n%s", xmlfile)
         log.debug('-' * 40)
-        log.debug("ACTUAL:\n" + pprint.pformat(parsed))
+        log.debug("ACTUAL:\n%s", pprint.pformat(parsed))
         log.debug('-' * 40)
-        log.debug("EXPECTED:\n" + pprint.pformat(expected))
+        log.debug("EXPECTED:\n%s", pprint.pformat(expected))
     if not d1 == d2:
         # Borrowed from assertDictEqual, though this doesn't
         # handle the case when unicode literals are used in one


### PR DESCRIPTION
Many logging calls within Botocore were eagerly formatting messages, which is a performance (cycles, memory) issue, and could in rare cases cause the code calling logging to fail (think an unformattable object).

This PR enables the Ruff [G (`flake8-logging-format`) group](https://docs.astral.sh/ruff/rules/#flake8-logging-format-g) and fixes the found issues.