### PR TITLE
Update wheel to 0.46.3

### DIFF
--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -110,7 +110,9 @@ jsonschema-specifications==2025.4.1 \
 packaging==25.0 \
     --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
     --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
-    # via pytest
+    # via
+    #   pytest
+    #   wheel
 parse==1.20.2 \
     --hash=sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558 \
     --hash=sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce
@@ -315,7 +317,7 @@ typing-extensions==4.13.2 \
     # via
     #   exceptiongroup
     #   referencing
-wheel==0.43.0 \
-    --hash=sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85 \
-    --hash=sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81
+wheel==0.46.3 \
+    --hash=sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d \
+    --hash=sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803
     # via -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-wheel==0.43.0
+wheel==0.46.3
 behave==1.2.5
 jsonschema==4.23.0
 coverage==7.2.7


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
From dependabot's https://github.com/boto/botocore/pull/3617, but dependabot is upgrading to 0.46.2 which has a known issue causing our CI to fail.  This was fixed in [0.46.3](https://github.com/pypa/wheel/blob/main/docs/news.rst).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
