### PR TITLE
Emit after-endpoint-resolution event after endpoint reesolution

### DIFF
--- a/.changes/next-release/enhancement-Events-52626.json
+++ b/.changes/next-release/enhancement-Events-52626.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Events",
+  "description": "Emit an ``after-endpoint-resolution`` event after endpoint resolution is completed."
+}

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -494,6 +494,7 @@ class EndpointRulesetResolver:
         request_context,
     ):
         """Invokes the provider with params defined in the service's ruleset"""
+        service_id = self._service_model.service_id.hyphenize()
         if call_args is None:
             call_args = {}
 
@@ -537,6 +538,13 @@ class EndpointRulesetResolver:
             headers={
                 key: val[0] for key, val in provider_result.headers.items()
             }
+        )
+
+        self._event_emitter.emit(
+            f'after-endpoint-resolution.{service_id}',
+            model=operation_model,
+            context=request_context,
+            provider_result=provider_result,
         )
 
         return provider_result


### PR DESCRIPTION
*Description of changes:*

* Emit an ``after-endpoint-resolution`` event after endpoint resolution is completed. This can be used by downstream applications, such as the AWS CLI v2, to benchmark endpoint resolution time.

*Description of tests:*

* Ran a test script that measures endpoint resolution time, and verified the behavior appears correct:

```python
import time
import botocore.session

start_time = None
end_time = None

def before_handler(builtins, model, params, context, **kwargs):
    global start_time
    if start_time is None:
        start_time = time.time_ns()

def after_handler(**kwargs):
    global end_time
    if end_time is None:
        end_time = time.time_ns()
        print(f'url: {kwargs['provider_result'].url}')


session = botocore.session.get_session()
client = session.create_client('s3')

client.meta.events.register_last(
    'before-endpoint-resolution', before_handler, unique_id='benchmark_eresolution'
)
client.meta.events.register_last(
    'after-endpoint-resolution', after_handler, unique_id='benchmark_eresolution_after'
)

response = client.list_objects_v2(
    Bucket='BUCKETNAME--usw2-az1--x-s3',
)

print(f'endpoint resolution time {(end_time - start_time) / 1000} ms')

```

Output:

```
url: https://BUCKETNAME--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com
endpoint resolution time 225.0 ms
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
