### PR TITLE
Fix CancelledError retry loops to enable immediate S3 upload cancellation

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -4,6 +4,7 @@ import os.path
 import socket
 import sys
 import warnings
+from asyncio import CancelledError
 from base64 import b64encode
 
 from urllib3 import PoolManager, Timeout, proxy_from_url
@@ -503,6 +504,12 @@ class URLLib3Session:
             raise ConnectionClosedError(
                 error=e, request=request, endpoint_url=request.url
             )
+
+        # For uses of concurrentFuture, we raise a cancelledError when we need to stop a future; such as a keyboard interrupt.
+        # Catching this here will prevent these errors from being seen as generic HTTPClientErrors which will get retried
+        except CancelledError:
+            raise
+
         except Exception as e:
             message = 'Exception received when sending urllib3 HTTP request'
             logger.debug(message, exc_info=True)

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -4,8 +4,8 @@ import os.path
 import socket
 import sys
 import warnings
-from asyncio import CancelledError
 from base64 import b64encode
+from concurrent.futures import CancelledError
 
 from urllib3 import PoolManager, Timeout, proxy_from_url
 from urllib3.exceptions import (
@@ -504,12 +504,8 @@ class URLLib3Session:
             raise ConnectionClosedError(
                 error=e, request=request, endpoint_url=request.url
             )
-
-        # For uses of concurrentFuture, we raise a cancelledError when we need to stop a future; such as a keyboard interrupt.
-        # Catching this here will prevent these errors from being seen as generic HTTPClientErrors which will get retried
         except CancelledError:
             raise
-
         except Exception as e:
             message = 'Exception received when sending urllib3 HTTP request'
             logger.debug(message, exc_info=True)

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -1,4 +1,5 @@
 import socket
+from concurrent.futures import CancelledError
 
 import pytest
 from urllib3.exceptions import NewConnectionError, ProtocolError, ProxyError
@@ -461,6 +462,12 @@ class TestURLLib3Session(unittest.TestCase):
         error = ProtocolError(None)
         with pytest.raises(ConnectionClosedError):
             self.make_request_with_error(error)
+
+    def test_catches_cancelled_error(self):
+        self.connection.urlopen.side_effect = CancelledError()
+        session = URLLib3Session()
+        with pytest.raises(CancelledError):
+            session.send(self.request.prepare())
 
     def test_catches_proxy_error(self):
         self.connection.urlopen.side_effect = ProxyError('test', None)


### PR DESCRIPTION
When using concurrent.futures to execute tasks asynchronously, if a task is canceled before it is able to be raised, an instance of `concurrent.futures.CanceledError` will be raised.  This can happen if they python interpreter is asked to shut down, for instance if a user presses Ctrl-C.

Any errors raised while the request is in transit will be caught and wrapped in a generic retryable `HTTPClientError` in httpsession.py.  Since the [CancelledError inherits from Python's `Exception` class](https://github.com/python/cpython/blob/af58a6f883108f02996c784de010df62e75f5e13/Lib/concurrent/futures/_base.py#L39-L45), when a cancel is initiated while a request is in-flight this winds up getting caught and the request is retried.  Each retry will also raise a CancelledError, and this will continue until retries are exhausted.  

This PR ensures that Ctrl-C and other cancellation signals immediately stop requests by preventing CancelledError retry loops in the HTTP session, allowing users to terminate operations promptly instead of waiting through lengthy retry cycles. 
