### PR TITLE
Add S3 presigned URL signature version documentation notes

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -772,6 +772,16 @@ def generate_presigned_url(
 ):
     """Generate a presigned url given a client, its method, and arguments
 
+    .. note::
+
+        Boto3 defaults to Signature Version 4 for S3 requests. However, in some environments, Signature Version 2 may be used and could potentially cause ``SignatureDoesNotMatch`` errors with presigned URLs.
+        As per `S3 API <https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html>`_, AWS Regions created before January 30, 2014 continue to support Signature Version 2, while newer Regions support only Signature Version 4.
+
+        To ensure consistent Signature Version 4 usage and avoid authentication errors, explicitly configure your client using `Configuration <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_:
+        ``Config(signature_version="s3v4")``
+
+        For presigned URLs with expiry greater than 7 days, specify Signature Version 2: ``Config(signature_version="s3")``
+
     :type ClientMethod: string
     :param ClientMethod: The client method to presign for
 
@@ -854,6 +864,16 @@ def generate_presigned_post(
     self, Bucket, Key, Fields=None, Conditions=None, ExpiresIn=3600
 ):
     """Builds the url and the form fields used for a presigned s3 post
+
+    .. note::
+
+        Boto3 defaults to Signature Version 4 for S3 requests. However, in some environments, Signature Version 2 may be used and could potentially cause ``SignatureDoesNotMatch`` errors with presigned URLs.
+        As per `S3 API <https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html>`_, AWS Regions created before January 30, 2014 continue to support Signature Version 2, while newer Regions support only Signature Version 4.
+
+        To ensure consistent Signature Version 4 usage and avoid authentication errors, explicitly configure your client using `Configuration <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_:
+        ``Config(signature_version="s3v4")``
+
+        For presigned URLs with expiry greater than 7 days, specify Signature Version 2: ``Config(signature_version="s3")``
 
     :type Bucket: string
     :param Bucket: The name of the bucket to presign the post to. Note that


### PR DESCRIPTION
This PR adds documentation notes to clarify S3 presigned URL signature version behavior and proactively set configuration to avoid 
errors such as Signature Mismatch. The changes address GitHub issues https://github.com/boto/boto3/issues/4598 and https://github.com/boto/boto3/issues/4351 where users encounter SignatureDoesNotMatch errors due to 
inconsistent signature version defaults across environments. The PR adds informative notes to the S3 presigned URLs guide and API reference pages,
recommending explicit use of Config(signature_version="s3v4") to ensure consistent Signature Version 4 usage. This documentation improvement 
helps users avoid authentication errors and reduces repetitive support questions about presigned URL signature mismatches.

• S3 Presigned URLs Guide: [https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html ](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html)
• generate_presigned_url API Reference: [https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/generate_presigned ](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/generate_presigned)_
url.html
• generate_presigned_post API Reference: [https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/generate_presigned ](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/generate_presigned)_
post.html
• S3 API Signature Version 4: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html


Tested with Sphinx