### PR TITLE
Add public chain manipulation methods to TokenProviderChain

### DIFF
--- a/.changes/next-release/enhancement-Identity-25418.json
+++ b/.changes/next-release/enhancement-Identity-25418.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Identity",
+  "description": "Add public methods to insert, remove, and retrieve providers in the token provider chain."
+}

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -185,6 +185,12 @@ class TokenRetrievalError(BotoCoreError):
     fmt = 'Error when retrieving token from {provider}: {error_msg}'
 
 
+class UnknownTokenProviderError(BotoCoreError):
+    """Tried to insert before/after an unregistered token provider."""
+
+    fmt = 'Token provider named {name} not found.'
+
+
 class PartialCredentialsError(BotoCoreError):
     """
     Only partial credentials were found.

--- a/botocore/tokens.py
+++ b/botocore/tokens.py
@@ -27,6 +27,7 @@ from botocore.exceptions import (
     ClientError,
     InvalidConfigError,
     TokenRetrievalError,
+    UnknownTokenProviderError,
 )
 from botocore.utils import (
     CachedProperty,
@@ -167,10 +168,74 @@ class TokenProviderChain:
     def __init__(self, providers=None):
         if providers is None:
             providers = []
-        self._providers = providers
+        self.providers = providers
+
+    def insert_before(self, name, token_provider):
+        """Insert a token provider before an existing provider in the chain.
+
+        :param name: The name of the token provider to insert before
+            (e.g. ``env`` or ``sso``). Existing names can be discovered
+            by accessing provider ``METHOD`` attributes.
+        :type name: str
+
+        :param token_provider: The token provider instance to insert.
+
+        :raises UnknownTokenProviderError: If no provider named
+            ``name`` exists in the chain.
+        """
+        offset = self._get_provider_offset(name)
+        self.providers.insert(offset, token_provider)
+
+    def insert_after(self, name, token_provider):
+        """Insert a token provider after an existing provider in the chain.
+
+        :param name: The name of the token provider to insert after
+            (e.g. ``env`` or ``sso``). Existing names can be discovered
+            by accessing provider ``METHOD`` attributes.
+        :type name: str
+
+        :param token_provider: The token provider instance to insert.
+
+        :raises UnknownTokenProviderError: If no provider named
+            ``name`` exists in the chain.
+        """
+        offset = self._get_provider_offset(name)
+        self.providers.insert(offset + 1, token_provider)
+
+    def remove(self, name):
+        """Remove a token provider from the chain by name.
+
+        If no provider with the given name exists, this is a no-op.
+
+        :param name: The name of the token provider to remove.
+        :type name: str
+        """
+        available_methods = [p.METHOD for p in self.providers]
+        if name not in available_methods:
+            return
+
+        offset = available_methods.index(name)
+        self.providers.pop(offset)
+
+    def get_provider(self, name):
+        """Return a token provider by name.
+
+        :param name: The name of the provider to retrieve.
+        :type name: str
+
+        :raises UnknownTokenProviderError: If no provider named
+            ``name`` exists in the chain.
+        """
+        return self.providers[self._get_provider_offset(name)]
+
+    def _get_provider_offset(self, name):
+        try:
+            return [p.METHOD for p in self.providers].index(name)
+        except ValueError:
+            raise UnknownTokenProviderError(name=name)
 
     def load_token(self, **kwargs):
-        for provider in self._providers:
+        for provider in self.providers:
             token = provider.load_token(**kwargs)
             if token is not None:
                 return token

--- a/botocore/tokens.py
+++ b/botocore/tokens.py
@@ -168,7 +168,7 @@ class TokenProviderChain:
     def __init__(self, providers=None):
         if providers is None:
             providers = []
-        self.providers = providers
+        self._providers = providers
 
     def insert_before(self, name, token_provider):
         """Insert a token provider before an existing provider in the chain.
@@ -184,7 +184,7 @@ class TokenProviderChain:
             ``name`` exists in the chain.
         """
         offset = self._get_provider_offset(name)
-        self.providers.insert(offset, token_provider)
+        self._providers.insert(offset, token_provider)
 
     def insert_after(self, name, token_provider):
         """Insert a token provider after an existing provider in the chain.
@@ -200,7 +200,7 @@ class TokenProviderChain:
             ``name`` exists in the chain.
         """
         offset = self._get_provider_offset(name)
-        self.providers.insert(offset + 1, token_provider)
+        self._providers.insert(offset + 1, token_provider)
 
     def remove(self, name):
         """Remove a token provider from the chain by name.
@@ -210,12 +210,12 @@ class TokenProviderChain:
         :param name: The name of the token provider to remove.
         :type name: str
         """
-        available_methods = [p.METHOD for p in self.providers]
+        available_methods = [p.METHOD for p in self._providers]
         if name not in available_methods:
             return
 
         offset = available_methods.index(name)
-        self.providers.pop(offset)
+        self._providers.pop(offset)
 
     def get_provider(self, name):
         """Return a token provider by name.
@@ -226,16 +226,16 @@ class TokenProviderChain:
         :raises UnknownTokenProviderError: If no provider named
             ``name`` exists in the chain.
         """
-        return self.providers[self._get_provider_offset(name)]
+        return self._providers[self._get_provider_offset(name)]
 
     def _get_provider_offset(self, name):
         try:
-            return [p.METHOD for p in self.providers].index(name)
+            return [p.METHOD for p in self._providers].index(name)
         except ValueError:
             raise UnknownTokenProviderError(name=name)
 
     def load_token(self, **kwargs):
-        for provider in self.providers:
+        for provider in self._providers:
             token = provider.load_token(**kwargs)
             if token is not None:
                 return token

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import unittest
 
 import dateutil.parser
 import pytest
@@ -18,12 +19,14 @@ from botocore.exceptions import (
     InvalidConfigError,
     SSOTokenLoadError,
     TokenRetrievalError,
+    UnknownTokenProviderError,
 )
 from botocore.session import Session
 from botocore.tokens import (
     FrozenAuthToken,
     ScopedEnvTokenProvider,
     SSOTokenProvider,
+    TokenProviderChain,
 )
 from tests import mock
 
@@ -384,3 +387,77 @@ def test_scoped_env_token_provider_returns_none_when_signing_name_missing():
     auth_token = provider.load_token()
 
     assert auth_token is None
+
+
+class TokenProviderChainTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.provider1 = mock.Mock()
+        self.provider1.METHOD = 'provider1'
+        self.provider2 = mock.Mock()
+        self.provider2.METHOD = 'provider2'
+
+    def test_inject_provider_before_existing(self):
+        custom_provider = mock.Mock()
+        custom_provider.METHOD = 'custom_provider'
+
+        provider_chain = TokenProviderChain([self.provider1, self.provider2])
+        provider_chain.insert_before(self.provider1.METHOD, custom_provider)
+        provider_chain.load_token()
+
+        custom_provider.load_token.assert_called_once()
+        self.provider1.load_token.assert_not_called()
+
+    def test_insert_before_raises_on_unknown_provider(self):
+        custom_provider = mock.Mock()
+        custom_provider.METHOD = 'custom_provider'
+        provider_chain = TokenProviderChain([self.provider1])
+        with pytest.raises(UnknownTokenProviderError):
+            provider_chain.insert_before('nonexistent', custom_provider)
+
+    def test_inject_provider_after_existing(self):
+        custom_provider = mock.Mock()
+        custom_provider.METHOD = 'custom_provider'
+        custom_provider.load_token.return_value = 'custom-token'
+        self.provider1.load_token.return_value = None
+
+        provider_chain = TokenProviderChain([self.provider1, self.provider2])
+        provider_chain.insert_after(self.provider1.METHOD, custom_provider)
+        loaded_token = provider_chain.load_token()
+
+        assert loaded_token == 'custom-token'
+        self.provider2.load_token.assert_not_called()
+
+    def test_insert_after_raises_on_unknown_provider(self):
+        custom_provider = mock.Mock()
+        custom_provider.METHOD = 'custom_provider'
+        provider_chain = TokenProviderChain([self.provider1])
+        with pytest.raises(UnknownTokenProviderError):
+            provider_chain.insert_after('nonexistent', custom_provider)
+
+    def test_remove_existing_provider(self):
+        provider_chain = TokenProviderChain([self.provider1, self.provider2])
+        provider_chain.remove(self.provider1.METHOD)
+        provider_chain.load_token()
+
+        self.provider1.load_token.assert_not_called()
+        self.provider2.load_token.assert_called_once()
+
+    def test_remove_noops_when_provider_not_present(self):
+        custom_provider = mock.Mock()
+        custom_provider.METHOD = 'custom_provider'
+        provider_chain = TokenProviderChain([self.provider1, self.provider2])
+        provider_chain.remove(custom_provider.METHOD)
+        provider_chain.load_token()
+
+        self.provider1.load_token.assert_called_once()
+
+    def test_get_provider(self):
+        provider_chain = TokenProviderChain([self.provider1, self.provider2])
+        provider = provider_chain.get_provider(self.provider1.METHOD)
+        assert provider == self.provider1
+
+    def test_get_provider_raises_on_unknown_provider(self):
+        provider_chain = TokenProviderChain([self.provider1])
+        with pytest.raises(UnknownTokenProviderError):
+            provider_chain.get_provider('nonexistent')


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/boto/boto3/issues/4723
https://github.com/langchain-ai/langchain-aws/issues/989
https://github.com/strands-agents/sdk-python/issues/1238

*Description of changes:*
Add `insert_before`, `insert_after`, `remove`, and `get_provider` methods to `TokenProviderChain`, mirroring the existing `CredentialResolver` API. This enables runtime manipulation of the token provider chain, allowing users to inject custom token providers at specific positions without relying on environment variables. Also adds `UnknownTokenProviderError` for when a referenced provider name doesn't exist in the chain, and makes `providers` a public attribute.

*Testing*
- Verified that the newly added tests pass 
- Manually verified end-to-end that a custom token provider injected via `insert_before` correctly resolves and produces a Bearer authorization header on outgoing requests
- Verified that all existing tests pass 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
