### PR TITLE
Add validation for WaiterConfig Delay and MaxAttempts values (#3674)

### DIFF
--- a/botocore/waiter.py
+++ b/botocore/waiter.py
@@ -334,6 +334,31 @@ class Waiter:
         self.name = name
         self.config = config
 
+    @staticmethod
+    def _validate_waiter_config(sleep_amount, max_attempts):
+        if (
+            isinstance(sleep_amount, bool)
+            or not isinstance(sleep_amount, (int, float))
+            or sleep_amount < 0
+        ):
+            raise WaiterConfigError(
+                error_msg=(
+                    f'Invalid value for WaiterConfig option Delay: '
+                    f'{sleep_amount!r}. Expected a non-negative number.'
+                )
+            )
+        if (
+            isinstance(max_attempts, bool)
+            or not isinstance(max_attempts, int)
+            or max_attempts < 1
+        ):
+            raise WaiterConfigError(
+                error_msg=(
+                    f'Invalid value for WaiterConfig option MaxAttempts: '
+                    f'{max_attempts!r}. Expected a positive integer.'
+                )
+            )
+
     @with_current_context(partial(register_feature_id, 'WAITER'))
     def wait(self, **kwargs):
         acceptors = list(self.config.acceptors)
@@ -342,6 +367,7 @@ class Waiter:
         config = kwargs.pop('WaiterConfig', {})
         sleep_amount = config.get('Delay', self.config.delay)
         max_attempts = config.get('MaxAttempts', self.config.max_attempts)
+        self._validate_waiter_config(sleep_amount, max_attempts)
         last_matched_acceptor = None
         num_attempts = 0
 

--- a/tests/unit/test_waiters.py
+++ b/tests/unit/test_waiters.py
@@ -732,6 +732,108 @@ class TestWaitersObjects(unittest.TestCase):
 
         self.assertEqual(operation_method.call_count, 2)
 
+    def test_waiter_config_rejects_negative_delay(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'Delay': -1})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_non_numeric_delay(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'Delay': 'fast'})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_zero_max_attempts(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'MaxAttempts': 0})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_negative_max_attempts(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'MaxAttempts': -1})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_non_integer_max_attempts(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'MaxAttempts': 'abc'})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_none_delay(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'Delay': None})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_boolean_delay(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'Delay': True})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_boolean_max_attempts(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'MaxAttempts': True})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_rejects_float_max_attempts(self):
+        config = self.create_waiter_config()
+        operation_method = mock.Mock()
+        waiter = Waiter('MyWaiter', config, operation_method)
+        with self.assertRaises(WaiterConfigError):
+            waiter.wait(WaiterConfig={'MaxAttempts': 1.5})
+        operation_method.assert_not_called()
+
+    def test_waiter_config_accepts_valid_values(self):
+        config = self.create_waiter_config(
+            acceptors=[
+                {'state': 'success', 'matcher': 'status', 'expected': 200},
+            ],
+        )
+        operation_method = mock.Mock()
+        self.client_responses_are(
+            {'ResponseMetadata': {'HTTPStatusCode': 200}},
+            for_operation=operation_method,
+        )
+        waiter = Waiter('MyWaiter', config, operation_method)
+        waiter.wait(WaiterConfig={'Delay': 0, 'MaxAttempts': 1})
+        self.assertEqual(operation_method.call_count, 1)
+
+    def test_waiter_config_accepts_float_delay(self):
+        config = self.create_waiter_config(
+            acceptors=[
+                {'state': 'success', 'matcher': 'status', 'expected': 200},
+            ],
+        )
+        operation_method = mock.Mock()
+        self.client_responses_are(
+            {'ResponseMetadata': {'HTTPStatusCode': 200}},
+            for_operation=operation_method,
+        )
+        waiter = Waiter('MyWaiter', config, operation_method)
+        waiter.wait(WaiterConfig={'Delay': 0.5, 'MaxAttempts': 1})
+        self.assertEqual(operation_method.call_count, 1)
+
 
 class TestCreateWaiter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3674 


*Description of changes:*

`Waiter.wait()` now validates `Delay` and `MaxAttempts` in `WaiterConfig`
before entering the polling loop.

Previously, invalid values caused confusing Python runtime errors or
silently broken behavior:

- `Delay: -1` -> `ValueError` from `time.sleep()`
- `MaxAttempts: 'abc'` -> `TypeError` from `>=` comparison
- `Delay: 0` -> rapid-fire API calls with no sleep
- `MaxAttempts: 0` -> polls once, then immediately raises `WaiterError`

Invalid values now raise `WaiterConfigError` with a clear message before
any API call is made. This is consistent with existing waiter config
validation (unsupported version, unknown matcher).

Validation rules:
- `Delay`: non-negative number (`int` or `float`, not `bool`)
- `MaxAttempts`: positive integer (`>= 1`, not `bool` or `float`)

Note: this intentionally validates against Python built-in numeric types
only (`int`, `float`), consistent with botocore's existing `isinstance`-based
validation patterns. Third-party numeric types (e.g. `numpy.int64`) that
previously worked implicitly via duck typing will now need to be converted
to native Python types before being passed in `WaiterConfig`.

*Description of tests:*

Added 11 unit tests in `tests/unit/test_waiters.py`:

Rejection cases (9):
- `Delay: -1` (negative)
- `Delay: 'fast'` (non-numeric)
- `Delay: None`
- `Delay: True` (bool)
- `MaxAttempts: 0` (zero)
- `MaxAttempts: -1` (negative)
- `MaxAttempts: 'abc'` (non-integer)
- `MaxAttempts: True` (bool)
- `MaxAttempts: 1.5` (float)

Acceptance cases (2):
- `Delay: 0, MaxAttempts: 1` (minimum valid)
- `Delay: 0.5, MaxAttempts: 1` (float delay)

All rejection tests verify `operation_method.assert_not_called()` to confirm
no API call is made before validation fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
