### PR TITLE
Bump pytest from 8.1.1 to 9.0.3

### DIFF
--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -127,9 +127,13 @@ pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via pytest
-pytest==8.1.1 \
-    --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \
-    --hash=sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via pytest
+pytest==9.0.3 \
+    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
+    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
     # via
     #   -r requirements-dev.txt
     #   pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ setuptools==71.1.0;python_version>="3.12"
 packaging==24.1;python_version>="3.12"  # Requirement for setuptools>=71
 
 # Pytest specific deps
-pytest==8.1.1
+pytest==9.0.3
 pytest-cov==5.0.0
 pytest-xdist==3.5.0
 atomicwrites>=1.0 # Windows requirement


### PR DESCRIPTION
## Summary

Botocore version of https://github.com/boto/boto3/pull/4782 and https://github.com/boto/s3transfer/pull/388.

Dependabot hasn't opened the related PR yet for this repo, but when it does, it will be wrong. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
