### PR TITLE
Fix use_ssl parameter ignored when custom HTTPS endpoint_url provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ env3
 docs/source/reference/services
 tests/coverage.xml
 tests/nosetests.xml
+botocore_maintest.py

--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,3 @@ env3
 docs/source/reference/services
 tests/coverage.xml
 tests/nosetests.xml
-botocore_maintest.py

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -521,7 +521,11 @@ class EndpointRulesetResolver:
         LOG.debug('Endpoint provider result: %s', provider_result.url)
 
         # The endpoint provider does not support non-secure transport.
-        if not self._use_ssl and provider_result.url.startswith('https://'):
+        if (
+            not self._use_ssl
+            and provider_result.url.startswith('https://')
+            and 'Endpoint' not in provider_params
+        ):
             provider_result = provider_result._replace(
                 url=f'http://{provider_result.url[8:]}'
             )

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -542,3 +542,136 @@ def test_aws_is_virtual_hostable_s3_bucket_allow_subdomains(
 def test_get_attr(rule_lib, value, path, expected_value):
     result = rule_lib.get_attr(value, path)
     assert result == expected_value
+
+
+@pytest.fixture()
+def ssl_resolver_true():
+    return EndpointRulesetResolver(
+        endpoint_ruleset_data={
+            'version': '1.0',
+            'parameters': {},
+            'rules': [],
+        },
+        partition_data={},
+        service_model=None,
+        builtins={},
+        client_context=None,
+        event_emitter=None,
+        use_ssl=True,
+        requested_auth_scheme=None,
+    )
+
+
+@pytest.fixture()
+def ssl_resolver_false():
+    return EndpointRulesetResolver(
+        endpoint_ruleset_data={
+            'version': '1.0',
+            'parameters': {},
+            'rules': [],
+        },
+        partition_data={},
+        service_model=None,
+        builtins={},
+        client_context=None,
+        event_emitter=None,
+        use_ssl=False,
+        requested_auth_scheme=None,
+    )
+
+
+def test_use_ssl_endpoint_combinations(ssl_resolver_true, ssl_resolver_false):
+    """Test all combinations of use_ssl and endpoint_url parameters"""
+    from unittest.mock import patch
+
+    from botocore.endpoint_provider import RuleSetEndpoint
+
+    # use_ssl=True, endpoint_url="http://..." → HTTP (use_ssl seems ignored)
+    with patch.object(
+        ssl_resolver_true._provider, 'resolve_endpoint'
+    ) as mock_resolve:
+        mock_resolve.return_value = RuleSetEndpoint(
+            url='http://custom.com', properties={}, headers={}
+        )
+        with patch.object(
+            ssl_resolver_true,
+            '_get_provider_params',
+            return_value={'Endpoint': 'http://custom.com'},
+        ):
+            result = ssl_resolver_true.construct_endpoint(None, None, None)
+            assert result.url == 'http://custom.com'
+
+    # use_ssl=True, endpoint_url="https://..." → HTTPS (not doing anything - https is used anyway)
+    with patch.object(
+        ssl_resolver_true._provider, 'resolve_endpoint'
+    ) as mock_resolve:
+        mock_resolve.return_value = RuleSetEndpoint(
+            url='https://custom.com', properties={}, headers={}
+        )
+        with patch.object(
+            ssl_resolver_true,
+            '_get_provider_params',
+            return_value={'Endpoint': 'https://custom.com'},
+        ):
+            result = ssl_resolver_true.construct_endpoint(None, None, None)
+            assert result.url == 'https://custom.com'
+
+    # use_ssl=False, endpoint_url="http://..." → HTTP (http is not used anyway)
+    with patch.object(
+        ssl_resolver_false._provider, 'resolve_endpoint'
+    ) as mock_resolve:
+        mock_resolve.return_value = RuleSetEndpoint(
+            url='http://custom.com', properties={}, headers={}
+        )
+        with patch.object(
+            ssl_resolver_false,
+            '_get_provider_params',
+            return_value={'Endpoint': 'http://custom.com'},
+        ):
+            result = ssl_resolver_false.construct_endpoint(None, None, None)
+            assert result.url == 'http://custom.com'
+
+    # use_ssl=False, endpoint_url="https://..." → HTTPS (bug fixed)  (before use_ssl was NOT ignored - it causes protocol downgrade)
+    with patch.object(
+        ssl_resolver_false._provider, 'resolve_endpoint'
+    ) as mock_resolve:
+        mock_resolve.return_value = RuleSetEndpoint(
+            url='https://custom.com', properties={}, headers={}
+        )
+        with patch.object(
+            ssl_resolver_false,
+            '_get_provider_params',
+            return_value={'Endpoint': 'https://custom.com'},
+        ):
+            result = ssl_resolver_false.construct_endpoint(None, None, None)
+            assert result.url == 'https://custom.com'
+
+    # use_ssl=True, no endpoint → HTTPS
+    with patch.object(
+        ssl_resolver_true._provider, 'resolve_endpoint'
+    ) as mock_resolve:
+        mock_resolve.return_value = RuleSetEndpoint(
+            url='https://s3-test-only-domain.amazonaws.com',
+            properties={},
+            headers={},
+        )
+        with patch.object(
+            ssl_resolver_true, '_get_provider_params', return_value={}
+        ):
+            result = ssl_resolver_true.construct_endpoint(None, None, None)
+            assert result.url == 'https://s3-test-only-domain.amazonaws.com'
+
+    # use_ssl=False, no endpoint → HTTP (downgrade applied)
+    with patch.object(
+        ssl_resolver_false._provider, 'resolve_endpoint'
+    ) as mock_resolve:
+        mock_resolve.return_value = RuleSetEndpoint(
+            url='https://s3-test-only-domain.amazonaws.com',
+            properties={},
+            headers={},
+        )
+        with patch.object(
+            ssl_resolver_false, '_get_provider_params', return_value={}
+        ):
+            result = ssl_resolver_false.construct_endpoint(None, None, None)
+            assert result.url == 'http://s3-test-only-domain.amazonaws.com'


### PR DESCRIPTION
Fixes a bug where setting `use_ssl=False` with a custom HTTPS endpoint incorrectly downgrades the connection to HTTP. According to the [documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html), when `endpoint_url` is provided, the `use_ssl` parameter should be ignored. The fix adds a check to ensure this downgrade only happens when no custom endpoint is specified, preserving the HTTPS protocol when customers explicitly provide an HTTPS URL.

**Links:**
- GitHub Issue: https://github.com/boto/boto3/issues/4252
- Code location: https://github.com/boto/botocore/blob/develop/botocore/regions.py#L524
- Documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html

Fixes boto/boto3#4252