### PR TITLE
Exclude additional hop-by-hop headers from SigV4 signing

### DIFF
--- a/.changes/next-release/enhancement-auth-88913.json
+++ b/.changes/next-release/enhancement-auth-88913.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "auth",
+  "description": "Exclude additional hop-by-hop headers from SigV4 signing to prevent signature mismatches when intermediaries mutate transport headers (connection, keep-alive, proxy-authenticate, proxy-authorization, TE, trailer, upgrade)."
+}

--- a/botocore/auth.py
+++ b/botocore/auth.py
@@ -62,8 +62,15 @@ PAYLOAD_BUFFER = 1024 * 1024
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 SIGV4_TIMESTAMP = '%Y%m%dT%H%M%SZ'
 SIGNED_HEADERS_BLACKLIST = [
+    'connection',
     'expect',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
     'transfer-encoding',
+    'upgrade',
     'user-agent',
     'x-amzn-trace-id',
 ]

--- a/tests/unit/auth/test_signers.py
+++ b/tests/unit/auth/test_signers.py
@@ -386,7 +386,12 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
         )
         auth = self.AuthClass(credentials, 's3', 'us-east-1')
         auth.add_auth(request)
-        self.assertNotIn(header, request.headers['Authorization'])
+        signed_headers = (
+            request.headers['Authorization']
+            .split('SignedHeaders=', 1)[1]
+            .split(',', 1)[0]
+        )
+        self.assertNotIn(header.lower(), signed_headers.split(';'))
 
     def test_blocklist_expect_headers(self):
         self._test_blocklist_header('expect', '100-continue')
@@ -401,6 +406,31 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
 
     def test_blocklist_transfer_encoding_header(self):
         self._test_blocklist_header('transfer-encoding', 'chunked')
+
+    def test_blocklist_connection_header(self):
+        self._test_blocklist_header('connection', 'keep-alive')
+
+    def test_blocklist_keep_alive_header(self):
+        self._test_blocklist_header('keep-alive', 'timeout=5')
+
+    def test_blocklist_proxy_authenticate_header(self):
+        self._test_blocklist_header(
+            'proxy-authenticate', 'Basic realm="proxy.example.com"'
+        )
+
+    def test_blocklist_proxy_authorization_header(self):
+        self._test_blocklist_header(
+            'proxy-authorization', 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'
+        )
+
+    def test_blocklist_te_header(self):
+        self._test_blocklist_header('te', 'trailers')
+
+    def test_blocklist_trailer_header(self):
+        self._test_blocklist_header('trailer', 'x-amz-checksum-sha256')
+
+    def test_blocklist_upgrade_header(self):
+        self._test_blocklist_header('upgrade', 'websocket')
 
     def test_uses_sha256_if_config_value_is_true(self):
         self.client_config.s3['payload_signing_enabled'] = True


### PR DESCRIPTION
## Overview
This PR aligns SigV4 header signing behavior with IAM guidance by excluding additional hop-by-hop headers from signature calculation. This prevents signature mismatch failures when intermediaries (for example, proxies or load balancers) mutate transport headers in transit.

## Background
Botocore already excluded a subset of volatile headers (`expect`, `transfer-encoding`, `user-agent`, `x-amzn-trace-id`), but it did not exclude the full IAM-documented hop-by-hop set.

## Summary
- Added the following headers to `SIGNED_HEADERS_BLACKLIST` in `botocore/auth.py`:
  - `connection`
  - `keep-alive`
  - `proxy-authenticate`
  - `proxy-authorization`
  - `te`
  - `trailer`
  - `upgrade`
- Added unit tests in `tests/unit/auth/test_signers.py` under `TestS3SigV4Auth` to verify each new header is excluded from `SignedHeaders`.
- Updated `_test_blocklist_header` to assert against parsed `SignedHeaders` tokens instead of raw substring matching in the full `Authorization` header (avoids false positives for short header names like `te`).
- Added changelog entry: `.changes/next-release/enhancement-auth-88913.json`.

## Testing
- `python -m pytest tests/unit/auth/test_signers.py`
- Live verification against STS (`GetCallerIdentity`):
  - Signed requests with each new hop-by-hop header present
  - Mutated those headers after signing
  - Confirmed no signature mismatch errors (received successful responses)

## References
- [IAM SigV4 guidance](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
