### PR TITLE
Make WaiterError copyable

### DIFF
--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -477,6 +477,12 @@ class WaiterError(BotoCoreError):
         super().__init__(name=name, reason=reason)
         self.last_response = last_response
 
+    def __reduce__(self):
+        return _exception_from_packed_args, (
+            self.__class__,
+            (self.kwargs['name'], self.kwargs['reason'], self.last_response),
+        )
+
 
 class IncompleteReadError(BotoCoreError):
     """HTTP response did not return expected number of bytes."""

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -11,6 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import copy
 import pickle
 
 import botocore.awsrequest
@@ -167,3 +168,31 @@ class TestPickleExceptions(unittest.TestCase):
         self.assertIsInstance(
             unpickled_exception.response, botocore.awsrequest.AWSResponse
         )
+
+    def test_waiter_error(self):
+        exception = botocore.exceptions.WaiterError(
+            name='MyWaiter',
+            reason='MyReason',
+            last_response={'State': 'pending'},
+        )
+        unpickled_exception = pickle.loads(pickle.dumps(exception))
+        self.assertIsInstance(
+            unpickled_exception, botocore.exceptions.WaiterError
+        )
+        self.assertEqual(str(unpickled_exception), str(exception))
+        self.assertEqual(unpickled_exception.kwargs, exception.kwargs)
+        self.assertEqual(
+            unpickled_exception.last_response, exception.last_response
+        )
+
+    def test_waiter_error_can_be_copied(self):
+        exception = botocore.exceptions.WaiterError(
+            name='MyWaiter',
+            reason='MyReason',
+            last_response={'State': 'pending'},
+        )
+        copied_exception = copy.copy(exception)
+        self.assertIsInstance(copied_exception, botocore.exceptions.WaiterError)
+        self.assertEqual(str(copied_exception), str(exception))
+        self.assertEqual(copied_exception.kwargs, exception.kwargs)
+        self.assertEqual(copied_exception.last_response, exception.last_response)


### PR DESCRIPTION
## Summary
- add a __reduce__() implementation for WaiterError so it can be reconstructed with its last_response
- add regression coverage for both pickling and copy.copy()

Fixes #2617.

## Testing
- python3 -m pytest tests/unit/test_exceptions.py -q
- python3 -m pytest tests/unit/test_waiters.py tests/unit/test_exceptions.py -q
- python3 -m ruff check botocore/exceptions.py tests/unit/test_exceptions.py
- git diff --check
