### PR TITLE
fix(utils): handle malformed JSON in JSONFileCache gracefully

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3569,7 +3569,19 @@ class JSONFileCache:
         try:
             with open(actual_key) as f:
                 return json.load(f)
-        except (OSError, ValueError):
+        except OSError:
+            raise KeyError(cache_key)
+        except ValueError as e:
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "Failed to parse cache file '%s': %s. "
+                "The file will be removed and treated as a cache miss.",
+                actual_key, e,
+            )
+            try:
+                os.remove(actual_key)
+            except OSError:
+                pass
             raise KeyError(cache_key)
 
     def __delitem__(self, cache_key):


### PR DESCRIPTION
When a cache file contains corrupted JSON (e.g., from a partial write or concurrent modification), `JSONFileCache.__getitem__` previously raised a bare `KeyError` showing only the cache key hash, giving users no indication of the root cause.

This change splits the error handling in `__getitem__`:
- `OSError` (file not found): raises `KeyError` immediately — normal cache miss
- `ValueError`/`JSONDecodeError` (malformed JSON): logs a **warning** with the file path and parse error, **removes the corrupted file** to prevent repeated failures on every call, then raises `KeyError` so callers treat it as a cache miss and re-fetch credentials

The corrupted file cleanup is important because without it, the same cryptic error repeats on every subsequent call until the user manually clears the cache directory.

Fixes #3106