### PR TITLE
Add atomic write of creating json cache

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -22,6 +22,7 @@ import os
 import random
 import re
 import socket
+import tempfile
 import time
 import warnings
 import weakref
@@ -3578,11 +3579,34 @@ class JSONFileCache:
             )
         if not os.path.isdir(self._working_dir):
             os.makedirs(self._working_dir, exist_ok=True)
-        with os.fdopen(
-            os.open(full_key, os.O_WRONLY | os.O_CREAT, 0o600), 'w'
-        ) as f:
-            f.truncate()
-            f.write(file_content)
+        try:
+            temp_fd, temp_path = tempfile.mkstemp(
+                dir=self._working_dir,
+                suffix='.tmp'
+            )
+            
+            os.fchmod(temp_fd, 0o600)
+            with os.fdopen(temp_fd, 'w') as f:
+                temp_fd = None
+                f.write(file_content)
+                f.flush()
+                os.fsync(f.fileno())
+            
+            os.replace(temp_path, full_key)
+            temp_path = None
+            
+        except Exception:
+            if temp_fd is not None:
+                try:
+                    os.close(temp_fd)
+                except OSError:
+                    pass
+            if temp_path is not None and os.path.exists(temp_path):
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass
+            raise
 
     def _convert_cache_key(self, cache_key):
         full_path = os.path.join(self._working_dir, cache_key + '.json')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,6 +14,9 @@ import copy
 import datetime
 import io
 import operator
+import shutil
+import tempfile
+import os
 from contextlib import contextmanager
 from sys import getrefcount
 
@@ -54,6 +57,7 @@ from botocore.utils import (
     ArgumentGenerator,
     ArnParser,
     CachedProperty,
+    JSONFileCache, 
     ContainerMetadataFetcher,
     IMDSRegionProvider,
     InstanceMetadataFetcher,
@@ -3679,3 +3683,79 @@ def test_get_token_from_environment_returns_none(
 ):
     monkeypatch.delenv(env_var, raising=False)
     assert get_token_from_environment(signing_name) is None
+
+class TestJSONFileCacheAtomicWrites(unittest.TestCase):
+    """Test atomic write operations in JSONFileCache."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.cache = JSONFileCache(working_dir=self.temp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @mock.patch('os.replace')
+    def test_uses_tempfile_and_replace_for_atomic_write(self, mock_replace):
+
+        self.cache['test_key'] = {'data': 'test_value'}
+        mock_replace.assert_called_once()
+
+        call_args = mock_replace.call_args[0]
+        temp_path = call_args[0]
+        final_path = call_args[1]
+
+        assert '.tmp' in temp_path
+
+    def test_concurrent_writes_same_key(self):
+        """Test concurrent writes to same key don't cause corruption."""
+        import threading
+        
+        key = 'concurrent_test'
+        errors = []
+        
+        def write_worker(thread_id):
+            try:
+                for i in range(3):
+                    self.cache[key] = {'thread': thread_id, 'iteration': i}
+            except Exception as e:
+                errors.append(f'Thread {thread_id}: {e}')
+        
+        threads = [threading.Thread(target=write_worker, args=(i,)) for i in range(3)]
+        
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        
+        self.assertEqual(len(errors), 0, f'Concurrent write errors: {errors}')
+        
+        # Verify final data is valid
+        final_data = self.cache[key]
+        self.assertIsInstance(final_data, dict)
+        self.assertIn('thread', final_data)
+
+    def test_atomic_write_preserves_data_on_failure(self):
+        """Test write failures don't corrupt existing data."""
+        key = 'atomic_test'
+        original_data = {'status': 'original'}
+        
+        self.cache[key] = original_data
+        
+        # Mock write failure
+        original_dumps = self.cache._dumps
+        self.cache._dumps = mock.Mock(side_effect=ValueError('Write failed'))
+        
+        with self.assertRaises(ValueError):
+            self.cache[key] = {'status': 'should_fail'}
+        
+        self.cache._dumps = original_dumps
+        
+        # Verify original data intact
+        self.assertEqual(self.cache[key], original_data)
+
+    def test_no_temp_files_after_write(self):
+        """Test temporary files cleaned up after writes."""
+        self.cache['test'] = {'data': 'value'}
+        
+        temp_files = [f for f in os.listdir(self.temp_dir) if f.endswith('.tmp')]
+        self.assertEqual(len(temp_files), 0, f'Temp files not cleaned: {temp_files}')


### PR DESCRIPTION
Add atomic file writing using `os.replace()` to prevent JSON file corruption that can occur during concurrent access to the file cache. 

**Fix:**
#3106 
#3213 

(aws-cli)
[#9632](https://github.com/aws/aws-cli/issues/9632)