### PR TITLE
Remove unreferenced arguments from S3 endpoint ruleset

### DIFF
--- a/botocore/data/s3/2006-03-01/endpoint-rule-set-1.json
+++ b/botocore/data/s3/2006-03-01/endpoint-rule-set-1.json
@@ -58,21 +58,6 @@
             "documentation": "Internal parameter to use object lambda endpoint for an operation (eg: WriteGetObjectResponse)",
             "type": "Boolean"
         },
-        "Key": {
-            "required": false,
-            "documentation": "The S3 Key used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 Key.",
-            "type": "String"
-        },
-        "Prefix": {
-            "required": false,
-            "documentation": "The S3 Prefix used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 Prefix.",
-            "type": "String"
-        },
-        "CopySource": {
-            "required": false,
-            "documentation": "The Copy Source used for Copy Object request. This is an optional parameter that will be set automatically for operations that are scoped to Copy Source.",
-            "type": "String"
-        },
         "DisableAccessPoints": {
             "required": false,
             "documentation": "Internal parameter to disable Access Point Buckets",


### PR DESCRIPTION
None of these arguments are referenced by the ruleset, but the set of arguments is used for caching endpoint resolution results via https://github.com/boto/botocore/blob/7ddc232fff4297fc19f89a70ce95014beb2d77bf/botocore/endpoint_provider.py#L707-L708.

This means that the entire endpoint ruleset is evaluated (only to end up with the same result) for every S3-related request with a different Key, IOW for every file stored in S3. Since evaluating the rule tree is pretty slow, this causes significant slowdowns in mass operations, not to mention memory bloat for the (useless) cache.

The three removed parameters are not in the [equivalent JS SDK code]( https://github.com/aws/aws-sdk-js-v3/blob/2e7d107003aa85474670fbd4e03212c473e23432/clients/client-s3/src/endpoint/endpointResolver.ts#L9-L27) either.

Refs #3528.