### PR TITLE
Remove redundant sort from already sorted list

### DIFF
--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -408,7 +408,7 @@ class Loader:
         if service_name not in known_services:
             raise UnknownServiceError(
                 service_name=service_name,
-                known_service_names=', '.join(sorted(known_services)),
+                known_service_names=', '.join(known_services),
             )
         if api_version is None:
             api_version = self.determine_latest_version(


### PR DESCRIPTION
*Description of changes:*
Hello! The `list_available_services` function already guarantees that the returned list is sorted.  
Because of that, calling `sorted(known_services)` is redundant.

This PR removes the extra sort to keep the code simpler and avoid redundant work.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
