### PR TITLE
fix: disable warning for mandatory refresh failures

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -599,6 +599,14 @@ class RefreshableCredentials(Credentials):
         try:
             metadata = self._refresh_using()
         except Exception:
+            if is_mandatory:
+                # If this is a mandatory refresh, then
+                # all errors that occur when we attempt to refresh
+                # credentials are propagated back to the user.
+                raise
+            # Only warn if we aren't raising an exception, since that exception
+            # carries the relevant information and can be suppressed more
+            # directly.
             period_name = 'mandatory' if is_mandatory else 'advisory'
             logger.warning(
                 "Refreshing temporary credentials failed "
@@ -606,11 +614,6 @@ class RefreshableCredentials(Credentials):
                 period_name,
                 exc_info=True,
             )
-            if is_mandatory:
-                # If this is a mandatory refresh, then
-                # all errors that occur when we attempt to refresh
-                # credentials are propagated back to the user.
-                raise
             # Otherwise we'll just return.
             # The end result will be that we'll use the current
             # set of temporary credentials we have.

--- a/botocore/tokens.py
+++ b/botocore/tokens.py
@@ -115,14 +115,18 @@ class DeferredRefreshableToken:
             self._next_refresh = now + timedelta(seconds=self._attempt_timeout)
             self._frozen_token = self._refresh_using()
         except Exception:
+            if refresh_type == "mandatory":
+                # This refresh was mandatory, error must be propagated back
+                raise
+
+            # Only warn if we aren't raising an exception, since that exception
+            # carries the relevant information and can be suppressed more
+            # directly.
             logger.warning(
                 "Refreshing token failed during the %s refresh period.",
                 refresh_type,
                 exc_info=True,
             )
-            if refresh_type == "mandatory":
-                # This refresh was mandatory, error must be propagated back
-                raise
 
         if self._is_expired():
             # Fresh credentials should never be expired


### PR DESCRIPTION
*Description of changes:*

During routine operation of AWS SSO sessions via botocore, tokens expire. When they expire, a cascade of exceptions occur before sending the end-user back to the browser to perform OIDC token exchange. These exceptions could be handled silently, but are currently visible as warnings in addition to exceptions. This results in a noisy user experience that can result in inexperienced users thinking the workflow didn't work as intended, when it in fact did.

<img width="2340" height="1323" alt="image" src="https://github.com/user-attachments/assets/6d5d8dcc-fef5-4a74-b7cb-a5305d90dace" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
