### PR TITLE
Remove ASCII character restrictions from S3 metadata validation 

### DIFF
--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -639,37 +639,6 @@ def document_base64_encoding(param):
     return append.append_documentation
 
 
-def validate_ascii_metadata(params, **kwargs):
-    """Verify S3 Metadata only contains ascii characters.
-
-    From: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
-
-    "Amazon S3 stores user-defined metadata in lowercase. Each name, value pair
-    must conform to US-ASCII when using REST and UTF-8 when using SOAP or
-    browser-based uploads via POST."
-
-    """
-    metadata = params.get('Metadata')
-    if not metadata or not isinstance(metadata, dict):
-        # We have to at least type check the metadata as a dict type
-        # because this handler is called before param validation.
-        # We'll go ahead and return because the param validator will
-        # give a descriptive error message for us.
-        # We might need a post-param validation event.
-        return
-    for key, value in metadata.items():
-        try:
-            key.encode('ascii')
-            value.encode('ascii')
-        except UnicodeEncodeError:
-            error_msg = (
-                'Non ascii characters found in S3 metadata '
-                f'for key "{key}", value: "{value}".  \nS3 metadata can only '
-                'contain ASCII characters. '
-            )
-            raise ParamValidationError(report=error_msg)
-
-
 def fix_route53_ids(params, model, **kwargs):
     """
     Check for and split apart Route53 resource IDs, setting
@@ -1499,12 +1468,6 @@ BUILTIN_HANDLERS = [
     ),
     ('before-parameter-build.s3.CopyObject', handle_copy_source_param),
     ('before-parameter-build.s3.UploadPartCopy', handle_copy_source_param),
-    ('before-parameter-build.s3.CopyObject', validate_ascii_metadata),
-    ('before-parameter-build.s3.PutObject', validate_ascii_metadata),
-    (
-        'before-parameter-build.s3.CreateMultipartUpload',
-        validate_ascii_metadata,
-    ),
     ('before-parameter-build.s3-control', remove_accid_host_prefix_from_model),
     ('docs.*.s3.CopyObject.complete-section', document_copy_source_form),
     ('docs.*.s3.UploadPartCopy.complete-section', document_copy_source_form),

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -1311,6 +1311,22 @@ class TestUnicodeCharsAllowed(BaseS3OperationTest):
                     Metadata={"goodkey": "good", "non-unicode": b"\xff"},
                 )
 
+    def test_validate_non_ascii_unicode_chars_are_accepted(self):
+        op_kwargs = {
+            "Bucket": "mybucket",
+            "Key": "mykey",
+            "Body": b"foo",
+            "Metadata": {"key": "漢字"},
+        }
+        client = _create_s3_client()
+        with ClientHTTPStubber(client) as http_stubber:
+            http_stubber.add_response()
+            client.put_object(**op_kwargs)
+            request_headers = http_stubber.requests[0].headers[
+                "x-amz-meta-key"
+            ]
+            assert request_headers == b'\xe6\xbc\xa2\xe5\xad\x97'
+
     def test_metadata_with_ascii_only_value_is_returned_as_is(self):
         s3 = self.session.create_client("s3")
         with ClientHTTPStubber(s3) as http_stubber:

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1465,16 +1465,3 @@ class TestBucketWithVersions(BaseS3ClientTest):
         versions = self.client.list_object_versions(Bucket=bucket)
         version_ids = self.extract_version_ids(versions)
         self.assertEqual(len(version_ids), 2)
-
-
-class TestS3Metadata(BaseS3ClientTest):
-    def test_can_use_non_ascii_unicode_value_for_metadata(self):
-        # Ensure we get no errors when we use non-ascii
-        # unicode for metadata key or value.
-        response = self.client.put_object(
-            Bucket=self.bucket_name,
-            Key='foo.txt',
-            Body=b'foobar',
-            Metadata={'foo': '云计算'},
-        )
-        self.assert_status_code(response, 200)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1465,3 +1465,16 @@ class TestBucketWithVersions(BaseS3ClientTest):
         versions = self.client.list_object_versions(Bucket=bucket)
         version_ids = self.extract_version_ids(versions)
         self.assertEqual(len(version_ids), 2)
+
+
+class TestS3Metadata(BaseS3ClientTest):
+    def test_can_use_non_ascii_unicode_value_for_metadata(self):
+        # Ensure we get no errors when we use non-ascii
+        # unicode for metadata key or value.
+        response = self.client.put_object(
+            Bucket=self.bucket_name,
+            Key='foo.txt',
+            Body=b'foobar',
+            Metadata={'foo': '云计算'},
+        )
+        self.assert_status_code(response, 200)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -846,26 +846,6 @@ class TestHandlers(BaseSessionTest):
             arn = 'arn:aws:ec2:us-west-2:123456789012:instance:myinstance'
             handlers.validate_bucket_name({'Bucket': arn})
 
-    def test_validate_non_ascii_metadata_values(self):
-        with self.assertRaises(ParamValidationError):
-            handlers.validate_ascii_metadata({'Metadata': {'foo': '\u2713'}})
-
-    def test_validate_non_ascii_metadata_keys(self):
-        with self.assertRaises(ParamValidationError):
-            handlers.validate_ascii_metadata({'Metadata': {'\u2713': 'bar'}})
-
-    def test_validate_non_triggered_when_no_md_specified(self):
-        original = {'NotMetadata': ''}
-        copied = original.copy()
-        handlers.validate_ascii_metadata(copied)
-        self.assertEqual(original, copied)
-
-    def test_validation_passes_when_all_ascii_chars(self):
-        original = {'Metadata': {'foo': 'bar'}}
-        copied = original.copy()
-        handlers.validate_ascii_metadata(original)
-        self.assertEqual(original, copied)
-
     def test_set_encoding_type(self):
         params = {}
         context = {}


### PR DESCRIPTION
This change does the following:
- Removes ASCII character restrictions from S3 metadata validation to allow Unicode characters in metadata values.
- Adds support to decode s3 encoded metadata values.
- Adds tests to validate that the encoded metadata are properly decoded.
- Adds tests to validate that the metadata with non-ascii values are allowed.

The following steps were performed to test the changes:
- Added and successfully ran the newly added tests along with the existing ones.
- Manually validated that s3 accepts non-ASCII unicode chars for metadata.
- Manually validated that the encoded metadata is decoded back to its original value.

