### PR TITLE
Delete not-useful flaky integ test

### DIFF
--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -89,7 +89,6 @@ SMOKE_TESTS = {
     'sns': {'ListTopics': {}},
     'sqs': {'ListQueues': {}},
     'ssm': {'ListDocuments': {}},
-    'storagegateway': {'ListGateways': {}},
     # sts tests would normally go here, but
     # there aren't any calls you can make when
     # using session credentials so we don't run any


### PR DESCRIPTION
Deleting an old smoke test from this package since it has been consistently flaky.  The service team confirmed this is due to a noisy neighbor.

The test directly above it is also on Json 1.1 and [tests a complex list of structs](https://github.com/boto/botocore/blob/bd9f6c72032f95e1e4a808465bdbe252843cba27/botocore/data/ssm/2014-11-06/service-2.json#L11056-L11068), which is the same as this test.  

No valuable assertions are being lost here.  