### PR TITLE
Add MD5 checksum algorithm support

### DIFF
--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -23,7 +23,7 @@ import base64
 import io
 import logging
 from binascii import crc32
-from hashlib import sha1, sha256, sha512
+from hashlib import md5, sha1, sha256, sha512
 
 from botocore.compat import HAS_CRT, has_minimum_crt_version, urlparse
 from botocore.exceptions import (
@@ -100,6 +100,16 @@ class CrtCrc32Checksum(BaseChecksum):
 
     def digest(self):
         return self._int_crc32.to_bytes(4, byteorder="big")
+
+class Md5Checksum(BaseChecksum):
+    def __init__(self):
+        self._checksum = md5()
+
+    def update(self, chunk):
+        self._checksum.update(chunk)
+
+    def digest(self):
+        return self._checksum.digest()
 
 
 class CrtCrc32cChecksum(BaseChecksum):
@@ -627,6 +637,7 @@ _CHECKSUM_CLS = {
     "sha1": Sha1Checksum,
     "sha256": Sha256Checksum,
     "sha512": Sha512Checksum,
+    "md5": Md5Checksum,
 }
 _CRT_CHECKSUM_ALGORITHMS = [
     "crc32",

--- a/tests/unit/test_httpchecksum.py
+++ b/tests/unit/test_httpchecksum.py
@@ -33,6 +33,7 @@ from botocore.httpchecksum import (
     CrtXxhash3Checksum,
     CrtXxhash64Checksum,
     CrtXxhash128Checksum,
+    Md5Checksum,
     Sha1Checksum,
     Sha256Checksum,
     Sha512Checksum,
@@ -830,6 +831,7 @@ _CHECKSUM_DIGEST_CASES = [
         Sha512Checksum,
         "MJ7MSJwS1utMxA9QyQLytNDtd+5RGnx6m808qG1M2G+YndNbxf9JlnDaNCVbRbDP2DDoH2Bdz33FVC6TrpzXbw==",
     ),
+    (Md5Checksum, "XrY7u+Ae7tCTyyK7j1rNww=="),
 ]
 if HAS_CRT:
     _CHECKSUM_DIGEST_CASES.extend(


### PR DESCRIPTION
## Summary

Fixes `FlexibleChecksumError: Unsupported checksum algorithm: md5` when callers pass `ChecksumAlgorithm=MD5` to S3 operations.

MD5 is a valid S3 checksum algorithm but was not registered in `_CHECKSUM_CLS`, so botocore raised an error at the checksum computation stage even when the algorithm was accepted by the service model.

**Changes:**
- Import `md5` from `hashlib`
- Add `Md5Checksum` class following the same pattern as `Sha1Checksum` and `Sha256Checksum`
- Register `"md5": Md5Checksum` in `_CHECKSUM_CLS`
- Add `Md5Checksum` to the `_CHECKSUM_DIGEST_CASES` parametrized test list

## Related

Companion PR in aws/aws-cli adds `MD5` to the `--checksum-algorithm` choices for high-level `s3` commands.

Relates to aws/aws-cli#10295

## Test plan

- [x] `test_checksum_digest[Md5Checksum-XrY7u+Ae7tCTyyK7j1rNww==]` passes
- [x] All existing `_CHECKSUM_DIGEST_CASES` tests continue to pass

Developed with AI assistance, reviewed and tested by shreyaskommuri