### PR TITLE
fix(parser): handle StreamingChecksumBody in generic error response detection

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -309,7 +309,10 @@ class ResponseParser:
             if 'body' not in response or response['body'] is None:
                 return True
 
-            body = response['body'].strip()
+            body = response['body']
+            if not hasattr(body, 'strip'):
+                body = body.read()
+            body = body.strip()
             return body.startswith(b'<html>') or not body
 
     def _do_generic_error_parse(self, response):


### PR DESCRIPTION
## Summary

When response checksums are enabled (e.g. `FlexibleChecksumStrategy`), the response body is wrapped in a `StreamingChecksumBody` object. This object extends `StreamingBody` and does not have a `strip()` method.

```_is_generic_error_response()`` calls `response['body'].strip()` unconditionally, which raises:

```
AttributeError: 'StreamingChecksumBody' object has no attribute 'strip'
```

## Changes

Read the body via `.read()` first when it lacks a `strip()` method before calling `.strip()`. This is safe for error responses (status >= 500) where the body is only needed to detect generic HTML error pages.

Fixes boto/boto3#4754
Related: boto/boto3#4765