### PR TITLE
Fix REQUESTS_CA_BUNDLE directory support in _setup_ssl_cert

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -389,7 +389,11 @@ class URLLib3Session:
     def _setup_ssl_cert(self, conn, url, verify):
         if url.lower().startswith('https') and verify:
             conn.cert_reqs = 'CERT_REQUIRED'
-            conn.ca_certs = get_cert_path(verify)
+            cert_path = get_cert_path(verify)
+            if os.path.isdir(cert_path):
+                conn.ca_cert_dir = cert_path
+            else:
+                conn.ca_certs = cert_path
         else:
             conn.cert_reqs = 'CERT_NONE'
             conn.ca_certs = None


### PR DESCRIPTION
## Summary

When `REQUESTS_CA_BUNDLE` is set to a directory path (which is valid per the requests documentation), botocore raises an `OSError: Is a directory` error because `_setup_ssl_cert` unconditionally assigns the path to `conn.ca_certs`, which expects a file path.

The fix checks whether the cert path is a directory and uses `conn.ca_cert_dir` instead, which is the correct urllib3 attribute for CA certificate directories.

## Issue

Fixes #2731

## Changes

- In `_setup_ssl_cert()`, check `os.path.isdir(cert_path)` before assigning to connection attributes
- Use `ca_cert_dir` for directories, `ca_certs` for files (existing behavior)

**Diff:** 5 lines added, 1 line removed