### PR TITLE
[Fix] Remove weakref usage in RequestSigner

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -13,6 +13,7 @@
 import base64
 import datetime
 import json
+import weakref
 
 import botocore
 import botocore.auth
@@ -84,7 +85,7 @@ class RequestSigner:
         self._auth_token = auth_token
         self._service_id = service_id
 
-        self._event_emitter = event_emitter
+        self._event_emitter = weakref.proxy(event_emitter)
 
     @property
     def region_name(self):


### PR DESCRIPTION
Remove weakref.proxy usage in RequestSigner. The weakref was added for Python 2.6 memory leak prevention and is no longer needed.

