### PR TITLE
Update awscrt to 0.32.2

### DIFF
--- a/.changes/next-release/enhancement-awscrt-16168.json
+++ b/.changes/next-release/enhancement-awscrt-16168.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "awscrt",
+  "description": "Update awscrt version to 0.32.2"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ requires_dist =
     urllib3>=1.25.4,!=2.2.0,<3; python_version>="3.10"
 
 [options.extras_require]
-crt = awscrt==0.31.2
+crt = awscrt==0.32.2

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requires = [
 ]
 
 extras_require = {
-    'crt': ['awscrt==0.31.2'],
+    'crt': ['awscrt==0.32.2'],
 }
 
 setup(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updates optional CRT pin to https://github.com/awslabs/aws-crt-python/releases/tag/v0.32.2. This includes the latest checksum changes for S3 from https://aws.amazon.com/about-aws/whats-new/2026/04/s3-five-additional-checksum-algorithms/.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
