### PR TITLE
Fix HTTP 100 Continue parsing to accept optional reason phrase

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -224,9 +224,9 @@ class AWSConnection:
 
     def _is_100_continue_status(self, maybe_status_line):
         parts = maybe_status_line.split(None, 2)
-        # Check for HTTP/<version> 100 Continue\r\n
+        # Check for HTTP/<version> 100 Continue\r\n or HTTP/<version> 100\r\n
         return (
-            len(parts) >= 3
+            len(parts) >= 2
             and parts[0].startswith(b'HTTP/')
             and parts[1] == b'100'
         )

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -442,6 +442,33 @@ class TestAWSHTTPConnection(unittest.TestCase):
             response = conn.getresponse()
             self.assertEqual(response.status, 500)
 
+    def test_expect_100_sends_connection_header_optional_continue(self):
+        # When using squid as an HTTP proxy, it will also send
+        # a Connection: keep-alive header back with the 100 continue
+        # response.  We need to ensure we handle this case.
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
+            # Shows the server first sending a 100 continue response
+            # then a 500 response.  We're picking 500 to confirm we
+            # actually parse the response instead of getting the
+            # default status of 200 which happens when we can't parse
+            # the response.
+            s = FakeSocket(
+                b'HTTP/1.1 100\r\n'  # HTTP/<version> 100\r\n - excluding reason "Continue"
+                b'Connection: keep-alive\r\n'
+                b'\r\n'
+                b'HTTP/1.1 500 Internal Service Error\r\n'
+            )
+            conn = AWSHTTPConnection('s3.amazonaws.com', 443)
+            conn.sock = s
+            wait_mock.return_value = True
+            conn.request(
+                'GET', '/bucket/foo', b'body', {'Expect': b'100-continue'}
+            )
+            # Assert that we waited for the 100-continue response
+            self.assertEqual(wait_mock.call_count, 1)
+            response = conn.getresponse()
+            self.assertEqual(response.status, 500)
+
     def test_expect_100_continue_sends_307(self):
         # This is the case where we send a 100 continue and the server
         # immediately sends a 307


### PR DESCRIPTION
Fixes HTTP 100 Continue parsing to accept responses without reason phrases, as allowed by RFC9110. The `_is_100_continue_status()` method currently requires exactly 3 parts (`HTTP/1.1 100 Continue`), which prevents botocore from recognizing valid HTTP 100 responses, causing the client to never see "100 Continue response seen". This breaks compatibility with legitimate HTTP servers that follow the current HTTP specification. The fix changes `len(parts) >= 3` to `len(parts) >= 2` to accept both formats (`HTTP/1.1 100 Continue` or `HTTP/1.1 100`) while maintaining backward compatibility with existing servers.

**Links:**
- GitHub Issue: https://github.com/boto/botocore/issues/3455
- Code location: https://github.com/boto/botocore/blob/develop/botocore/awsrequest.py
- RFC9110 specification: https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.1

Fixes #3455