### PR TITLE
Fix setuptools deprecation warnings in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import codecs
 import os.path
 import re
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -44,7 +44,7 @@ setup(
     author='Amazon Web Services',
     url='https://github.com/boto/botocore',
     scripts=[],
-    packages=find_packages(exclude=['tests*']),
+    packages=find_namespace_packages(exclude=['tests*']),
     package_data={
         'botocore': ['cacert.pem', 'data/*.json', 'data/*/*.json'],
         'botocore.vendored.requests': ['*.pem'],
@@ -52,14 +52,13 @@ setup(
     include_package_data=True,
     install_requires=requires,
     extras_require=extras_require,
-    license="Apache License 2.0",
+    license="Apache-2.0",
     python_requires=">= 3.9",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Natural Language :: English',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
When building botocore with `python -m build -w`, setuptools generates deprecation warnings:
1. **License classifier warning**: The `License :: OSI Approved :: Apache Software License` classifier is deprecated in favor of SPDX license expressions
2. **Package discovery warnings**: `botocore.data` directories are not included in the packages configuration, causing setuptools to warn they may be ignored

This PR fixes setuptools deprecation warnings that appear during package building as described above.

## Changes Made

- Removed deprecated `License :: OSI Approved :: Apache Software License` from classifiers
- Added `license="Apache-2.0"` field using SPDX identifier  
- Replaced `find_packages()` with `find_namespace_packages()` to properly include data-only directories
- Updated import to include `find_namespace_packages`

## Testing

- Verified `python -m build -w` runs without warnings
- Confirmed package installation still works correctly
- All existing functionality preserved

Resolves: https://github.com/boto/botocore/issues/3434