### PR TITLE
Fix AttributeError when response body is StreamingBody in error response handling

### DIFF
--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -309,7 +309,10 @@ class ResponseParser:
             if 'body' not in response or response['body'] is None:
                 return True
 
-            body = response['body'].strip()
+            body = response['body']
+            if hasattr(body, 'read'):
+                body = body.read()
+            body = body.strip()
             return body.startswith(b'<html>') or not body
 
     def _do_generic_error_parse(self, response):


### PR DESCRIPTION
## Description

Fixes #4754

When an S3-compatible service (e.g., Wasabi) returns a 5xx error, the error handling path in `_is_generic_error_response` calls `.strip()` on the response body. When checksum validation is enabled (default since 1.36.0), the response body is wrapped in a `StreamingChecksumBody` (or `StreamingBody`) object, which does not have a `.strip()` method. This causes an `AttributeError` that masks the original server error.

## Changes

Read the body content via `.read()` if it is a file-like object before calling `.strip()`. This handles both `StreamingChecksumBody`, `StreamingBody`, and regular bytes/string bodies without affecting existing behavior for non-streaming responses.

## Testing

- Existing test suite passes (83 tests in test_parsers.py)
- The fix is minimal and defensive — only activates when body has a read() method