### PR TITLE
Update documentation for queue attributes

### DIFF
--- a/botocore/data/sqs/2012-11-05/service-2.json
+++ b/botocore/data/sqs/2012-11-05/service-2.json
@@ -834,7 +834,7 @@
           "documentation":"<p>A map of attributes to their respective values.</p>"
         }
       },
-      "documentation":"<p>A list of returned queue attributes.</p>"
+      "documentation":"<p>A dictionary containing a single member, Attributes.</p>"
     },
     "GetQueueUrlRequest":{
       "type":"structure",


### PR DESCRIPTION
*Description of changes:*

Corrects the service definition for the SQS GetQueueAttributes result type which is not a list but a single member dictionary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
