### PR TITLE
Use an existing function to calculate offset

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -2172,10 +2172,7 @@ class CredentialResolver:
             you'd like to add to the chain.
         :type cred_instance: A subclass of ``Credentials``
         """
-        try:
-            offset = [p.METHOD for p in self.providers].index(name)
-        except ValueError:
-            raise UnknownCredentialError(name=name)
+        offset = self._get_provider_offset(name)
         self.providers.insert(offset, credential_provider)
 
     def insert_after(self, name, credential_provider):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use the existing `_get_provider_offset` function to calculate offset in `insert_before` operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
