### PR TITLE
fixes utils _parse_timestamp_with_tzinfo

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -958,8 +958,9 @@ def _epoch_seconds_to_datetime(value, tzinfo):
 
 def _parse_timestamp_with_tzinfo(value, tzinfo):
     """Parse timestamp with pluggable tzinfo options."""
-    if isinstance(value, (int, float)):
-        # Possibly an epoch time.
+    if isinstance(value, (int, float))and value > 9999999999:
+        # Possibly an epoch time in milliseconds.
+        value = value / 1000.0
         return datetime.datetime.fromtimestamp(value, tzinfo())
     else:
         try:

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -958,7 +958,7 @@ def _epoch_seconds_to_datetime(value, tzinfo):
 
 def _parse_timestamp_with_tzinfo(value, tzinfo):
     """Parse timestamp with pluggable tzinfo options."""
-    if isinstance(value, (int, float))and value > 9999999999:
+    if isinstance(value, (int, float)) and value > 9999999999:
         # Possibly an epoch time in milliseconds.
         value = value / 1000.0
         return datetime.datetime.fromtimestamp(value, tzinfo())


### PR DESCRIPTION
1. ISSUE:
   list_chats API (devops-agent) returns millisecond-precision epoch timestamps in createdAt/updatedAt fields, causing botocore's _parse_timestamp_with_tzinfo to throw a RuntimeError when parsing the response.

2. STEPS TO REPRODUCE:
   ```python
   import datetime
   import botocore
   from dateutil.tz import tzutc
   import botocore.utils
   
   _original_parse = botocore.utils._parse_timestamp_with_tzinfo
   
   print(f"botocore version: {botocore.__version__}")
   
   # Normal seconds-based epoch — works fine
   normal_value = 1776931200
   print(f"Normal ({normal_value}):", _original_parse(normal_value, tzutc))
   
   # Millisecond epoch as returned by list_chats API — raises RuntimeError
   millis_value = 1776330251517
   print(f"Millis ({millis_value}):", _original_parse(millis_value, tzutc))
   ```

3. EXPECTED:
   Both values parse successfully into datetime objects.
 
4. ACTUAL:
   Second call raises: RuntimeError: Unable to calculate correct timezone offset for "1776330251517"

6. ERROR:
```
File "venv\Lib\site-packages\botocore\[parsers.py](http://parsers.py/)", line 347, in _parse_shape
    return handler(shape, node)
  File "venv\Lib\site-packages\botocore\[parsers.py](http://parsers.py/)", line 725, in _handle_timestamp
    return self._timestamp_parser(value)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "venv\Lib\site-packages\botocore\[utils.py](http://utils.py/)", line 1021, in parse_timestamp
    ^
  File "\venv\Lib\site-packages\botocore\[parsers.py](http://parsers.py/)", line 347, in _parse_shape
    return handler(shape, node)
  File "\venv\Lib\site-packages\botocore\[parsers.py](http://parsers.py/)", line 725, in _handle_timestamp
    return self._timestamp_parser(value)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "\venv\Lib\site-packages\botocore\[utils.py](http://utils.py/)", line 1021, in parse_timestamp
    raise RuntimeError(
        f'Unable to calculate correct timezone offset for "{value}"'
    )
RuntimeError: Unable to calculate correct timezone offset for "1776330251517"
```

7. ROOT CAUSE:
   _parse_timestamp_with_tzinfo in botocore/utils.py (line 9634) passes the value directly to datetime.datetime.fromtimestamp(), which expects seconds. The list_chats API returns timestamps in milliseconds (1776330251517 = 13 digits), causing an overflow that Python cannot resolve to a valid timezone offset:

   ```python
   def _parse_timestamp_with_tzinfo(value, tzinfo):
       if isinstance(value, (int, float)):
           return datetime.datetime.fromtimestamp(value, tzinfo())  # ← fails on ms epoch
     
   ```

8. Affected SERVICE/COMPONENT:

AWS DevOps Agent — ListChats operation
SDK: botocore (confirmed on Python 3.14)
Fields affected: createdAt, updatedAt in ListChats response

9. Suggested fix: divide by 1000.0 to convert to seconds if milliseconds
```python
def _parse_timestamp_with_tzinfo(value, tzinfo):
    """Parse timestamp with pluggable tzinfo options."""
    if isinstance(value, (int, float)) and value > 9999999999:
        # Possibly an epoch time in milliseconds.
        value = value / 1000.0
        return datetime.datetime.fromtimestamp(value, tzinfo())
    else:
        try:
            return datetime.datetime.fromtimestamp(float(value), tzinfo())
        except (TypeError, ValueError):
            pass
    try:
        # In certain cases, a timestamp marked with GMT can be parsed into a
        # different time zone, so here we provide a context which will
        # enforce that GMT == UTC.
        return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
    except (TypeError, ValueError) as e:
        raise ValueError(f'Invalid timestamp "{value}": {e}')
```

---
