### PR TITLE
Fix except block issue in s3 integ tests

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -103,7 +103,7 @@ def clear_out_bucket(bucket, region, delete_bucket=False):
         for _ in range(5):
             try:
                 s3.delete_bucket(Bucket=bucket)
-                break
+                return
             except s3.exceptions.NoSuchBucket:
                 exists_waiter.wait(Bucket=bucket)
             except Exception as e:
@@ -117,9 +117,13 @@ def clear_out_bucket(bucket, region, delete_bucket=False):
                 not_exists_waiter = s3.get_waiter('bucket_not_exists')
                 try:
                     not_exists_waiter.wait(Bucket=bucket)
-                    break
+                    return
                 except WaiterError:
                     continue
+        # If all attempts to delete the bucket fail, we still need to raise an error
+        raise RuntimeError(
+            f"Bucket {bucket} still exists after attempted deletion."
+        )
 
 
 def teardown_module():


### PR DESCRIPTION
During distributed runs of our integration tests, we sometimes encounter a race condition when tearing down S3 buckets. Occasionally, S3 returns the following error during DeleteBucket:

```botocore.exceptions.ClientError: An error occurred (OperationAborted) when calling the DeleteBucket operation: A conflicting conditional operation is currently in progress against this resource. Please try again.```

This likely happens because S3 is still processing final deletes. The current code is intended to retry bucket deletion up to 5 times and wait for the bucket to be deleted if a failure occurs. In the existing logic, the waiter depletes its attempts for and raises a `WaiterError`, which isn’t properly caught or retried, causing the teardown to fail prematurely.

This PR fixes the retry logic to ensure bucket deletions are properly retried and the teardown is more robust against transient S3 errors.