### PR TITLE
Import `ssl` standard library module directly

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -2,6 +2,7 @@ import logging
 import os
 import os.path
 import socket
+import ssl
 import sys
 import warnings
 from base64 import b64encode
@@ -27,7 +28,6 @@ from urllib3.util.ssl_ import (
     OP_NO_SSLv2,
     OP_NO_SSLv3,
     is_ipaddress,
-    ssl,
 )
 from urllib3.util.url import parse_url
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

`botocore.httpsession` imports `ssl` from `urllib3.util.ssl_`, which is simply a reference to the `ssl` module from the Python standard library:

```
Python 3.10.12 (main, Jan 26 2026, 14:55:28) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from urllib3.util.ssl_ import ssl
>>> ssl
<module 'ssl' from '/usr/lib/python3.10/ssl.py'>
```

Avoid the extra degree of indirection by just importing `ssl` from the standard library in `botocore.httpsession`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
