### PR TITLE
Add Free Threading support to CI

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15-dev']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       PYO3_USE_ABI3_FORWARD_COMPATIBILITY: ${{ matrix.python-version == '3.15-dev' && '1' || '' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15-dev']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       PYO3_USE_ABI3_FORWARD_COMPATIBILITY: ${{ matrix.python-version == '3.15-dev' && '1' || '' }}

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3.14',
+        'Programming Language :: Python :: Free Threading :: 2 - Beta',
     ],
 )

--- a/tests/functional/leak/test_resource_leaks.py
+++ b/tests/functional/leak/test_resource_leaks.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import sysconfig
+
 from tests import BaseClientDriverTest
 
 
@@ -22,9 +24,15 @@ class TestDoesNotLeakMemory(BaseClientDriverTest):
     # a substantial amount of time to the total test run time.
     INJECT_DUMMY_CREDS = True
     # We're making up numbers here, but let's say arbitrarily
-    # that the memory can't increase by more than 16MB.
+    # that the memory can't increase by more than {SCALING_FACTOR} MBs.
 
-    MAX_GROWTH_BYTES = 16 * 1024 * 1024
+    if sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
+        # Free-threaded Python objects require additional
+        # memory for per-object locks and synchronization.
+        SCALING_FACTOR = 16
+    else:
+        SCALING_FACTOR = 13
+    MAX_GROWTH_BYTES = SCALING_FACTOR * 1024 * 1024
 
     def test_create_single_client_memory_constant(self):
         self.cmd('create_client', 's3')

--- a/tests/functional/leak/test_resource_leaks.py
+++ b/tests/functional/leak/test_resource_leaks.py
@@ -22,10 +22,9 @@ class TestDoesNotLeakMemory(BaseClientDriverTest):
     # a substantial amount of time to the total test run time.
     INJECT_DUMMY_CREDS = True
     # We're making up numbers here, but let's say arbitrarily
-    # that the memory can't increase by more than 13MB.
+    # that the memory can't increase by more than 16MB.
 
-    # TODO: Attempt to bring this back to 10MB once Python 3.14 releases
-    MAX_GROWTH_BYTES = 13 * 1024 * 1024
+    MAX_GROWTH_BYTES = 16 * 1024 * 1024
 
     def test_create_single_client_memory_constant(self):
         self.cmd('create_client', 's3')


### PR DESCRIPTION
*Description of changes:*
The primary blocker for supporting [free threading](https://peps.python.org/pep-0779/) in Boto3/Botocore/Smithy Python was support in the upstream dependency, awscrt. Starting in awscrt 0.32.0 (https://github.com/awslabs/aws-crt-python/pull/725), releases began distributing artifacts for Python 3.13t and 3.14t. While 3.13t was released as experimental, 3.14t is starting to gain adoption.

Given there are no remaining blockers, this PR adds beta support for free threaded builds and makes sure that contract is validated in CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
