### PR TITLE
Change default S3 presign signature from SigV2 to SigV4

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -457,7 +457,7 @@ class ClientCreator:
         # the customer hasn't set a signature version so we default the
         # signature version to sigv2.
         client_meta.events.register(
-            'choose-signer.s3', self._default_s3_presign_to_sigv2
+            'choose-signer.s3', self._default_s3_presign_to_sigv4
         )
 
     def _inject_s3_input_parameters(self, params, context, **kwargs):
@@ -469,11 +469,11 @@ class ClientCreator:
                     inject_parameter
                 ]
 
-    def _default_s3_presign_to_sigv2(self, signature_version, **kwargs):
+    def _default_s3_presign_to_sigv4(self, signature_version, **kwargs):
         """
-        Returns the 's3' (sigv2) signer if presigning an s3 request. This is
-        intended to be used to set the default signature version for the signer
-        to sigv2. Situations where an asymmetric signature is required are the
+        Returns the 's3v4' (sigv4) signer if presigning an s3 request. This is
+        intended to be used to set the default signature version for the signer to sigv4.
+        Situations where an asymmetric signature is required are the
         exception, for example MRAP needs v4a.
 
         :type signature_version: str
@@ -482,7 +482,7 @@ class ClientCreator:
         :type signing_name: str
         :param signing_name: The signing name of the service.
 
-        :return: 's3' if the request is an s3 presign request, None otherwise
+        :return: 's3v4' if the request is an s3 presign request, None otherwise
         """
         if signature_version.startswith('v4a'):
             return
@@ -492,7 +492,7 @@ class ClientCreator:
 
         for suffix in ['-query', '-presign-post']:
             if signature_version.endswith(suffix):
-                return f's3{suffix}'
+                return f's3v4{suffix}'
 
     def _register_importexport_events(
         self,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1985,6 +1985,54 @@ class TestConfig(unittest.TestCase):
             botocore.config.Config(retries={'mode': 'turbo-mode'})
 
 
+class TestS3PresignSignatureVersion(unittest.TestCase):
+    """Test that S3 presigned URLs default to sigv4 instead of sigv2"""
+
+    def setUp(self):
+        self.client_creator = client.ClientCreator(
+            loader=mock.Mock(),
+            endpoint_resolver=mock.Mock(),
+            user_agent='test-agent',
+            event_emitter=mock.Mock(),
+            retry_handler_factory=mock.Mock(),
+            retry_config_translator=mock.Mock(),
+            response_parser_factory=mock.Mock(),
+            exceptions_factory=mock.Mock(),
+            config_store=mock.Mock(),
+            user_agent_creator=mock.Mock(),
+        )
+
+    def test_default_s3_presign_returns_s3v4_query(self):
+        result = self.client_creator._default_s3_presign_to_sigv4(
+            signature_version='v4-query'
+        )
+        self.assertEqual(result, 's3v4-query')
+
+    def test_default_s3_presign_returns_s3v4_presign_post(self):
+        result = self.client_creator._default_s3_presign_to_sigv4(
+            signature_version='v4-presign-post'
+        )
+        self.assertEqual(result, 's3v4-presign-post')
+
+    def test_default_s3_presign_ignores_v4a(self):
+        result = self.client_creator._default_s3_presign_to_sigv4(
+            signature_version='v4a-query'
+        )
+        self.assertIsNone(result)
+
+    def test_default_s3_presign_preserves_s3express(self):
+        result = self.client_creator._default_s3_presign_to_sigv4(
+            signature_version='v4-s3express-query'
+        )
+        self.assertEqual(result, 'v4-s3express-query')
+
+    def test_default_s3_presign_ignores_non_presign_signatures(self):
+        result = self.client_creator._default_s3_presign_to_sigv4(
+            signature_version='v4'
+        )
+        self.assertIsNone(result)
+
+
 class TestClientEndpointBridge(unittest.TestCase):
     def setUp(self):
         self.resolver = mock.Mock()


### PR DESCRIPTION
Changes the default signature version for S3 presign from SigV2 to SigV4, enabling support for conditional headers. SigV2 silently ignores conditional headers like IfNoneMatch and IfMatch, creating security issues. SigV4 supports header signing and is the modern AWS standard. 

Breaking change: Users requiring SigV2 must explicitly set signature_version='s3' in client [config](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file). 

Adresses: https://github.com/boto/boto3/issues/4367 


