### PR TITLE
Remove shortbread domain override

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -198,10 +198,7 @@ function setupKeyboardFriendlyNavigation() {
 
 function loadShortbread() {
 	if (typeof AWSCShortbread !== "undefined") {
-		const shortbread = AWSCShortbread({
-			// If you're testing in your dev environment, use ".cloudfront.net" for domain, else "botocore.amazonaws.com"
-			domain: "botocore.amazonaws.com",
-		});
+		const shortbread = AWSCShortbread();
 
 		// Check for cookie consent
 		shortbread.checkForCookieConsent();


### PR DESCRIPTION
> [!NOTE]
> This is the Botocore version of https://github.com/boto/boto3/pull/4721

### Overview
This PR removes the `domain` parameter passed to `AWSCShortbread` as part of the migration to `docs.aws.amazon.com`. Shortbread guidance specifies that the domain should not be set when running on `.aws.amazon.com`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
