### PR TITLE
Remove list_available_services from client creation happy path

### DIFF
--- a/.changes/next-release/enhancement-Session-37279.json
+++ b/.changes/next-release/enhancement-Session-37279.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``Session``",
+  "description": "Removes list_available_services from the happy path for client creation to save time on client creation"
+}

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -127,7 +127,7 @@ class ClientCreator:
                 service_name, api_version
             )
             partition_data = self._loader.load_data('partitions')
-        except UnknownServiceError:
+        except (UnknownServiceError, DataNotFoundError):
             endpoints_ruleset_data = None
             partition_data = None
             logger.info(

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -404,24 +404,34 @@ class Loader:
         """
         # Wrapper around the load_data.  This will calculate the path
         # to call load_data with.
-        known_services = self.list_available_services(type_name)
-        if service_name not in known_services:
-            raise UnknownServiceError(
-                service_name=service_name,
-                known_service_names=', '.join(known_services),
-            )
         if api_version is None:
-            api_version = self.determine_latest_version(
-                service_name, type_name
-            )
+            try:
+                api_version = self.determine_latest_version(
+                    service_name, type_name
+                )
+            except DataNotFoundError:
+                self._raise_unknown_service_error(service_name, type_name)
         full_path = os.path.join(service_name, api_version, type_name)
-        model = self.load_data(full_path)
+        try:
+            model = self.load_data(full_path)
+        except DataNotFoundError:
+            known_services = self.list_available_services(type_name)
+            if service_name not in known_services:
+                self._raise_unknown_service_error(service_name, type_name)
+            raise
 
         # Load in all the extras
         extras_data = self._find_extras(service_name, type_name, api_version)
         self._extras_processor.process(model, extras_data)
 
         return model
+
+    def _raise_unknown_service_error(self, service_name, type_name):
+        known_services = self.list_available_services(type_name)
+        raise UnknownServiceError(
+            service_name=service_name,
+            known_service_names=', '.join(known_services),
+        )
 
     def _find_extras(self, service_name, type_name, api_version):
         """Creates an iterator over all the extras data."""

--- a/botocore/loaders.py
+++ b/botocore/loaders.py
@@ -404,6 +404,8 @@ class Loader:
         """
         # Wrapper around the load_data.  This will calculate the path
         # to call load_data with.
+        if not self._verify_service_name_casing(service_name):
+            self._raise_unknown_service_error(service_name, type_name)
         if api_version is None:
             try:
                 api_version = self.determine_latest_version(
@@ -412,19 +414,22 @@ class Loader:
             except DataNotFoundError:
                 self._raise_unknown_service_error(service_name, type_name)
         full_path = os.path.join(service_name, api_version, type_name)
-        try:
-            model = self.load_data(full_path)
-        except DataNotFoundError:
-            known_services = self.list_available_services(type_name)
-            if service_name not in known_services:
-                self._raise_unknown_service_error(service_name, type_name)
-            raise
+        model = self.load_data(full_path)
 
         # Load in all the extras
         extras_data = self._find_extras(service_name, type_name, api_version)
         self._extras_processor.process(model, extras_data)
 
         return model
+
+    def _verify_service_name_casing(self, service_name):
+        for path in self.search_paths:
+            try:
+                if service_name in os.listdir(path):
+                    return True
+            except OSError:
+                continue
+        return False
 
     def _raise_unknown_service_error(self, service_name, type_name):
         known_services = self.list_available_services(type_name)

--- a/tests/functional/test_client.py
+++ b/tests/functional/test_client.py
@@ -1,6 +1,27 @@
 import unittest
 
 import botocore
+from botocore.exceptions import DataNotFoundError
+from tests import mock
+
+FAKE_SERVICE_MODEL = {
+    'metadata': {
+        'serviceFullName': 'Custom Service',
+        'apiVersion': '2020-01-01',
+        'endpointPrefix': 'customservice',
+        'signatureVersion': 'v4',
+        'protocol': 'json',
+        'serviceId': 'CustomService',
+    },
+    'operations': {},
+    'shapes': {},
+}
+
+
+def _fake_load_service_model(service_name, type_name, api_version=None):
+    if type_name == 'service-2':
+        return FAKE_SERVICE_MODEL
+    raise DataNotFoundError(data_path='endpoint-rule-set-1')
 
 
 class TestCreateClients(unittest.TestCase):
@@ -19,3 +40,33 @@ class TestCreateClients(unittest.TestCase):
             self.session.create_client(
                 'cloudformation', region_name='invalid region name'
             )
+
+    def test_client_creates_with_missing_endpoint_ruleset(self):
+        # Without explicit api_version, load_service_model converts the
+        # DataNotFoundError into UnknownServiceError via
+        # determine_latest_version. Verify the fallback works.
+        loader = self.session.get_component('data_loader')
+        with mock.patch.object(
+            loader, 'load_service_model', _fake_load_service_model
+        ):
+            client = self.session.create_client(
+                'customservice', region_name='us-east-1'
+            )
+        self.assertIsNotNone(client)
+
+    def test_client_creates_with_missing_endpoint_ruleset_explicit_version(
+        self,
+    ):
+        # With explicit api_version, load_service_model skips
+        # determine_latest_version and load_data raises DataNotFoundError
+        # directly. Verify the fallback catches this too.
+        loader = self.session.get_component('data_loader')
+        with mock.patch.object(
+            loader, 'load_service_model', _fake_load_service_model
+        ):
+            client = self.session.create_client(
+                'customservice',
+                region_name='us-east-1',
+                api_version='2020-01-01',
+            )
+        self.assertIsNotNone(client)

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -174,6 +174,7 @@ class TestLoader(BaseEnvVar):
             loader.determine_latest_version('unknownservice', 'service-2')
 
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
+    @mock.patch('os.listdir', mock.Mock(return_value=['baz']))
     def test_load_service_model(self):
         class FakeLoader:
             def load_file(self, name):
@@ -263,10 +264,14 @@ class TestMergeExtras(BaseEnvVar):
         isdir_mock = mock.Mock(return_value=True)
         self.isdir_patch = mock.patch('os.path.isdir', isdir_mock)
         self.isdir_patch.start()
+        listdir_mock = mock.Mock(return_value=['myservice'])
+        self.listdir_patch = mock.patch('os.listdir', listdir_mock)
+        self.listdir_patch.start()
 
     def tearDown(self):
         super().tearDown()
         self.isdir_patch.stop()
+        self.listdir_patch.stop()
 
     def test_merge_extras(self):
         service_data = {'foo': 'service', 'bar': 'service'}


### PR DESCRIPTION
*Description of changes:*
For all service creation, we have a cached `list_available_services` method that we call, but the output is only used if we encounter an error during client creation.  This iterates through multiple directories to get all available service names, including the botocore/data directory with 424 seconds. 

This PR removes the call to this method if the service is able to be found.  Removing this step removes an average of 45.5ms for successful s3 client creation when run locally on my machine.  The performance improvement of this will vary between machines.

```
import time
import statistics
import botocore.session

times = []
for _ in range(500):
    session = botocore.session.get_session()
    start = time.perf_counter()
    session.create_client('s3', region_name='us-east-1')
    times.append((time.perf_counter() - start) * 1000)

print(f"Average:     {statistics.mean(times):.1f}ms")
p95_index = int(len(times) * 0.95)
print(f"P95:      {sorted(times)[p95_index]:.1f}ms")

# Before:
# Average:     626.4ms
# P95:      838.0ms

# After:
# Average:     580.9ms
# P95:      778.4ms
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
