### PR TITLE
Fix typo in CONTRIBUTING.rst: codstyle to codestyle

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,7 +73,7 @@ Reporting An Issue/Feature
 Codestyle
 ---------
 This project uses `ruff <https://github.com/astral-sh/ruff>`__ to enforce
-codstyle requirements. We've codified this process using a tool called
+codestyle requirements. We've codified this process using a tool called
 `pre-commit <https://pre-commit.com/>`__. pre-commit allows us to specify a
 config file with all tools required for code linting, and surfaces either a
 git commit hook, or single command, for enforcing these.


### PR DESCRIPTION
*Description of changes:*
This PR fixes a typo in CONTRIBUTING.rst, changing "codstyle" to "codestyle".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
