### PR TITLE
Update resource leak test scaling factors and CI Python resolution

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -34,6 +34,7 @@ jobs:
           python-version: '${{ matrix.python-version }}'
           cache: 'pip'
           allow-prereleases: true
+          check-latest: true
       - name: Install dependencies and CRT
         run: |
           python scripts/ci/install --extras crt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,7 @@ jobs:
           python-version: '${{ matrix.python-version }}'
           cache: 'pip'
           allow-prereleases: true
+          check-latest: true
       - name: Install dependencies
         run: |
           python scripts/ci/install

--- a/tests/functional/leak/test_resource_leaks.py
+++ b/tests/functional/leak/test_resource_leaks.py
@@ -31,7 +31,7 @@ class TestDoesNotLeakMemory(BaseClientDriverTest):
         # memory for per-object locks and synchronization.
         SCALING_FACTOR = 16
     else:
-        SCALING_FACTOR = 13
+        SCALING_FACTOR = 4
     MAX_GROWTH_BYTES = SCALING_FACTOR * 1024 * 1024
 
     def test_create_single_client_memory_constant(self):

--- a/tests/functional/leak/test_resource_leaks.py
+++ b/tests/functional/leak/test_resource_leaks.py
@@ -29,7 +29,7 @@ class TestDoesNotLeakMemory(BaseClientDriverTest):
     if sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
         # Free-threaded Python objects require additional
         # memory for per-object locks and synchronization.
-        SCALING_FACTOR = 16
+        SCALING_FACTOR = 17
     else:
         SCALING_FACTOR = 4
     MAX_GROWTH_BYTES = SCALING_FACTOR * 1024 * 1024


### PR DESCRIPTION
## Summary
Python 3.14.5 [reverted the incremental garbage collector](https://www.python.org/downloads/release/python-3145/) that was introduced in 3.14.0, restoring the generational GC from 3.13 due to reports of significant memory pressure in production environments.

The `MAX_GROWTH_BYTES` scaling factor in our resource leak tests had been bumped from 10 MB to 12 MB and then 13 MB to absorb the additional memory growth caused by the incremental GC (see #3522, which added a TODO to lower it once 3.14 stabilized). With the revert in 3.14.5, that headroom is no longer needed.

This PR includes the following changes:

- Drops the standard (non-free-threaded) `SCALING_FACTOR` from 13 to 4, giving us tighter regression detection.
- Bumps the free-threaded `SCALING_FACTOR` from 16 to 17 after observing repeated CI failures at 16. Per-object locking in free-threaded builds still requires the additional headroom.
- Adds `check-latest: true` to the `setup-python` step in `run-tests.yml` and `run-crt-test.yml` so CI always resolves to the latest available patch release rather than a cached older version, ensuring we pick up fixes like the 3.14.5 GC revert promptly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.