### PR TITLE
Fix bug with auth_scheme_preference when endpoint resolves from EP2.0 or operation-level trait

### DIFF
--- a/.changes/next-release/bugfix-signing-59481.json
+++ b/.changes/next-release/bugfix-signing-59481.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "signing",
+  "description": "Fix bug so that configured auth scheme preference is used when auth scheme is resolved from endpoints rulesets, or from operation-level auth trait. Auth scheme preference can be configured using the existing ``auth_scheme_preference`` client config option, the ``auth_scheme_preference`` shared config setting, or the existing ``AWS_AUTH_SCHEME_PREFERENCE`` environment variable."
+}

--- a/botocore/args.py
+++ b/botocore/args.py
@@ -143,6 +143,7 @@ class ClientArgsCreator:
         s3_disable_express_session_auth = config_kwargs[
             's3_disable_express_session_auth'
         ]
+        auth_scheme_preference = config_kwargs['auth_scheme_preference']
 
         event_emitter = copy.copy(self._event_emitter)
         signer = RequestSigner(
@@ -207,6 +208,7 @@ class ClientArgsCreator:
             credentials,
             account_id_endpoint_mode,
             s3_disable_express_session_auth,
+            auth_scheme_preference,
         )
 
         # Copy the session's user agent factory and adds client configuration.
@@ -736,6 +738,7 @@ class ClientArgsCreator:
         credentials,
         account_id_endpoint_mode,
         s3_disable_express_session_auth,
+        auth_scheme_preference,
     ):
         if endpoints_ruleset_data is None:
             return None
@@ -792,6 +795,7 @@ class ClientArgsCreator:
             event_emitter=event_emitter,
             use_ssl=is_secure,
             requested_auth_scheme=sig_version,
+            auth_scheme_preference=auth_scheme_preference,
         )
 
     def compute_endpoint_resolver_builtin_defaults(

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -18,7 +18,11 @@ from botocore import (
     xform_name,
 )
 from botocore.args import ClientArgsCreator
-from botocore.auth import AUTH_TYPE_MAPS, resolve_auth_type
+from botocore.auth import (
+    AUTH_TYPE_MAPS,
+    resolve_auth_scheme_preference,
+    resolve_auth_type,
+)
 from botocore.awsrequest import prepare_request_dict
 from botocore.compress import maybe_compress_request
 from botocore.config import Config
@@ -1007,11 +1011,23 @@ class BaseClient:
             logger.debug(
                 'Warning: %s.%s() is deprecated', service_name, operation_name
             )
+        # If the operation has the `auth` property and the client has a
+        # configured auth scheme preference, use both to compute the
+        # auth type. Otherwise, fallback to auth/auth_type resolution.
+        if operation_model.auth and self.meta.config.auth_scheme_preference:
+            preferred_schemes = (
+                self.meta.config.auth_scheme_preference.split(',')
+            )
+            auth_type = resolve_auth_scheme_preference(
+                preferred_schemes, operation_model.auth
+            )
+        else:
+            auth_type = operation_model.resolved_auth_type
         request_context = {
             'client_region': self.meta.region_name,
             'client_config': self.meta.config,
             'has_streaming_input': operation_model.has_streaming_input,
-            'auth_type': operation_model.resolved_auth_type,
+            'auth_type': auth_type,
             'unsigned_payload': operation_model.unsigned_payload,
             'auth_options': self._service_model.metadata.get('auth'),
         }

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -1015,8 +1015,8 @@ class BaseClient:
         # configured auth scheme preference, use both to compute the
         # auth type. Otherwise, fallback to auth/auth_type resolution.
         if operation_model.auth and self.meta.config.auth_scheme_preference:
-            preferred_schemes = (
-                self.meta.config.auth_scheme_preference.split(',')
+            preferred_schemes = self.meta.config.auth_scheme_preference.split(
+                ','
             )
             auth_type = resolve_auth_scheme_preference(
                 preferred_schemes, operation_model.auth

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -25,7 +25,11 @@ from enum import Enum
 import jmespath
 
 from botocore import UNSIGNED, xform_name
-from botocore.auth import AUTH_TYPE_MAPS, HAS_CRT
+from botocore.auth import (
+    AUTH_TYPE_MAPS,
+    HAS_CRT,
+    resolve_auth_scheme_preference
+)
 from botocore.crt import CRT_SUPPORTED_AUTH_TYPES
 from botocore.endpoint_provider import EndpointProvider
 from botocore.exceptions import (
@@ -478,6 +482,7 @@ class EndpointRulesetResolver:
         event_emitter,
         use_ssl=True,
         requested_auth_scheme=None,
+        auth_scheme_preference=None,
     ):
         self._provider = EndpointProvider(
             ruleset_data=endpoint_ruleset_data,
@@ -490,6 +495,7 @@ class EndpointRulesetResolver:
         self._event_emitter = event_emitter
         self._use_ssl = use_ssl
         self._requested_auth_scheme = requested_auth_scheme
+        self._auth_scheme_preference = auth_scheme_preference
         self._instance_cache = {}
 
     def construct_endpoint(
@@ -703,6 +709,9 @@ class EndpointRulesetResolver:
         if self._requested_auth_scheme == UNSIGNED:
             return 'none', {}
 
+        available_ruleset_names = [
+            s['name'].split('#')[-1] for s in auth_schemes
+        ]
         auth_schemes = [
             {**scheme, 'name': self._strip_sig_prefix(scheme['name'])}
             for scheme in auth_schemes
@@ -724,6 +733,14 @@ class EndpointRulesetResolver:
                 # exception, instead default to the logic in botocore
                 # customizations.
                 return None, {}
+        elif self._auth_scheme_preference is not None:
+            prefs = self._auth_scheme_preference.split(',')
+            auth_schemes_by_auth_type = {
+                self._strip_sig_prefix(s['name'].split('#')[-1]): s
+                for s in auth_schemes
+            }
+            name = resolve_auth_scheme_preference(prefs, available_ruleset_names)
+            scheme = auth_schemes_by_auth_type[name]
         else:
             try:
                 name, scheme = next(

--- a/botocore/regions.py
+++ b/botocore/regions.py
@@ -28,7 +28,7 @@ from botocore import UNSIGNED, xform_name
 from botocore.auth import (
     AUTH_TYPE_MAPS,
     HAS_CRT,
-    resolve_auth_scheme_preference
+    resolve_auth_scheme_preference,
 )
 from botocore.crt import CRT_SUPPORTED_AUTH_TYPES
 from botocore.endpoint_provider import EndpointProvider
@@ -739,7 +739,9 @@ class EndpointRulesetResolver:
                 self._strip_sig_prefix(s['name'].split('#')[-1]): s
                 for s in auth_schemes
             }
-            name = resolve_auth_scheme_preference(prefs, available_ruleset_names)
+            name = resolve_auth_scheme_preference(
+                prefs, available_ruleset_names
+            )
             scheme = auth_schemes_by_auth_type[name]
         else:
             try:

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -710,7 +710,7 @@ def test_auth_scheme_preference(
             'botocore.auth.AUTH_PREF_TO_SIGNATURE_VERSION',
             {'bar': 'bar', 'foo': 'foo'},
             clear=True,
-        )
+        ),
     ):
         name, scheme = resolver.auth_schemes_to_signing_ctx(auth_schemes)
     assert name == expected_auth_scheme_name

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -82,6 +82,28 @@ ENDPOINT_DICT = {
         ],
     },
 }
+ENDPOINT_AUTH_SCHEMES_DICT = {
+    "url": URL_TEMPLATE,
+    "properties": {
+        "authSchemes": [
+            {
+                "disableDoubleEncoding": True,
+                "name": "foo",
+                "signingName": "s3-outposts",
+                "signingRegionSet": [
+                    "*"
+                ]
+            },
+            {
+                "disableDoubleEncoding": True,
+                "name": "bar",
+                "signingName": "s3-outposts",
+                "signingRegion": REGION_TEMPLATE,
+            },
+        ],
+    },
+    "headers": {},
+}
 
 
 @pytest.fixture(scope="module")
@@ -619,3 +641,78 @@ def test_construct_endpoint_parametrized(
         ):
             result = resolver.construct_endpoint(None, None, None)
             assert result.url == expected_url
+
+
+@pytest.mark.parametrize(
+    "auth_scheme_preference,expected_auth_scheme_name",
+    [
+        (
+            'foo,bar',
+            'foo',
+        ),
+        (
+            'bar,foo',
+            'bar',
+        ),
+        (
+            'xyz,foo,bar',
+            'foo',
+        ),
+    ],
+)
+def test_auth_scheme_preference(
+    auth_scheme_preference,
+    expected_auth_scheme_name,
+    monkeypatch
+):
+    conditions = [
+        PARSE_ARN_FUNC,
+        {
+            "fn": "not",
+            "argv": [STRING_EQUALS_FUNC],
+        },
+        {
+            "fn": "aws.partition",
+            "argv": [REGION_REF],
+            "assign": "PartitionResults",
+        },
+    ],
+    resolver = EndpointRulesetResolver(
+        endpoint_ruleset_data={
+            'version': '1.0',
+            'parameters': {},
+            'rules': [
+                {
+                    'conditions': conditions,
+                    'type': 'endpoint',
+                    'endpoint': ENDPOINT_AUTH_SCHEMES_DICT,
+                }
+            ],
+        },
+        partition_data={},
+        service_model=None,
+        builtins={},
+        client_context=None,
+        event_emitter=None,
+        use_ssl=True,
+        requested_auth_scheme=None,
+        auth_scheme_preference=auth_scheme_preference,
+    )
+    auth_schemes = [
+        {'name': 'foo', 'signingName': 's3', 'signingRegion': 'ap-south-1'},
+        {'name': 'bar', 'signingName': 's3', 'signingRegion': 'ap-south-2'},
+    ]
+    with (
+        patch.dict(
+            'botocore.auth.AUTH_TYPE_MAPS',
+            {'bar': None, 'foo': None},
+            clear=True
+        ),
+        patch.dict(
+            'botocore.auth.AUTH_PREF_TO_SIGNATURE_VERSION',
+            {'bar': 'bar', 'foo': 'foo'},
+            clear=True
+        )
+    ):
+        name, scheme = resolver.auth_schemes_to_signing_ctx(auth_schemes)
+    assert name == expected_auth_scheme_name

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -90,9 +90,7 @@ ENDPOINT_AUTH_SCHEMES_DICT = {
                 "disableDoubleEncoding": True,
                 "name": "foo",
                 "signingName": "s3-outposts",
-                "signingRegionSet": [
-                    "*"
-                ]
+                "signingRegionSet": ["*"],
             },
             {
                 "disableDoubleEncoding": True,
@@ -661,22 +659,22 @@ def test_construct_endpoint_parametrized(
     ],
 )
 def test_auth_scheme_preference(
-    auth_scheme_preference,
-    expected_auth_scheme_name,
-    monkeypatch
+    auth_scheme_preference, expected_auth_scheme_name, monkeypatch
 ):
-    conditions = [
-        PARSE_ARN_FUNC,
-        {
-            "fn": "not",
-            "argv": [STRING_EQUALS_FUNC],
-        },
-        {
-            "fn": "aws.partition",
-            "argv": [REGION_REF],
-            "assign": "PartitionResults",
-        },
-    ],
+    conditions = (
+        [
+            PARSE_ARN_FUNC,
+            {
+                "fn": "not",
+                "argv": [STRING_EQUALS_FUNC],
+            },
+            {
+                "fn": "aws.partition",
+                "argv": [REGION_REF],
+                "assign": "PartitionResults",
+            },
+        ],
+    )
     resolver = EndpointRulesetResolver(
         endpoint_ruleset_data={
             'version': '1.0',
@@ -706,12 +704,12 @@ def test_auth_scheme_preference(
         patch.dict(
             'botocore.auth.AUTH_TYPE_MAPS',
             {'bar': None, 'foo': None},
-            clear=True
+            clear=True,
         ),
         patch.dict(
             'botocore.auth.AUTH_PREF_TO_SIGNATURE_VERSION',
             {'bar': 'bar', 'foo': 'foo'},
-            clear=True
+            clear=True,
         )
     ):
         name, scheme = resolver.auth_schemes_to_signing_ctx(auth_schemes)


### PR DESCRIPTION
*Notes:*

* Ports https://github.com/aws/aws-cli/pull/10169 to botocore.

*Description of changes:*

* auth_scheme_preference is now used to reprioritize auth schemes, if configured, if the endpoint is resolved from the endpoint or from an operation-level trait.

*Description of tests:*

* Successfully ran AWS CLI v2 pre-prod build workflow with the same changes.
* Manually tested `auth_scheme_preference` Client config using the following test cases:

### Endpoint-level auth test

User configured `sigv4` over `sigv4a`. We expect `sigv4` to be used.

AWS shared config file:

```
sigv4a_signing_region_set = us-east-1,us-west-2
```

```
my_config = Config(
    auth_scheme_preference='sigv4,sigv4a'
)
client = session.create_client('s3', region_name='us-east-1', config=my_config)
response = client.get_object(
        Bucket='arn:aws:s3-outposts:us-east-1:REDACTED:outpost/op-REDACTED/accesspoint/my-outpost-ap-2',
        Key='test-object.txt',
)
```

```
DEBUG:botocore.endpoint:Sending http request: 
<AWSPreparedRequest stream_output=True, 
method=GET,
 url=https://my-outpost-ap-2-REDACTED.op-REDACTED.s3-outposts.us-east-1.amazonaws.com/test-object.txt, 
headers={
'x-amz-checksum-mode': b'ENABLED', 
'User-Agent': b'Botocore/1.42.87 md/awscrt#0.31.1 ua/2.1 os/macos#25.4.0 md/arch#arm64 lang/python#3.12.6 md/pyimpl#CPython m/Z,D,b,n cfg/retry-mode#legacy', 
'host': b'my-outpost-ap-2-REDACTED.op-redacted.s3-outposts.us-east-1.amazonaws.com', 
'X-Amz-Security-Token': b'REDACTED', 
'X-Amz-Date': b'20260410T194809Z', 
'x-amz-content-sha256': b'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', 
'Authorization': b'AWS4-HMAC-SHA256 Credential=REDACTED/us-east-1/s3-outposts/aws4_request, SignedHeaders=host;x-amz-checksum-mode;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=0f7f5f80b293bf3e32c574b562d35dd7e6d0117dace3a852c11f340810cba9ca', 
'amz-sdk-invocation-id': b'REDACTED', 
'amz-sdk-request': b'attempt=3; max=5'
}>
```

Result: `AWS4-HMAC-SHA256` in the `Authorization` header value confirms `sigv4` was used. Also, the `X-Amz-Region-Set` header is not set, as expected.

___

User configures `sigv4a` over `sigv4`. We expect `sigv4a` to be used.

AWS shared config file:

```
sigv4a_signing_region_set = us-east-1,us-west-2
```

```
my_config = Config(
    auth_scheme_preference='sigv4a,sigv4'
)
client = session.create_client('s3', region_name='us-east-1', config=my_config)
response = client.get_object(
        Bucket='arn:aws:s3-outposts:us-east-1:REDACTED:outpost/op-REDACTED/accesspoint/my-outpost-ap-2',
        Key='test-object.txt',
)
```

```
DEBUG:botocore.endpoint:Sending http request: 
<AWSPreparedRequest stream_output=True, 
method=GET, 
url=https://my-outpost-ap-2-REDACTED.op-REDACTED.s3-outposts.us-east-1.amazonaws.com/test-object.txt, 
headers={
'x-amz-checksum-mode': b'ENABLED', 
'User-Agent': b'Botocore/1.42.87 md/awscrt#0.31.1 ua/2.1 os/macos#25.4.0 md/arch#arm64 lang/python#3.12.6 md/pyimpl#CPython m/n,Z,b,D,S cfg/retry-mode#legacy', 
'host': b'my-outpost-ap-2-REDACTED.op-redacted.s3-outposts.us-east-1.amazonaws.com', 
'X-Amz-Security-Token': b'REDACTED, 
'X-Amz-Date': b'20260410T195543Z', 
'X-Amz-Region-Set': b'us-east-1,us-west-2', 
'x-amz-content-sha256': b'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', 
'Authorization': b'AWS4-ECDSA-P256-SHA256 Credential=REDACTED/20260410/s3-outposts/aws4_request, SignedHeaders=host;x-amz-checksum-mode;x-amz-content-sha256;x-amz-date;x-amz-region-set;x-amz-security-token, Signature=3046022100d950ebd9f273b73c4f40e78a96963f81937e2e83371f17aa1aee3fefd3504632022100db58d3ce0f57ac8cab22b048e8c45cf672acb33e0f279cb562687871c009b65e', 
'amz-sdk-invocation-id': b'REDACTED', 
'amz-sdk-request': b'attempt=1'}>
```

Result: `AWS4-ECDSA-P256-SHA256` in the `Authorization` header value confirms `sigv4a` was used. Also, `X-Amz-Region-Set` is correctly set to `us-east-1,us-west-2`.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
