### PR TITLE
Add retries to handle IAM eventual consistency issues

### DIFF
--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -287,7 +287,7 @@ class TestAssumeRoleCredentials(BaseEnvVar):
         s3 = session.create_client('s3')
         s3.list_buckets()
 
-        # Calls to other services should not.Retry on InvalidClientTokenId
+        # Calls to other services should not succeed. Retry on InvalidClientTokenId
         # to handle IAM eventual consistency where credentials may not have
         # fully propagated to all services yet.
         iam = session.create_client('iam')


### PR DESCRIPTION
## Summary

Integration test are failing intermittently due to IAM evential consistency, where newly created credentials hadn't fully propagated across all AWS services yet. This affects tests such as [test_assume_role_with_credential_source](https://github.com/boto/botocore/blob/0f5933b110759ac9f122a51a2aaea83c8168fe80/tests/integration/test_credentials.py#L355). 

The test(s) create and assumes a role with read only access to S3. They then wait for credentials to propagate to STS and makes a successful call to S3. Because the test doesn't have permissions to use the IAM service, it attempts to make a `list_groups` call and expects it to fail with an `AccessDenied` error code. However, because credentials haven't propagated to IAM, we're instead seeing `AccessDenied` errors which cause the test to fail.

This PR adds retry logic with exponential backoff to handle `InvalidClientTokenId` errors in credential integration tests.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
