### PR TITLE
Remove S3 endpoint s3v4 test

### DIFF
--- a/tests/functional/test_regions.py
+++ b/tests/functional/test_regions.py
@@ -450,18 +450,6 @@ def test_single_service_region_endpoint(
     assert result['endpoint_url'] == expected
 
 
-# Ensure that all S3 regions use s3v4 instead of v4
-def test_all_s3_endpoints_have_s3v4(patched_session):
-    session = patched_session
-    partitions = session.get_available_partitions()
-    resolver = session._get_internal_component('endpoint_resolver')
-    for partition_name in partitions:
-        for endpoint in session.get_available_regions('s3', partition_name):
-            resolved = resolver.construct_endpoint('s3', endpoint)
-            assert 's3v4' in resolved['signatureVersions']
-            assert 'v4' not in resolved['signatureVersions']
-
-
 @pytest.mark.parametrize(
     "service_name, expected_endpoint", KNOWN_AWS_PARTITION_WIDE.items()
 )


### PR DESCRIPTION
https://github.com/boto/botocore/pull/3465 swapped the priority of the signature version from `endpoints.json` to EP2.0 and always resolves it to `s3v4` if service name is `s3` or `s3-control`. This existing test is grabbing the resolved signature version directly from `endpoints.json` and is not testing the actual runtime behavior.