### PR TITLE
Support default millisecond timestamp precision for custom services

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -170,8 +170,11 @@ class ClientArgsCreator:
             proxies_config=new_config.proxies_config,
         )
 
-        serializer_kwargs = {'timestamp_precision': 'second'}
+        # Emit event to allow service-specific or customer customization of serializer kwargs
         event_name = f'creating-serializer.{service_name}'
+        serializer_kwargs = {
+            'timestamp_precision': botocore.serialize.TIMESTAMP_PRECISION_DEFAULT
+        }
         event_emitter.emit(
             event_name,
             protocol_name=protocol,

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -170,8 +170,19 @@ class ClientArgsCreator:
             proxies_config=new_config.proxies_config,
         )
 
+        serializer_kwargs = {'timestamp_precision': 'second'}
+        event_name = f'creating-serializer.{service_name}'
+        event_emitter.emit(
+            event_name,
+            protocol_name=protocol,
+            service_model=service_model,
+            serializer_kwargs=serializer_kwargs,
+        )
+
         serializer = botocore.serialize.create_serializer(
-            protocol, parameter_validation
+            protocol,
+            parameter_validation,
+            timestamp_precision=serializer_kwargs['timestamp_precision'],
         )
         response_parser = botocore.parsers.create_parser(protocol)
 

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -60,6 +60,7 @@ from botocore.exceptions import (
     UnsupportedTLSVersionWarning,
 )
 from botocore.regions import EndpointResolverBuiltins
+from botocore.serialize import TIMESTAMP_PRECISION_MILLISECOND
 from botocore.signers import (
     add_dsql_generate_db_auth_token_methods,
     add_generate_db_auth_token,
@@ -1069,9 +1070,9 @@ def remove_bedrock_runtime_invoke_model_with_bidirectional_stream(
         del class_attributes['invoke_model_with_bidirectional_stream']
 
 
-def customize_bedrock_agentcore_serializer(serializer_kwargs, **kwargs):
-    """Event handler to enable millisecond precision for bedrock-agentcore."""
-    serializer_kwargs['timestamp_precision'] = 'millisecond'
+def enable_millisecond_timestamp_precision(serializer_kwargs, **kwargs):
+    """Event handler to enable millisecond precision"""
+    serializer_kwargs['timestamp_precision'] = TIMESTAMP_PRECISION_MILLISECOND
 
 
 def add_retry_headers(request, **kwargs):
@@ -1478,7 +1479,7 @@ BUILTIN_HANDLERS = [
     ),
     (
         'creating-serializer.bedrock-agentcore',
-        customize_bedrock_agentcore_serializer,
+        enable_millisecond_timestamp_precision,
     ),
     ('after-call.iam', json_decode_policies),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1069,6 +1069,11 @@ def remove_bedrock_runtime_invoke_model_with_bidirectional_stream(
         del class_attributes['invoke_model_with_bidirectional_stream']
 
 
+def customize_bedrock_agentcore_serializer(serializer_kwargs, **kwargs):
+    """Event handler to enable millisecond precision for bedrock-agentcore."""
+    serializer_kwargs['timestamp_precision'] = 'millisecond'
+
+
 def add_retry_headers(request, **kwargs):
     retries_context = request.context.get('retries')
     if not retries_context:
@@ -1470,6 +1475,10 @@ BUILTIN_HANDLERS = [
     (
         'creating-client-class.bedrock-runtime',
         remove_bedrock_runtime_invoke_model_with_bidirectional_stream,
+    ),
+    (
+        'creating-serializer.bedrock-agentcore',
+        customize_bedrock_agentcore_serializer,
     ),
     ('after-call.iam', json_decode_policies),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -67,9 +67,22 @@ ISO8601_MICRO = '%Y-%m-%dT%H:%M:%S.%fZ'
 HOST_PREFIX_RE = re.compile(r"^[A-Za-z0-9\.\-]+$")
 
 
-def create_serializer(protocol_name, include_validation=True):
+def create_serializer(
+    protocol_name, include_validation=True, timestamp_precision='second'
+):
+    """Create a serializer for the given protocol.
+
+    :param protocol_name: The protocol name to create a serializer for.
+    :param include_validation: Whether to include parameter validation.
+    :param timestamp_precision: Timestamp precision level.
+        - 'second': Standard second precision (default)
+        - 'millisecond': Millisecond precision for high-accuracy timestamps
+    :return: A serializer instance for the given protocol.
+    """
     # TODO: Unknown protocols.
-    serializer = SERIALIZERS[protocol_name]()
+    serializer = SERIALIZERS[protocol_name](
+        timestamp_precision=timestamp_precision
+    )
     if include_validation:
         validator = validate.ParamValidator()
         serializer = validate.ParamValidationDecorator(validator, serializer)
@@ -84,6 +97,11 @@ class Serializer:
     # tests.
     MAP_TYPE = dict
     DEFAULT_ENCODING = 'utf-8'
+
+    def __init__(self, timestamp_precision='second'):
+        if timestamp_precision is None:
+            timestamp_precision = 'second'
+        self._timestamp_precision = timestamp_precision
 
     def serialize_to_request(self, parameters, operation_model):
         """Serialize parameters into an HTTP request.
@@ -139,18 +157,36 @@ class Serializer:
     # Some extra utility methods subclasses can use.
 
     def _timestamp_iso8601(self, value):
-        if value.microsecond > 0:
-            timestamp_format = ISO8601_MICRO
+        """Return ISO8601 timestamp with precision based on timestamp_precision."""
+        # Smithy's standard is milliseconds, so we truncate the timestamp if the millisecond flag is set to true
+        if self._timestamp_precision == 'millisecond':
+            milliseconds = value.microsecond // 1000
+            return (
+                value.strftime('%Y-%m-%dT%H:%M:%S') + f'.{milliseconds:03d}Z'
+            )
         else:
-            timestamp_format = ISO8601
-        return value.strftime(timestamp_format)
+            # Otherwise we continue supporting microseconds in iso8601 for legacy reasons
+            if value.microsecond > 0:
+                timestamp_format = ISO8601_MICRO
+            else:
+                timestamp_format = ISO8601
+            return value.strftime(timestamp_format)
 
     def _timestamp_unixtimestamp(self, value):
-        return int(calendar.timegm(value.timetuple()))
+        """Return unix timestamp with precision based on timestamp_precision."""
+        # As of the addition of the precision flag, we support millisecond precision here as well
+        if self._timestamp_precision == 'millisecond':
+            base_timestamp = calendar.timegm(value.timetuple())
+            milliseconds = (value.microsecond // 1000) / 1000.0
+            return base_timestamp + milliseconds
+        else:
+            return int(calendar.timegm(value.timetuple()))
 
     def _timestamp_rfc822(self, value):
+        """Return RFC822 timestamp (always second precision - RFC doesn't support sub-second)."""
+        # RFC 2822 doesn't support sub-second precision, so always use second precision format
         if isinstance(value, datetime.datetime):
-            value = self._timestamp_unixtimestamp(value)
+            value = int(calendar.timegm(value.timetuple()))
         return formatdate(value, usegmt=True)
 
     def _convert_timestamp_to_str(self, value, timestamp_format=None):

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -715,29 +715,22 @@ class TestTimestampPrecisionParameter(unittest.TestCase):
         )
 
     def test_rfc822_timestamp_always_uses_second_precision(self):
-        """RFC822 format doesn't support sub-second precision."""
+        # RFC822 format doesn't support sub-second precision.
         test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 123456)
-
-        # Both second and millisecond modes should produce same result for RFC822
         request_second = self.serialize_to_request(
             {'Rfc822Timestamp': test_datetime},
         )
         request_milli = self.serialize_to_request(
             {'Rfc822Timestamp': test_datetime}, TIMESTAMP_PRECISION_MILLISECOND
         )
-
-        # RFC 2822 doesn't support sub-second precision, so both should be identical
         self.assertEqual(
             request_second['body']['Rfc822Timestamp'],
             request_milli['body']['Rfc822Timestamp'],
         )
-        # Verify it's a valid RFC822 format (e.g., "Mon, 01 Jan 2024 12:00:00 GMT")
         self.assertIn('2024', request_second['body']['Rfc822Timestamp'])
         self.assertIn('GMT', request_second['body']['Rfc822Timestamp'])
 
     def test_invalid_timestamp_precision_raises_error(self):
-        """Invalid timestamp precision values should raise ValueError."""
-
         with self.assertRaises(ValueError) as context:
             serialize.create_serializer(
                 self.service_model.metadata['protocol'],


### PR DESCRIPTION
### Overview:
Currently, only the ISO8601 timestamp format supports sub-second precision (microseconds). However, the [Smithy standard](https://github.com/smithy-lang/smithy/blob/main/designs/defining-timestamps.md#protocol-limitations-rationale) specifies millisecond precision as the maximum supported granularity.

This mismatch is causing issues for bedrock-agentcore, which requires millisecond-precise timestamps to function correctly. This PR adds service-level millisecond precision support that complies with Smithy standards while maintaining backward compatibility.

### Implementation:
Introduces a new `creating-serializer` event that allows services to override timestamp precision during serializer creation. We can customize services to allow them to opt into millisecond precision without requiring client-side configuration changes.

### Alternatives Considered:
- **Client-side configuration:** Environment variables, config files, or SDK parameters. Rejected because this service needs millisecond precision by default - requiring all customers to configure this would create a poor user experience.
- **Operation-level precision:** More granular control per API call. Would require significant architectural changes (similar to parsers.py request-level overrides) that exceed current requirements.
- **Global default change:** Change all services to millisecond precision. Quickly dismissed as a breaking change.
