### PR TITLE
Add documentation for awsrequest

### DIFF
--- a/docs/source/reference/awsrequest.rst
+++ b/docs/source/reference/awsrequest.rst
@@ -13,3 +13,13 @@ botocore.awsrequest
 
 .. autoclass:: botocore.awsrequest.AWSResponse
    :members:
+
+.. autoclass:: botocore.awsrequest.AWSRequest
+   :members:
+
+.. autoclass:: botocore.awsrequest.AWSRequestPreparer
+   :members:
+
+.. autofunction:: botocore.awsrequest.prepare_request_dict
+
+.. autofunction:: botocore.awsrequest.create_request_object


### PR DESCRIPTION
### What Changed 

I added references to already existing documentation in *botocore/awsrequest.py* to *docs/reference/awsrequest.rst* for the following clases and functions:

- AWSRequest
- AWSRequestPreparer
- prepare_request_dict
- create_request_object

### How did I test it

I tested the changes by building the docs and checking it rendered ok.