### PR TITLE
Refactor feature ID registration for IMDS and HTTP credential providers

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -44,6 +44,7 @@ from botocore.exceptions import (
     UnknownCredentialError,
 )
 from botocore.tokens import SSOTokenProvider
+from botocore.useragent import register_feature_id
 from botocore.utils import (
     ArnParser,
     ContainerMetadataFetcher,
@@ -1133,6 +1134,7 @@ class InstanceMetadataProvider(CredentialProvider):
         metadata = fetcher.retrieve_iam_role_credentials()
         if not metadata:
             return None
+        register_feature_id('CREDENTIALS_IMDS')
         logger.info(
             'Found credentials from IAM Role: %s', metadata['role_name']
         )
@@ -2060,6 +2062,7 @@ class ContainerProvider(CredentialProvider):
                 response = self._fetcher.retrieve_full_uri(
                     full_uri, headers=headers
                 )
+                register_feature_id('CREDENTIALS_HTTP')
             except MetadataRetrievalError as e:
                 logger.debug(
                     "Error retrieving container metadata: %s", e, exc_info=True

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -26,7 +26,6 @@ from botocore.exceptions import (
     UnsupportedSignatureVersionError,
 )
 from botocore.tokens import FrozenAuthToken
-from botocore.useragent import register_feature_id
 from botocore.utils import (
     ArnParser,
     datetime2timestamp,
@@ -68,11 +67,6 @@ class RequestSigner:
     :type event_emitter: :py:class:`~botocore.hooks.BaseEventHooks`
     :param event_emitter: Extension mechanism to fire events.
     """
-
-    METHOD_FEATURE_MAP = {
-        "container-role": "CREDENTIALS_HTTP",
-        "iam-role": "CREDENTIALS_IMDS",
-    }
 
     def __init__(
         self,
@@ -303,10 +297,6 @@ class RequestSigner:
             return auth
 
         credentials = request_credentials or self._credentials
-        if credentials and (
-            cred_method := getattr(credentials, 'method', None)
-        ):
-            self.check_and_register_feature_id(cred_method)
         if getattr(cls, "REQUIRES_IDENTITY_CACHE", None) is True:
             cache = kwargs["identity_cache"]
             key = kwargs["cache_key"]
@@ -331,10 +321,6 @@ class RequestSigner:
 
     # Alias get_auth for backwards compatibility.
     get_auth = get_auth_instance
-
-    def check_and_register_feature_id(self, method_name):
-        if feature_id := self.METHOD_FEATURE_MAP.get(method_name):
-            register_feature_id(feature_id)
 
     def generate_presigned_url(
         self,

--- a/tests/functional/test_credentials.py
+++ b/tests/functional/test_credentials.py
@@ -1221,12 +1221,17 @@ class TestFeatureIdRegistered:
 
         client = patched_session.create_client("s3", region_name="us-east-1")
         with ClientHTTPStubber(client, strict=True) as http_stubber:
+            # We want to call this twice to assert that the feature id exists
+            # for multiple calls with the same credentials
+            http_stubber.add_response()
             http_stubber.add_response()
             client.list_buckets()
+            client.list_buckets()
 
-        ua_string = get_captured_ua_strings(http_stubber)[0]
-        feature_list = parse_registered_feature_ids(ua_string)
-        assert '0' in feature_list
+        ua_string = get_captured_ua_strings(http_stubber)
+        feature_list_one = parse_registered_feature_ids(ua_string[0])
+        feature_list_two = parse_registered_feature_ids(ua_string[1])
+        assert '0' in feature_list_one and '0' in feature_list_two
 
     @patch("botocore.credentials.ContainerMetadataFetcher.retrieve_full_uri")
     @patch("botocore.credentials.ConfigProvider.load", return_value=None)
@@ -1261,9 +1266,14 @@ class TestFeatureIdRegistered:
 
         client = patched_session.create_client("s3", region_name="us-east-1")
         with ClientHTTPStubber(client, strict=True) as http_stubber:
+            # We want to call this twice to assert that the feature id exists
+            # for multiple calls with the same credentials
+            http_stubber.add_response()
             http_stubber.add_response()
             client.list_buckets()
+            client.list_buckets()
 
-        ua_string = get_captured_ua_strings(http_stubber)[0]
-        feature_list = parse_registered_feature_ids(ua_string)
-        assert 'z' in feature_list
+        ua_string = get_captured_ua_strings(http_stubber)
+        feature_list_one = parse_registered_feature_ids(ua_string[0])
+        feature_list_two = parse_registered_feature_ids(ua_string[1])
+        assert 'z' in feature_list_one and 'z' in feature_list_two


### PR DESCRIPTION
This PR modifies the registration timing of feature IDs for IMDS and HTTPS credentials by moving the registration logic from signers.py to credentials.py. This change ensures feature IDs are registered at the point of credential retrieval rather than during signing. [This](https://github.com/boto/botocore/pull/3539) is the initial PR that registered the two feature ids.

changes:


```
- Moved registration of CREDENTIALS_HTTP and CREDENTIALS_IMDS feature IDs from signers.py to credentials.py
- Modified the functional tests to reflect the changes and validated that the feature ids are registered each time the imds and http credentials are retreived.

Tests:
Validated the changes with functional tests.
```
