### PR TITLE
Enable Dependabot updates for pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
         update-types: ["version-update:semver-patch"]
     cooldown:
       default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,13 @@ exclude: "\
     )"
 repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
-    rev: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: d1b833175a5d08a925900115526febd8fe71c98e  # frozen: v0.15.11
     hooks:
       - id: ruff-check
         args: [ --fix ]

--- a/tests/unit/docs/test_docstring.py
+++ b/tests/unit/docs/test_docstring.py
@@ -35,22 +35,22 @@ class TestLazyLoadedDocstring(unittest.TestCase):
 
     def test_expandtabs(self):
         docstring = MockedLazyLoadedDocstring()
-        docstring.mocked_writer_method.side_effect = (
-            lambda section: section.write('foo\t')
+        docstring.mocked_writer_method.side_effect = lambda section: (
+            section.write('foo\t')
         )
         self.assertEqual('foo ', docstring.expandtabs(1))
 
     def test_str(self):
         docstring = MockedLazyLoadedDocstring()
-        docstring.mocked_writer_method.side_effect = (
-            lambda section: section.write('foo')
+        docstring.mocked_writer_method.side_effect = lambda section: (
+            section.write('foo')
         )
         self.assertEqual('foo', str(docstring))
 
     def test_repr(self):
         docstring = MockedLazyLoadedDocstring()
-        docstring.mocked_writer_method.side_effect = (
-            lambda section: section.write('foo')
+        docstring.mocked_writer_method.side_effect = lambda section: (
+            section.write('foo')
         )
         self.assertEqual('foo', repr(docstring))
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -181,7 +181,7 @@ class TestValidateDocumentType(BaseTestValidate):
             given_shapes=self.shapes,
             input_params={
                 'inlineDocument': {
-                    'number': complex(1j),
+                    'number': 1j,
                     'date': datetime(2017, 4, 27, 0, 0),
                     'list': [invalid_document],
                     'dict': {'foo': (1, 2, 3)},


### PR DESCRIPTION
## Summary

Enable Dependabot support for `pre-commit` hook updates and refresh our current hook pins in `.pre-commit-config.yaml`.

## Why

GitHub added native Dependabot support for `pre-commit` hooks on March 10, 2026 ([source](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/)). With this change, Dependabot can now parse `.pre-commit-config.yaml` and open PRs when hook revisions need to be updated.

This lets us keep our pre-commit tooling current through the same automated workflow we already use for other dependency updates, instead of updating hook versions manually.

## Changes

- Add a `pre-commit` update entry to `.github/dependabot.yml`
- Update `.pre-commit-config.yaml` to the latest hook revisions
- Keep hooks pinned using frozen SHAs for reproducibility

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
