### PR TITLE
Support passing session token via create client param

### DIFF
--- a/.changes/next-version.json
+++ b/.changes/next-version.json
@@ -1,0 +1,7 @@
+[
+  {
+    "category": "Session",
+    "description": "Add support for ``aws_bearer_token_bedrock`` parameter in ``Session.create_client()`` to enable per-client Bedrock API key authentication. This allows safe multi-tenant usage without relying on the global ``AWS_BEARER_TOKEN_BEDROCK`` environment variable.",
+    "type": "feature"
+  }
+]

--- a/.changes/next-version.json
+++ b/.changes/next-version.json
@@ -1,7 +1,7 @@
 [
   {
     "category": "Session",
-    "description": "Add support for ``aws_bearer_token_bedrock`` parameter in ``Session.create_client()`` to enable per-client Bedrock API key authentication. This allows safe multi-tenant usage without relying on the global ``AWS_BEARER_TOKEN_BEDROCK`` environment variable.",
+    "description": "Add support for ``aws_bearer_token`` parameter in ``Session.create_client()`` to enable per-client bearer token authentication for services that support it (e.g. Bedrock). This allows safe multi-tenant usage without relying on global environment variables like ``AWS_BEARER_TOKEN_BEDROCK``.",
     "type": "feature"
   }
 ]

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -857,6 +857,7 @@ class Session:
         aws_session_token=None,
         config=None,
         aws_account_id=None,
+        aws_bearer_token_bedrock=None,
     ):
         """Create a botocore client.
 
@@ -927,6 +928,12 @@ class Session:
         :param aws_account_id: The account id to use when creating
             the client.  Same semantics as aws_access_key_id above.
 
+        :type aws_bearer_token_bedrock: string
+        :param aws_bearer_token_bedrock: The Bedrock API key to use for
+            bearer token authentication with Bedrock services. If provided,
+            this takes precedence over the AWS_BEARER_TOKEN_BEDROCK environment
+            variable. Same semantics as aws_access_key_id above.
+
         :rtype: botocore.client.BaseClient
         :return: A botocore client instance
 
@@ -986,6 +993,11 @@ class Session:
             credentials = self.get_credentials()
         if getattr(credentials, 'method', None) == 'explicit':
             register_feature_id('CREDENTIALS_CODE')
+
+        # Create auth token resolver that uses explicit bearer token if provided
+        auth_token_resolver = self._get_auth_token_resolver(
+            aws_bearer_token_bedrock
+        )
         auth_token = self.get_auth_token()
         endpoint_resolver = self._get_internal_component('endpoint_resolver')
         exceptions_factory = self._get_internal_component('exceptions_factory')
@@ -1026,7 +1038,7 @@ class Session:
             exceptions_factory,
             config_store,
             user_agent_creator=user_agent_creator,
-            auth_token_resolver=self.get_auth_token,
+            auth_token_resolver=auth_token_resolver,
         )
         client = client_creator.create_client(
             service_name=service_name,
@@ -1045,6 +1057,34 @@ class Session:
             monitor.register(client.meta.events)
         self._register_client_plugins(client)
         return client
+
+    def _get_auth_token_resolver(self, aws_bearer_token_bedrock=None):
+        """
+        Get an auth token resolver function.
+
+        If aws_bearer_token_bedrock is provided, returns a resolver that
+        uses the explicit token for 'bedrock' signing name, falling back
+        to the default resolver for other services.
+
+        If aws_bearer_token_bedrock is not provided, returns the default
+        get_auth_token method.
+        """
+        if aws_bearer_token_bedrock is None:
+            return self.get_auth_token
+
+        from botocore.tokens import FrozenAuthToken
+
+        bedrock_auth_token = FrozenAuthToken(aws_bearer_token_bedrock)
+
+        def auth_token_resolver(**kwargs):
+            signing_name = kwargs.get('signing_name')
+            # Bedrock services use 'bedrock' as the signing name
+            if signing_name == 'bedrock':
+                return bedrock_auth_token
+            # For other services, use the default resolver
+            return self.get_auth_token(**kwargs)
+
+        return auth_token_resolver
 
     def _resolve_region_name(self, region_name, config):
         # Figure out the user-provided region based on the various

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -27,6 +27,7 @@ import botocore.client
 import botocore.configloader
 import botocore.credentials
 import botocore.tokens
+from botocore.tokens import FrozenAuthToken
 from botocore import (
     UNSIGNED,
     __version__,
@@ -857,7 +858,7 @@ class Session:
         aws_session_token=None,
         config=None,
         aws_account_id=None,
-        aws_bearer_token_bedrock=None,
+        aws_bearer_token=None,
     ):
         """Create a botocore client.
 
@@ -928,11 +929,13 @@ class Session:
         :param aws_account_id: The account id to use when creating
             the client.  Same semantics as aws_access_key_id above.
 
-        :type aws_bearer_token_bedrock: string
-        :param aws_bearer_token_bedrock: The Bedrock API key to use for
-            bearer token authentication with Bedrock services. If provided,
-            this takes precedence over the AWS_BEARER_TOKEN_BEDROCK environment
-            variable. Same semantics as aws_access_key_id above.
+        :type aws_bearer_token: string
+        :param aws_bearer_token: The bearer token to use for
+            authentication with services that support bearer token auth
+            (e.g. Bedrock). If provided, this takes precedence over any
+            bearer token resolved from environment variables (e.g.
+            AWS_BEARER_TOKEN_BEDROCK). Same semantics as
+            aws_access_key_id above.
 
         :rtype: botocore.client.BaseClient
         :return: A botocore client instance
@@ -995,9 +998,7 @@ class Session:
             register_feature_id('CREDENTIALS_CODE')
 
         # Create auth token resolver that uses explicit bearer token if provided
-        auth_token_resolver = self._get_auth_token_resolver(
-            aws_bearer_token_bedrock
-        )
+        auth_token_resolver = self._get_auth_token_resolver(aws_bearer_token)
         auth_token = self.get_auth_token()
         endpoint_resolver = self._get_internal_component('endpoint_resolver')
         exceptions_factory = self._get_internal_component('exceptions_factory')
@@ -1058,31 +1059,24 @@ class Session:
         self._register_client_plugins(client)
         return client
 
-    def _get_auth_token_resolver(self, aws_bearer_token_bedrock=None):
+    def _get_auth_token_resolver(self, aws_bearer_token=None):
         """
         Get an auth token resolver function.
 
-        If aws_bearer_token_bedrock is provided, returns a resolver that
-        uses the explicit token for 'bedrock' signing name, falling back
-        to the default resolver for other services.
+        If aws_bearer_token is provided, returns a resolver that returns
+        the explicit token for any signing name, taking precedence over
+        the default resolver.
 
-        If aws_bearer_token_bedrock is not provided, returns the default
+        If aws_bearer_token is not provided, returns the default
         get_auth_token method.
         """
-        if aws_bearer_token_bedrock is None:
+        if aws_bearer_token is None:
             return self.get_auth_token
 
-        from botocore.tokens import FrozenAuthToken
-
-        bedrock_auth_token = FrozenAuthToken(aws_bearer_token_bedrock)
+        frozen_token = FrozenAuthToken(aws_bearer_token)
 
         def auth_token_resolver(**kwargs):
-            signing_name = kwargs.get('signing_name')
-            # Bedrock services use 'bedrock' as the signing name
-            if signing_name == 'bedrock':
-                return bedrock_auth_token
-            # For other services, use the default resolver
-            return self.get_auth_token(**kwargs)
+            return frozen_token
 
         return auth_token_resolver
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -802,6 +802,53 @@ class TestCreateClient(BaseSessionTest):
         self.assertEqual(credentials.account_id, 'bin')
 
     @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_with_aws_bearer_token_bedrock(self, client_creator):
+        # Test that aws_bearer_token_bedrock is accepted and creates a custom
+        # auth token resolver
+        self.session.create_client(
+            'bedrock-runtime',
+            'us-west-2',
+            aws_bearer_token_bedrock='test-bearer-token',
+        )
+        # Verify the client creator was called
+        self.assertTrue(client_creator.called)
+        # Get the auth_token_resolver passed to ClientCreator
+        call_kwargs = client_creator.call_args[1]
+        auth_token_resolver = call_kwargs['auth_token_resolver']
+        # The resolver should return a FrozenAuthToken for 'bedrock' signing name
+        from botocore.tokens import FrozenAuthToken
+
+        token = auth_token_resolver(signing_name='bedrock')
+        self.assertIsInstance(token, FrozenAuthToken)
+        self.assertEqual(token.token, 'test-bearer-token')
+
+    @mock.patch('botocore.client.ClientCreator')
+    def test_create_client_without_bearer_token_uses_default_resolver(
+        self, client_creator
+    ):
+        # Test that without aws_bearer_token_bedrock, the default resolver is used
+        self.session.create_client('bedrock-runtime', 'us-west-2')
+        call_kwargs = client_creator.call_args[1]
+        auth_token_resolver = call_kwargs['auth_token_resolver']
+        # The resolver should be the session's get_auth_token method
+        self.assertEqual(auth_token_resolver, self.session.get_auth_token)
+
+    @mock.patch('botocore.client.ClientCreator')
+    def test_bearer_token_resolver_fallback_for_other_services(self, client_creator):
+        # Test that the custom resolver falls back to default for non-bedrock services
+        self.session.create_client(
+            's3',
+            'us-west-2',
+            aws_bearer_token_bedrock='test-bearer-token',
+        )
+        call_kwargs = client_creator.call_args[1]
+        auth_token_resolver = call_kwargs['auth_token_resolver']
+        # For non-bedrock signing name, should return None (no token)
+        token = auth_token_resolver(signing_name='s3')
+        # Should fall back to the default resolver which returns None for s3
+        self.assertIsNone(token)
+
+    @mock.patch('botocore.client.ClientCreator')
     def test_create_client_with_ignored_credentials(self, client_creator):
         with self.assertLogs('botocore.session', level='DEBUG') as log:
             self.session.create_client(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -802,20 +802,20 @@ class TestCreateClient(BaseSessionTest):
         self.assertEqual(credentials.account_id, 'bin')
 
     @mock.patch('botocore.client.ClientCreator')
-    def test_create_client_with_aws_bearer_token_bedrock(self, client_creator):
-        # Test that aws_bearer_token_bedrock is accepted and creates a custom
+    def test_create_client_with_aws_bearer_token(self, client_creator):
+        # Test that aws_bearer_token is accepted and creates a custom
         # auth token resolver
         self.session.create_client(
             'bedrock-runtime',
             'us-west-2',
-            aws_bearer_token_bedrock='test-bearer-token',
+            aws_bearer_token='test-bearer-token',
         )
         # Verify the client creator was called
         self.assertTrue(client_creator.called)
         # Get the auth_token_resolver passed to ClientCreator
         call_kwargs = client_creator.call_args[1]
         auth_token_resolver = call_kwargs['auth_token_resolver']
-        # The resolver should return a FrozenAuthToken for 'bedrock' signing name
+        # The resolver should return a FrozenAuthToken
         from botocore.tokens import FrozenAuthToken
 
         token = auth_token_resolver(signing_name='bedrock')
@@ -826,27 +826,12 @@ class TestCreateClient(BaseSessionTest):
     def test_create_client_without_bearer_token_uses_default_resolver(
         self, client_creator
     ):
-        # Test that without aws_bearer_token_bedrock, the default resolver is used
+        # Test that without aws_bearer_token, the default resolver is used
         self.session.create_client('bedrock-runtime', 'us-west-2')
         call_kwargs = client_creator.call_args[1]
         auth_token_resolver = call_kwargs['auth_token_resolver']
         # The resolver should be the session's get_auth_token method
         self.assertEqual(auth_token_resolver, self.session.get_auth_token)
-
-    @mock.patch('botocore.client.ClientCreator')
-    def test_bearer_token_resolver_fallback_for_other_services(self, client_creator):
-        # Test that the custom resolver falls back to default for non-bedrock services
-        self.session.create_client(
-            's3',
-            'us-west-2',
-            aws_bearer_token_bedrock='test-bearer-token',
-        )
-        call_kwargs = client_creator.call_args[1]
-        auth_token_resolver = call_kwargs['auth_token_resolver']
-        # For non-bedrock signing name, should return None (no token)
-        token = auth_token_resolver(signing_name='s3')
-        # Should fall back to the default resolver which returns None for s3
-        self.assertIsNone(token)
 
     @mock.patch('botocore.client.ClientCreator')
     def test_create_client_with_ignored_credentials(self, client_creator):


### PR DESCRIPTION
Groundwork to fix: https://github.com/boto/boto3/issues/4723

This PR adds support for the `aws_bearer_token_bedrock` parameter to `Session.create_client()`, enabling per-client Bedrock API key authentication. This allows safe multi-tenant usage without relying on the global `AWS_BEARER_TOKEN_BEDROCK` environment variable.

### Motivation

Currently, the `AWS_BEARER_TOKEN_BEDROCK` environment variable is the only way to configure a Bedrock API key for bearer token authentication. This creates challenges for multi-tenant systems that need to use different API keys for different clients within the same process:

1. **Thread safety**: Setting the environment variable affects all clients globally
2. **No isolation**: Different tenants cannot use different API keys simultaneously
3. **Security**: API keys cannot be scoped to specific client instances

### Changes

- Added `aws_bearer_token_bedrock` parameter to `Session.create_client()` method
- When provided, creates a custom auth token resolver that returns a `FrozenAuthToken` for the 'bedrock' signing name
- Falls back to the default auth token resolver for non-Bedrock services
- Added unit tests for the new functionality

### Usage

```python
import botocore.session

# Per-client API key
session = botocore.session.get_session()
client = session.create_client(
    'bedrock-runtime',
    region_name='us-east-1',
    aws_bearer_token_bedrock='my-api-key'
)

# Multiple clients with different API keys in the same process
client1 = session.create_client('bedrock-runtime', aws_bearer_token_bedrock='tenant1-key')
client2 = session.create_client('bedrock-runtime', aws_bearer_token_bedrock='tenant2-key')
```
