### PR TITLE
Treat empty config subsection values as empty dicts

### DIFF
--- a/botocore/configloader.py
+++ b/botocore/configloader.py
@@ -165,6 +165,13 @@ def raw_config_parse(config_filename, parse_subsections=True):
                             raise botocore.exceptions.ConfigParseError(
                                 path=_unicode_path(path), error=e
                             ) from None
+                    elif parse_subsections and config_value == '':
+                        # An empty value for a subsection key (e.g.
+                        # "s3 =" with nothing after it) should be
+                        # treated as an empty mapping rather than an
+                        # empty string, so that downstream code
+                        # expecting a dict does not break.
+                        config_value = {}
                     config[section][option] = config_value
     return config
 

--- a/tests/unit/cfg/aws_config_nested_empty
+++ b/tests/unit/cfg/aws_config_nested_empty
@@ -1,0 +1,5 @@
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = bar
+s3 =
+region=us-west-2

--- a/tests/unit/test_configloader.py
+++ b/tests/unit/test_configloader.py
@@ -125,6 +125,24 @@ class TestConfigLoader(unittest.TestCase):
             '\nsignature_version = s3v4\naddressing_style = path',
         )
 
+    def test_nested_hierarchy_with_empty_subsection(self):
+        filename = path('aws_config_nested_empty')
+        loaded_config = load_config(filename)
+        config = loaded_config['profiles']['default']
+        self.assertEqual(config['aws_access_key_id'], 'foo')
+        self.assertEqual(config['region'], 'us-west-2')
+        # An empty subsection value (e.g. "s3 =" with nothing after
+        # it) should be treated as an empty dict, not an empty string.
+        self.assertEqual(config['s3'], {})
+
+    def test_nested_hierarchy_empty_subsection_allows_get(self):
+        filename = path('aws_config_nested_empty')
+        loaded_config = load_config(filename)
+        config = loaded_config['profiles']['default']
+        # This should not raise AttributeError on the empty dict.
+        result = config.get('s3', {}).get('use_dualstack_endpoint')
+        self.assertIsNone(result)
+
     def test_nested_bad_config(self):
         filename = path('aws_config_nested_bad')
         with self.assertRaises(botocore.exceptions.ConfigParseError):


### PR DESCRIPTION
## Description

When a config file contains an empty subsection key such as `s3 =` with no value or indented block following it, the INI parser returns an empty string. Downstream code that calls `.get('s3', {}).get(...)` on the parsed config raises `AttributeError` because `str` has no `.get()` method, producing the cryptic message:

```
'str' object has no attribute 'get'
```

This error surfaces for **any** AWS CLI command, not just S3, because botocore checks the s3 config for dualstack endpoint settings during client construction.

## Fix

In `raw_config_parse()`, when `parse_subsections` is enabled and a config value is an empty string, treat it as an empty dict `{}` rather than storing the raw empty string. This matches the logical meaning of an empty subsection block.

## Reproduction

```ini
[default]
region=us-west-2
s3=
endpoint_url=http://localhost:1234/
```

```
$ aws sts get-caller-identity
'str' object has no attribute 'get'
```

After fix, the command proceeds normally (no config parse error for the empty s3 block).

## Testing

- Added test config file `aws_config_nested_empty`
- Added `test_nested_hierarchy_with_empty_subsection`: verifies empty `s3=` produces `{}`
- Added `test_nested_hierarchy_empty_subsection_allows_get`: verifies downstream `.get()` chain works
- All 19 configloader tests pass

Fixes aws/aws-cli#9469

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.