### PR TITLE
null values in sparse map serialization and deserialization

### DIFF
--- a/.changes/next-release/bugfix-Serialization-42891.json
+++ b/.changes/next-release/bugfix-Serialization-42891.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Serialization",
+  "description": "Handle null values in sparse map serialization for JSON and CBOR protocols, and fix the CBOR map parser which was silently dropping null values instead of preserving them."
+}

--- a/botocore/parsers.py
+++ b/botocore/parsers.py
@@ -714,7 +714,12 @@ class BaseJSONParser(ResponseParser):
         value_shape = shape.value
         for key, value in value.items():
             actual_key = self._parse_shape(key_shape, key)
-            actual_value = self._parse_shape(value_shape, value)
+            # Treat all maps as sparse during parsing to safely handle null
+            # values that may be present in service responses.
+            if value is None:
+                actual_value = None
+            else:
+                actual_value = self._parse_shape(value_shape, value)
             parsed[actual_key] = actual_value
         return parsed
 
@@ -892,8 +897,7 @@ class BaseCBORParser(ResponseParser):
     def _parse_key_value_pair(self, stream, items):
         key = self.parse_data_item(stream)
         value = self.parse_data_item(stream)
-        if value is not None:
-            items[key] = value
+        items[key] = value
 
     # Major type 6 is tags.  The only tag we currently support is tag 1 for unix
     # timestamps

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -481,19 +481,27 @@ class JSONSerializer(Serializer):
         map_obj = self.MAP_TYPE()
         serialized[key] = map_obj
         for sub_key, sub_value in value.items():
-            self._serialize(map_obj, sub_value, shape.value, sub_key)
+            if sub_value is None:
+                map_obj[sub_key] = None
+            else:
+                self._serialize(map_obj, sub_value, shape.value, sub_key)
 
     def _serialize_type_list(self, serialized, value, shape, key):
         list_obj = []
         serialized[key] = list_obj
         for list_item in value:
-            wrapper = {}
-            # The JSON list serialization is the only case where we aren't
-            # setting a key on a dict.  We handle this by using
-            # a __current__ key on a wrapper dict to serialize each
-            # list item before appending it to the serialized list.
-            self._serialize(wrapper, list_item, shape.member, "__current__")
-            list_obj.append(wrapper["__current__"])
+            if list_item is None:
+                list_obj.append(None)
+            else:
+                wrapper = {}
+                # The JSON list serialization is the only case where we aren't
+                # setting a key on a dict.  We handle this by using
+                # a __current__ key on a wrapper dict to serialize each
+                # list item before appending it to the serialized list.
+                self._serialize(
+                    wrapper, list_item, shape.member, "__current__"
+                )
+                list_obj.append(wrapper["__current__"])
 
     def _default_serialize(self, serialized, value, shape, key):
         serialized[key] = value
@@ -604,7 +612,14 @@ class CBORSerializer(Serializer):
         else:
             serialized.extend(initial_byte + length.to_bytes(num_bytes, "big"))
         for item in value:
-            self._serialize_data_item(serialized, item, shape.member)
+            if item is None:
+                serialized.extend(
+                    self._get_initial_byte(
+                        self.FLOAT_AND_SIMPLE_MAJOR_TYPE, 22
+                    )
+                )
+            else:
+                self._serialize_data_item(serialized, item, shape.member)
 
     def _serialize_type_map(self, serialized, value, shape, key):
         length = len(value)
@@ -620,7 +635,14 @@ class CBORSerializer(Serializer):
             serialized.extend(initial_byte + length.to_bytes(num_bytes, "big"))
         for key_item, item in value.items():
             self._serialize_data_item(serialized, key_item, shape.key)
-            self._serialize_data_item(serialized, item, shape.value)
+            if item is None:
+                serialized.extend(
+                    self._get_initial_byte(
+                        self.FLOAT_AND_SIMPLE_MAJOR_TYPE, 22
+                    )
+                )
+            else:
+                self._serialize_data_item(serialized, item, shape.value)
 
     def _serialize_type_structure(self, serialized, value, shape, key):
         if key is not None:

--- a/tests/unit/protocols/input/ec2.json
+++ b/tests/unit/protocols/input/ec2.json
@@ -2,11 +2,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputInput": {
@@ -17,6 +26,7 @@
         "cases": [
             {
                 "id": "Ec2QueryEmptyInputAndEmptyOutput",
+                "description": "Empty input serializes no extra query params",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -28,7 +38,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty input serializes no extra query params",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -43,17 +52,28 @@
     },
     {
         "description": "Test cases for EndpointOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "Ec2QueryEndpointTrait",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "given": {
                     "name": "EndpointOperation",
                     "http": {
@@ -64,29 +84,37 @@
                         "hostPrefix": "foo."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "Action=EndpointOperation&Version=2020-01-08",
+                    "host": "foo.example.com",
                     "headers": {
                         "Content-Type": "application/x-www-form-urlencoded"
-                    },
-                    "host": "foo.example.com"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for EndpointWithHostLabelOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "HostLabelInput": {
@@ -108,6 +136,7 @@
         "cases": [
             {
                 "id": "Ec2QueryEndpointTraitWithHostLabel",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "given": {
                     "name": "EndpointWithHostLabelOperation",
                     "http": {
@@ -121,7 +150,6 @@
                         "hostPrefix": "foo.{label}."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "params": {
                     "label": "bar"
                 },
@@ -129,28 +157,38 @@
                     "method": "POST",
                     "uri": "/",
                     "body": "Action=EndpointWithHostLabelOperation&Version=2020-01-08&Label=bar",
+                    "host": "foo.bar.example.com",
                     "headers": {
                         "Content-Type": "application/x-www-form-urlencoded"
-                    },
-                    "host": "foo.bar.example.com"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for HostWithPathOperation operation",
+        "clientEndpoint": "https://example.com/custom",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "Ec2QueryHostWithPath",
+                "description": "Custom endpoints supplied by users can have paths",
                 "given": {
                     "name": "HostWithPathOperation",
                     "http": {
@@ -158,7 +196,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Custom endpoints supplied by users can have paths",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -167,19 +204,31 @@
                     "host": "example.com/custom"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com/custom"
+        ]
     },
     {
         "description": "Test cases for NestedStructures operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
             "NestedStructuresInput": {
                 "type": "structure",
                 "members": {
@@ -187,6 +236,9 @@
                         "shape": "StructArg"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             },
             "StructArg": {
                 "type": "structure",
@@ -201,18 +253,12 @@
                         "shape": "StructArg"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "Ec2NestedStructures",
+                "description": "Serializes nested structures using dots",
                 "given": {
                     "name": "NestedStructures",
                     "http": {
@@ -224,7 +270,6 @@
                     },
                     "documentation": "<p>This test serializes nested and recursive structure members.</p>"
                 },
-                "description": "Serializes nested structures using dots",
                 "params": {
                     "Nested": {
                         "StringArg": "foo",
@@ -251,16 +296,26 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "Ec2QueryNoInputAndOutput",
+                "description": "No input serializes no payload",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -269,7 +324,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request payload or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No input serializes no payload",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -285,11 +339,20 @@
     {
         "description": "Test cases for PutWithContentEncoding operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "PutWithContentEncodingInput": {
@@ -310,6 +373,7 @@
         "cases": [
             {
                 "id": "SDKAppliedContentEncoding_ec2Query",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -325,7 +389,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "params": {
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
                 },
@@ -339,6 +402,7 @@
             },
             {
                 "id": "SDKAppendsGzipAndIgnoresHttpProvidedEncoding_ec2Query",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the ec2Query protocol.\n",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -354,7 +418,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the ec2Query protocol.\n",
                 "params": {
                     "encoding": "custom",
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
@@ -372,11 +435,20 @@
     {
         "description": "Test cases for QueryIdempotencyTokenAutoFill operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "QueryIdempotencyTokenAutoFillInput": {
@@ -395,6 +467,7 @@
         "cases": [
             {
                 "id": "Ec2ProtocolIdempotencyTokenAutoFill",
+                "description": "Automatically adds idempotency token when not set",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -406,7 +479,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Automatically adds idempotency token when not set",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -422,6 +494,7 @@
             },
             {
                 "id": "Ec2ProtocolIdempotencyTokenAutoFillIsSet",
+                "description": "Uses the given idempotency token as-is",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -433,7 +506,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Uses the given idempotency token as-is",
                 "params": {
                     "token": "00000000-0000-4000-8000-000000000123"
                 },
@@ -454,13 +526,51 @@
     {
         "description": "Test cases for QueryLists operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "GreetingList": {
+                "type": "list",
+                "member": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "ListWithXmlName": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "NestedStructWithList": {
+                "type": "structure",
+                "members": {
+                    "ListArg": {
+                        "shape": "StringList"
+                    }
+                }
+            },
             "QueryListsInput": {
                 "type": "structure",
                 "members": {
@@ -482,48 +592,20 @@
                     }
                 }
             },
+            "String": {
+                "type": "string"
+            },
             "StringList": {
                 "type": "list",
                 "member": {
                     "shape": "String"
-                }
-            },
-            "GreetingList": {
-                "type": "list",
-                "member": {
-                    "shape": "GreetingStruct"
-                }
-            },
-            "ListWithXmlName": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "NestedStructWithList": {
-                "type": "structure",
-                "members": {
-                    "ListArg": {
-                        "shape": "StringList"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
                 }
             }
         },
         "cases": [
             {
                 "id": "Ec2Lists",
+                "description": "Serializes query lists. All EC2 lists are flattened.",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -535,7 +617,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Serializes query lists. All EC2 lists are flattened.",
                 "params": {
                     "ListArg": [
                         "foo",
@@ -562,6 +643,7 @@
             },
             {
                 "id": "Ec2EmptyQueryLists",
+                "description": "Does not serialize empty query lists.",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -573,7 +655,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Does not serialize empty query lists.",
                 "params": {
                     "ListArg": []
                 },
@@ -588,6 +669,7 @@
             },
             {
                 "id": "Ec2ListArgWithXmlNameMember",
+                "description": "An xmlName trait in the member of a list has no effect on the list serialization.",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -599,7 +681,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "An xmlName trait in the member of a list has no effect on the list serialization.",
                 "params": {
                     "ListArgWithXmlNameMember": [
                         "A",
@@ -617,6 +698,7 @@
             },
             {
                 "id": "Ec2ListMemberWithXmlName",
+                "description": "Changes the name of the list using the xmlName trait",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -628,7 +710,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Changes the name of the list using the xmlName trait",
                 "params": {
                     "ListArgWithXmlName": [
                         "A",
@@ -646,6 +727,7 @@
             },
             {
                 "id": "Ec2ListNestedStructWithList",
+                "description": "Nested structure with a list member",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -657,7 +739,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Nested structure with a list member",
                 "params": {
                     "NestedWithList": {
                         "ListArg": [
@@ -680,13 +761,26 @@
     {
         "description": "Test cases for QueryTimestamps operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
             "QueryTimestampsInput": {
                 "type": "structure",
                 "members": {
@@ -701,21 +795,18 @@
                     }
                 }
             },
-            "Timestamp": {
-                "type": "timestamp"
-            },
             "SyntheticTimestamp_epoch_seconds": {
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
             },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "Ec2TimestampsInput",
+                "description": "Serializes timestamps",
                 "given": {
                     "name": "QueryTimestamps",
                     "http": {
@@ -727,7 +818,6 @@
                     },
                     "documentation": "<p>This test serializes timestamps.</p> <ol> <li>Timestamps are serialized as RFC 3339 date-time values by default.</li> <li>A timestampFormat trait on a member changes the format.</li> <li>A timestampFormat trait on the shape targeted by the member changes the format.</li> </ol>"
                 },
-                "description": "Serializes timestamps",
                 "params": {
                     "normalFormat": 1422172800,
                     "epochMember": 1422172800,
@@ -750,13 +840,51 @@
     {
         "description": "Test cases for SimpleInputParams operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
             "SimpleInputParamsInput": {
                 "type": "structure",
                 "members": {
@@ -799,40 +927,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
             }
         },
         "cases": [
             {
                 "id": "Ec2SimpleInputParamsStrings",
+                "description": "Serializes strings",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -844,7 +944,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes strings",
                 "params": {
                     "Foo": "val1",
                     "Bar": "val2"
@@ -863,6 +962,7 @@
             },
             {
                 "id": "Ec2SimpleInputParamsStringAndBooleanTrue",
+                "description": "Serializes booleans that are true",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -874,7 +974,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes booleans that are true",
                 "params": {
                     "Foo": "val1",
                     "Baz": true
@@ -893,6 +992,7 @@
             },
             {
                 "id": "Ec2SimpleInputParamsStringsAndBooleanFalse",
+                "description": "Serializes booleans that are false",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -904,7 +1004,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes booleans that are false",
                 "params": {
                     "Baz": false
                 },
@@ -922,6 +1021,7 @@
             },
             {
                 "id": "Ec2SimpleInputParamsInteger",
+                "description": "Serializes integers",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -933,7 +1033,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes integers",
                 "params": {
                     "Bam": 10
                 },
@@ -951,6 +1050,7 @@
             },
             {
                 "id": "Ec2SimpleInputParamsFloat",
+                "description": "Serializes floats",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -962,7 +1062,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes floats",
                 "params": {
                     "Boo": 10.8
                 },
@@ -980,6 +1079,7 @@
             },
             {
                 "id": "Ec2SimpleInputParamsBlob",
+                "description": "Blobs are base64 encoded in the query string",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -991,7 +1091,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Blobs are base64 encoded in the query string",
                 "params": {
                     "Qux": "value"
                 },
@@ -1009,6 +1108,7 @@
             },
             {
                 "id": "Ec2Enums",
+                "description": "Serializes enums in the query string",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1020,7 +1120,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes enums in the query string",
                 "params": {
                     "FooEnum": "Foo"
                 },
@@ -1038,6 +1137,7 @@
             },
             {
                 "id": "Ec2Query",
+                "description": "Serializes query using ec2QueryName trait.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1049,7 +1149,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes query using ec2QueryName trait.",
                 "params": {
                     "HasQueryName": "Hi"
                 },
@@ -1067,6 +1166,7 @@
             },
             {
                 "id": "Ec2QueryIsPreferred",
+                "description": "ec2QueryName trait is preferred over xmlName.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1078,7 +1178,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "ec2QueryName trait is preferred over xmlName.",
                 "params": {
                     "HasQueryAndXmlName": "Hi"
                 },
@@ -1096,6 +1195,7 @@
             },
             {
                 "id": "Ec2XmlNameIsUppercased",
+                "description": "xmlName is used with the ec2 protocol, but the first character is uppercased",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1107,7 +1207,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "xmlName is used with the ec2 protocol, but the first character is uppercased",
                 "params": {
                     "UsesXmlName": "Hi"
                 },
@@ -1125,6 +1224,7 @@
             },
             {
                 "id": "Ec2QuerySupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1136,7 +1236,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Supports handling NaN float values.",
                 "params": {
                     "FloatValue": "NaN",
                     "Boo": "NaN"
@@ -1155,6 +1254,7 @@
             },
             {
                 "id": "Ec2QuerySupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1166,7 +1266,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "FloatValue": "Infinity",
                     "Boo": "Infinity"
@@ -1185,6 +1284,7 @@
             },
             {
                 "id": "Ec2QuerySupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1196,7 +1296,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Supports handling -Infinity float values.",
                 "params": {
                     "FloatValue": "-Infinity",
                     "Boo": "-Infinity"

--- a/tests/unit/protocols/input/json.json
+++ b/tests/unit/protocols/input/json.json
@@ -2,18 +2,28 @@
     {
         "description": "Test cases for EmptyOperation operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "sends_requests_to_slash",
+                "description": "Sends requests to /",
                 "given": {
                     "name": "EmptyOperation",
                     "http": {
@@ -21,19 +31,19 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Sends requests to /",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.EmptyOperation"
+                        "X-Amz-Target": "JsonProtocol.EmptyOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "includes_x_amz_target_and_content_type",
+                "description": "Includes X-Amz-Target header and Content-Type",
                 "given": {
                     "name": "EmptyOperation",
                     "http": {
@@ -41,19 +51,19 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Includes X-Amz-Target header and Content-Type",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.EmptyOperation"
+                        "X-Amz-Target": "JsonProtocol.EmptyOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "json_1_1_client_sends_empty_payload_for_no_input_shape",
+                "description": "Clients must always send an empty JSON object payload for\noperations with no input (that is, `{}`). While AWS service\nimplementations support requests with no payload or requests\nthat send `{}`, always sending `{}` from the client is\npreferred for forward compatibility in case input is ever\nadded to an operation.",
                 "given": {
                     "name": "EmptyOperation",
                     "http": {
@@ -61,15 +71,14 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Clients must always send an empty JSON object payload for\noperations with no input (that is, `{}`). While AWS service\nimplementations support requests with no payload or requests\nthat send `{}`, always sending `{}` from the client is\npreferred for forward compatibility in case input is ever\nadded to an operation.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.EmptyOperation"
+                        "X-Amz-Target": "JsonProtocol.EmptyOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             }
@@ -77,19 +86,30 @@
     },
     {
         "description": "Test cases for EndpointOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsJson11EndpointTrait",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "given": {
                     "name": "EndpointOperation",
                     "http": {
@@ -100,32 +120,40 @@
                         "hostPrefix": "foo."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "{}",
+                    "host": "foo.example.com",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.EndpointOperation"
-                    },
-                    "host": "foo.example.com"
+                        "X-Amz-Target": "JsonProtocol.EndpointOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for EndpointWithHostLabelOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "HostLabelInput": {
@@ -147,6 +175,7 @@
         "cases": [
             {
                 "id": "AwsJson11EndpointTraitWithHostLabel",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "given": {
                     "name": "EndpointWithHostLabelOperation",
                     "http": {
@@ -160,7 +189,6 @@
                         "hostPrefix": "foo.{label}."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "params": {
                     "label": "bar"
                 },
@@ -168,31 +196,41 @@
                     "method": "POST",
                     "uri": "/",
                     "body": "{\"label\": \"bar\"}",
+                    "host": "foo.bar.example.com",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.EndpointWithHostLabelOperation"
-                    },
-                    "host": "foo.bar.example.com"
+                        "X-Amz-Target": "JsonProtocol.EndpointWithHostLabelOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for HostWithPathOperation operation",
+        "clientEndpoint": "https://example.com/custom",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsJson11HostWithPath",
+                "description": "Custom endpoints supplied by users can have paths",
                 "given": {
                     "name": "HostWithPathOperation",
                     "http": {
@@ -200,34 +238,72 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Custom endpoints supplied by users can have paths",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/custom/",
                     "body": "{}",
+                    "host": "example.com/custom",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.HostWithPathOperation"
-                    },
-                    "host": "example.com/custom"
+                        "X-Amz-Target": "JsonProtocol.HostWithPathOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com/custom"
+        ]
     },
     {
         "description": "Test cases for JsonEnums operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "JsonEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -251,37 +327,6 @@
                     }
                 }
             },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -289,6 +334,7 @@
         "cases": [
             {
                 "id": "AwsJson11Enums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "JsonEnums",
                     "http": {
@@ -301,7 +347,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -324,8 +369,8 @@
                     "uri": "/",
                     "body": "{\n    \"fooEnum1\": \"Foo\",\n    \"fooEnum2\": \"0\",\n    \"fooEnum3\": \"1\",\n    \"fooEnumList\": [\n        \"Foo\",\n        \"0\"\n    ],\n    \"fooEnumSet\": [\n        \"Foo\",\n        \"0\"\n    ],\n    \"fooEnumMap\": {\n        \"hi\": \"Foo\",\n        \"zero\": \"0\"\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonEnums"
+                        "X-Amz-Target": "JsonProtocol.JsonEnums",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             }
@@ -334,15 +379,49 @@
     {
         "description": "Test cases for JsonIntEnums operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
             "JsonIntEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -366,31 +445,6 @@
                     }
                 }
             },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -398,6 +452,7 @@
         "cases": [
             {
                 "id": "AwsJson11IntEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "JsonIntEnums",
                     "http": {
@@ -410,7 +465,6 @@
                     "documentation": "<p>This example serializes intEnums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "intEnum1": 1,
                     "intEnum2": 2,
@@ -433,8 +487,8 @@
                     "uri": "/",
                     "body": "{\n    \"intEnum1\": 1,\n    \"intEnum2\": 2,\n    \"intEnum3\": 3,\n    \"intEnumList\": [\n        1,\n        2\n    ],\n    \"intEnumSet\": [\n        1,\n        2\n    ],\n    \"intEnumMap\": {\n        \"a\": 1,\n        \"b\": 2\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonIntEnums"
+                        "X-Amz-Target": "JsonProtocol.JsonIntEnums",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             }
@@ -443,23 +497,52 @@
     {
         "description": "Test cases for JsonUnions operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
-            "UnionInputOutput": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "GreetingStruct": {
                 "type": "structure",
                 "members": {
-                    "contents": {
-                        "shape": "MyUnion"
+                    "hi": {
+                        "shape": "String"
                     }
-                },
-                "documentation": "<p>A shared structure that contains a single union member.</p>"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
             },
             "MyUnion": {
                 "type": "structure",
@@ -498,30 +581,6 @@
             "String": {
                 "type": "string"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -537,18 +596,23 @@
                     "shape": "String"
                 }
             },
-            "GreetingStruct": {
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "UnionInputOutput": {
                 "type": "structure",
                 "members": {
-                    "hi": {
-                        "shape": "String"
+                    "contents": {
+                        "shape": "MyUnion"
                     }
-                }
+                },
+                "documentation": "<p>A shared structure that contains a single union member.</p>"
             }
         },
         "cases": [
             {
                 "id": "AwsJson11SerializeStringUnionValue",
+                "description": "Serializes a string union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -561,7 +625,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a string union value",
                 "params": {
                     "contents": {
                         "stringValue": "foo"
@@ -572,13 +635,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"stringValue\": \"foo\"\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeBooleanUnionValue",
+                "description": "Serializes a boolean union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -591,7 +655,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a boolean union value",
                 "params": {
                     "contents": {
                         "booleanValue": true
@@ -602,13 +665,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"booleanValue\": true\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeNumberUnionValue",
+                "description": "Serializes a number union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -621,7 +685,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a number union value",
                 "params": {
                     "contents": {
                         "numberValue": 1
@@ -632,13 +695,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"numberValue\": 1\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeBlobUnionValue",
+                "description": "Serializes a blob union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -651,7 +715,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a blob union value",
                 "params": {
                     "contents": {
                         "blobValue": "foo"
@@ -662,13 +725,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"blobValue\": \"Zm9v\"\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeTimestampUnionValue",
+                "description": "Serializes a timestamp union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -681,7 +745,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a timestamp union value",
                 "params": {
                     "contents": {
                         "timestampValue": 1398796238
@@ -692,13 +755,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"timestampValue\": 1398796238\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeEnumUnionValue",
+                "description": "Serializes an enum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -711,7 +775,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes an enum union value",
                 "params": {
                     "contents": {
                         "enumValue": "Foo"
@@ -722,13 +785,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"enumValue\": \"Foo\"\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeListUnionValue",
+                "description": "Serializes a list union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -741,7 +805,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a list union value",
                 "params": {
                     "contents": {
                         "listValue": [
@@ -755,13 +818,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"listValue\": [\"foo\", \"bar\"]\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeMapUnionValue",
+                "description": "Serializes a map union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -774,7 +838,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a map union value",
                 "params": {
                     "contents": {
                         "mapValue": {
@@ -788,13 +851,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"mapValue\": {\n            \"foo\": \"bar\",\n            \"spam\": \"eggs\"\n        }\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SerializeStructureUnionValue",
+                "description": "Serializes a structure union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -807,7 +871,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure union value",
                 "params": {
                     "contents": {
                         "structureValue": {
@@ -820,8 +883,8 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"structureValue\": {\n            \"hi\": \"hello\"\n        }\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonUnions"
+                        "X-Amz-Target": "JsonProtocol.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             }
@@ -830,15 +893,50 @@
     {
         "description": "Test cases for KitchenSinkOperation operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "EmptyStruct": {
+                "type": "structure",
+                "members": {}
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "JsonValue": {
+                "type": "string"
+            },
             "KitchenSink": {
                 "type": "structure",
                 "members": {
@@ -923,39 +1021,11 @@
                     }
                 }
             },
-            "Blob": {
-                "type": "blob"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "EmptyStruct": {
-                "type": "structure",
-                "members": {}
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "JsonValue": {
-                "type": "string"
+            "ListOfKitchenSinks": {
+                "type": "list",
+                "member": {
+                    "shape": "KitchenSink"
+                }
             },
             "ListOfListOfStrings": {
                 "type": "list",
@@ -984,6 +1054,15 @@
             "Long": {
                 "type": "long",
                 "box": true
+            },
+            "MapOfKitchenSinks": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "KitchenSink"
+                }
             },
             "MapOfListsOfStrings": {
                 "type": "map",
@@ -1021,21 +1100,6 @@
                     "shape": "SimpleStruct"
                 }
             },
-            "ListOfKitchenSinks": {
-                "type": "list",
-                "member": {
-                    "shape": "KitchenSink"
-                }
-            },
-            "MapOfKitchenSinks": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "KitchenSink"
-                }
-            },
             "SimpleStruct": {
                 "type": "structure",
                 "members": {
@@ -1055,17 +1119,26 @@
                     }
                 }
             },
-            "Timestamp": {
-                "type": "timestamp"
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
             },
             "SyntheticTimestamp_epoch_seconds": {
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "serializes_string_shapes",
+                "description": "Serializes string shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1076,7 +1149,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes string shapes",
                 "params": {
                     "String": "abc xyz"
                 },
@@ -1085,8 +1157,8 @@
                     "uri": "/",
                     "body": "{\"String\":\"abc xyz\"}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1095,6 +1167,7 @@
             },
             {
                 "id": "serializes_string_shapes_with_jsonvalue_trait",
+                "description": "Serializes string shapes with jsonvalue trait",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1105,7 +1178,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes string shapes with jsonvalue trait",
                 "params": {
                     "JsonValue": "{\"string\":\"value\",\"number\":1234.5,\"boolTrue\":true,\"boolFalse\":false,\"array\":[1,2,3,4],\"object\":{\"key\":\"value\"},\"null\":null}"
                 },
@@ -1114,8 +1186,8 @@
                     "uri": "/",
                     "body": "{\"JsonValue\":\"{\\\"string\\\":\\\"value\\\",\\\"number\\\":1234.5,\\\"boolTrue\\\":true,\\\"boolFalse\\\":false,\\\"array\\\":[1,2,3,4],\\\"object\\\":{\\\"key\\\":\\\"value\\\"},\\\"null\\\":null}\"}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1124,6 +1196,7 @@
             },
             {
                 "id": "serializes_integer_shapes",
+                "description": "Serializes integer shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1134,7 +1207,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes integer shapes",
                 "params": {
                     "Integer": 1234
                 },
@@ -1143,8 +1215,8 @@
                     "uri": "/",
                     "body": "{\"Integer\":1234}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1153,6 +1225,7 @@
             },
             {
                 "id": "serializes_long_shapes",
+                "description": "Serializes long shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1163,7 +1236,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes long shapes",
                 "params": {
                     "Long": 999999999999
                 },
@@ -1172,8 +1244,8 @@
                     "uri": "/",
                     "body": "{\"Long\":999999999999}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1182,6 +1254,7 @@
             },
             {
                 "id": "serializes_float_shapes",
+                "description": "Serializes float shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1192,7 +1265,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes float shapes",
                 "params": {
                     "Float": 1234.5
                 },
@@ -1201,8 +1273,8 @@
                     "uri": "/",
                     "body": "{\"Float\":1234.5}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1211,6 +1283,7 @@
             },
             {
                 "id": "serializes_double_shapes",
+                "description": "Serializes double shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1221,7 +1294,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes double shapes",
                 "params": {
                     "Double": 1234.5
                 },
@@ -1230,8 +1302,8 @@
                     "uri": "/",
                     "body": "{\"Double\":1234.5}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1240,6 +1312,7 @@
             },
             {
                 "id": "serializes_blob_shapes",
+                "description": "Serializes blob shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1250,7 +1323,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes blob shapes",
                 "params": {
                     "Blob": "binary-value"
                 },
@@ -1259,8 +1331,8 @@
                     "uri": "/",
                     "body": "{\"Blob\":\"YmluYXJ5LXZhbHVl\"}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1269,6 +1341,7 @@
             },
             {
                 "id": "serializes_boolean_shapes_true",
+                "description": "Serializes boolean shapes (true)",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1279,7 +1352,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes boolean shapes (true)",
                 "params": {
                     "Boolean": true
                 },
@@ -1288,8 +1360,8 @@
                     "uri": "/",
                     "body": "{\"Boolean\":true}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1298,6 +1370,7 @@
             },
             {
                 "id": "serializes_boolean_shapes_false",
+                "description": "Serializes boolean shapes (false)",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1308,7 +1381,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes boolean shapes (false)",
                 "params": {
                     "Boolean": false
                 },
@@ -1317,8 +1389,8 @@
                     "uri": "/",
                     "body": "{\"Boolean\":false}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1327,6 +1399,7 @@
             },
             {
                 "id": "serializes_timestamp_shapes",
+                "description": "Serializes timestamp shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1337,7 +1410,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes timestamp shapes",
                 "params": {
                     "Timestamp": 946845296
                 },
@@ -1346,8 +1418,8 @@
                     "uri": "/",
                     "body": "{\"Timestamp\":946845296}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1356,6 +1428,7 @@
             },
             {
                 "id": "serializes_timestamp_shapes_with_iso8601_timestampformat",
+                "description": "Serializes timestamp shapes with iso8601 timestampFormat",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1366,7 +1439,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes timestamp shapes with iso8601 timestampFormat",
                 "params": {
                     "Iso8601Timestamp": 946845296
                 },
@@ -1375,8 +1447,8 @@
                     "uri": "/",
                     "body": "{\"Iso8601Timestamp\":\"2000-01-02T20:34:56Z\"}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1385,6 +1457,7 @@
             },
             {
                 "id": "serializes_timestamp_shapes_with_httpdate_timestampformat",
+                "description": "Serializes timestamp shapes with httpdate timestampFormat",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1395,7 +1468,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes timestamp shapes with httpdate timestampFormat",
                 "params": {
                     "HttpdateTimestamp": 946845296
                 },
@@ -1404,8 +1476,8 @@
                     "uri": "/",
                     "body": "{\"HttpdateTimestamp\":\"Sun, 02 Jan 2000 20:34:56 GMT\"}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1414,6 +1486,7 @@
             },
             {
                 "id": "serializes_timestamp_shapes_with_unixtimestamp_timestampformat",
+                "description": "Serializes timestamp shapes with unixTimestamp timestampFormat",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1424,7 +1497,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes timestamp shapes with unixTimestamp timestampFormat",
                 "params": {
                     "UnixTimestamp": 946845296
                 },
@@ -1433,8 +1505,8 @@
                     "uri": "/",
                     "body": "{\"UnixTimestamp\":946845296}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1443,6 +1515,7 @@
             },
             {
                 "id": "serializes_list_shapes",
+                "description": "Serializes list shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1453,7 +1526,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes list shapes",
                 "params": {
                     "ListOfStrings": [
                         "abc",
@@ -1466,8 +1538,8 @@
                     "uri": "/",
                     "body": "{\"ListOfStrings\":[\"abc\",\"mno\",\"xyz\"]}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1476,6 +1548,7 @@
             },
             {
                 "id": "serializes_empty_list_shapes",
+                "description": "Serializes empty list shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1486,7 +1559,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes empty list shapes",
                 "params": {
                     "ListOfStrings": []
                 },
@@ -1495,8 +1567,8 @@
                     "uri": "/",
                     "body": "{\"ListOfStrings\":[]}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1505,6 +1577,7 @@
             },
             {
                 "id": "serializes_list_of_map_shapes",
+                "description": "Serializes list of map shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1515,7 +1588,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes list of map shapes",
                 "params": {
                     "ListOfMapsOfStrings": [
                         {
@@ -1534,8 +1606,8 @@
                     "uri": "/",
                     "body": "{\"ListOfMapsOfStrings\":[{\"foo\":\"bar\"},{\"abc\":\"xyz\"},{\"red\":\"blue\"}]}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1544,6 +1616,7 @@
             },
             {
                 "id": "serializes_list_of_structure_shapes",
+                "description": "Serializes list of structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1554,7 +1627,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes list of structure shapes",
                 "params": {
                     "ListOfStructs": [
                         {
@@ -1573,8 +1645,8 @@
                     "uri": "/",
                     "body": "{\"ListOfStructs\":[{\"Value\":\"abc\"},{\"Value\":\"mno\"},{\"Value\":\"xyz\"}]}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1583,6 +1655,7 @@
             },
             {
                 "id": "serializes_list_of_recursive_structure_shapes",
+                "description": "Serializes list of recursive structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1593,7 +1666,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes list of recursive structure shapes",
                 "params": {
                     "RecursiveList": [
                         {
@@ -1614,8 +1686,8 @@
                     "uri": "/",
                     "body": "{\"RecursiveList\":[{\"RecursiveList\":[{\"RecursiveList\":[{\"Integer\":123}]}]}]}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1624,6 +1696,7 @@
             },
             {
                 "id": "serializes_map_shapes",
+                "description": "Serializes map shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1634,7 +1707,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes map shapes",
                 "params": {
                     "MapOfStrings": {
                         "abc": "xyz",
@@ -1646,8 +1718,8 @@
                     "uri": "/",
                     "body": "{\"MapOfStrings\":{\"abc\":\"xyz\",\"mno\":\"hjk\"}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1656,6 +1728,7 @@
             },
             {
                 "id": "serializes_empty_map_shapes",
+                "description": "Serializes empty map shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1666,7 +1739,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes empty map shapes",
                 "params": {
                     "MapOfStrings": {}
                 },
@@ -1675,8 +1747,8 @@
                     "uri": "/",
                     "body": "{\"MapOfStrings\":{}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1685,6 +1757,7 @@
             },
             {
                 "id": "serializes_map_of_list_shapes",
+                "description": "Serializes map of list shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1695,7 +1768,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes map of list shapes",
                 "params": {
                     "MapOfListsOfStrings": {
                         "abc": [
@@ -1713,8 +1785,8 @@
                     "uri": "/",
                     "body": "{\"MapOfListsOfStrings\":{\"abc\":[\"abc\",\"xyz\"],\"mno\":[\"xyz\",\"abc\"]}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1723,6 +1795,7 @@
             },
             {
                 "id": "serializes_map_of_structure_shapes",
+                "description": "Serializes map of structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1733,7 +1806,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes map of structure shapes",
                 "params": {
                     "MapOfStructs": {
                         "key1": {
@@ -1749,8 +1821,8 @@
                     "uri": "/",
                     "body": "{\"MapOfStructs\":{\"key1\":{\"Value\":\"value-1\"},\"key2\":{\"Value\":\"value-2\"}}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1759,6 +1831,7 @@
             },
             {
                 "id": "serializes_map_of_recursive_structure_shapes",
+                "description": "Serializes map of recursive structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1769,7 +1842,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes map of recursive structure shapes",
                 "params": {
                     "RecursiveMap": {
                         "key1": {
@@ -1790,8 +1862,8 @@
                     "uri": "/",
                     "body": "{\"RecursiveMap\":{\"key1\":{\"RecursiveMap\":{\"key2\":{\"RecursiveMap\":{\"key3\":{\"Boolean\":false}}}}}}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1800,6 +1872,7 @@
             },
             {
                 "id": "serializes_structure_shapes",
+                "description": "Serializes structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1810,7 +1883,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes structure shapes",
                 "params": {
                     "SimpleStruct": {
                         "Value": "abc"
@@ -1821,8 +1893,8 @@
                     "uri": "/",
                     "body": "{\"SimpleStruct\":{\"Value\":\"abc\"}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1831,6 +1903,7 @@
             },
             {
                 "id": "serializes_structure_members_with_locationname_traits",
+                "description": "Serializes structure members with locationName traits",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1841,7 +1914,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes structure members with locationName traits",
                 "params": {
                     "StructWithJsonName": {
                         "Value": "some-value"
@@ -1852,8 +1924,8 @@
                     "uri": "/",
                     "body": "{\"StructWithJsonName\":{\"Value\":\"some-value\"}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1862,6 +1934,7 @@
             },
             {
                 "id": "serializes_empty_structure_shapes",
+                "description": "Serializes empty structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1872,7 +1945,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes empty structure shapes",
                 "params": {
                     "SimpleStruct": {}
                 },
@@ -1881,8 +1953,8 @@
                     "uri": "/",
                     "body": "{\"SimpleStruct\":{}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1891,6 +1963,7 @@
             },
             {
                 "id": "serializes_structure_which_have_no_members",
+                "description": "Serializes structure which have no members",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1901,7 +1974,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes structure which have no members",
                 "params": {
                     "EmptyStruct": {}
                 },
@@ -1910,8 +1982,8 @@
                     "uri": "/",
                     "body": "{\"EmptyStruct\":{}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1920,6 +1992,7 @@
             },
             {
                 "id": "serializes_recursive_structure_shapes",
+                "description": "Serializes recursive structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1930,7 +2003,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Serializes recursive structure shapes",
                 "params": {
                     "String": "top-value",
                     "Boolean": false,
@@ -1957,8 +2029,8 @@
                     "uri": "/",
                     "body": "{\"String\":\"top-value\",\"Boolean\":false,\"RecursiveStruct\":{\"String\":\"nested-value\",\"Boolean\":true,\"RecursiveList\":[{\"String\":\"string-only\"},{\"RecursiveStruct\":{\"MapOfStrings\":{\"color\":\"red\",\"size\":\"large\"}}}]}}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation"
+                        "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1970,13 +2042,22 @@
     {
         "description": "Test cases for NullOperation operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "NullOperationInputOutput": {
@@ -1994,6 +2075,7 @@
         "cases": [
             {
                 "id": "AwsJson11StructuresDontSerializeNullValues",
+                "description": "Null structure values are dropped",
                 "given": {
                     "name": "NullOperation",
                     "http": {
@@ -2004,7 +2086,6 @@
                         "shape": "NullOperationInputOutput"
                     }
                 },
-                "description": "Null structure values are dropped",
                 "params": {
                     "string": null
                 },
@@ -2013,8 +2094,8 @@
                     "uri": "/",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.NullOperation"
+                        "X-Amz-Target": "JsonProtocol.NullOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             }
@@ -2023,13 +2104,22 @@
     {
         "description": "Test cases for OperationWithOptionalInputOutput operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "OperationWithOptionalInputOutputInput": {
@@ -2047,6 +2137,7 @@
         "cases": [
             {
                 "id": "can_call_operation_with_no_input_or_output",
+                "description": "Can call operations with no input or output",
                 "given": {
                     "name": "OperationWithOptionalInputOutput",
                     "http": {
@@ -2057,20 +2148,20 @@
                         "shape": "OperationWithOptionalInputOutputInput"
                     }
                 },
-                "description": "Can call operations with no input or output",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
+                        "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "can_call_operation_with_optional_input",
+                "description": "Can invoke operations with optional input",
                 "given": {
                     "name": "OperationWithOptionalInputOutput",
                     "http": {
@@ -2081,7 +2172,6 @@
                         "shape": "OperationWithOptionalInputOutputInput"
                     }
                 },
-                "description": "Can invoke operations with optional input",
                 "params": {
                     "Value": "Hi"
                 },
@@ -2090,8 +2180,8 @@
                     "uri": "/",
                     "body": "{\"Value\":\"Hi\"}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput"
+                        "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             }
@@ -2100,15 +2190,29 @@
     {
         "description": "Test cases for PutAndGetInlineDocuments operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "PutAndGetInlineDocumentsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2116,16 +2220,12 @@
                         "shape": "Document"
                     }
                 }
-            },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
             }
         },
         "cases": [
             {
                 "id": "PutAndGetInlineDocumentsInput",
+                "description": "Serializes inline documents in a JSON request.",
                 "given": {
                     "name": "PutAndGetInlineDocuments",
                     "http": {
@@ -2137,7 +2237,6 @@
                     },
                     "documentation": "<p>This example serializes an inline document as part of the payload.</p>"
                 },
-                "description": "Serializes inline documents in a JSON request.",
                 "params": {
                     "inlineDocument": {
                         "foo": "bar"
@@ -2148,8 +2247,8 @@
                     "uri": "/",
                     "body": "{\n    \"inlineDocument\": {\"foo\": \"bar\"}\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.PutAndGetInlineDocuments"
+                        "X-Amz-Target": "JsonProtocol.PutAndGetInlineDocuments",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -2161,13 +2260,22 @@
     {
         "description": "Test cases for PutWithContentEncoding operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "PutWithContentEncodingInput": {
@@ -2188,6 +2296,7 @@
         "cases": [
             {
                 "id": "SDKAppliedContentEncoding_awsJson1_1",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -2203,7 +2312,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "params": {
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
                 },
@@ -2217,6 +2325,7 @@
             },
             {
                 "id": "SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_1",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the awsJson1_1 protocol.\n",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -2232,7 +2341,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the awsJson1_1 protocol.\n",
                 "params": {
                     "encoding": "custom",
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
@@ -2250,15 +2358,32 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "SimpleScalarPropertiesInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2269,19 +2394,12 @@
                         "shape": "Double"
                     }
                 }
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "AwsJson11SupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2292,7 +2410,6 @@
                         "shape": "SimpleScalarPropertiesInputOutput"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "params": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -2302,13 +2419,14 @@
                     "uri": "/",
                     "body": "{\n    \"floatValue\": \"NaN\",\n    \"doubleValue\": \"NaN\"\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.SimpleScalarProperties"
+                        "X-Amz-Target": "JsonProtocol.SimpleScalarProperties",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2319,7 +2437,6 @@
                         "shape": "SimpleScalarPropertiesInputOutput"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -2329,13 +2446,14 @@
                     "uri": "/",
                     "body": "{\n    \"floatValue\": \"Infinity\",\n    \"doubleValue\": \"Infinity\"\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.SimpleScalarProperties"
+                        "X-Amz-Target": "JsonProtocol.SimpleScalarProperties",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             },
             {
                 "id": "AwsJson11SupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2346,7 +2464,6 @@
                         "shape": "SimpleScalarPropertiesInputOutput"
                     }
                 },
-                "description": "Supports handling -Infinity float values.",
                 "params": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -2356,8 +2473,120 @@
                     "uri": "/",
                     "body": "{\n    \"floatValue\": \"-Infinity\",\n    \"doubleValue\": \"-Infinity\"\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.SimpleScalarProperties"
+                        "X-Amz-Target": "JsonProtocol.SimpleScalarProperties",
+                        "Content-Type": "application/x-amz-json-1.1"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SparseNullsOperation operation",
+        "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
+            "protocol": "json",
+            "protocols": [
+                "json"
+            ],
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
+        },
+        "shapes": {
+            "SparseNullsOperationInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStringList": {
+                        "shape": "SparseStringList"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
+                    }
+                }
+            },
+            "SparseStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "AwsJson11SparseMapsSerializeNullValues",
+                "description": "Serializes null values in maps",
+                "given": {
+                    "name": "SparseNullsOperation",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseStringMap": {
+                        "foo": null
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/",
+                    "body": "{\n    \"sparseStringMap\": {\n        \"foo\": null\n    }\n}",
+                    "headers": {
+                        "X-Amz-Target": "JsonProtocol.SparseNullsOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
+                    }
+                }
+            },
+            {
+                "id": "AwsJson11SparseListsSerializeNull",
+                "description": "Serializes null values in lists",
+                "given": {
+                    "name": "SparseNullsOperation",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseStringList": [
+                        null
+                    ]
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/",
+                    "body": "{\n    \"sparseStringList\": [\n        null\n    ]\n}",
+                    "headers": {
+                        "X-Amz-Target": "JsonProtocol.SparseNullsOperation",
+                        "Content-Type": "application/x-amz-json-1.1"
                     }
                 }
             }

--- a/tests/unit/protocols/input/json_1_0-query-compatible.json
+++ b/tests/unit/protocols/input/json_1_0-query-compatible.json
@@ -24,6 +24,7 @@
         "cases": [
             {
                 "id": "QueryCompatibleAwsJson10CborSendsQueryModeHeader",
+                "description": "Clients for query-compatible services MUST send the x-amzn-query-mode header.",
                 "given": {
                     "name": "QueryCompatibleOperation",
                     "http": {
@@ -32,16 +33,15 @@
                     },
                     "idempotent": true
                 },
-                "description": "Clients for query-compatible services MUST send the x-amzn-query-mode header.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
                         "X-Amz-Target": "QueryCompatibleJsonRpc10.QueryCompatibleOperation",
-                        "x-amzn-query-mode": "true"
+                        "x-amzn-query-mode": "true",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             }

--- a/tests/unit/protocols/input/json_1_0.json
+++ b/tests/unit/protocols/input/json_1_0.json
@@ -2,13 +2,22 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputInput": {
@@ -19,6 +28,7 @@
         "cases": [
             {
                 "id": "AwsJson10EmptyInputAndEmptyOutput",
+                "description": "Clients must always send an empty object if input is modeled.",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -30,15 +40,14 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has an empty input and empty output structure that reuses the same shape. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Clients must always send an empty object if input is modeled.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.EmptyInputAndEmptyOutput"
+                        "X-Amz-Target": "JsonRpc10.EmptyInputAndEmptyOutput",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             }
@@ -46,19 +55,30 @@
     },
     {
         "description": "Test cases for EndpointOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsJson10EndpointTrait",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "given": {
                     "name": "EndpointOperation",
                     "http": {
@@ -69,7 +89,6 @@
                         "hostPrefix": "foo."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -78,19 +97,28 @@
                     "host": "foo.example.com"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for EndpointWithHostLabelOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
             "EndpointWithHostLabelOperationInput": {
@@ -112,6 +140,7 @@
         "cases": [
             {
                 "id": "AwsJson10EndpointTraitWithHostLabel",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "given": {
                     "name": "EndpointWithHostLabelOperation",
                     "http": {
@@ -125,7 +154,6 @@
                         "hostPrefix": "foo.{label}."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "params": {
                     "label": "bar"
                 },
@@ -136,24 +164,34 @@
                     "host": "foo.bar.example.com"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for HostWithPathOperation operation",
+        "clientEndpoint": "https://example.com/custom",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsJson10HostWithPath",
+                "description": "Custom endpoints supplied by users can have paths",
                 "given": {
                     "name": "HostWithPathOperation",
                     "http": {
@@ -161,7 +199,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Custom endpoints supplied by users can have paths",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -170,21 +207,62 @@
                     "host": "example.com/custom"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com/custom"
+        ]
     },
     {
         "description": "Test cases for JsonUnions operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
             "JsonUnionsInput": {
                 "type": "structure",
                 "members": {
@@ -233,34 +311,6 @@
             "String": {
                 "type": "string"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -276,18 +326,14 @@
                     "shape": "String"
                 }
             },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "AwsJson10SerializeStringUnionValue",
+                "description": "Serializes a string union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -300,7 +346,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a string union value",
                 "params": {
                     "contents": {
                         "stringValue": "foo"
@@ -311,13 +356,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"stringValue\": \"foo\"\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeBooleanUnionValue",
+                "description": "Serializes a boolean union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -330,7 +376,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a boolean union value",
                 "params": {
                     "contents": {
                         "booleanValue": true
@@ -341,13 +386,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"booleanValue\": true\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeNumberUnionValue",
+                "description": "Serializes a number union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -360,7 +406,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a number union value",
                 "params": {
                     "contents": {
                         "numberValue": 1
@@ -371,13 +416,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"numberValue\": 1\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeBlobUnionValue",
+                "description": "Serializes a blob union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -390,7 +436,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a blob union value",
                 "params": {
                     "contents": {
                         "blobValue": "foo"
@@ -401,13 +446,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"blobValue\": \"Zm9v\"\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeTimestampUnionValue",
+                "description": "Serializes a timestamp union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -420,7 +466,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a timestamp union value",
                 "params": {
                     "contents": {
                         "timestampValue": 1398796238
@@ -431,13 +476,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"timestampValue\": 1398796238\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeEnumUnionValue",
+                "description": "Serializes an enum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -450,7 +496,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes an enum union value",
                 "params": {
                     "contents": {
                         "enumValue": "Foo"
@@ -461,13 +506,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"enumValue\": \"Foo\"\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeIntEnumUnionValue",
+                "description": "Serializes an intEnum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -480,7 +526,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes an intEnum union value",
                 "params": {
                     "contents": {
                         "intEnumValue": 1
@@ -491,13 +536,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"intEnumValue\": 1\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeListUnionValue",
+                "description": "Serializes a list union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -510,7 +556,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a list union value",
                 "params": {
                     "contents": {
                         "listValue": [
@@ -524,13 +569,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"listValue\": [\"foo\", \"bar\"]\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeMapUnionValue",
+                "description": "Serializes a map union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -543,7 +589,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a map union value",
                 "params": {
                     "contents": {
                         "mapValue": {
@@ -557,13 +602,14 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"mapValue\": {\n            \"foo\": \"bar\",\n            \"spam\": \"eggs\"\n        }\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SerializeStructureUnionValue",
+                "description": "Serializes a structure union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -576,7 +622,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure union value",
                 "params": {
                     "contents": {
                         "structureValue": {
@@ -589,8 +634,8 @@
                     "uri": "/",
                     "body": "{\n    \"contents\": {\n        \"structureValue\": {\n            \"hi\": \"hello\"\n        }\n    }\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.JsonUnions"
+                        "X-Amz-Target": "JsonRpc10.JsonUnions",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             }
@@ -599,18 +644,28 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsJson10MustAlwaysSendEmptyJsonPayload",
+                "description": "Clients must always send an empty JSON object payload for\noperations with no input (that is, `{}`). While AWS service\nimplementations support requests with no payload or requests\nthat send `{}`, always sending `{}` from the client is\npreferred for forward compatibility in case input is ever\nadded to an operation.",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -619,15 +674,14 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Clients must always send an empty JSON object payload for\noperations with no input (that is, `{}`). While AWS service\nimplementations support requests with no payload or requests\nthat send `{}`, always sending `{}` from the client is\npreferred for forward compatibility in case input is ever\nadded to an operation.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.NoInputAndNoOutput"
+                        "X-Amz-Target": "JsonRpc10.NoInputAndNoOutput",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             }
@@ -636,18 +690,28 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsJson10NoInputAndOutput",
+                "description": "A client should always send and empty JSON object payload.",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -656,15 +720,14 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input and the output is empty. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "A client should always send and empty JSON object payload.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.NoInputAndOutput"
+                        "X-Amz-Target": "JsonRpc10.NoInputAndOutput",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             }
@@ -673,13 +736,22 @@
     {
         "description": "Test cases for PutWithContentEncoding operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
             "PutWithContentEncodingInput": {
@@ -700,6 +772,7 @@
         "cases": [
             {
                 "id": "SDKAppliedContentEncoding_awsJson1_0",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -715,7 +788,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "params": {
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
                 },
@@ -729,6 +801,7 @@
             },
             {
                 "id": "SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_0",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the awsJson1_0 protocol.\n",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -744,7 +817,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the awsJson1_0 protocol.\n",
                 "params": {
                     "encoding": "custom",
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
@@ -760,17 +832,80 @@
         ]
     },
     {
-        "description": "Test cases for SimpleScalarProperties operation",
+        "description": "Test cases for QueryIncompatibleOperation operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
+        },
+        "shapes": {},
+        "cases": [
+            {
+                "id": "NonQueryCompatibleAwsJson10ForbidsQueryModeHeader",
+                "description": "The query mode header MUST NOT be set on non-query-compatible services.",
+                "given": {
+                    "name": "QueryIncompatibleOperation",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "idempotent": true
+                },
+                "params": {},
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/",
+                    "body": "{}",
+                    "headers": {
+                        "X-Amz-Target": "JsonRpc10.QueryIncompatibleOperation",
+                        "Content-Type": "application/x-amz-json-1.0"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SimpleScalarProperties operation",
+        "metadata": {
             "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
             "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "protocol": "json",
+            "protocols": [
+                "json"
+            ],
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "SimpleScalarPropertiesInput": {
                 "type": "structure",
                 "members": {
@@ -781,19 +916,12 @@
                         "shape": "Double"
                     }
                 }
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "AwsJson10SupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -804,7 +932,6 @@
                         "shape": "SimpleScalarPropertiesInput"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "params": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -814,13 +941,14 @@
                     "uri": "/",
                     "body": "{\n    \"floatValue\": \"NaN\",\n    \"doubleValue\": \"NaN\"\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.SimpleScalarProperties"
+                        "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -831,7 +959,6 @@
                         "shape": "SimpleScalarPropertiesInput"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -841,13 +968,14 @@
                     "uri": "/",
                     "body": "{\n    \"floatValue\": \"Infinity\",\n    \"doubleValue\": \"Infinity\"\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.SimpleScalarProperties"
+                        "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             },
             {
                 "id": "AwsJson10SupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -858,7 +986,6 @@
                         "shape": "SimpleScalarPropertiesInput"
                     }
                 },
-                "description": "Supports handling -Infinity float values.",
                 "params": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -868,8 +995,8 @@
                     "uri": "/",
                     "body": "{\n    \"floatValue\": \"-Infinity\",\n    \"doubleValue\": \"-Infinity\"\n}",
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "X-Amz-Target": "JsonRpc10.SimpleScalarProperties"
+                        "X-Amz-Target": "JsonRpc10.SimpleScalarProperties",
+                        "Content-Type": "application/x-amz-json-1.0"
                     }
                 }
             }

--- a/tests/unit/protocols/input/query.json
+++ b/tests/unit/protocols/input/query.json
@@ -2,11 +2,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputInput": {
@@ -17,6 +26,7 @@
         "cases": [
             {
                 "id": "QueryEmptyInputAndEmptyOutput",
+                "description": "Empty input serializes no extra query params",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -28,7 +38,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty input serializes no extra query params",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -43,17 +52,28 @@
     },
     {
         "description": "Test cases for EndpointOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsQueryEndpointTrait",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "given": {
                     "name": "EndpointOperation",
                     "http": {
@@ -64,29 +84,37 @@
                         "hostPrefix": "foo."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/",
                     "body": "Action=EndpointOperation&Version=2020-01-08",
+                    "host": "foo.example.com",
                     "headers": {
                         "Content-Type": "application/x-www-form-urlencoded"
-                    },
-                    "host": "foo.example.com"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for EndpointWithHostLabelOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "HostLabelInput": {
@@ -108,6 +136,7 @@
         "cases": [
             {
                 "id": "AwsQueryEndpointTraitWithHostLabel",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "given": {
                     "name": "EndpointWithHostLabelOperation",
                     "http": {
@@ -121,7 +150,6 @@
                         "hostPrefix": "foo.{label}."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "params": {
                     "label": "bar"
                 },
@@ -129,28 +157,38 @@
                     "method": "POST",
                     "uri": "/",
                     "body": "Action=EndpointWithHostLabelOperation&Version=2020-01-08&label=bar",
+                    "host": "foo.bar.example.com",
                     "headers": {
                         "Content-Type": "application/x-www-form-urlencoded"
-                    },
-                    "host": "foo.bar.example.com"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for HostWithPathOperation operation",
+        "clientEndpoint": "https://example.com/custom",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "QueryHostWithPath",
+                "description": "Custom endpoints supplied by users can have paths",
                 "given": {
                     "name": "HostWithPathOperation",
                     "http": {
@@ -158,7 +196,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Custom endpoints supplied by users can have paths",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -167,19 +204,31 @@
                     "host": "example.com/custom"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com/custom"
+        ]
     },
     {
         "description": "Test cases for NestedStructures operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
             "NestedStructuresInput": {
                 "type": "structure",
                 "members": {
@@ -187,6 +236,9 @@
                         "shape": "StructArg"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             },
             "StructArg": {
                 "type": "structure",
@@ -201,18 +253,12 @@
                         "shape": "StructArg"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "NestedStructures",
+                "description": "Serializes nested structures using dots",
                 "given": {
                     "name": "NestedStructures",
                     "http": {
@@ -224,7 +270,6 @@
                     },
                     "documentation": "<p>This test serializes nested and recursive structure members.</p>"
                 },
-                "description": "Serializes nested structures using dots",
                 "params": {
                     "Nested": {
                         "StringArg": "foo",
@@ -251,16 +296,26 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "QueryNoInputAndNoOutput",
+                "description": "No input serializes no additional query params",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -269,7 +324,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No input serializes no additional query params",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -285,11 +339,20 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "NoInputAndOutputInput": {
@@ -300,6 +363,7 @@
         "cases": [
             {
                 "id": "QueryNoInputAndOutput",
+                "description": "No input serializes no payload",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -311,7 +375,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request payload or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No input serializes no payload",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -327,11 +390,20 @@
     {
         "description": "Test cases for PutWithContentEncoding operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "PutWithContentEncodingInput": {
@@ -352,6 +424,7 @@
         "cases": [
             {
                 "id": "SDKAppliedContentEncoding_awsQuery",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -367,7 +440,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "params": {
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
                 },
@@ -381,6 +453,7 @@
             },
             {
                 "id": "SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsQuery",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the awsQuery protocol.\n",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -396,7 +469,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is NOT in the Content-Encoding header since HTTP binding\ntraits are ignored in the awsQuery protocol.\n",
                 "params": {
                     "encoding": "custom",
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
@@ -414,11 +486,20 @@
     {
         "description": "Test cases for QueryIdempotencyTokenAutoFill operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "QueryIdempotencyTokenAutoFillInput": {
@@ -437,6 +518,7 @@
         "cases": [
             {
                 "id": "QueryProtocolIdempotencyTokenAutoFill",
+                "description": "Automatically adds idempotency token when not set",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -448,7 +530,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Automatically adds idempotency token when not set",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -464,6 +545,7 @@
             },
             {
                 "id": "QueryProtocolIdempotencyTokenAutoFillIsSet",
+                "description": "Uses the given idempotency token as-is",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -475,7 +557,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Uses the given idempotency token as-is",
                 "params": {
                     "token": "00000000-0000-4000-8000-000000000123"
                 },
@@ -496,13 +577,51 @@
     {
         "description": "Test cases for QueryLists operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "GreetingList": {
+                "type": "list",
+                "member": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "ListWithXmlName": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "NestedStructWithList": {
+                "type": "structure",
+                "members": {
+                    "ListArg": {
+                        "shape": "StringList"
+                    }
+                }
+            },
             "QueryListsInput": {
                 "type": "structure",
                 "members": {
@@ -529,48 +648,20 @@
                     }
                 }
             },
+            "String": {
+                "type": "string"
+            },
             "StringList": {
                 "type": "list",
                 "member": {
                     "shape": "String"
-                }
-            },
-            "GreetingList": {
-                "type": "list",
-                "member": {
-                    "shape": "GreetingStruct"
-                }
-            },
-            "ListWithXmlName": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "NestedStructWithList": {
-                "type": "structure",
-                "members": {
-                    "ListArg": {
-                        "shape": "StringList"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
                 }
             }
         },
         "cases": [
             {
                 "id": "QueryLists",
+                "description": "Serializes query lists",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -582,7 +673,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Serializes query lists",
                 "params": {
                     "ListArg": [
                         "foo",
@@ -609,6 +699,7 @@
             },
             {
                 "id": "EmptyQueryLists",
+                "description": "Serializes empty query lists",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -620,7 +711,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Serializes empty query lists",
                 "params": {
                     "ListArg": []
                 },
@@ -635,6 +725,7 @@
             },
             {
                 "id": "FlattenedQueryLists",
+                "description": "Flattens query lists by repeating the member name and removing the member element",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -646,7 +737,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Flattens query lists by repeating the member name and removing the member element",
                 "params": {
                     "FlattenedListArg": [
                         "A",
@@ -664,6 +754,7 @@
             },
             {
                 "id": "QueryListArgWithXmlNameMember",
+                "description": "Changes the member of lists using xmlName trait",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -675,7 +766,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Changes the member of lists using xmlName trait",
                 "params": {
                     "ListArgWithXmlNameMember": [
                         "A",
@@ -693,6 +783,7 @@
             },
             {
                 "id": "QueryFlattenedListArgWithXmlName",
+                "description": "Changes the name of flattened lists using xmlName trait on the structure member",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -704,7 +795,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Changes the name of flattened lists using xmlName trait on the structure member",
                 "params": {
                     "FlattenedListArgWithXmlName": [
                         "A",
@@ -722,6 +812,7 @@
             },
             {
                 "id": "QueryNestedStructWithList",
+                "description": "Nested structure with a list member",
                 "given": {
                     "name": "QueryLists",
                     "http": {
@@ -733,7 +824,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex lists.</p>"
                 },
-                "description": "Nested structure with a list member",
                 "params": {
                     "NestedWithList": {
                         "ListArg": [
@@ -756,13 +846,67 @@
     {
         "description": "Test cases for QueryMaps operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "ComplexMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "MapOfLists": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringList"
+                }
+            },
+            "MapWithXmlName": {
+                "type": "map",
+                "key": {
+                    "shape": "String",
+                    "locationName": "K"
+                },
+                "value": {
+                    "shape": "String",
+                    "locationName": "V"
+                }
+            },
+            "NestedStructWithMap": {
+                "type": "structure",
+                "members": {
+                    "MapArg": {
+                        "shape": "StringMap"
+                    }
+                }
+            },
             "QueryMapsInput": {
                 "type": "structure",
                 "members": {
@@ -796,52 +940,6 @@
                     }
                 }
             },
-            "StringMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "String"
-                }
-            },
-            "ComplexMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "GreetingStruct"
-                }
-            },
-            "MapWithXmlName": {
-                "type": "map",
-                "key": {
-                    "shape": "String",
-                    "locationName": "K"
-                },
-                "value": {
-                    "shape": "String",
-                    "locationName": "V"
-                }
-            },
-            "MapOfLists": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "StringList"
-                }
-            },
-            "NestedStructWithMap": {
-                "type": "structure",
-                "members": {
-                    "MapArg": {
-                        "shape": "StringMap"
-                    }
-                }
-            },
             "String": {
                 "type": "string"
             },
@@ -851,18 +949,20 @@
                     "shape": "String"
                 }
             },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
+            "StringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
                 }
             }
         },
         "cases": [
             {
                 "id": "QuerySimpleQueryMaps",
+                "description": "Serializes query maps",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -874,7 +974,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes query maps",
                 "params": {
                     "MapArg": {
                         "bar": "Bar",
@@ -892,6 +991,7 @@
             },
             {
                 "id": "QuerySimpleQueryMapsWithXmlName",
+                "description": "Serializes query maps and uses xmlName",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -903,7 +1003,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes query maps and uses xmlName",
                 "params": {
                     "RenamedMapArg": {
                         "foo": "Foo"
@@ -920,6 +1019,7 @@
             },
             {
                 "id": "QueryComplexQueryMaps",
+                "description": "Serializes complex query maps",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -931,7 +1031,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes complex query maps",
                 "params": {
                     "ComplexMapArg": {
                         "bar": {
@@ -953,6 +1052,7 @@
             },
             {
                 "id": "QueryEmptyQueryMaps",
+                "description": "Does not serialize empty query maps",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -964,7 +1064,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Does not serialize empty query maps",
                 "params": {
                     "MapArg": {}
                 },
@@ -979,6 +1078,7 @@
             },
             {
                 "id": "QueryQueryMapWithMemberXmlName",
+                "description": "Serializes query maps where the member has an xmlName trait",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -990,7 +1090,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes query maps where the member has an xmlName trait",
                 "params": {
                     "MapWithXmlMemberName": {
                         "bar": "Bar",
@@ -1008,6 +1107,7 @@
             },
             {
                 "id": "QueryFlattenedQueryMaps",
+                "description": "Serializes flattened query maps",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -1019,7 +1119,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes flattened query maps",
                 "params": {
                     "FlattenedMap": {
                         "bar": "Bar",
@@ -1037,6 +1136,7 @@
             },
             {
                 "id": "QueryFlattenedQueryMapsWithXmlName",
+                "description": "Serializes flattened query maps that use an xmlName",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -1048,7 +1148,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes flattened query maps that use an xmlName",
                 "params": {
                     "FlattenedMapWithXmlName": {
                         "bar": "Bar",
@@ -1066,6 +1165,7 @@
             },
             {
                 "id": "QueryQueryMapOfLists",
+                "description": "Serializes query map of lists",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -1077,7 +1177,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes query map of lists",
                 "params": {
                     "MapOfLists": {
                         "bar": [
@@ -1101,6 +1200,7 @@
             },
             {
                 "id": "QueryNestedStructWithMap",
+                "description": "Serializes nested struct with map member",
                 "given": {
                     "name": "QueryMaps",
                     "http": {
@@ -1112,7 +1212,6 @@
                     },
                     "documentation": "<p>This test serializes simple and complex maps.</p>"
                 },
-                "description": "Serializes nested struct with map member",
                 "params": {
                     "NestedStructWithMap": {
                         "MapArg": {
@@ -1135,13 +1234,26 @@
     {
         "description": "Test cases for QueryTimestamps operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
             "QueryTimestampsInput": {
                 "type": "structure",
                 "members": {
@@ -1156,21 +1268,18 @@
                     }
                 }
             },
-            "Timestamp": {
-                "type": "timestamp"
-            },
             "SyntheticTimestamp_epoch_seconds": {
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
             },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "QueryTimestampsInput",
+                "description": "Serializes timestamps",
                 "given": {
                     "name": "QueryTimestamps",
                     "http": {
@@ -1182,7 +1291,6 @@
                     },
                     "documentation": "<p>This test serializes timestamps.</p> <ol> <li>Timestamps are serialized as RFC 3339 date-time values by default.</li> <li>A timestampFormat trait on a member changes the format.</li> <li>A timestampFormat trait on the shape targeted by the member changes the format.</li> </ol>"
                 },
-                "description": "Serializes timestamps",
                 "params": {
                     "normalFormat": 1422172800,
                     "epochMember": 1422172800,
@@ -1205,13 +1313,55 @@
     {
         "description": "Test cases for SimpleInputParams operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
             "SimpleInputParamsInput": {
                 "type": "structure",
                 "members": {
@@ -1246,44 +1396,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "QuerySimpleInputParamsStrings",
+                "description": "Serializes strings",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1295,7 +1413,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes strings",
                 "params": {
                     "Foo": "val1",
                     "Bar": "val2"
@@ -1314,6 +1431,7 @@
             },
             {
                 "id": "QuerySimpleInputParamsStringAndBooleanTrue",
+                "description": "Serializes booleans that are true",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1325,7 +1443,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes booleans that are true",
                 "params": {
                     "Foo": "val1",
                     "Baz": true
@@ -1344,6 +1461,7 @@
             },
             {
                 "id": "QuerySimpleInputParamsStringsAndBooleanFalse",
+                "description": "Serializes booleans that are false",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1355,7 +1473,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes booleans that are false",
                 "params": {
                     "Baz": false
                 },
@@ -1373,6 +1490,7 @@
             },
             {
                 "id": "QuerySimpleInputParamsInteger",
+                "description": "Serializes integers",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1384,7 +1502,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes integers",
                 "params": {
                     "Bam": 10
                 },
@@ -1402,6 +1519,7 @@
             },
             {
                 "id": "QuerySimpleInputParamsFloat",
+                "description": "Serializes floats",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1413,7 +1531,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes floats",
                 "params": {
                     "Boo": 10.8
                 },
@@ -1431,6 +1548,7 @@
             },
             {
                 "id": "QuerySimpleInputParamsBlob",
+                "description": "Blobs are base64 encoded in the query string",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1442,7 +1560,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Blobs are base64 encoded in the query string",
                 "params": {
                     "Qux": "value"
                 },
@@ -1460,6 +1577,7 @@
             },
             {
                 "id": "QueryEnums",
+                "description": "Serializes enums in the query string",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1471,7 +1589,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes enums in the query string",
                 "params": {
                     "FooEnum": "Foo"
                 },
@@ -1489,6 +1606,7 @@
             },
             {
                 "id": "QueryIntEnums",
+                "description": "Serializes intEnums in the query string",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1500,7 +1618,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Serializes intEnums in the query string",
                 "params": {
                     "IntegerEnum": 1
                 },
@@ -1518,6 +1635,7 @@
             },
             {
                 "id": "AwsQuerySupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1529,7 +1647,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Supports handling NaN float values.",
                 "params": {
                     "FloatValue": "NaN",
                     "Boo": "NaN"
@@ -1548,6 +1665,7 @@
             },
             {
                 "id": "AwsQuerySupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1559,7 +1677,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "FloatValue": "Infinity",
                     "Boo": "Infinity"
@@ -1578,6 +1695,7 @@
             },
             {
                 "id": "AwsQuerySupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleInputParams",
                     "http": {
@@ -1589,7 +1707,6 @@
                     },
                     "documentation": "<p>This test serializes strings, numbers, and boolean values.</p>"
                 },
-                "description": "Supports handling -Infinity float values.",
                 "params": {
                     "FloatValue": "-Infinity",
                     "Boo": "-Infinity"

--- a/tests/unit/protocols/input/rest-json.json
+++ b/tests/unit/protocols/input/rest-json.json
@@ -2,11 +2,20 @@
     {
         "description": "Test cases for AllQueryStringTypes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "AllQueryStringTypesInput": {
@@ -118,44 +127,15 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "Integer": {
-                "type": "integer",
+            "Boolean": {
+                "type": "boolean",
                 "box": true
             },
-            "IntegerList": {
+            "BooleanList": {
                 "type": "list",
                 "member": {
-                    "shape": "Integer"
+                    "shape": "Boolean"
                 }
-            },
-            "IntegerSet": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
             },
             "Double": {
                 "type": "double",
@@ -167,24 +147,9 @@
                     "shape": "Double"
                 }
             },
-            "Boolean": {
-                "type": "boolean",
+            "Float": {
+                "type": "float",
                 "box": true
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
             },
             "FooEnum": {
                 "type": "string",
@@ -202,6 +167,10 @@
                     "shape": "FooEnum"
                 }
             },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
             "IntegerEnum": {
                 "type": "integer",
                 "box": true
@@ -212,6 +181,31 @@
                     "shape": "IntegerEnum"
                 }
             },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "IntegerSet": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
             "StringListMap": {
                 "type": "map",
                 "key": {
@@ -220,11 +214,27 @@
                 "value": {
                     "shape": "StringList"
                 }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
             }
         },
         "cases": [
             {
                 "id": "RestJsonAllQueryStringTypes",
+                "description": "Serializes query string parameters with all supported types",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -235,9 +245,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes query string parameters with all supported types",
                 "params": {
                     "queryString": "Hello there",
                     "queryStringList": [
@@ -384,6 +394,7 @@
             },
             {
                 "id": "RestJsonQueryStringMap",
+                "description": "Handles query string maps",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -394,9 +405,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Handles query string maps",
                 "params": {
                     "queryParamsMapOfStringList": {
                         "QueryParamsStringKeyA": [
@@ -415,6 +426,7 @@
             },
             {
                 "id": "RestJsonQueryStringEscaping",
+                "description": "Handles escaping all required characters in the query string.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -425,9 +437,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Handles escaping all required characters in the query string.",
                 "params": {
                     "queryString": " %:/?#[]@!$&'()*+,;=😹",
                     "queryParamsMapOfStringList": {
@@ -444,6 +456,7 @@
             },
             {
                 "id": "RestJsonSupportsNaNFloatQueryValues",
+                "description": "Supports handling NaN float query values.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -454,9 +467,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Supports handling NaN float query values.",
                 "params": {
                     "queryFloat": "NaN",
                     "queryDouble": "NaN",
@@ -477,6 +490,7 @@
             },
             {
                 "id": "RestJsonSupportsInfinityFloatQueryValues",
+                "description": "Supports handling Infinity float query values.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -487,9 +501,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Supports handling Infinity float query values.",
                 "params": {
                     "queryFloat": "Infinity",
                     "queryDouble": "Infinity",
@@ -510,6 +524,7 @@
             },
             {
                 "id": "RestJsonSupportsNegativeInfinityFloatQueryValues",
+                "description": "Supports handling -Infinity float query values.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -520,9 +535,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Supports handling -Infinity float query values.",
                 "params": {
                     "queryFloat": "-Infinity",
                     "queryDouble": "-Infinity",
@@ -543,6 +558,7 @@
             },
             {
                 "id": "RestJsonZeroAndFalseQueryValues",
+                "description": "Query values of 0 and false are serialized",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -553,9 +569,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Query values of 0 and false are serialized",
                 "params": {
                     "queryInteger": 0,
                     "queryBoolean": false,
@@ -579,11 +595,20 @@
     {
         "description": "Test cases for ConstantAndVariableQueryString operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "ConstantAndVariableQueryStringInput": {
@@ -608,6 +633,7 @@
         "cases": [
             {
                 "id": "RestJsonConstantAndVariableQueryStringMissingOneValue",
+                "description": "Mixes constant and variable query string parameters",
                 "given": {
                     "name": "ConstantAndVariableQueryString",
                     "http": {
@@ -618,9 +644,9 @@
                     "input": {
                         "shape": "ConstantAndVariableQueryStringInput"
                     },
-                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>"
+                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>",
+                    "readonly": true
                 },
-                "description": "Mixes constant and variable query string parameters",
                 "params": {
                     "baz": "bam"
                 },
@@ -632,6 +658,7 @@
             },
             {
                 "id": "RestJsonConstantAndVariableQueryStringAllValues",
+                "description": "Mixes constant and variable query string parameters",
                 "given": {
                     "name": "ConstantAndVariableQueryString",
                     "http": {
@@ -642,9 +669,9 @@
                     "input": {
                         "shape": "ConstantAndVariableQueryStringInput"
                     },
-                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>"
+                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>",
+                    "readonly": true
                 },
-                "description": "Mixes constant and variable query string parameters",
                 "params": {
                     "baz": "bam",
                     "maybeSet": "yes"
@@ -660,11 +687,20 @@
     {
         "description": "Test cases for ConstantQueryString operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "ConstantQueryStringInput": {
@@ -687,6 +723,7 @@
         "cases": [
             {
                 "id": "RestJsonConstantQueryString",
+                "description": "Includes constant query string parameters",
                 "given": {
                     "name": "ConstantQueryString",
                     "http": {
@@ -697,9 +734,9 @@
                     "input": {
                         "shape": "ConstantQueryStringInput"
                     },
-                    "documentation": "<p>This example uses a constant query string parameters and a label. This simply tests that labels and query string parameters are compatible. The fixed query string parameter named &quot;hello&quot; should in no way conflict with the label, <code>{hello}</code>.</p>"
+                    "documentation": "<p>This example uses a constant query string parameters and a label. This simply tests that labels and query string parameters are compatible. The fixed query string parameter named &quot;hello&quot; should in no way conflict with the label, <code>{hello}</code>.</p>",
+                    "readonly": true
                 },
-                "description": "Includes constant query string parameters",
                 "params": {
                     "hello": "hi"
                 },
@@ -714,13 +751,27 @@
     {
         "description": "Test cases for DocumentType operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "DocumentTypeInputOutput": {
                 "type": "structure",
                 "members": {
@@ -734,16 +785,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
             }
         },
         "cases": [
             {
                 "id": "DocumentTypeInputWithObject",
+                "description": "Serializes document types as part of the JSON request payload with no escaping.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -757,7 +804,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes document types as part of the JSON request payload with no escaping.",
                 "params": {
                     "stringValue": "string",
                     "documentValue": {
@@ -775,6 +821,7 @@
             },
             {
                 "id": "DocumentInputWithString",
+                "description": "Serializes document types using a string.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -788,7 +835,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes document types using a string.",
                 "params": {
                     "stringValue": "string",
                     "documentValue": "hello"
@@ -804,6 +850,7 @@
             },
             {
                 "id": "DocumentInputWithNumber",
+                "description": "Serializes document types using a number.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -817,7 +864,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes document types using a number.",
                 "params": {
                     "stringValue": "string",
                     "documentValue": 10
@@ -833,6 +879,7 @@
             },
             {
                 "id": "DocumentInputWithBoolean",
+                "description": "Serializes document types using a boolean.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -846,7 +893,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes document types using a boolean.",
                 "params": {
                     "stringValue": "string",
                     "documentValue": true
@@ -862,6 +908,7 @@
             },
             {
                 "id": "DocumentInputWithList",
+                "description": "Serializes document types using a list.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -875,7 +922,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes document types using a list.",
                 "params": {
                     "stringValue": "string",
                     "documentValue": [
@@ -909,13 +955,27 @@
     {
         "description": "Test cases for DocumentTypeAsMapValue operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "DocumentTypeAsMapValueInputOutput": {
                 "type": "structure",
                 "members": {
@@ -933,11 +993,6 @@
                     "shape": "Document"
                 }
             },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
-            },
             "String": {
                 "type": "string"
             }
@@ -945,6 +1000,7 @@
         "cases": [
             {
                 "id": "DocumentTypeAsMapValueInput",
+                "description": "Serializes a map that uses documents as the value.",
                 "given": {
                     "name": "DocumentTypeAsMapValue",
                     "http": {
@@ -958,7 +1014,6 @@
                     "documentation": "<p>This example serializes documents as the value of maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a map that uses documents as the value.",
                 "params": {
                     "docValuedMap": {
                         "foo": {
@@ -987,13 +1042,27 @@
     {
         "description": "Test cases for DocumentTypeAsPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "DocumentTypeAsPayloadInputOutput": {
                 "type": "structure",
                 "members": {
@@ -1002,16 +1071,12 @@
                     }
                 },
                 "payload": "documentValue"
-            },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
             }
         },
         "cases": [
             {
                 "id": "DocumentTypeAsPayloadInput",
+                "description": "Serializes a document as the target of the httpPayload trait.",
                 "given": {
                     "name": "DocumentTypeAsPayload",
                     "http": {
@@ -1025,7 +1090,6 @@
                     "documentation": "<p>This example serializes a document as the entire HTTP payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a document as the target of the httpPayload trait.",
                 "params": {
                     "documentValue": {
                         "foo": "bar"
@@ -1042,6 +1106,7 @@
             },
             {
                 "id": "DocumentTypeAsPayloadInputString",
+                "description": "Serializes a document as the target of the httpPayload trait using a string.",
                 "given": {
                     "name": "DocumentTypeAsPayload",
                     "http": {
@@ -1055,7 +1120,6 @@
                     "documentation": "<p>This example serializes a document as the entire HTTP payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a document as the target of the httpPayload trait using a string.",
                 "params": {
                     "documentValue": "hello"
                 },
@@ -1073,11 +1137,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputInput": {
@@ -1088,6 +1161,7 @@
         "cases": [
             {
                 "id": "RestJsonEmptyInputAndEmptyOutput",
+                "description": "Clients should not serialize a JSON payload when no parameters\nare given that are sent in the body. A service will tolerate\nclients that omit a payload or that send a JSON object.",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -1100,7 +1174,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has an empty input and empty output structure that reuses the same shape. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Clients should not serialize a JSON payload when no parameters\nare given that are sent in the body. A service will tolerate\nclients that omit a payload or that send a JSON object.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -1112,17 +1185,28 @@
     },
     {
         "description": "Test cases for EndpointOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonEndpointTrait",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "given": {
                     "name": "EndpointOperation",
                     "http": {
@@ -1134,7 +1218,6 @@
                         "hostPrefix": "foo."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -1143,17 +1226,26 @@
                     "host": "foo.example.com"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for EndpointWithHostLabelOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HostLabelInput": {
@@ -1175,6 +1267,7 @@
         "cases": [
             {
                 "id": "RestJsonEndpointTraitWithHostLabel",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "given": {
                     "name": "EndpointWithHostLabelOperation",
                     "http": {
@@ -1189,7 +1282,6 @@
                         "hostPrefix": "foo.{label}."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "params": {
                     "label": "bar"
                 },
@@ -1200,31 +1292,41 @@
                     "host": "foo.bar.example.com"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for HostWithPathOperation operation",
+        "clientEndpoint": "https://example.com/custom",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonHostWithPath",
+                "description": "Custom endpoints supplied by users can have paths",
                 "given": {
                     "name": "HostWithPathOperation",
                     "http": {
                         "method": "GET",
                         "requestUri": "/HostWithPathOperation",
                         "responseCode": 200
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Custom endpoints supplied by users can have paths",
                 "params": {},
                 "serialized": {
                     "method": "GET",
@@ -1233,17 +1335,25 @@
                     "host": "example.com/custom"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com/custom"
+        ]
     },
     {
         "description": "Test cases for HttpChecksumRequired operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpChecksumRequiredInputOutput": {
@@ -1261,6 +1371,7 @@
         "cases": [
             {
                 "id": "RestJsonHttpChecksumRequired",
+                "description": "Adds Content-MD5 header",
                 "given": {
                     "name": "HttpChecksumRequired",
                     "http": {
@@ -1274,7 +1385,6 @@
                     "documentation": "<p>This example tests httpChecksumRequired trait</p>",
                     "httpChecksumRequired": true
                 },
-                "description": "Adds Content-MD5 header",
                 "params": {
                     "foo": "base64 encoded md5 checksum"
                 },
@@ -1291,13 +1401,105 @@
         ]
     },
     {
-        "description": "Test cases for HttpEnumPayload operation",
+        "description": "Test cases for HttpEmptyPrefixHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
+        },
+        "shapes": {
+            "HttpEmptyPrefixHeadersInput": {
+                "type": "structure",
+                "members": {
+                    "prefixHeaders": {
+                        "shape": "StringMap",
+                        "location": "headers",
+                        "locationName": ""
+                    },
+                    "specificHeader": {
+                        "shape": "String",
+                        "location": "header",
+                        "locationName": "hello"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RestJsonHttpEmptyPrefixHeadersRequestClient",
+                "description": "Serializes all request headers, using specific when present",
+                "given": {
+                    "name": "HttpEmptyPrefixHeaders",
+                    "http": {
+                        "method": "GET",
+                        "requestUri": "/HttpEmptyPrefixHeaders",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "HttpEmptyPrefixHeadersInput"
+                    },
+                    "documentation": "<p>Clients that perform this test extract all headers from the response.</p>",
+                    "readonly": true
+                },
+                "params": {
+                    "prefixHeaders": {
+                        "x-foo": "Foo",
+                        "hello": "Hello"
+                    },
+                    "specificHeader": "There"
+                },
+                "serialized": {
+                    "method": "GET",
+                    "uri": "/HttpEmptyPrefixHeaders",
+                    "body": "",
+                    "headers": {
+                        "x-foo": "Foo",
+                        "hello": "There"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for HttpEnumPayload operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
+            "protocol": "rest-json",
+            "protocols": [
+                "rest-json"
+            ],
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "EnumPayloadInput": {
@@ -1347,13 +1549,25 @@
     {
         "description": "Test cases for HttpPayloadTraits operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "HttpPayloadTraitsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -1370,14 +1584,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpPayloadTraitsWithBlob",
+                "description": "Serializes a blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -1390,7 +1602,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no JSON document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes a blob in the HTTP payload",
                 "params": {
                     "foo": "Foo",
                     "blob": "blobby blob blob"
@@ -1400,8 +1611,8 @@
                     "uri": "/HttpPayloadTraits",
                     "body": "blobby blob blob",
                     "headers": {
-                        "Content-Type": "application/octet-stream",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/octet-stream"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -1410,6 +1621,7 @@
             },
             {
                 "id": "RestJsonHttpPayloadTraitsWithNoBlobBody",
+                "description": "Serializes an empty blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -1422,7 +1634,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no JSON document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes an empty blob in the HTTP payload",
                 "params": {
                     "foo": "Foo"
                 },
@@ -1440,11 +1651,20 @@
     {
         "description": "Test cases for HttpPayloadWithStructure operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithStructureInputOutput": {
@@ -1474,6 +1694,7 @@
         "cases": [
             {
                 "id": "RestJsonHttpPayloadWithStructure",
+                "description": "Serializes a structure in the payload",
                 "given": {
                     "name": "HttpPayloadWithStructure",
                     "http": {
@@ -1487,7 +1708,6 @@
                     "documentation": "<p>This example serializes a structure in the payload.</p> <p>Note that serializing a structure changes the wrapper element name to match the targeted structure.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload",
                 "params": {
                     "nested": {
                         "greeting": "hello",
@@ -1511,11 +1731,20 @@
     {
         "description": "Test cases for HttpPayloadWithUnion operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithUnionInputOutput": {
@@ -1527,6 +1756,9 @@
                 },
                 "payload": "nested"
             },
+            "String": {
+                "type": "string"
+            },
             "UnionPayload": {
                 "type": "structure",
                 "members": {
@@ -1535,14 +1767,12 @@
                     }
                 },
                 "union": true
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpPayloadWithUnion",
+                "description": "Serializes a union in the payload.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -1556,7 +1786,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a union in the payload.",
                 "params": {
                     "nested": {
                         "greeting": "hello"
@@ -1576,6 +1805,7 @@
             },
             {
                 "id": "RestJsonHttpPayloadWithUnsetUnion",
+                "description": "No payload is sent if the union has no value.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -1589,7 +1819,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "No payload is sent if the union has no value.",
                 "params": {},
                 "serialized": {
                     "method": "PUT",
@@ -1602,11 +1831,20 @@
     {
         "description": "Test cases for HttpPrefixHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPrefixHeadersInput": {
@@ -1640,6 +1878,7 @@
         "cases": [
             {
                 "id": "RestJsonHttpPrefixHeadersArePresent",
+                "description": "Adds headers by prefix",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1650,9 +1889,9 @@
                     "input": {
                         "shape": "HttpPrefixHeadersInput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "Adds headers by prefix",
                 "params": {
                     "foo": "Foo",
                     "fooMap": {
@@ -1666,13 +1905,14 @@
                     "body": "",
                     "headers": {
                         "x-foo": "Foo",
-                        "x-foo-abc": "Abc value",
-                        "x-foo-def": "Def value"
+                        "x-foo-def": "Def value",
+                        "x-foo-abc": "Abc value"
                     }
                 }
             },
             {
                 "id": "RestJsonHttpPrefixHeadersAreNotPresent",
+                "description": "No prefix headers are serialized because the value is not present",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1683,9 +1923,9 @@
                     "input": {
                         "shape": "HttpPrefixHeadersInput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "No prefix headers are serialized because the value is not present",
                 "params": {
                     "foo": "Foo",
                     "fooMap": {}
@@ -1701,6 +1941,7 @@
             },
             {
                 "id": "RestJsonHttpPrefixEmptyHeaders",
+                "description": "Serialize prefix headers were the value is present but empty",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1711,9 +1952,9 @@
                     "input": {
                         "shape": "HttpPrefixHeadersInput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "Serialize prefix headers were the value is present but empty",
                 "params": {
                     "fooMap": {
                         "abc": ""
@@ -1731,15 +1972,127 @@
         ]
     },
     {
-        "description": "Test cases for HttpRequestWithFloatLabels operation",
+        "description": "Test cases for HttpQueryParamsOnlyOperation operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "HttpQueryParamsOnlyInput": {
+                "type": "structure",
+                "members": {
+                    "queryMap": {
+                        "shape": "QueryMap",
+                        "location": "querystring"
+                    }
+                }
+            },
+            "QueryMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "HttpQueryParamsOnlyRequest",
+                "description": "Test that httpQueryParams are included in request when no other query parameters exist",
+                "given": {
+                    "name": "HttpQueryParamsOnlyOperation",
+                    "http": {
+                        "method": "GET",
+                        "requestUri": "/http-query-params-only",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "HttpQueryParamsOnlyInput"
+                    },
+                    "documentation": "<p>This example tests httpQueryParams when no other query parameters exist.</p>",
+                    "readonly": true
+                },
+                "params": {
+                    "queryMap": {
+                        "a": "b",
+                        "c": "d"
+                    }
+                },
+                "serialized": {
+                    "method": "GET",
+                    "uri": "/http-query-params-only?a=b&c=d"
+                }
+            },
+            {
+                "id": "HttpQueryParamsOnlyEmptyRequest",
+                "description": "Test that empty httpQueryParams map results in no query parameters",
+                "given": {
+                    "name": "HttpQueryParamsOnlyOperation",
+                    "http": {
+                        "method": "GET",
+                        "requestUri": "/http-query-params-only",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "HttpQueryParamsOnlyInput"
+                    },
+                    "documentation": "<p>This example tests httpQueryParams when no other query parameters exist.</p>",
+                    "readonly": true
+                },
+                "params": {
+                    "queryMap": {}
+                },
+                "serialized": {
+                    "method": "GET",
+                    "uri": "/http-query-params-only"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for HttpRequestWithFloatLabels operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
+            "protocol": "rest-json",
+            "protocols": [
+                "rest-json"
+            ],
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
+        },
+        "shapes": {
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "HttpRequestWithFloatLabelsInput": {
                 "type": "structure",
                 "required": [
@@ -1758,19 +2111,12 @@
                         "locationName": "double"
                     }
                 }
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "RestJsonSupportsNaNFloatLabels",
+                "description": "Supports handling NaN float label values.",
                 "given": {
                     "name": "HttpRequestWithFloatLabels",
                     "http": {
@@ -1780,9 +2126,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithFloatLabelsInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Supports handling NaN float label values.",
                 "params": {
                     "float": "NaN",
                     "double": "NaN"
@@ -1795,6 +2141,7 @@
             },
             {
                 "id": "RestJsonSupportsInfinityFloatLabels",
+                "description": "Supports handling Infinity float label values.",
                 "given": {
                     "name": "HttpRequestWithFloatLabels",
                     "http": {
@@ -1804,9 +2151,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithFloatLabelsInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Supports handling Infinity float label values.",
                 "params": {
                     "float": "Infinity",
                     "double": "Infinity"
@@ -1819,6 +2166,7 @@
             },
             {
                 "id": "RestJsonSupportsNegativeInfinityFloatLabels",
+                "description": "Supports handling -Infinity float label values.",
                 "given": {
                     "name": "HttpRequestWithFloatLabels",
                     "http": {
@@ -1828,9 +2176,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithFloatLabelsInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Supports handling -Infinity float label values.",
                 "params": {
                     "float": "-Infinity",
                     "double": "-Infinity"
@@ -1846,11 +2194,20 @@
     {
         "description": "Test cases for HttpRequestWithGreedyLabelInPath operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpRequestWithGreedyLabelInPathInput": {
@@ -1879,6 +2236,7 @@
         "cases": [
             {
                 "id": "RestJsonHttpRequestWithGreedyLabelInPath",
+                "description": "Serializes greedy labels and normal labels",
                 "given": {
                     "name": "HttpRequestWithGreedyLabelInPath",
                     "http": {
@@ -1888,9 +2246,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithGreedyLabelInPathInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Serializes greedy labels and normal labels",
                 "params": {
                     "foo": "hello/escape",
                     "baz": "there/guy"
@@ -1906,13 +2264,34 @@
     {
         "description": "Test cases for HttpRequestWithLabels operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "HttpRequestWithLabelsInput": {
                 "type": "structure",
                 "required": [
@@ -1970,9 +2349,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "Integer": {
                 "type": "integer",
                 "box": true
@@ -1981,17 +2357,8 @@
                 "type": "long",
                 "box": true
             },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
+            "String": {
+                "type": "string"
             },
             "Timestamp": {
                 "type": "timestamp"
@@ -2000,6 +2367,7 @@
         "cases": [
             {
                 "id": "RestJsonInputWithHeadersAndAllParams",
+                "description": "Sends a GET request that uses URI label bindings",
                 "given": {
                     "name": "HttpRequestWithLabels",
                     "http": {
@@ -2010,9 +2378,9 @@
                     "input": {
                         "shape": "HttpRequestWithLabelsInput"
                     },
-                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>"
+                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>",
+                    "readonly": true
                 },
-                "description": "Sends a GET request that uses URI label bindings",
                 "params": {
                     "string": "string",
                     "short": 1,
@@ -2031,6 +2399,7 @@
             },
             {
                 "id": "RestJsonHttpRequestLabelEscaping",
+                "description": "Sends a GET request that uses URI label bindings",
                 "given": {
                     "name": "HttpRequestWithLabels",
                     "http": {
@@ -2041,9 +2410,9 @@
                     "input": {
                         "shape": "HttpRequestWithLabelsInput"
                     },
-                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>"
+                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>",
+                    "readonly": true
                 },
-                "description": "Sends a GET request that uses URI label bindings",
                 "params": {
                     "string": " %:/?#[]@!$&'()*+,;=😹",
                     "short": 1,
@@ -2065,13 +2434,34 @@
     {
         "description": "Test cases for HttpRequestWithLabelsAndTimestampFormat operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
             "HttpRequestWithLabelsAndTimestampFormatInput": {
                 "type": "structure",
                 "required": [
@@ -2121,6 +2511,10 @@
                     }
                 }
             },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "SyntheticTimestamp_epoch_seconds": {
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
@@ -2129,29 +2523,14 @@
                 "type": "timestamp",
                 "timestampFormat": "rfc822"
             },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
             "Timestamp": {
                 "type": "timestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpRequestWithLabelsAndTimestampFormat",
+                "description": "Serializes different timestamp formats in URI labels",
                 "given": {
                     "name": "HttpRequestWithLabelsAndTimestampFormat",
                     "http": {
@@ -2162,9 +2541,9 @@
                     "input": {
                         "shape": "HttpRequestWithLabelsAndTimestampFormatInput"
                     },
-                    "documentation": "<p>The example tests how requests serialize different timestamp formats in the URI path.</p>"
+                    "documentation": "<p>The example tests how requests serialize different timestamp formats in the URI path.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes different timestamp formats in URI labels",
                 "params": {
                     "memberEpochSeconds": 1576540098,
                     "memberHttpDate": 1576540098,
@@ -2185,11 +2564,20 @@
     {
         "description": "Test cases for HttpRequestWithRegexLiteral operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpRequestWithRegexLiteralInput": {
@@ -2212,6 +2600,7 @@
         "cases": [
             {
                 "id": "RestJsonToleratesRegexCharsInSegments",
+                "description": "Path matching is not broken by regex expressions in literal segments",
                 "given": {
                     "name": "HttpRequestWithRegexLiteral",
                     "http": {
@@ -2221,9 +2610,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithRegexLiteralInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Path matching is not broken by regex expressions in literal segments",
                 "params": {
                     "str": "abc"
                 },
@@ -2238,13 +2627,25 @@
     {
         "description": "Test cases for HttpStringPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "StringPayloadInput": {
                 "type": "structure",
                 "members": {
@@ -2253,9 +2654,6 @@
                     }
                 },
                 "payload": "payload"
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
@@ -2292,13 +2690,56 @@
     {
         "description": "Test cases for InputAndOutputWithHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "InputAndOutputWithHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -2394,28 +2835,32 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "Integer": {
                 "type": "integer",
                 "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
             },
             "Long": {
                 "type": "long",
                 "box": true
             },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
+            "String": {
+                "type": "string"
             },
             "StringList": {
                 "type": "list",
@@ -2429,57 +2874,20 @@
                     "shape": "String"
                 }
             },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
+            "Timestamp": {
+                "type": "timestamp"
             },
             "TimestampList": {
                 "type": "list",
                 "member": {
                     "shape": "Timestamp"
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "Timestamp": {
-                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "RestJsonInputAndOutputWithStringHeaders",
+                "description": "Tests requests with string header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2492,7 +2900,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with string header bindings",
                 "params": {
                     "headerString": "Hello",
                     "headerStringList": [
@@ -2511,14 +2918,15 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-String": "Hello",
                         "X-StringList": "a, b, c",
+                        "X-String": "Hello",
                         "X-StringSet": "a, b, c"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithQuotedStringHeaders",
+                "description": "Tests requests with string list header bindings that require quoting",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2531,7 +2939,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with string list header bindings that require quoting",
                 "params": {
                     "headerStringList": [
                         "b,c",
@@ -2550,6 +2957,7 @@
             },
             {
                 "id": "RestJsonInputAndOutputWithNumericHeaders",
+                "description": "Tests requests with numeric header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2562,7 +2970,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with numeric header bindings",
                 "params": {
                     "headerByte": 1,
                     "headerShort": 123,
@@ -2581,18 +2988,19 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
+                        "X-Integer": "123",
+                        "X-Short": "123",
                         "X-Byte": "1",
+                        "X-Long": "123",
                         "X-Double": "1.1",
                         "X-Float": "1.1",
-                        "X-Integer": "123",
-                        "X-IntegerList": "1, 2, 3",
-                        "X-Long": "123",
-                        "X-Short": "123"
+                        "X-IntegerList": "1, 2, 3"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithBooleanHeaders",
+                "description": "Tests requests with boolean header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2605,7 +3013,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with boolean header bindings",
                 "params": {
                     "headerTrueBool": true,
                     "headerFalseBool": false,
@@ -2620,14 +3027,15 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
+                        "X-BooleanList": "true, false, true",
                         "X-Boolean1": "true",
-                        "X-Boolean2": "false",
-                        "X-BooleanList": "true, false, true"
+                        "X-Boolean2": "false"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithTimestampHeaders",
+                "description": "Tests requests with timestamp header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2640,7 +3048,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with timestamp header bindings",
                 "params": {
                     "headerTimestampList": [
                         1576540098,
@@ -2658,6 +3065,7 @@
             },
             {
                 "id": "RestJsonInputAndOutputWithEnumHeaders",
+                "description": "Tests requests with enum header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2670,7 +3078,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with enum header bindings",
                 "params": {
                     "headerEnum": "Foo",
                     "headerEnumList": [
@@ -2684,13 +3091,14 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Enum": "Foo",
-                        "X-EnumList": "Foo, Bar, Baz"
+                        "X-EnumList": "Foo, Bar, Baz",
+                        "X-Enum": "Foo"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithIntEnumHeaders",
+                "description": "Tests requests with intEnum header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2703,7 +3111,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with intEnum header bindings",
                 "params": {
                     "headerIntegerEnum": 1,
                     "headerIntegerEnumList": [
@@ -2717,13 +3124,14 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-IntegerEnum": "1",
-                        "X-IntegerEnumList": "1, 2, 3"
+                        "X-IntegerEnumList": "1, 2, 3",
+                        "X-IntegerEnum": "1"
                     }
                 }
             },
             {
                 "id": "RestJsonSupportsNaNFloatHeaderInputs",
+                "description": "Supports handling NaN float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2736,7 +3144,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling NaN float header values.",
                 "params": {
                     "headerFloat": "NaN",
                     "headerDouble": "NaN"
@@ -2746,13 +3153,14 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Double": "NaN",
-                        "X-Float": "NaN"
+                        "X-Float": "NaN",
+                        "X-Double": "NaN"
                     }
                 }
             },
             {
                 "id": "RestJsonSupportsInfinityFloatHeaderInputs",
+                "description": "Supports handling Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2765,7 +3173,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling Infinity float header values.",
                 "params": {
                     "headerFloat": "Infinity",
                     "headerDouble": "Infinity"
@@ -2775,13 +3182,14 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Double": "Infinity",
-                        "X-Float": "Infinity"
+                        "X-Float": "Infinity",
+                        "X-Double": "Infinity"
                     }
                 }
             },
             {
                 "id": "RestJsonSupportsNegativeInfinityFloatHeaderInputs",
+                "description": "Supports handling -Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2794,7 +3202,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling -Infinity float header values.",
                 "params": {
                     "headerFloat": "-Infinity",
                     "headerDouble": "-Infinity"
@@ -2804,8 +3211,8 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Double": "-Infinity",
-                        "X-Float": "-Infinity"
+                        "X-Float": "-Infinity",
+                        "X-Double": "-Infinity"
                     }
                 }
             }
@@ -2814,13 +3221,25 @@
     {
         "description": "Test cases for JsonBlobs operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "JsonBlobsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2828,14 +3247,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "RestJsonJsonBlobs",
+                "description": "Blobs are base64 encoded",
                 "given": {
                     "name": "JsonBlobs",
                     "http": {
@@ -2848,7 +3265,6 @@
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Blobs are base64 encoded",
                 "params": {
                     "data": "value"
                 },
@@ -2866,13 +3282,53 @@
     {
         "description": "Test cases for JsonEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "JsonEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2896,37 +3352,6 @@
                     }
                 }
             },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -2934,6 +3359,7 @@
         "cases": [
             {
                 "id": "RestJsonJsonEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "JsonEnums",
                     "http": {
@@ -2947,7 +3373,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -2979,13 +3404,47 @@
     {
         "description": "Test cases for JsonIntEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
             "JsonIntEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -3009,31 +3468,6 @@
                     }
                 }
             },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -3041,6 +3475,7 @@
         "cases": [
             {
                 "id": "RestJsonJsonIntEnums",
+                "description": "Serializes intEnums as integers",
                 "given": {
                     "name": "JsonIntEnums",
                     "http": {
@@ -3054,7 +3489,6 @@
                     "documentation": "<p>This example serializes intEnums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes intEnums as integers",
                 "params": {
                     "integerEnum1": 1,
                     "integerEnum2": 2,
@@ -3087,13 +3521,68 @@
     {
         "description": "Test cases for JsonLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
             "JsonListsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -3127,6 +3616,16 @@
                     }
                 }
             },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "String": {
+                "type": "string"
+            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -3138,43 +3637,6 @@
                 "member": {
                     "shape": "String"
                 }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
             },
             "StructureList": {
                 "type": "list",
@@ -3195,38 +3657,20 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "Timestamp": {
                 "type": "timestamp"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
             }
         },
         "cases": [
             {
                 "id": "RestJsonLists",
+                "description": "Serializes JSON lists",
                 "given": {
                     "name": "JsonLists",
                     "http": {
@@ -3240,7 +3684,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal JSON lists.</li> <li>Normal JSON sets.</li> <li>JSON lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes JSON lists",
                 "params": {
                     "stringList": [
                         "foo",
@@ -3302,6 +3745,7 @@
             },
             {
                 "id": "RestJsonListsEmpty",
+                "description": "Serializes empty JSON lists",
                 "given": {
                     "name": "JsonLists",
                     "http": {
@@ -3315,7 +3759,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal JSON lists.</li> <li>Normal JSON sets.</li> <li>JSON lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes empty JSON lists",
                 "params": {
                     "stringList": []
                 },
@@ -3333,13 +3776,83 @@
     {
         "description": "Test cases for JsonMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "DenseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                }
+            },
+            "DenseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                }
+            },
+            "DenseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                }
+            },
+            "DenseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
+            "DenseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
             "JsonMapsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -3360,80 +3873,20 @@
                     }
                 }
             },
-            "DenseStructMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "GreetingStruct"
-                }
-            },
-            "DenseNumberMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Integer"
-                }
-            },
-            "DenseBooleanMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Boolean"
-                }
-            },
-            "DenseStringMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "String"
-                }
-            },
-            "DenseSetMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "StringSet"
-                }
+            "String": {
+                "type": "string"
             },
             "StringSet": {
                 "type": "list",
                 "member": {
                     "shape": "String"
                 }
-            },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
             }
         },
         "cases": [
             {
                 "id": "RestJsonJsonMaps",
+                "description": "Serializes JSON maps",
                 "given": {
                     "name": "JsonMaps",
                     "http": {
@@ -3446,7 +3899,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Serializes JSON maps",
                 "params": {
                     "denseStructMap": {
                         "foo": {
@@ -3468,6 +3920,7 @@
             },
             {
                 "id": "RestJsonSerializesZeroValuesInMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "given": {
                     "name": "JsonMaps",
                     "http": {
@@ -3480,7 +3933,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "params": {
                     "denseNumberMap": {
                         "x": 0
@@ -3500,6 +3952,7 @@
             },
             {
                 "id": "RestJsonSerializesDenseSetMap",
+                "description": "A request that contains a dense map of sets.",
                 "given": {
                     "name": "JsonMaps",
                     "http": {
@@ -3512,7 +3965,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "A request that contains a dense map of sets.",
                 "params": {
                     "denseSetMap": {
                         "x": [],
@@ -3536,13 +3988,34 @@
     {
         "description": "Test cases for JsonTimestamps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
             "JsonTimestampsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -3569,14 +4042,7 @@
                     }
                 }
             },
-            "Timestamp": {
-                "type": "timestamp"
-            },
             "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "DateTime": {
                 "type": "timestamp",
                 "timestampFormat": "iso8601"
             },
@@ -3584,22 +4050,18 @@
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
             },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
             "SyntheticTimestamp_http_date": {
                 "type": "timestamp",
                 "timestampFormat": "rfc822"
             },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "RestJsonJsonTimestamps",
+                "description": "Tests how normal timestamps are serialized",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3612,7 +4074,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Tests how normal timestamps are serialized",
                 "params": {
                     "normal": 1398796238
                 },
@@ -3627,6 +4088,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithDateTimeFormat",
+                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3639,7 +4101,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "params": {
                     "dateTime": 1398796238
                 },
@@ -3654,6 +4115,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
+                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3666,7 +4128,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "params": {
                     "dateTimeOnTarget": 1398796238
                 },
@@ -3681,6 +4142,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithEpochSecondsFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3693,7 +4155,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "params": {
                     "epochSeconds": 1398796238
                 },
@@ -3708,6 +4169,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3720,7 +4182,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "params": {
                     "epochSecondsOnTarget": 1398796238
                 },
@@ -3735,6 +4196,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithHttpDateFormat",
+                "description": "Ensures that the timestampFormat of http-date works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3747,7 +4209,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date works",
                 "params": {
                     "httpDate": 1398796238
                 },
@@ -3762,6 +4223,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
+                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3774,7 +4236,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "params": {
                     "httpDateOnTarget": 1398796238
                 },
@@ -3792,21 +4253,50 @@
     {
         "description": "Test cases for JsonUnions operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
-            "UnionInputOutput": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "GreetingStruct": {
                 "type": "structure",
                 "members": {
-                    "contents": {
-                        "shape": "MyUnion"
+                    "hi": {
+                        "shape": "String"
                     }
-                },
-                "documentation": "<p>A shared structure that contains a single union member.</p>"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
             },
             "MyUnion": {
                 "type": "structure",
@@ -3845,32 +4335,16 @@
                 "documentation": "<p>A union with a representative set of types for members.</p>",
                 "union": true
             },
+            "RenamedGreeting": {
+                "type": "structure",
+                "members": {
+                    "salutation": {
+                        "shape": "String"
+                    }
+                }
+            },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
             },
             "StringList": {
                 "type": "list",
@@ -3887,26 +4361,23 @@
                     "shape": "String"
                 }
             },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
+            "Timestamp": {
+                "type": "timestamp"
             },
-            "RenamedGreeting": {
+            "UnionInputOutput": {
                 "type": "structure",
                 "members": {
-                    "salutation": {
-                        "shape": "String"
+                    "contents": {
+                        "shape": "MyUnion"
                     }
-                }
+                },
+                "documentation": "<p>A shared structure that contains a single union member.</p>"
             }
         },
         "cases": [
             {
                 "id": "RestJsonSerializeStringUnionValue",
+                "description": "Serializes a string union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3920,7 +4391,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a string union value",
                 "params": {
                     "contents": {
                         "stringValue": "foo"
@@ -3937,6 +4407,7 @@
             },
             {
                 "id": "RestJsonSerializeBooleanUnionValue",
+                "description": "Serializes a boolean union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3950,7 +4421,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a boolean union value",
                 "params": {
                     "contents": {
                         "booleanValue": true
@@ -3967,6 +4437,7 @@
             },
             {
                 "id": "RestJsonSerializeNumberUnionValue",
+                "description": "Serializes a number union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3980,7 +4451,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a number union value",
                 "params": {
                     "contents": {
                         "numberValue": 1
@@ -3997,6 +4467,7 @@
             },
             {
                 "id": "RestJsonSerializeBlobUnionValue",
+                "description": "Serializes a blob union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -4010,7 +4481,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a blob union value",
                 "params": {
                     "contents": {
                         "blobValue": "foo"
@@ -4027,6 +4497,7 @@
             },
             {
                 "id": "RestJsonSerializeTimestampUnionValue",
+                "description": "Serializes a timestamp union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -4040,7 +4511,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a timestamp union value",
                 "params": {
                     "contents": {
                         "timestampValue": 1398796238
@@ -4057,6 +4527,7 @@
             },
             {
                 "id": "RestJsonSerializeEnumUnionValue",
+                "description": "Serializes an enum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -4070,7 +4541,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes an enum union value",
                 "params": {
                     "contents": {
                         "enumValue": "Foo"
@@ -4087,6 +4557,7 @@
             },
             {
                 "id": "RestJsonSerializeListUnionValue",
+                "description": "Serializes a list union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -4100,7 +4571,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a list union value",
                 "params": {
                     "contents": {
                         "listValue": [
@@ -4120,6 +4590,7 @@
             },
             {
                 "id": "RestJsonSerializeMapUnionValue",
+                "description": "Serializes a map union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -4133,7 +4604,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a map union value",
                 "params": {
                     "contents": {
                         "mapValue": {
@@ -4153,6 +4623,7 @@
             },
             {
                 "id": "RestJsonSerializeStructureUnionValue",
+                "description": "Serializes a structure union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -4166,7 +4637,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure union value",
                 "params": {
                     "contents": {
                         "structureValue": {
@@ -4185,6 +4655,7 @@
             },
             {
                 "id": "RestJsonSerializeRenamedStructureUnionValue",
+                "description": "Serializes a renamed structure union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -4198,7 +4669,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a renamed structure union value",
                 "params": {
                     "contents": {
                         "renamedStructureValue": {
@@ -4220,13 +4690,25 @@
     {
         "description": "Test cases for MediaTypeHeader operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "JsonValue": {
+                "type": "string"
+            },
             "MediaTypeHeaderInput": {
                 "type": "structure",
                 "members": {
@@ -4237,14 +4719,12 @@
                         "locationName": "X-Json"
                     }
                 }
-            },
-            "JsonValue": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "MediaTypeHeaderInputBase64",
+                "description": "Headers that target strings with a mediaType are base64 encoded",
                 "given": {
                     "name": "MediaTypeHeader",
                     "http": {
@@ -4255,9 +4735,9 @@
                     "input": {
                         "shape": "MediaTypeHeaderInput"
                     },
-                    "documentation": "<p>This example ensures that mediaType strings are base64 encoded in headers.</p>"
+                    "documentation": "<p>This example ensures that mediaType strings are base64 encoded in headers.</p>",
+                    "readonly": true
                 },
-                "description": "Headers that target strings with a mediaType are base64 encoded",
                 "params": {
                     "json": "true"
                 },
@@ -4275,16 +4755,26 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonNoInputAndNoOutput",
+                "description": "No input serializes no payload. When clients do not need to\nserialize any data in the payload, they should omit a payload\naltogether.",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -4294,7 +4784,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No input serializes no payload. When clients do not need to\nserialize any data in the payload, they should omit a payload\naltogether.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -4307,16 +4796,26 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonNoInputAndOutput",
+                "description": "No input serializes no payload. When clients do not need to\nserialize any data in the payload, they should omit a payload\naltogether.",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -4326,7 +4825,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input and the output is empty. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No input serializes no payload. When clients do not need to\nserialize any data in the payload, they should omit a payload\naltogether.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -4339,11 +4837,20 @@
     {
         "description": "Test cases for NullAndEmptyHeadersClient operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "NullAndEmptyHeadersIO": {
@@ -4379,6 +4886,7 @@
         "cases": [
             {
                 "id": "RestJsonNullAndEmptyHeaders",
+                "description": "Do not send null values, but do send empty strings and empty lists over the wire in headers",
                 "given": {
                     "name": "NullAndEmptyHeadersClient",
                     "http": {
@@ -4389,9 +4897,9 @@
                     "input": {
                         "shape": "NullAndEmptyHeadersIO"
                     },
-                    "documentation": "<p>Null headers are not sent over the wire, empty headers are serialized to &quot;&quot;</p>"
+                    "documentation": "<p>Null headers are not sent over the wire, empty headers are serialized to &quot;&quot;</p>",
+                    "readonly": true
                 },
-                "description": "Do not send null values, but do send empty strings and empty lists over the wire in headers",
                 "params": {
                     "a": null,
                     "b": "",
@@ -4415,11 +4923,20 @@
     {
         "description": "Test cases for OmitsNullSerializesEmptyString operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "OmitsNullSerializesEmptyStringInput": {
@@ -4444,6 +4961,7 @@
         "cases": [
             {
                 "id": "RestJsonOmitsNullQuery",
+                "description": "Omits null query values",
                 "given": {
                     "name": "OmitsNullSerializesEmptyString",
                     "http": {
@@ -4454,9 +4972,9 @@
                     "input": {
                         "shape": "OmitsNullSerializesEmptyStringInput"
                     },
-                    "documentation": "<p>Omits null, but serializes empty string value.</p>"
+                    "documentation": "<p>Omits null, but serializes empty string value.</p>",
+                    "readonly": true
                 },
-                "description": "Omits null query values",
                 "params": {
                     "nullValue": null
                 },
@@ -4468,6 +4986,7 @@
             },
             {
                 "id": "RestJsonSerializesEmptyQueryValue",
+                "description": "Serializes empty query strings",
                 "given": {
                     "name": "OmitsNullSerializesEmptyString",
                     "http": {
@@ -4478,9 +4997,9 @@
                     "input": {
                         "shape": "OmitsNullSerializesEmptyStringInput"
                     },
-                    "documentation": "<p>Omits null, but serializes empty string value.</p>"
+                    "documentation": "<p>Omits null, but serializes empty string value.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes empty query strings",
                 "params": {
                     "emptyString": ""
                 },
@@ -4495,13 +5014,78 @@
     {
         "description": "Test cases for OmitsSerializingEmptyLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "DoubleList": {
+                "type": "list",
+                "member": {
+                    "shape": "Double"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
             "OmitsSerializingEmptyListsInput": {
                 "type": "structure",
                 "members": {
@@ -4542,84 +5126,29 @@
                     }
                 }
             },
+            "String": {
+                "type": "string"
+            },
             "StringList": {
                 "type": "list",
                 "member": {
                     "shape": "String"
                 }
             },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "DoubleList": {
-                "type": "list",
-                "member": {
-                    "shape": "Double"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
+            "Timestamp": {
+                "type": "timestamp"
             },
             "TimestampList": {
                 "type": "list",
                 "member": {
                     "shape": "Timestamp"
                 }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonOmitsEmptyListQueryValues",
+                "description": "Supports omitting empty lists.",
                 "given": {
                     "name": "OmitsSerializingEmptyLists",
                     "http": {
@@ -4632,7 +5161,6 @@
                     },
                     "documentation": "<p>Omits serializing empty lists. Because empty strings are serilized as <code>Foo=</code>, empty lists cannot also be serialized as <code>Foo=</code> and instead must be omitted.</p>"
                 },
-                "description": "Supports omitting empty lists.",
                 "params": {
                     "queryStringList": [],
                     "queryIntegerList": [],
@@ -4653,11 +5181,20 @@
     {
         "description": "Test cases for PostUnionWithJsonName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "PostUnionWithJsonNameInput": {
@@ -4667,6 +5204,9 @@
                         "shape": "UnionWithJsonName"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             },
             "UnionWithJsonName": {
                 "type": "structure",
@@ -4684,14 +5224,12 @@
                     }
                 },
                 "union": true
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "PostUnionWithJsonNameRequest1",
+                "description": "Tests that jsonName works with union members.",
                 "given": {
                     "name": "PostUnionWithJsonName",
                     "http": {
@@ -4704,7 +5242,6 @@
                     },
                     "documentation": "<p>This operation defines a union that uses jsonName on some members.</p>"
                 },
-                "description": "Tests that jsonName works with union members.",
                 "params": {
                     "value": {
                         "foo": "hi"
@@ -4721,6 +5258,7 @@
             },
             {
                 "id": "PostUnionWithJsonNameRequest2",
+                "description": "Tests that jsonName works with union members.",
                 "given": {
                     "name": "PostUnionWithJsonName",
                     "http": {
@@ -4733,7 +5271,6 @@
                     },
                     "documentation": "<p>This operation defines a union that uses jsonName on some members.</p>"
                 },
-                "description": "Tests that jsonName works with union members.",
                 "params": {
                     "value": {
                         "baz": "hi"
@@ -4750,6 +5287,7 @@
             },
             {
                 "id": "PostUnionWithJsonNameRequest3",
+                "description": "Tests that jsonName works with union members.",
                 "given": {
                     "name": "PostUnionWithJsonName",
                     "http": {
@@ -4762,7 +5300,6 @@
                     },
                     "documentation": "<p>This operation defines a union that uses jsonName on some members.</p>"
                 },
-                "description": "Tests that jsonName works with union members.",
                 "params": {
                     "value": {
                         "bar": "hi"
@@ -4782,11 +5319,20 @@
     {
         "description": "Test cases for PutWithContentEncoding operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "PutWithContentEncodingInput": {
@@ -4809,6 +5355,7 @@
         "cases": [
             {
                 "id": "SDKAppliedContentEncoding_restJson1",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -4825,7 +5372,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "params": {
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
                 },
@@ -4839,6 +5385,7 @@
             },
             {
                 "id": "SDKAppendedGzipAfterProvidedEncoding_restJson1",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is in the Content-Encoding header before the\nrequest compression encoding from the HTTP binding.\n",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -4855,7 +5402,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is in the Content-Encoding header before the\nrequest compression encoding from the HTTP binding.\n",
                 "params": {
                     "encoding": "custom",
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
@@ -4873,11 +5419,20 @@
     {
         "description": "Test cases for QueryIdempotencyTokenAutoFill operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "QueryIdempotencyTokenAutoFillInput": {
@@ -4898,6 +5453,7 @@
         "cases": [
             {
                 "id": "RestJsonQueryIdempotencyTokenAutoFill",
+                "description": "Automatically adds idempotency token when not set",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -4910,7 +5466,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Automatically adds idempotency token when not set",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -4920,6 +5475,7 @@
             },
             {
                 "id": "RestJsonQueryIdempotencyTokenAutoFillIsSet",
+                "description": "Uses the given idempotency token as-is",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -4932,7 +5488,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Uses the given idempotency token as-is",
                 "params": {
                     "token": "00000000-0000-4000-8000-000000000000"
                 },
@@ -4947,11 +5502,20 @@
     {
         "description": "Test cases for QueryParamsAsStringListMap operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "QueryParamsAsStringListMapInput": {
@@ -4971,6 +5535,12 @@
             "String": {
                 "type": "string"
             },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
             "StringListMap": {
                 "type": "map",
                 "key": {
@@ -4979,17 +5549,12 @@
                 "value": {
                     "shape": "StringList"
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
             }
         },
         "cases": [
             {
                 "id": "RestJsonQueryParamsStringListMap",
+                "description": "Serialize query params from map of list strings",
                 "given": {
                     "name": "QueryParamsAsStringListMap",
                     "http": {
@@ -5001,7 +5566,6 @@
                         "shape": "QueryParamsAsStringListMapInput"
                     }
                 },
-                "description": "Serialize query params from map of list strings",
                 "params": {
                     "qux": "named",
                     "foo": {
@@ -5022,11 +5586,20 @@
     {
         "description": "Test cases for QueryPrecedence operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "QueryPrecedenceInput": {
@@ -5059,6 +5632,7 @@
         "cases": [
             {
                 "id": "RestJsonQueryPrecedence",
+                "description": "Prefer named query parameters when serializing",
                 "given": {
                     "name": "QueryPrecedence",
                     "http": {
@@ -5070,7 +5644,6 @@
                         "shape": "QueryPrecedenceInput"
                     }
                 },
-                "description": "Prefer named query parameters when serializing",
                 "params": {
                     "foo": "named",
                     "baz": {
@@ -5089,11 +5662,20 @@
     {
         "description": "Test cases for RecursiveShapes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "RecursiveShapesInputOutput": {
@@ -5115,9 +5697,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveShapesInputOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -5128,11 +5707,15 @@
                         "shape": "RecursiveShapesInputOutputNested1"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonRecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveShapes",
                     "http": {
@@ -5146,7 +5729,6 @@
                     "documentation": "<p>Recursive shapes</p>",
                     "idempotent": true
                 },
-                "description": "Serializes recursive structures",
                 "params": {
                     "nested": {
                         "foo": "Foo1",
@@ -5175,13 +5757,42 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarPropertiesInputOutput": {
                 "type": "structure",
                 "members": {
@@ -5222,31 +5833,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "RestJsonSimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -5259,7 +5851,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "foo": "Foo",
                     "stringValue": "string",
@@ -5277,13 +5868,14 @@
                     "uri": "/SimpleScalarProperties",
                     "body": "{\n    \"stringValue\": \"string\",\n    \"trueBooleanValue\": true,\n    \"falseBooleanValue\": false,\n    \"byteValue\": 1,\n    \"shortValue\": 2,\n    \"integerValue\": 3,\n    \"longValue\": 4,\n    \"floatValue\": 5.5,\n    \"DoubleDribble\": 6.5\n}",
                     "headers": {
-                        "Content-Type": "application/json",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/json"
                     }
                 }
             },
             {
                 "id": "RestJsonDoesntSerializeNullStructureValues",
+                "description": "Rest Json should not serialize null structure values",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -5296,7 +5888,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Rest Json should not serialize null structure values",
                 "params": {
                     "stringValue": null
                 },
@@ -5311,6 +5902,7 @@
             },
             {
                 "id": "RestJsonSupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -5323,7 +5915,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling NaN float values.",
                 "params": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -5339,6 +5930,7 @@
             },
             {
                 "id": "RestJsonSupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -5351,7 +5943,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -5367,6 +5958,7 @@
             },
             {
                 "id": "RestJsonSupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -5379,7 +5971,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling -Infinity float values.",
                 "params": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -5396,15 +5987,409 @@
         ]
     },
     {
-        "description": "Test cases for TestBodyStructure operation",
+        "description": "Test cases for SparseJsonLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "SparseJsonListsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStringList": {
+                        "shape": "SparseStringList"
+                    },
+                    "sparseShortList": {
+                        "shape": "SparseShortList"
+                    }
+                }
+            },
+            "SparseShortList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                },
+                "sparse": true
+            },
+            "SparseStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "RestJsonSparseListsSerializeNull",
+                "description": "Serializes null values in sparse lists",
+                "given": {
+                    "name": "SparseJsonLists",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/SparseJsonLists",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "SparseJsonListsInputOutput"
+                    },
+                    "idempotent": true
+                },
+                "params": {
+                    "sparseStringList": [
+                        null,
+                        "hi"
+                    ],
+                    "sparseShortList": [
+                        null,
+                        2
+                    ]
+                },
+                "serialized": {
+                    "method": "PUT",
+                    "uri": "/SparseJsonLists",
+                    "body": "{\n    \"sparseStringList\": [\n        null,\n        \"hi\"\n    ],\n    \"sparseShortList\": [\n        null,\n        2\n    ]\n}",
+                    "headers": {
+                        "Content-Type": "application/json"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SparseJsonMaps operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
+            "protocol": "rest-json",
+            "protocols": [
+                "rest-json"
+            ],
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
+        },
+        "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "SparseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                },
+                "sparse": true
+            },
+            "SparseJsonMapsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStructMap": {
+                        "shape": "SparseStructMap"
+                    },
+                    "sparseNumberMap": {
+                        "shape": "SparseNumberMap"
+                    },
+                    "sparseBooleanMap": {
+                        "shape": "SparseBooleanMap"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
+                    },
+                    "sparseSetMap": {
+                        "shape": "SparseSetMap"
+                    }
+                }
+            },
+            "SparseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                },
+                "sparse": true
+            },
+            "SparseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                },
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "SparseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RestJsonSparseJsonMaps",
+                "description": "Serializes JSON maps",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "params": {
+                    "sparseStructMap": {
+                        "foo": {
+                            "hi": "there"
+                        },
+                        "baz": {
+                            "hi": "bye"
+                        }
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/SparseJsonMaps",
+                    "body": "{\n    \"sparseStructMap\": {\n        \"foo\": {\n            \"hi\": \"there\"\n        },\n        \"baz\": {\n            \"hi\": \"bye\"\n        }\n    }\n}",
+                    "headers": {
+                        "Content-Type": "application/json"
+                    }
+                }
+            },
+            {
+                "id": "RestJsonSerializesSparseNullMapValues",
+                "description": "Serializes JSON map values in sparse maps",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "params": {
+                    "sparseBooleanMap": {
+                        "x": null
+                    },
+                    "sparseNumberMap": {
+                        "x": null
+                    },
+                    "sparseStringMap": {
+                        "x": null
+                    },
+                    "sparseStructMap": {
+                        "x": null
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/SparseJsonMaps",
+                    "body": "{\n    \"sparseBooleanMap\": {\n        \"x\": null\n    },\n    \"sparseNumberMap\": {\n        \"x\": null\n    },\n    \"sparseStringMap\": {\n        \"x\": null\n    },\n    \"sparseStructMap\": {\n        \"x\": null\n    }\n}",
+                    "headers": {
+                        "Content-Type": "application/json"
+                    }
+                }
+            },
+            {
+                "id": "RestJsonSerializesZeroValuesInSparseMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "params": {
+                    "sparseNumberMap": {
+                        "x": 0
+                    },
+                    "sparseBooleanMap": {
+                        "x": false
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/SparseJsonMaps",
+                    "body": "{\n    \"sparseNumberMap\": {\n        \"x\": 0\n    },\n    \"sparseBooleanMap\": {\n        \"x\": false\n    }\n}",
+                    "headers": {
+                        "Content-Type": "application/json"
+                    }
+                }
+            },
+            {
+                "id": "RestJsonSerializesSparseSetMap",
+                "description": "A request that contains a sparse map of sets",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "params": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ]
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/SparseJsonMaps",
+                    "body": "{\n    \"sparseSetMap\": {\n        \"x\": [],\n        \"y\": [\"a\", \"b\"]\n    }\n}",
+                    "headers": {
+                        "Content-Type": "application/json"
+                    }
+                }
+            },
+            {
+                "id": "RestJsonSerializesSparseSetMapAndRetainsNull",
+                "description": "A request that contains a sparse map of sets.",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "params": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ],
+                        "z": null
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/SparseJsonMaps",
+                    "body": "{\n    \"sparseSetMap\": {\n        \"x\": [],\n        \"y\": [\"a\", \"b\"],\n        \"z\": null\n    }\n}",
+                    "headers": {
+                        "Content-Type": "application/json"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for TestBodyStructure operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
+            "protocol": "rest-json",
+            "protocols": [
+                "rest-json"
+            ],
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
+        },
+        "shapes": {
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "String": {
+                "type": "string"
+            },
             "TestBodyStructureInputOutput": {
                 "type": "structure",
                 "members": {
@@ -5418,9 +6403,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "TestConfig": {
                 "type": "structure",
                 "members": {
@@ -5428,15 +6410,12 @@
                         "shape": "Integer"
                     }
                 }
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "RestJsonTestBodyStructure",
+                "description": "Serializes a structure",
                 "given": {
                     "name": "TestBodyStructure",
                     "http": {
@@ -5450,7 +6429,6 @@
                     "documentation": "<p>This example operation serializes a structure in the HTTP body.</p> <p>It should ensure Content-Type: application/json is used in all requests and that an &quot;empty&quot; body is an empty JSON document ({}).</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure",
                 "params": {
                     "testConfig": {
                         "timeout": 10
@@ -5470,6 +6448,7 @@
             },
             {
                 "id": "RestJsonHttpWithEmptyBody",
+                "description": "Serializes an empty structure in the body",
                 "given": {
                     "name": "TestBodyStructure",
                     "http": {
@@ -5483,7 +6462,6 @@
                     "documentation": "<p>This example operation serializes a structure in the HTTP body.</p> <p>It should ensure Content-Type: application/json is used in all requests and that an &quot;empty&quot; body is an empty JSON document ({}).</p>",
                     "idempotent": true
                 },
-                "description": "Serializes an empty structure in the body",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -5502,16 +6480,26 @@
     {
         "description": "Test cases for TestGetNoInputNoPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonHttpGetWithNoInput",
+                "description": "Serializes a GET request for an operation with no input, and therefore no modeled body",
                 "given": {
                     "name": "TestGetNoInputNoPayload",
                     "http": {
@@ -5519,9 +6507,9 @@
                         "requestUri": "/no_input_no_payload",
                         "responseCode": 200
                     },
-                    "documentation": "<p>This example GET operation has no input and serializes a request without a HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Length, Content-Type) to operations that semantically cannot produce an HTTP body.</p>"
+                    "documentation": "<p>This example GET operation has no input and serializes a request without a HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Length, Content-Type) to operations that semantically cannot produce an HTTP body.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes a GET request for an operation with no input, and therefore no modeled body",
                 "params": {},
                 "serialized": {
                     "method": "GET",
@@ -5538,13 +6526,25 @@
     {
         "description": "Test cases for TestGetNoPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "TestNoPayloadInputOutput": {
                 "type": "structure",
                 "members": {
@@ -5554,14 +6554,12 @@
                         "locationName": "X-Amz-Test-Id"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpGetWithNoModeledBody",
+                "description": "Serializes a GET request with no modeled body",
                 "given": {
                     "name": "TestGetNoPayload",
                     "http": {
@@ -5572,9 +6570,9 @@
                     "input": {
                         "shape": "TestNoPayloadInputOutput"
                     },
-                    "documentation": "<p>This example GET operation serializes a request without a modeled HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Length, Content-Type) to operations that semantically cannot produce an HTTP body.</p>"
+                    "documentation": "<p>This example GET operation serializes a request without a modeled HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Length, Content-Type) to operations that semantically cannot produce an HTTP body.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes a GET request with no modeled body",
                 "params": {},
                 "serialized": {
                     "method": "GET",
@@ -5588,6 +6586,7 @@
             },
             {
                 "id": "RestJsonHttpGetWithHeaderMemberNoModeledBody",
+                "description": "Serializes a GET request with header member but no modeled body",
                 "given": {
                     "name": "TestGetNoPayload",
                     "http": {
@@ -5598,9 +6597,9 @@
                     "input": {
                         "shape": "TestNoPayloadInputOutput"
                     },
-                    "documentation": "<p>This example GET operation serializes a request without a modeled HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Length, Content-Type) to operations that semantically cannot produce an HTTP body.</p>"
+                    "documentation": "<p>This example GET operation serializes a request without a modeled HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Length, Content-Type) to operations that semantically cannot produce an HTTP body.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes a GET request with header member but no modeled body",
                 "params": {
                     "testId": "t-12345"
                 },
@@ -5622,13 +6621,28 @@
     {
         "description": "Test cases for TestPayloadBlob operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "String": {
+                "type": "string"
+            },
             "TestPayloadBlobInputOutput": {
                 "type": "structure",
                 "members": {
@@ -5642,17 +6656,12 @@
                     }
                 },
                 "payload": "data"
-            },
-            "String": {
-                "type": "string"
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpWithEmptyBlobPayload",
+                "description": "Serializes a payload targeting an empty blob",
                 "given": {
                     "name": "TestPayloadBlob",
                     "http": {
@@ -5666,7 +6675,6 @@
                     "documentation": "<p>This example operation serializes a payload targeting a blob.</p> <p>The Blob shape is not structured content and we cannot make assumptions about what data will be sent. This test ensures only a generic &quot;Content-Type: application/octet-stream&quot; header is used, and that we are not treating an empty body as an empty JSON document.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a payload targeting an empty blob",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -5676,6 +6684,7 @@
             },
             {
                 "id": "RestJsonTestPayloadBlob",
+                "description": "Serializes a payload targeting a blob",
                 "given": {
                     "name": "TestPayloadBlob",
                     "http": {
@@ -5689,7 +6698,6 @@
                     "documentation": "<p>This example operation serializes a payload targeting a blob.</p> <p>The Blob shape is not structured content and we cannot make assumptions about what data will be sent. This test ensures only a generic &quot;Content-Type: application/octet-stream&quot; header is used, and that we are not treating an empty body as an empty JSON document.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a payload targeting a blob",
                 "params": {
                     "contentType": "image/jpg",
                     "data": "1234"
@@ -5711,13 +6719,37 @@
     {
         "description": "Test cases for TestPayloadStructure operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "PayloadConfig": {
+                "type": "structure",
+                "members": {
+                    "data": {
+                        "shape": "Integer"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "TestPayloadStructureInputOutput": {
                 "type": "structure",
                 "members": {
@@ -5731,26 +6763,12 @@
                     }
                 },
                 "payload": "payloadConfig"
-            },
-            "String": {
-                "type": "string"
-            },
-            "PayloadConfig": {
-                "type": "structure",
-                "members": {
-                    "data": {
-                        "shape": "Integer"
-                    }
-                }
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpWithEmptyStructurePayload",
+                "description": "Serializes a payload targeting an empty structure",
                 "given": {
                     "name": "TestPayloadStructure",
                     "http": {
@@ -5764,7 +6782,6 @@
                     "documentation": "<p>This example operation serializes a payload targeting a structure.</p> <p>This enforces the same requirements as TestBodyStructure but with the body specified by the @httpPayload trait.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a payload targeting an empty structure",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -5780,6 +6797,7 @@
             },
             {
                 "id": "RestJsonTestPayloadStructure",
+                "description": "Serializes a payload targeting a structure",
                 "given": {
                     "name": "TestPayloadStructure",
                     "http": {
@@ -5793,7 +6811,6 @@
                     "documentation": "<p>This example operation serializes a payload targeting a structure.</p> <p>This enforces the same requirements as TestBodyStructure but with the body specified by the @httpPayload trait.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a payload targeting a structure",
                 "params": {
                     "payloadConfig": {
                         "data": 25
@@ -5813,6 +6830,7 @@
             },
             {
                 "id": "RestJsonHttpWithHeadersButNoPayload",
+                "description": "Serializes an request with header members but no payload",
                 "given": {
                     "name": "TestPayloadStructure",
                     "http": {
@@ -5826,7 +6844,6 @@
                     "documentation": "<p>This example operation serializes a payload targeting a structure.</p> <p>This enforces the same requirements as TestBodyStructure but with the body specified by the @httpPayload trait.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes an request with header members but no payload",
                 "params": {
                     "testId": "t-12345"
                 },
@@ -5835,8 +6852,8 @@
                     "uri": "/payload",
                     "body": "{}",
                     "headers": {
-                        "Content-Type": "application/json",
-                        "X-Amz-Test-Id": "t-12345"
+                        "X-Amz-Test-Id": "t-12345",
+                        "Content-Type": "application/json"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -5848,16 +6865,26 @@
     {
         "description": "Test cases for TestPostNoInputNoPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonHttpPostWithNoInput",
+                "description": "Serializes a POST request for an operation with no input, and therefore no modeled body",
                 "given": {
                     "name": "TestPostNoInputNoPayload",
                     "http": {
@@ -5867,7 +6894,6 @@
                     },
                     "documentation": "<p>This example POST operation has no input and serializes a request without a HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Type) to a POST operation with no modeled input.</p>"
                 },
-                "description": "Serializes a POST request for an operation with no input, and therefore no modeled body",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -5883,13 +6909,25 @@
     {
         "description": "Test cases for TestPostNoPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "TestNoPayloadInputOutput": {
                 "type": "structure",
                 "members": {
@@ -5899,14 +6937,12 @@
                         "locationName": "X-Amz-Test-Id"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpPostWithNoModeledBody",
+                "description": "Serializes a POST request with no modeled body",
                 "given": {
                     "name": "TestPostNoPayload",
                     "http": {
@@ -5919,7 +6955,6 @@
                     },
                     "documentation": "<p>This example POST operation serializes a request without a modeled HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Type) to a POST operation with no modeled payload.</p>"
                 },
-                "description": "Serializes a POST request with no modeled body",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -5932,6 +6967,7 @@
             },
             {
                 "id": "RestJsonHttpWithPostHeaderMemberNoModeledBody",
+                "description": "Serializes a POST request with header member but no modeled body",
                 "given": {
                     "name": "TestPostNoPayload",
                     "http": {
@@ -5944,7 +6980,6 @@
                     },
                     "documentation": "<p>This example POST operation serializes a request without a modeled HTTP body.</p> <p>These tests are to ensure we do not attach a body or related headers (Content-Type) to a POST operation with no modeled payload.</p>"
                 },
-                "description": "Serializes a POST request with header member but no modeled body",
                 "params": {
                     "testId": "t-12345"
                 },
@@ -5965,13 +7000,49 @@
     {
         "description": "Test cases for TimestampFormatHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "TimestampFormatHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -6011,38 +7082,12 @@
                         "locationName": "X-targetDateTime"
                     }
                 }
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RestJsonTimestampFormatHeaders",
+                "description": "Tests how timestamp request headers are serialized",
                 "given": {
                     "name": "TimestampFormatHeaders",
                     "http": {
@@ -6055,7 +7100,6 @@
                     },
                     "documentation": "<p>This example tests how timestamp request and response headers are serialized.</p>"
                 },
-                "description": "Tests how timestamp request headers are serialized",
                 "params": {
                     "memberEpochSeconds": 1576540098,
                     "memberHttpDate": 1576540098,
@@ -6070,13 +7114,13 @@
                     "uri": "/TimestampFormatHeaders",
                     "body": "",
                     "headers": {
-                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberDateTime": "2019-12-16T23:48:18Z",
-                        "X-memberEpochSeconds": "1576540098",
+                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-targetDateTime": "2019-12-16T23:48:18Z",
                         "X-targetEpochSeconds": "1576540098",
-                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT"
+                        "X-memberEpochSeconds": "1576540098",
+                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT"
                     }
                 }
             }
@@ -6085,16 +7129,26 @@
     {
         "description": "Test cases for UnitInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonUnitInputAndOutput",
+                "description": "A unit type input serializes no payload. When clients do not\nneed to serialize any data in the payload, they should omit\na payload altogether.",
                 "given": {
                     "name": "UnitInputAndOutput",
                     "http": {
@@ -6104,7 +7158,6 @@
                     },
                     "documentation": "<p>This test is similar to NoInputAndNoOutput, but uses explicit Unit types.</p>"
                 },
-                "description": "A unit type input serializes no payload. When clients do not\nneed to serialize any data in the payload, they should omit\na payload altogether.",
                 "params": {},
                 "serialized": {
                     "method": "POST",

--- a/tests/unit/protocols/input/rest-xml.json
+++ b/tests/unit/protocols/input/rest-xml.json
@@ -2,11 +2,20 @@
     {
         "description": "Test cases for AllQueryStringTypes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "AllQueryStringTypesInput": {
@@ -118,44 +127,15 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "Integer": {
-                "type": "integer",
+            "Boolean": {
+                "type": "boolean",
                 "box": true
             },
-            "IntegerList": {
+            "BooleanList": {
                 "type": "list",
                 "member": {
-                    "shape": "Integer"
+                    "shape": "Boolean"
                 }
-            },
-            "IntegerSet": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
             },
             "Double": {
                 "type": "double",
@@ -167,24 +147,9 @@
                     "shape": "Double"
                 }
             },
-            "Boolean": {
-                "type": "boolean",
+            "Float": {
+                "type": "float",
                 "box": true
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
             },
             "FooEnum": {
                 "type": "string",
@@ -202,6 +167,10 @@
                     "shape": "FooEnum"
                 }
             },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
             "IntegerEnum": {
                 "type": "integer",
                 "box": true
@@ -212,6 +181,31 @@
                     "shape": "IntegerEnum"
                 }
             },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "IntegerSet": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
             "StringMap": {
                 "type": "map",
                 "key": {
@@ -220,11 +214,27 @@
                 "value": {
                     "shape": "String"
                 }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
             }
         },
         "cases": [
             {
                 "id": "AllQueryStringTypes",
+                "description": "Serializes query string parameters with all supported types",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -235,9 +245,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes query string parameters with all supported types",
                 "params": {
                     "queryString": "Hello there",
                     "queryStringList": [
@@ -303,6 +313,7 @@
             },
             {
                 "id": "RestXmlQueryStringMap",
+                "description": "Handles query string maps",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -313,9 +324,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Handles query string maps",
                 "params": {
                     "queryParamsMapOfStrings": {
                         "QueryParamsStringKeyA": "Foo",
@@ -330,6 +341,7 @@
             },
             {
                 "id": "RestXmlQueryStringEscaping",
+                "description": "Handles escaping all required characters in the query string.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -340,9 +352,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Handles escaping all required characters in the query string.",
                 "params": {
                     "queryString": " %:/?#[]@!$&'()*+,;=😹"
                 },
@@ -354,6 +366,7 @@
             },
             {
                 "id": "RestXmlSupportsNaNFloatQueryValues",
+                "description": "Supports handling NaN float query values.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -364,9 +377,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Supports handling NaN float query values.",
                 "params": {
                     "queryFloat": "NaN",
                     "queryDouble": "NaN"
@@ -379,6 +392,7 @@
             },
             {
                 "id": "RestXmlSupportsInfinityFloatQueryValues",
+                "description": "Supports handling Infinity float query values.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -389,9 +403,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Supports handling Infinity float query values.",
                 "params": {
                     "queryFloat": "Infinity",
                     "queryDouble": "Infinity"
@@ -404,6 +418,7 @@
             },
             {
                 "id": "RestXmlSupportsNegativeInfinityFloatQueryValues",
+                "description": "Supports handling -Infinity float query values.",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -414,9 +429,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Supports handling -Infinity float query values.",
                 "params": {
                     "queryFloat": "-Infinity",
                     "queryDouble": "-Infinity"
@@ -429,6 +444,7 @@
             },
             {
                 "id": "RestXmlZeroAndFalseQueryValues",
+                "description": "Query values of 0 and false are serialized",
                 "given": {
                     "name": "AllQueryStringTypes",
                     "http": {
@@ -439,9 +455,9 @@
                     "input": {
                         "shape": "AllQueryStringTypesInput"
                     },
-                    "documentation": "<p>This example uses all query string types.</p>"
+                    "documentation": "<p>This example uses all query string types.</p>",
+                    "readonly": true
                 },
-                "description": "Query values of 0 and false are serialized",
                 "params": {
                     "queryInteger": 0,
                     "queryBoolean": false
@@ -457,11 +473,20 @@
     {
         "description": "Test cases for BodyWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "BodyWithXmlNameInputOutput": {
@@ -489,6 +514,7 @@
         "cases": [
             {
                 "id": "BodyWithXmlName",
+                "description": "Serializes a payload using a wrapper name based on the xmlName",
                 "given": {
                     "name": "BodyWithXmlName",
                     "http": {
@@ -503,7 +529,6 @@
                     "documentation": "<p>The following example serializes a body that uses an XML name, changing the wrapper name.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a payload using a wrapper name based on the xmlName",
                 "params": {
                     "nested": {
                         "name": "Phreddy"
@@ -526,11 +551,20 @@
     {
         "description": "Test cases for ConstantAndVariableQueryString operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "ConstantAndVariableQueryStringInput": {
@@ -555,6 +589,7 @@
         "cases": [
             {
                 "id": "ConstantAndVariableQueryStringMissingOneValue",
+                "description": "Mixes constant and variable query string parameters",
                 "given": {
                     "name": "ConstantAndVariableQueryString",
                     "http": {
@@ -565,9 +600,9 @@
                     "input": {
                         "shape": "ConstantAndVariableQueryStringInput"
                     },
-                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>"
+                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>",
+                    "readonly": true
                 },
-                "description": "Mixes constant and variable query string parameters",
                 "params": {
                     "baz": "bam"
                 },
@@ -579,6 +614,7 @@
             },
             {
                 "id": "ConstantAndVariableQueryStringAllValues",
+                "description": "Mixes constant and variable query string parameters",
                 "given": {
                     "name": "ConstantAndVariableQueryString",
                     "http": {
@@ -589,9 +625,9 @@
                     "input": {
                         "shape": "ConstantAndVariableQueryStringInput"
                     },
-                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>"
+                    "documentation": "<p>This example uses fixed query string params and variable query string params. The fixed query string parameters and variable parameters must both be serialized (implementations may need to merge them together).</p>",
+                    "readonly": true
                 },
-                "description": "Mixes constant and variable query string parameters",
                 "params": {
                     "baz": "bam",
                     "maybeSet": "yes"
@@ -607,11 +643,20 @@
     {
         "description": "Test cases for ConstantQueryString operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "ConstantQueryStringInput": {
@@ -634,6 +679,7 @@
         "cases": [
             {
                 "id": "ConstantQueryString",
+                "description": "Includes constant query string parameters",
                 "given": {
                     "name": "ConstantQueryString",
                     "http": {
@@ -644,9 +690,9 @@
                     "input": {
                         "shape": "ConstantQueryStringInput"
                     },
-                    "documentation": "<p>This example uses a constant query string parameters and a label. This simply tests that labels and query string parameters are compatible. The fixed query string parameter named &quot;hello&quot; should in no way conflict with the label, <code>{hello}</code>.</p>"
+                    "documentation": "<p>This example uses a constant query string parameters and a label. This simply tests that labels and query string parameters are compatible. The fixed query string parameter named &quot;hello&quot; should in no way conflict with the label, <code>{hello}</code>.</p>",
+                    "readonly": true
                 },
-                "description": "Includes constant query string parameters",
                 "params": {
                     "hello": "hi"
                 },
@@ -661,11 +707,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputInput": {
@@ -676,6 +731,7 @@
         "cases": [
             {
                 "id": "EmptyInputAndEmptyOutput",
+                "description": "Empty input serializes no payload",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -688,7 +744,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has an empty input and empty output structure that reuses the same shape. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty input serializes no payload",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -700,17 +755,28 @@
     },
     {
         "description": "Test cases for EndpointOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestXmlEndpointTrait",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "given": {
                     "name": "EndpointOperation",
                     "http": {
@@ -722,7 +788,6 @@
                         "hostPrefix": "foo."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -731,17 +796,26 @@
                     "host": "foo.example.com"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for EndpointWithHostLabelHeaderOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HostLabelHeaderInput": {
@@ -765,6 +839,7 @@
         "cases": [
             {
                 "id": "RestXmlEndpointTraitWithHostLabelAndHttpBinding",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input. The label must also\nbe serialized in into any other location it is bound to, such\nas the body or in this case an http header.",
                 "given": {
                     "name": "EndpointWithHostLabelHeaderOperation",
                     "http": {
@@ -779,7 +854,6 @@
                         "hostPrefix": "{accountId}."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input. The label must also\nbe serialized in into any other location it is bound to, such\nas the body or in this case an http header.",
                 "params": {
                     "accountId": "bar"
                 },
@@ -787,23 +861,32 @@
                     "method": "POST",
                     "uri": "/EndpointWithHostLabelHeaderOperation",
                     "body": "",
+                    "host": "bar.example.com",
                     "headers": {
                         "X-Amz-Account-Id": "bar"
-                    },
-                    "host": "bar.example.com"
+                    }
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for EndpointWithHostLabelOperation operation",
+        "clientEndpoint": "https://example.com",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "EndpointWithHostLabelOperationRequest": {
@@ -825,6 +908,7 @@
         "cases": [
             {
                 "id": "RestXmlEndpointTraitWithHostLabel",
+                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "given": {
                     "name": "EndpointWithHostLabelOperation",
                     "http": {
@@ -840,7 +924,6 @@
                         "hostPrefix": "foo.{label}."
                     }
                 },
-                "description": "Operations can prepend to the given host if they define the\nendpoint trait, and can use the host label trait to define\nfurther customization based on user input.",
                 "params": {
                     "label": "bar"
                 },
@@ -851,17 +934,25 @@
                     "host": "foo.bar.example.com"
                 }
             }
-        ],
-        "clientEndpoint": "https://example.com"
+        ]
     },
     {
         "description": "Test cases for FlattenedXmlMap operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "FlattenedXmlMapRequest": {
@@ -871,15 +962,6 @@
                         "shape": "FooEnumMap",
                         "flattened": true
                     }
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
                 }
             },
             "FooEnum": {
@@ -892,6 +974,15 @@
                     "0"
                 ]
             },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
             "String": {
                 "type": "string"
             }
@@ -899,6 +990,7 @@
         "cases": [
             {
                 "id": "FlattenedXmlMap",
+                "description": "Serializes flattened XML maps in requests",
                 "given": {
                     "name": "FlattenedXmlMap",
                     "http": {
@@ -912,7 +1004,6 @@
                     },
                     "documentation": "<p>Flattened maps</p>"
                 },
-                "description": "Serializes flattened XML maps in requests",
                 "params": {
                     "myMap": {
                         "foo": "Foo",
@@ -933,23 +1024,22 @@
     {
         "description": "Test cases for FlattenedXmlMapWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "FlattenedXmlMapWithXmlNameRequest": {
-                "type": "structure",
-                "members": {
-                    "myMap": {
-                        "shape": "FlattenedXmlMapWithXmlNameInputOutputMap",
-                        "flattened": true,
-                        "locationName": "KVP"
-                    }
-                }
-            },
             "FlattenedXmlMapWithXmlNameInputOutputMap": {
                 "type": "map",
                 "key": {
@@ -961,6 +1051,16 @@
                     "locationName": "V"
                 }
             },
+            "FlattenedXmlMapWithXmlNameRequest": {
+                "type": "structure",
+                "members": {
+                    "myMap": {
+                        "shape": "FlattenedXmlMapWithXmlNameInputOutputMap",
+                        "flattened": true,
+                        "locationName": "KVP"
+                    }
+                }
+            },
             "String": {
                 "type": "string"
             }
@@ -968,6 +1068,7 @@
         "cases": [
             {
                 "id": "FlattenedXmlMapWithXmlName",
+                "description": "Serializes flattened XML maps in requests that have xmlName on members",
                 "given": {
                     "name": "FlattenedXmlMapWithXmlName",
                     "http": {
@@ -981,7 +1082,6 @@
                     },
                     "documentation": "<p>Flattened maps with @xmlName</p>"
                 },
-                "description": "Serializes flattened XML maps in requests that have xmlName on members",
                 "params": {
                     "myMap": {
                         "a": "A",
@@ -1000,13 +1100,105 @@
         ]
     },
     {
-        "description": "Test cases for HttpEnumPayload operation",
+        "description": "Test cases for HttpEmptyPrefixHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
+        },
+        "shapes": {
+            "HttpEmptyPrefixHeadersInput": {
+                "type": "structure",
+                "members": {
+                    "prefixHeaders": {
+                        "shape": "StringMap",
+                        "location": "headers",
+                        "locationName": ""
+                    },
+                    "specificHeader": {
+                        "shape": "String",
+                        "location": "header",
+                        "locationName": "hello"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "HttpEmptyPrefixHeadersRequestClient",
+                "description": "Serializes all request headers, using specific when present",
+                "given": {
+                    "name": "HttpEmptyPrefixHeaders",
+                    "http": {
+                        "method": "GET",
+                        "requestUri": "/HttpEmptyPrefixHeaders",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "HttpEmptyPrefixHeadersInput"
+                    },
+                    "documentation": "<p>Clients that perform this test extract all headers from the response.</p>",
+                    "readonly": true
+                },
+                "params": {
+                    "prefixHeaders": {
+                        "x-foo": "Foo",
+                        "hello": "Hello"
+                    },
+                    "specificHeader": "There"
+                },
+                "serialized": {
+                    "method": "GET",
+                    "uri": "/HttpEmptyPrefixHeaders",
+                    "body": "",
+                    "headers": {
+                        "x-foo": "Foo",
+                        "hello": "There"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for HttpEnumPayload operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
+            "protocol": "rest-xml",
+            "protocols": [
+                "rest-xml"
+            ],
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "EnumPayloadInput": {
@@ -1056,13 +1248,25 @@
     {
         "description": "Test cases for HttpPayloadTraits operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "HttpPayloadTraitsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -1079,14 +1283,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "HttpPayloadTraitsWithBlob",
+                "description": "Serializes a blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -1099,7 +1301,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no XML document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes a blob in the HTTP payload",
                 "params": {
                     "foo": "Foo",
                     "blob": "blobby blob blob"
@@ -1118,6 +1319,7 @@
             },
             {
                 "id": "HttpPayloadTraitsWithNoBlobBody",
+                "description": "Serializes an empty blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -1130,7 +1332,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no XML document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes an empty blob in the HTTP payload",
                 "params": {
                     "foo": "Foo"
                 },
@@ -1148,11 +1349,20 @@
     {
         "description": "Test cases for HttpPayloadWithMemberXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithMemberXmlNameInputOutput": {
@@ -1181,6 +1391,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithMemberXmlName",
+                "description": "Serializes a structure in the payload using a wrapper name based on member xmlName",
                 "given": {
                     "name": "HttpPayloadWithMemberXmlName",
                     "http": {
@@ -1194,7 +1405,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML name on the member, changing the wrapper name.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper name based on member xmlName",
                 "params": {
                     "nested": {
                         "name": "Phreddy"
@@ -1217,11 +1427,20 @@
     {
         "description": "Test cases for HttpPayloadWithStructure operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithStructureInputOutput": {
@@ -1252,6 +1471,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithStructure",
+                "description": "Serializes a structure in the payload",
                 "given": {
                     "name": "HttpPayloadWithStructure",
                     "http": {
@@ -1265,7 +1485,6 @@
                     "documentation": "<p>This example serializes a structure in the payload.</p> <p>Note that serializing a structure changes the wrapper element name to match the targeted structure.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload",
                 "params": {
                     "nested": {
                         "greeting": "hello",
@@ -1289,11 +1508,20 @@
     {
         "description": "Test cases for HttpPayloadWithUnion operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithUnionInputOutput": {
@@ -1306,6 +1534,9 @@
                 },
                 "payload": "nested"
             },
+            "String": {
+                "type": "string"
+            },
             "UnionPayload": {
                 "type": "structure",
                 "members": {
@@ -1314,14 +1545,12 @@
                     }
                 },
                 "union": true
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestXmlHttpPayloadWithUnion",
+                "description": "Serializes a union in the payload.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -1335,7 +1564,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a union in the payload.",
                 "params": {
                     "nested": {
                         "greeting": "hello"
@@ -1355,6 +1583,7 @@
             },
             {
                 "id": "RestXmlHttpPayloadWithUnsetUnion",
+                "description": "No payload is sent if the union has no value.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -1368,7 +1597,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "No payload is sent if the union has no value.",
                 "params": {},
                 "serialized": {
                     "method": "PUT",
@@ -1381,11 +1609,20 @@
     {
         "description": "Test cases for HttpPayloadWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithXmlNameInputOutput": {
@@ -1414,6 +1651,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithXmlName",
+                "description": "Serializes a structure in the payload using a wrapper name based on xmlName",
                 "given": {
                     "name": "HttpPayloadWithXmlName",
                     "http": {
@@ -1427,7 +1665,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML name, changing the wrapper name.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper name based on xmlName",
                 "params": {
                     "nested": {
                         "name": "Phreddy"
@@ -1450,11 +1687,20 @@
     {
         "description": "Test cases for HttpPayloadWithXmlNamespace operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithXmlNamespaceInputOutput": {
@@ -1483,6 +1729,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithXmlNamespace",
+                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "given": {
                     "name": "HttpPayloadWithXmlNamespace",
                     "http": {
@@ -1496,7 +1743,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML namespace.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "params": {
                     "nested": {
                         "name": "Phreddy"
@@ -1519,11 +1765,20 @@
     {
         "description": "Test cases for HttpPayloadWithXmlNamespaceAndPrefix operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithXmlNamespaceAndPrefixInputOutput": {
@@ -1555,6 +1810,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithXmlNamespaceAndPrefix",
+                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "given": {
                     "name": "HttpPayloadWithXmlNamespaceAndPrefix",
                     "http": {
@@ -1568,7 +1824,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML namespace.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "params": {
                     "nested": {
                         "name": "Phreddy"
@@ -1591,13 +1846,31 @@
     {
         "description": "Test cases for HttpPrefixHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "FooPrefixHeaders": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
             "HttpPrefixHeadersInputOutput": {
                 "type": "structure",
                 "members": {
@@ -1615,20 +1888,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "FooPrefixHeaders": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "String"
-                }
             }
         },
         "cases": [
             {
                 "id": "HttpPrefixHeadersArePresent",
+                "description": "Adds headers by prefix",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1639,9 +1904,9 @@
                     "input": {
                         "shape": "HttpPrefixHeadersInputOutput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "Adds headers by prefix",
                 "params": {
                     "foo": "Foo",
                     "fooMap": {
@@ -1655,13 +1920,14 @@
                     "body": "",
                     "headers": {
                         "x-foo": "Foo",
-                        "x-foo-abc": "Abc value",
-                        "x-foo-def": "Def value"
+                        "x-foo-def": "Def value",
+                        "x-foo-abc": "Abc value"
                     }
                 }
             },
             {
                 "id": "HttpPrefixHeadersAreNotPresent",
+                "description": "No prefix headers are serialized because the value is not present",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1672,9 +1938,9 @@
                     "input": {
                         "shape": "HttpPrefixHeadersInputOutput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "No prefix headers are serialized because the value is not present",
                 "params": {
                     "foo": "Foo",
                     "fooMap": {}
@@ -1690,6 +1956,7 @@
             },
             {
                 "id": "HttpPrefixEmptyHeaders",
+                "description": "Serialize prefix headers were the value is present but empty",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1700,9 +1967,9 @@
                     "input": {
                         "shape": "HttpPrefixHeadersInputOutput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "Serialize prefix headers were the value is present but empty",
                 "params": {
                     "fooMap": {
                         "abc": ""
@@ -1722,13 +1989,30 @@
     {
         "description": "Test cases for HttpRequestWithFloatLabels operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "HttpRequestWithFloatLabelsInput": {
                 "type": "structure",
                 "required": [
@@ -1747,19 +2031,12 @@
                         "locationName": "double"
                     }
                 }
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "RestXmlSupportsNaNFloatLabels",
+                "description": "Supports handling NaN float label values.",
                 "given": {
                     "name": "HttpRequestWithFloatLabels",
                     "http": {
@@ -1769,9 +2046,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithFloatLabelsInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Supports handling NaN float label values.",
                 "params": {
                     "float": "NaN",
                     "double": "NaN"
@@ -1784,6 +2061,7 @@
             },
             {
                 "id": "RestXmlSupportsInfinityFloatLabels",
+                "description": "Supports handling Infinity float label values.",
                 "given": {
                     "name": "HttpRequestWithFloatLabels",
                     "http": {
@@ -1793,9 +2071,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithFloatLabelsInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Supports handling Infinity float label values.",
                 "params": {
                     "float": "Infinity",
                     "double": "Infinity"
@@ -1808,6 +2086,7 @@
             },
             {
                 "id": "RestXmlSupportsNegativeInfinityFloatLabels",
+                "description": "Supports handling -Infinity float label values.",
                 "given": {
                     "name": "HttpRequestWithFloatLabels",
                     "http": {
@@ -1817,9 +2096,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithFloatLabelsInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Supports handling -Infinity float label values.",
                 "params": {
                     "float": "-Infinity",
                     "double": "-Infinity"
@@ -1835,11 +2114,20 @@
     {
         "description": "Test cases for HttpRequestWithGreedyLabelInPath operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpRequestWithGreedyLabelInPathInput": {
@@ -1868,6 +2156,7 @@
         "cases": [
             {
                 "id": "HttpRequestWithGreedyLabelInPath",
+                "description": "Serializes greedy labels and normal labels",
                 "given": {
                     "name": "HttpRequestWithGreedyLabelInPath",
                     "http": {
@@ -1877,9 +2166,9 @@
                     },
                     "input": {
                         "shape": "HttpRequestWithGreedyLabelInPathInput"
-                    }
+                    },
+                    "readonly": true
                 },
-                "description": "Serializes greedy labels and normal labels",
                 "params": {
                     "foo": "hello",
                     "baz": "there/guy"
@@ -1895,13 +2184,34 @@
     {
         "description": "Test cases for HttpRequestWithLabels operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "HttpRequestWithLabelsInput": {
                 "type": "structure",
                 "required": [
@@ -1959,9 +2269,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "Integer": {
                 "type": "integer",
                 "box": true
@@ -1970,17 +2277,8 @@
                 "type": "long",
                 "box": true
             },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
+            "String": {
+                "type": "string"
             },
             "Timestamp": {
                 "type": "timestamp"
@@ -1989,6 +2287,7 @@
         "cases": [
             {
                 "id": "InputWithHeadersAndAllParams",
+                "description": "Sends a GET request that uses URI label bindings",
                 "given": {
                     "name": "HttpRequestWithLabels",
                     "http": {
@@ -1999,9 +2298,9 @@
                     "input": {
                         "shape": "HttpRequestWithLabelsInput"
                     },
-                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>"
+                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>",
+                    "readonly": true
                 },
-                "description": "Sends a GET request that uses URI label bindings",
                 "params": {
                     "string": "string",
                     "short": 1,
@@ -2020,6 +2319,7 @@
             },
             {
                 "id": "HttpRequestLabelEscaping",
+                "description": "Sends a GET request that uses URI label bindings",
                 "given": {
                     "name": "HttpRequestWithLabels",
                     "http": {
@@ -2030,9 +2330,9 @@
                     "input": {
                         "shape": "HttpRequestWithLabelsInput"
                     },
-                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>"
+                    "documentation": "<p>The example tests how requests are serialized when there's no input payload but there are HTTP labels.</p>",
+                    "readonly": true
                 },
-                "description": "Sends a GET request that uses URI label bindings",
                 "params": {
                     "string": " %:/?#[]@!$&'()*+,;=😹",
                     "short": 1,
@@ -2054,13 +2354,34 @@
     {
         "description": "Test cases for HttpRequestWithLabelsAndTimestampFormat operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
             "HttpRequestWithLabelsAndTimestampFormatInput": {
                 "type": "structure",
                 "required": [
@@ -2110,6 +2431,10 @@
                     }
                 }
             },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "SyntheticTimestamp_epoch_seconds": {
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
@@ -2118,29 +2443,14 @@
                 "type": "timestamp",
                 "timestampFormat": "rfc822"
             },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
             "Timestamp": {
                 "type": "timestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "HttpRequestWithLabelsAndTimestampFormat",
+                "description": "Serializes different timestamp formats in URI labels",
                 "given": {
                     "name": "HttpRequestWithLabelsAndTimestampFormat",
                     "http": {
@@ -2151,9 +2461,9 @@
                     "input": {
                         "shape": "HttpRequestWithLabelsAndTimestampFormatInput"
                     },
-                    "documentation": "<p>The example tests how requests serialize different timestamp formats in the URI path.</p>"
+                    "documentation": "<p>The example tests how requests serialize different timestamp formats in the URI path.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes different timestamp formats in URI labels",
                 "params": {
                     "memberEpochSeconds": 1576540098,
                     "memberHttpDate": 1576540098,
@@ -2174,13 +2484,25 @@
     {
         "description": "Test cases for HttpStringPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "StringPayloadInput": {
                 "type": "structure",
                 "members": {
@@ -2189,9 +2511,6 @@
                     }
                 },
                 "payload": "payload"
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
@@ -2225,13 +2544,56 @@
     {
         "description": "Test cases for InputAndOutputWithHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "InputAndOutputWithHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -2317,28 +2679,22 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "Integer": {
                 "type": "integer",
                 "box": true
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
             },
             "Long": {
                 "type": "long",
                 "box": true
             },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
+            "String": {
+                "type": "string"
             },
             "StringList": {
                 "type": "list",
@@ -2352,47 +2708,20 @@
                     "shape": "String"
                 }
             },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
+            "Timestamp": {
+                "type": "timestamp"
             },
             "TimestampList": {
                 "type": "list",
                 "member": {
                     "shape": "Timestamp"
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "Timestamp": {
-                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "InputAndOutputWithStringHeaders",
+                "description": "Tests requests with string header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2405,7 +2734,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with string header bindings",
                 "params": {
                     "headerString": "Hello",
                     "headerStringList": [
@@ -2424,14 +2752,15 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-String": "Hello",
                         "X-StringList": "a, b, c",
+                        "X-String": "Hello",
                         "X-StringSet": "a, b, c"
                     }
                 }
             },
             {
                 "id": "InputAndOutputWithNumericHeaders",
+                "description": "Tests requests with numeric header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2444,7 +2773,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with numeric header bindings",
                 "params": {
                     "headerByte": 1,
                     "headerShort": 123,
@@ -2463,18 +2791,19 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
+                        "X-Integer": "123",
+                        "X-Short": "123",
                         "X-Byte": "1",
+                        "X-Long": "123",
                         "X-Double": "1.1",
                         "X-Float": "1.1",
-                        "X-Integer": "123",
-                        "X-IntegerList": "1, 2, 3",
-                        "X-Long": "123",
-                        "X-Short": "123"
+                        "X-IntegerList": "1, 2, 3"
                     }
                 }
             },
             {
                 "id": "InputAndOutputWithBooleanHeaders",
+                "description": "Tests requests with boolean header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2487,7 +2816,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with boolean header bindings",
                 "params": {
                     "headerTrueBool": true,
                     "headerFalseBool": false,
@@ -2502,14 +2830,15 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
+                        "X-BooleanList": "true, false, true",
                         "X-Boolean1": "true",
-                        "X-Boolean2": "false",
-                        "X-BooleanList": "true, false, true"
+                        "X-Boolean2": "false"
                     }
                 }
             },
             {
                 "id": "InputAndOutputWithTimestampHeaders",
+                "description": "Tests requests with timestamp header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2522,7 +2851,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with timestamp header bindings",
                 "params": {
                     "headerTimestampList": [
                         1576540098,
@@ -2540,6 +2868,7 @@
             },
             {
                 "id": "InputAndOutputWithEnumHeaders",
+                "description": "Tests requests with enum header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2552,7 +2881,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests requests with enum header bindings",
                 "params": {
                     "headerEnum": "Foo",
                     "headerEnumList": [
@@ -2566,13 +2894,14 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Enum": "Foo",
-                        "X-EnumList": "Foo, Bar, Baz"
+                        "X-EnumList": "Foo, Bar, Baz",
+                        "X-Enum": "Foo"
                     }
                 }
             },
             {
                 "id": "RestXmlSupportsNaNFloatHeaderInputs",
+                "description": "Supports handling NaN float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2585,7 +2914,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling NaN float header values.",
                 "params": {
                     "headerFloat": "NaN",
                     "headerDouble": "NaN"
@@ -2595,13 +2923,14 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Double": "NaN",
-                        "X-Float": "NaN"
+                        "X-Float": "NaN",
+                        "X-Double": "NaN"
                     }
                 }
             },
             {
                 "id": "RestXmlSupportsInfinityFloatHeaderInputs",
+                "description": "Supports handling Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2614,7 +2943,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling Infinity float header values.",
                 "params": {
                     "headerFloat": "Infinity",
                     "headerDouble": "Infinity"
@@ -2624,13 +2952,14 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Double": "Infinity",
-                        "X-Float": "Infinity"
+                        "X-Float": "Infinity",
+                        "X-Double": "Infinity"
                     }
                 }
             },
             {
                 "id": "RestXmlSupportsNegativeInfinityFloatHeaderInputs",
+                "description": "Supports handling -Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2643,7 +2972,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling -Infinity float header values.",
                 "params": {
                     "headerFloat": "-Infinity",
                     "headerDouble": "-Infinity"
@@ -2653,8 +2981,8 @@
                     "uri": "/InputAndOutputWithHeaders",
                     "body": "",
                     "headers": {
-                        "X-Double": "-Infinity",
-                        "X-Float": "-Infinity"
+                        "X-Float": "-Infinity",
+                        "X-Double": "-Infinity"
                     }
                 }
             }
@@ -2663,13 +2991,50 @@
     {
         "description": "Test cases for NestedXmlMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "NestedMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnumMap"
+                }
+            },
             "NestedXmlMapsRequest": {
                 "type": "structure",
                 "members": {
@@ -2682,34 +3047,6 @@
                     }
                 }
             },
-            "NestedMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnumMap"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "String": {
                 "type": "string"
             }
@@ -2717,6 +3054,7 @@
         "cases": [
             {
                 "id": "NestedXmlMapRequest",
+                "description": "Tests requests with nested maps.",
                 "given": {
                     "name": "NestedXmlMaps",
                     "http": {
@@ -2729,7 +3067,6 @@
                         "locationName": "NestedXmlMapsRequest"
                     }
                 },
-                "description": "Tests requests with nested maps.",
                 "params": {
                     "nestedMap": {
                         "foo": {
@@ -2748,6 +3085,7 @@
             },
             {
                 "id": "FlatNestedXmlMapRequest",
+                "description": "Tests requests with nested flat maps. Since maps can only be\nflattened when they're structure members, only the outer map is flat.",
                 "given": {
                     "name": "NestedXmlMaps",
                     "http": {
@@ -2760,7 +3098,6 @@
                         "locationName": "NestedXmlMapsRequest"
                     }
                 },
-                "description": "Tests requests with nested flat maps. Since maps can only be\nflattened when they're structure members, only the outer map is flat.",
                 "params": {
                     "flatNestedMap": {
                         "foo": {
@@ -2782,19 +3119,31 @@
     {
         "description": "Test cases for NestedXmlMapWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "NestedXmlMapWithXmlNameRequest": {
-                "type": "structure",
-                "members": {
-                    "nestedXmlMapWithXmlNameMap": {
-                        "shape": "NestedXmlMapWithXmlNameMap"
-                    }
+            "NestedXmlMapWithXmlNameInnerMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String",
+                    "locationName": "InnerKey"
+                },
+                "value": {
+                    "shape": "String",
+                    "locationName": "InnerValue"
                 }
             },
             "NestedXmlMapWithXmlNameMap": {
@@ -2807,15 +3156,12 @@
                     "shape": "NestedXmlMapWithXmlNameInnerMap"
                 }
             },
-            "NestedXmlMapWithXmlNameInnerMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String",
-                    "locationName": "InnerKey"
-                },
-                "value": {
-                    "shape": "String",
-                    "locationName": "InnerValue"
+            "NestedXmlMapWithXmlNameRequest": {
+                "type": "structure",
+                "members": {
+                    "nestedXmlMapWithXmlNameMap": {
+                        "shape": "NestedXmlMapWithXmlNameMap"
+                    }
                 }
             },
             "String": {
@@ -2825,6 +3171,7 @@
         "cases": [
             {
                 "id": "NestedXmlMapWithXmlNameSerializes",
+                "description": "Serializes nested XML Maps in requests that have xmlName on members",
                 "given": {
                     "name": "NestedXmlMapWithXmlName",
                     "http": {
@@ -2838,7 +3185,6 @@
                     },
                     "documentation": "<p>Nested Xml Maps with key/values with @xmlName</p>"
                 },
-                "description": "Serializes nested XML Maps in requests that have xmlName on members",
                 "params": {
                     "nestedXmlMapWithXmlNameMap": {
                         "foo": {
@@ -2865,16 +3211,26 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "NoInputAndNoOutput",
+                "description": "No input serializes no payload",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -2884,7 +3240,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No input serializes no payload",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -2897,16 +3252,26 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "NoInputAndOutput",
+                "description": "No input serializes no payload",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -2916,7 +3281,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input and the output is empty. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No input serializes no payload",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -2929,11 +3293,20 @@
     {
         "description": "Test cases for NullAndEmptyHeadersClient operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "NullAndEmptyHeadersIO": {
@@ -2969,6 +3342,7 @@
         "cases": [
             {
                 "id": "NullAndEmptyHeaders",
+                "description": "Do not send null values, but do send empty strings and empty lists over the wire in headers",
                 "given": {
                     "name": "NullAndEmptyHeadersClient",
                     "http": {
@@ -2979,9 +3353,9 @@
                     "input": {
                         "shape": "NullAndEmptyHeadersIO"
                     },
-                    "documentation": "<p>Null headers are not sent over the wire, empty headers are serialized to &quot;&quot;</p>"
+                    "documentation": "<p>Null headers are not sent over the wire, empty headers are serialized to &quot;&quot;</p>",
+                    "readonly": true
                 },
-                "description": "Do not send null values, but do send empty strings and empty lists over the wire in headers",
                 "params": {
                     "a": null,
                     "b": "",
@@ -3005,11 +3379,20 @@
     {
         "description": "Test cases for OmitsNullSerializesEmptyString operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "OmitsNullSerializesEmptyStringInput": {
@@ -3034,6 +3417,7 @@
         "cases": [
             {
                 "id": "RestXmlOmitsNullQuery",
+                "description": "Omits null query values",
                 "given": {
                     "name": "OmitsNullSerializesEmptyString",
                     "http": {
@@ -3044,9 +3428,9 @@
                     "input": {
                         "shape": "OmitsNullSerializesEmptyStringInput"
                     },
-                    "documentation": "<p>Omits null, but serializes empty string value.</p>"
+                    "documentation": "<p>Omits null, but serializes empty string value.</p>",
+                    "readonly": true
                 },
-                "description": "Omits null query values",
                 "params": {
                     "nullValue": null
                 },
@@ -3058,6 +3442,7 @@
             },
             {
                 "id": "RestXmlSerializesEmptyString",
+                "description": "Serializes empty query strings",
                 "given": {
                     "name": "OmitsNullSerializesEmptyString",
                     "http": {
@@ -3068,9 +3453,9 @@
                     "input": {
                         "shape": "OmitsNullSerializesEmptyStringInput"
                     },
-                    "documentation": "<p>Omits null, but serializes empty string value.</p>"
+                    "documentation": "<p>Omits null, but serializes empty string value.</p>",
+                    "readonly": true
                 },
-                "description": "Serializes empty query strings",
                 "params": {
                     "emptyString": ""
                 },
@@ -3085,11 +3470,20 @@
     {
         "description": "Test cases for PutWithContentEncoding operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "PutWithContentEncodingInput": {
@@ -3112,6 +3506,7 @@
         "cases": [
             {
                 "id": "SDKAppliedContentEncoding_restXml",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -3129,7 +3524,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header.",
                 "params": {
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
                 },
@@ -3143,6 +3537,7 @@
             },
             {
                 "id": "SDKAppendedGzipAfterProvidedEncoding_restXml",
+                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is in the Content-Encoding header before the\nrequest compression encoding from the HTTP binding.\n",
                 "given": {
                     "name": "PutWithContentEncoding",
                     "http": {
@@ -3160,7 +3555,6 @@
                         ]
                     }
                 },
-                "description": "Compression algorithm encoding is appended to the Content-Encoding header, and the\nuser-provided content-encoding is in the Content-Encoding header before the\nrequest compression encoding from the HTTP binding.\n",
                 "params": {
                     "encoding": "custom",
                     "data": "RjCEL3kBwqPivZUXGiyA5JCujtWgJAkKRlnTEsNYfBRGOS0f7LT6R3bCSOXeJ4auSHzQ4BEZZTklUyj5\n1HEojihShQC2jkQJrNdGOZNSW49yRO0XbnGmeczUHbZqZRelLFKW4xjru9uTuB8lFCtwoGgciFsgqTF8\n5HYcoqINTRxuAwGuRUMoNO473QT0BtCQoKUkAyVaypG0hBZdGNoJhunBfW0d3HWTYlzz9pXElyZhq3C1\n2PDB17GEoOYXmTxDecysmPOdo5z6T0HFhujfeJFIQQ8dirmXcG4F3v0bZdf6AZ3jsiVh6RnEXIPxPbOi\ngIXDWTMUr4Pg3f2LdYCM01eAb2qTdgsEN0MUDhEIfn68I2tnWvcozyUFpg1ez6pyWP8ssWVfFrckREIM\nMb0cTUVqSVSM8bnFiF9SoXM6ZoGMKfX1mT708OYk7SqZ1JlCTkecDJDoR5ED2q2MWKUGR6jjnEV0GtD8\nWJO6AcF0DptY9Hk16Bav3z6c5FeBvrGDrxTFVgRUk8SychzjrcqJ4qskwN8rL3zslC0oqobQRnLFOvwJ\nprSzBIwdH2yAuxokXAdVRa1u9NGNRvfWJfKkwbbVz8yV76RUF9KNhAUmwyYDrLnxNj8ROl8B7dv8Gans\n7Bit52wcdiJyjBW1pAodB7zqqVwtBx5RaSpF7kEMXexYXp9N0J1jlXzdeg5Wgg4pO7TJNr2joiPVAiFf\nefwMMCNBkYx2z7cRxVxCJZMXXzxSKMGgdTN24bJ5UgE0TxyV52RC0wGWG49S1x5jGrvmxKCIgYPs0w3Z\n0I3XcdB0WEj4x4xRztB9Cx2Mc4qFYQdzS9kOioAgNBti1rBySZ8lFZM2zqxvBsJTTJsmcKPr1crqiXjM\noVWdM4ObOO6QA7Pu4c1hT68CrTmbcecjFcxHkgsqdixnFtN6keMGL9Z2YMjZOjYYzbUEwLJqUVWalkIB\nBkgBRqZpzxx5nB5t0qDH35KjsfKM5cinQaFoRq9y9Z82xdCoKZOsUbxZkk1kVmy1jPDCBhkhixkc5PKS\nFoSKTbeK7kuCEZCtR9OfF2k2MqbygGFsFu2sgb1Zn2YdDbaRwRGeaLhswta09UNSMUo8aTixgoYVHxwy\nvraLB6olPSPegeLOnmBeWyKmEfPdbpdGm4ev4vA2AUFuLIeFz0LkCSN0NgQMrr8ALEm1UNpJLReg1ZAX\nzZh7gtQTZUaBVdMJokaJpLk6FPxSA6zkwB5TegSqhrFIsmvpY3VNWmTUq7H0iADdh3dRQ8Is97bTsbwu\nvAEOjh4FQ9wPSFzEtcSJeYQft5GfWYPisDImjjvHVFshFFkNy2nN18pJmhVPoJc456tgbdfEIdGhIADC\n6UPcSSzE1FxlPpILqZrp3i4NvvKoiOa4a8tnALd2XRHHmsvALn2Wmfu07b86gZlu4yOyuUFNoWI6tFvd\nbHnqSJYNQlFESv13gJw609DBzNnrIgBGYBAcDRrIGAnflRKwVDUnDFrUQmE8xNG6jRlyb1p2Y2RrfBtG\ncKqhuGNiT2DfxpY89ektZ98waPhJrFEPJToNH8EADzBorh3T0h4YP1IeLmaI7SOxeuVrk1kjRqMK0rUB\nlUJgJNtCE35jCyoHMwPQlyi78ZaVv8COVQ24zcGpw0MTy6JUsDzAC3jLNY6xCb40SZV9XzG7nWvXA5Ej\nYC1gTXxF4AtFexIdDZ4RJbtYMyXt8LsEJerwwpkfqvDwsiFuqYC6vIn9RoZO5kI0F35XtUITDQYKZ4eq\nWBV0itxTyyR5Rp6g30pZEmEqOusDaIh96CEmHpOBYAQZ7u1QTfzRdysIGMpzbx5gj9Dxm2PO1glWzY7P\nlVqQiBlXSGDOkBkrB6SkiAxknt9zsPdTTsf3r3nid4hdiPrZmGWNgjOO1khSxZSzBdltrCESNnQmlnP5\nZOHA0eSYXwy8j4od5ZmjA3IpFOEPW2MutMbxIbJpg5dIx2x7WxespftenRLgl3CxcpPDcnb9w8LCHBg7\nSEjrEer6Y8wVLFWsQiv6nTdCPZz9cGqwgtCaiHRy8lTWFgdfWd397vw9rduGld3uUFeFRGjYrphqEmHi\nhiG0GhE6wRFVUsGJtvOCYkVREvbEdxPFeJvlAvOcs9HKbtptlTusvYB86vR2bNcIY4f5JZu2X6sGa354\n7LRk0ps2zqYjat3hMR7XDC8KiKceBteFsXoDjfVxTYKelpedTxqWAafrKhaoAVuNM98PSnkuIWGzjSUC\nNsDJTt6vt1D1afBVPWVmnQ7ZQdtEtLIEwAWYjemAztreELIr1E9fPEILm1Ke4KctP9I0I72Dh4eylNZD\n0DEr2Hg7cWFckuZ0Av5d0IPRARXikEGDHl8uh12TXL9v2Uh0ZVSJMEYvxGSbZvkWz8TjWSk3hKA2a7GL\nJm3Ho7e1C34gE1XRGcEthxvURxt4OKBqN3ZNaMIuDTWinoQAutMcUqtm4MoL7RGPiCHUrvTwQPSirsmA\nQmOEu8nOpnP77Fivh9jLGx5ta7nL6jrsWUsBqiN1lzpdPYLRR4mUIAj6sNWiDEk4pkbHSMEcqbWw6Zl7\npsEyPDHalCNhWMA3RSK3skURzQDZ0oBV5W7vjVIZ4d3uCKsk6zrzEI9u5mx7p9RdNKodXfzqYt0ULdtc\n3RW0hIfw2KvrO3BD2QrtgAkfrFBGVvlJSUoh0MvLz8DeXxfuiuq9Ttu7wvsqVI4Piah6WNEXtHHGPJO3\nGhc75Bnv2To4VS2v8rmyKAPIIVTuYBHZN6sZ4FhFzbrslCIdk0eadaU60naqiNWU3CsxplIYGyeThmJ7\n9u4h6Y2OmiPZjFPS2bAzwgAozYTVefII9aEaWZ0hxHZeu1FW7r79dkdO73ZqRfas9u8Z7LLBPCw5pV0F\n5I0pHDgNb6MogoxF4NZJfVtIX1vCHhhVLrXjrYNJU2fD9Fw8kT8Ie2HDBJnqAvYKmryQ1r9ulo3Me3rH\nq9s2Y5uCDxu9iQNhnpwIm57WYGFeqd2fnQeY2IziD3Jgx0KSrmOH0jgi0RwJyfGXaORPq3bQQqljuACo\nkO6io9t5VI8PbNxSHTRbtYiPciUslbT0g7SpCLrRPOBRJ4DDk56pjghpeoUagJ5xJ4wjBzBuXnAGkNnP\nTfpiuz2r3oSBAi8sB9wiYK2z9sp4gZyQsqdVNzAEgKatOxBRBmJCBYpjO98ZQrF83XApPpfFg0ujB2PW\n1iYF9NkgwIKB5oB6KVTOmSKJk11mVermPgeugHbzdd2zUP6fP8fWbhseqk2t8ahGvqjs2CDHFIWXl5jc\nfCknbykE3ANt7lnAfJQ2ddduLGiqrX4HWx6jcWw08Es6BkleO0IDbaWrb95d5isvFlzJsf0TyDIXF4uq\nbBDCi0XPWqtRJ2iqmnJa2GbBe9GmAOWMkBFSilMyC4sR395WSDpD56fx0NGoU6cHrRu9xF2Bgh7RGSfl\nch2GXEeE02fDpSHFNvJBlOEqqfkIX6oCa6KY9NThqeIjYsT184XR2ZI7akXRaw1gMOGpk4FmUxk6WIuX\n4ei1SLQgSdl7OEdRtJklZ76eFrMbkJQ2TDhu8f7mVuiy53GUMIvCrP9xYGZGmCIDm2e4U2BDi3F7C5xK\n3bDZXwlQp6z4BSqTy2OVEWxXUJfjPMOL5Mc7AvDeKtxAS73pVIv0HgHIa4NBAdC7uLG0zXuu1FF6z2XY\nyUhk03fMZhYe7vVxsul3WE7U01fuN8z2y0eKwBW1RFBE1eKIaR9Y01sIWQWbSrfHfDrdZiElhmhHehfs\n0EfrR4sLYdQshJuvhTeKGJDaEhtPQwwJ9mUYGtuCL9RozWx1XI4bHNlzBTW0BVokYiJGlPe7wdxNzJD7\nJgS7Lwv6jGKngVf86imGZyzqwiteWFPdNUoWdTvUPSMO5xIUK9mo5QpwbBOAmyYzVq42o3Qs90N9khEV\nU36LB99fw8PtGHH5wsCHshfauwnNPj0blGXzke0kQ4JNCVH7Jtn0Y0aeejkSxFtwtxoYs6zHl1Lxxpsd\nsw5vBy49CEtoltDW367lVAwDjWdx20msGB7qJCkEDrzu7EXSO22782QX9NBRcN9ppX0C25I0FMA4Wnhz\n9zIpiXRrsTH35jzM8Cjt4EVLGNU3O0HuEvAer3cENnMJtngdrT86ox3fihMQbiuy4Bh4DEcP5in2VjbT\n3qbnoCNvOi8Fmmf7KlGlWAOceL5OHVE5lljjQEMzEQOCEgrk5mDKgwSBJQBNauIDSC1a5iEQjB8Xxp4C\nqeKyyWY9IOntNrtU5ny4lNprHJd36dKFeBLKcGCOvgHBXdOZloMF0YTRExw7hreEO9IoTGVHJ4teWsNr\nHdtagUHjkeZkdMMfnUGNv5aBNtFMqhcZH6EitEa9lGPkKBbJpoom3u8D8EHSIF1H5EZqqx9TLY5hWAIG\nPwJ4qwkpCGw5rCLVrjw7ARKukIFzNULANqjHUMcJ002TlUosJM4xJ4aAgckpLVGOGuPDhGAAexEcQmbg\nUsZdmqQrtuVUyyLteLbLbqtR6CTlcAIwY3xyMCmPgyefE0FEUODBoxQtRUuYTL9RC5o1sYb2PvcxUQfb\niJFi2CAl99pAzcckU2qVCxniARslIxM5pmMRGsQX9ZzYAfZrbg6ce6S74I8UMlgRQ2QVyvUjKKOE6IrJ\nLng370emHfe5m6LZULD5YiZutkD5ipjL2Bz77DvTE5kNPUhuoKBcTJcUgytfXAKUTWOcRKNlq0GImrxM\nJfr7AWbLFFNKGLeTrVDBwpcokJCv0zcOKWe8fd2xkeXkZTdmM66IgM27cyYmtQ6YF26Kd0qrWJeVZJV9\n3fyLYYvKN5csbRY2BHoYE5ERARRW65IrpkXMf48OrCXMtDIP0Z7wxI9DiTeKKeH4uuguhCJnwzR3WxLA\nVU6eBJEd7ZjS6JA83w7decq8uDI7LGKjcz1FySp3B7fE9DkHRGXxbsL7Fjar6vW2mAv8CuvI20B6jctp\n2yLDs24sPfB3sSxrrlhbuT1m6DZqiN0dl6umKx7NGZhmOTVGr20jfcxhqPQwTJfd7kel4rvxip4BqkvT\n7STy8knJ2BXGyJeNgwo1PXUZRDVy0LCTsSF1RFuRZe8cktHl9lgw8ntdPn1pVFL0MwJkJfdXBNUp5gNv\n50FTkrpo1t6wq4CVbcfj2XOrOzvBUzNH26sXGABI1gGxCdp2jEZrHgqQaWIaTJVTuguZhxqDvdYsrwFW\nYN58uuNcKHIrGdRSigyZInwQDYk0pjcqdSeU0WVU3Y9htzZBR7XRaCJr5YTZvq7fwermb5tuwb37lPLq\nB2IGg0iftkVbXaSyfCwVaRbfLBb88so0QqpmJGirFu8FcDiXOV1zTr8yW9XLdYQuUjh43xrXLdgsuYff\nCagInUk1eU1aLjVZoJRsNmStmOEpAqlYMwTvx7w6j2f421Cxr5cNZBIVlAxlXN2QiDqJ9v3sHhHkTanc\nlQuH8ptUyX8qncpBuXXBn7cSez9N0EoxCBl1GHUagbjstgJo4gzLvTmVIY6MiWYOBitzNUHfyqKwtKUr\nVoSCdZcGeA9lHUPA7PUprRRaT3m1hGKPyshtVS2ikG48w3oVerln1N1qGdtz46gZCrndw3LZ1B362RfW\nzDPuXbpsyLsRMTt1Rz1oKHRXp3iE41hkhQH6pxlvyCW2INnHt5XU8zRamOB3oW0udOhMpQFDjRkOcy06\nb4t0QTHvoRqmBna3WXzIMZyeK3GChF5eF8oDXRbjhk7BB6YKCgqwWUzEJ5K47HMSlhFkBUjaPRjdGM0z\nzOMwhW6b1NvSwP7XM1P5yi1oPvOspts1vr29SXqrMMrBhVogeodWyd69NqrO4jkyBxKmlXifoTowpfiY\n2cUCE0XMZqxUN39LCP09JqZifaEcBEo3mgtm1tWu5QR2GNq7UyQf4RIPSDOpDCAtwoPhRgdT1lJdcj4U\nlnH0wrJ8Uwu7c08L7ErnIrDATqCrOjpSbzGP1xHENABYONC4TknFPrJ8pe40A8fzGT0qBw9mAM1SKcHO\nfoiLcMC9AjHTqJzDG3xplSLPG9or2rMeq7Fzp9r0y7uJRMxgg51EbjfvYlH466A3ggvL2WQlDXjJqPW3\nBJGWAWDNN9LK8f46bADKPxakpkx23S9O47rGSXfDhVSIZsDympxWX1UOzWwMZRHkofVeKqizgbKkGgUT\nWykE9gRoRAOd9wfHZDYKa9i0LaPDiaUMvnU1gdBIqIoiVsdJ9swX47oxvMtOxtcS0zlD6llDkBuIiU5g\nPwRCYmtkkb25c8iRJXwGFPjI1wJ34I1z1ENicPdosPiUe9ZC2jnXIKzEdv01x2ER7DNDF3yxOwOhxNxI\nGqsmC92j25UQQFu9ZstOZ28AoCkuOYs0Uycm5u8jR1T39dMBwrko09rC65ENLnsxM8oebmyFCPiGJ1ED\n5Xqc9qZ237f1OnETAoEOwqUSvrdPTv56U7hV91EMTyC812MLQpr2710E3VVpsUCUMNhIxdt7UXZ1UNFb\njgzpZLXnf4DHrv6B7kq6UI50KMxcw1HZE2GpODfUTzNFLaqdrvzxKe5eUWdcojBaRbD4fFdVYJTElYDH\nNNVh6ofkoeWcs9CWGFmSBe0T4K8phFeygQg0prKMELNEy6qENzVtG9ZDcqj3a7L6ZLtvq50anWp7fAVu\nfwz55g4iM2Z2fA0pnwHDL7tt67zTxGITvsnJsZSpeq1EQsZcwtkBV9liu7Rl7jiVT1IIRtchB8TsTiaA\nwVHIQQ9RIOTiPQdKNqi1kC9iGlUqWK93gblNWlBw1eYB9Wk8FQogutwTf0caNMx8D4nPbANcmOOlskIy\nzALh15OlTrWnhP95rf08AN2J026zDE2DUF9k0eCevYBQIDjqKNW4XCZnjbHoIcKzbY5VzPbMs3ZyMz8K\nSucBmgPg6wrSK5ykbkapS5vuqvXc9GbjQJ8bPNzoxoWGyjbZvDs2OBrIqBmcQb2DLJ8v38McQ4mC4UsS\njf4PyfSCtpk274QZjvLCZbLiCBxQegk7jUU0NmTFJAcYCxd9xMWdlFkiszcltT2YzwuFFz7iA6aa4n5L\nHpBNfUA01GcAi1aCMYhmooS4zSlYcSOZkovMz36U3Fd9WtqIEOJLi7HMgHQDgNMdK6DTzAdHQtxerxVF\nHJnPrfNVG7270r3bp0bPnLNYLhObbAn6zqSAUeLtI2Y4KJDjBKCAh2vvYGbu0e2REYJWRj7MkGevsSSy\nb1kCXLt6tKGWAb7lt5c0xyJgUIJW7pdtnwgT0ZCa24BecCAwNnG5U2EwQbcjZGsFxqNGfaemd3oFEhES\nBaE0Fxms9UKTnMafu8wvZ2xymMrUduuRzOjDeX7oD5YsLC88V8CGMLxbbxIpt94KGykbr6e7L0R4oZl1\ntKMgFwQ2p9Txdbp0Y293LcsJymKizqI0F2xEp7y4SmWOJqHZtsbz80wVV9nv41CvtfxuSoGZJ5cNB7pI\nBgzNcQCeH3Jt0RaGGwboxxpuFbzilmkMFXxJm87tD4WNgu01nHfGCKeQcySEBZpVfJgi6sDFJ8uWnvKm\n9mPLHurtWzEfKqUEa1iC71bXjw5wrvhv9BYW8JSUELHmDquftQyKdq0DZXhULMHGQLf4e95WIaoA14LL\nbThz77kuhKULPTu2MNrBUKGorurhGugo5gs4ZUezSsUOe3KxYdrFMdGgny1GgTxMSMTp2RAZytKjv4kQ\nVx7XgzvpQLIbDjUPAkJv6lScwIRq1W3Ne0Rh0V6Bmn6U5uIuWnJjULmbaQiSODj3z0mAZvak0mSWIGwT\nTX83HztcC4W7e1f6a1thmcc5K61Icehla2hBELWPpixTkyC4eEVmk9Rq0m0ZXtx0JX2ZQXqXDEyePyMe\nJ70sdSzXk72zusqhY4yuOMGgbYNHqxOToK6NxujR7e4dV3Wk5JnSUthym8scjcPeCiKDNY4cHfTMnDXJ\n9zLVy01LtNKYpJ1s8FxVxigmxQNKEbIamxhx6yqwGC4aiISVOOUEjvNOdaUfXfUsE6jEwtwxyGxjlRK1\ncLyxXttq4QWN6PehgHv7jXykzPjInbEysebFvvPOOMdunmJvcCNMSvjUda8fL6xfGo0FDrLg8XZipd6S\noPVdYtyIM1Dg40KbBA3JuumPYtXuJaHrZnjZmdnM5OVo4ZNxktfCVT0c6bnD4bAeyn4bYt1ZPaX6hQHh\nJtvNYfpD0ONYlmqKuToQAMlz52Fh6bj45EbX89L5eLlSpWeyBlGotzriB0EPlclrGi5l2B5oPb1aB1ag\nyyYuu44l0F1oOVYnBIZsxIsHVITxi9lEuVPFkWASOUNuVQXfM4n5hxWR9qtuKnIcPsvbJsv1U10XlKh3\nKisqPhHU15xrCLr5gwFxPUKiNTLUBrkzgBOHXPVsHcLCiSD0YU56TRGfvEom43TWUKPPfl9Z54tgVQuT\njCRlaljAzeniQIcbbHZnn3f0HxbDG3DFYqWSxNrXabHhRsIOhhUHSPENyhGSTVO5t0XX5CdMspJPCd02\n3Oqv32ccbUK4O3YH6LEvp0WO3kSl5n50odVkI9B0i0iq4UPFGMkM8bEQJbgJoOH71P10vtdevJFQE4g2\nyhimiM53ZJRWgSZveHtENZc0Gjo0F9eioak9BnPpY1QxAFPC817svuhEstcU69bLCA4D1rO5R8AuIIBq\nyQJcifFLvbpAEYTLKJqysZrU8EEl3TSdC13A9hZvk4NC8VGEDAxcNrKw313dZp17kZPO5HSd1y6sljAW\nA9M1d6FMYV5SlBWf3WZNCUPS7qKNlda2YBsC6IUVB363f5RLGQOQHwbaijBSRCkrVoRxBHtc0Bd5J9V9\nP5uMTXkpZOxRcCQvImGgcmGuxxLb5zTqfS2xu7v3Sf3IIesSt9tVzcEcdbEvLGVJkLk4mb3G30DbIbri\nPZ09JkweDvMaQ3bxT2nfkz3Ilihkw9jqikkCCCz7E8h6z6KbhQErEW9VzJZzMCgJsyPjFam6iNwpe07S\nhyOvNVw2t9wpzL5xM11DvVzQwDaWEytNRHzDBs4KwEtpI2IpjUyVZHSwA0UGqqkzoCgrJFlNOvPlXqcS\nIcREouUIBmuttkrhPWJtSxOOgpsdvBR3kTOzAXNzSKxoaBAb0c5SDMUc6FIyGA8x5wg5DkUgjFUUodEt\nOYaB2VHVePW9mxHeBTdKWLzJow4ZZvjnoBuVigXljKCNh137ckV2y3Yg3Xi4UzJEI2V5Rw9AfnMs7xUw\nVHOFCg189maD3bmZAe7b4eaGZhyy4HVKjqCXmIH7vsEjRvbnfB0SQxxpuqBDJbHNCtW4vM643ZQQBVPP\na7oXSQIq9w2dHp0A7dtkocCZdQp9FKR9XdJAFIbVSHzIF1ZogeZlc0pXuNE0tagvD57xwDRFkAuoQyMu\nYDdZasXrpSmEE5UjHVkyYsISn8QsfXurzDybX468aoRoks654jjmRY5zi1oB8TcMdC2c3sicNaqfeuhd\nH1nPX7l4RpdqWMR7gGx9slXtG8S3KxpOi4qCD7yg3saD66nun4dzksQURoTUdXyrJR5UpHsfIlTF1aJa\nMdXyQtQnrkl00TeghQd00rRFZsCnhi0qrCSKiBfB2EVrd9RPpbgwJGZHuIQecdBmNetc2ylSEClqVBPR\nGOPPIxrnswEZjmnS0jxKW9VSM1QVxSPJnPFswCqT95SoKD6CP4xdX28WIUGiNaIKodXXJHEIsXBCxLsr\nPwWPCtoplC6hhpKmW5dQo92iCTyY2KioKzO8XR6FKm6qonMKVEwQNtlYE9c97KMtEnp25VOdMP46SQXS\nYsSVp7vm8LP87VYI8SOKcW3s2oedYFtt45rvDzoTF0GmS6wELQ9uo98HhjQAI1Dt91cgjJOwygNmLoZE\nX5K2zQiNA163uMCl5xzaBqY4YTL0wgALg3IFdYSp0RFYLWdt6IxoGI1tnoxcjlUEPo5eGIc3mS3SmaLn\nOdumfUQQ4Jgmgaa5anUVQsfBDrlAN5oaX7O0JO71SSPSWiHBsT9WIPy2J1Cace9ZZLRxblFPSXcvsuHh\nhvnhWQltEDAe7MgvkFQ8lGVFa8jhzijoF9kLmMhMILSzYnfXnZPNP7TlAAwlLHK1RqlpHskJqb6CPpGP\nQvOAhEMsM3zJ2KejZx0esxkjxA0ZufVvGAMN3vTUMplQaF4RiQkp9fzBXf3CMk01dWjOMMIEXTeKzIQe\nEcffzjixWU9FpAyGp2rVl4ETRgqljOGw4UgK31r0ZIEGnH0xGz1FtbW1OcQM008JVujRqulCucEMmntr\n"
@@ -3178,11 +3572,20 @@
     {
         "description": "Test cases for QueryIdempotencyTokenAutoFill operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "QueryIdempotencyTokenAutoFillInput": {
@@ -3203,6 +3606,7 @@
         "cases": [
             {
                 "id": "QueryIdempotencyTokenAutoFill",
+                "description": "Automatically adds idempotency token when not set",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -3215,7 +3619,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Automatically adds idempotency token when not set",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -3225,6 +3628,7 @@
             },
             {
                 "id": "QueryIdempotencyTokenAutoFillIsSet",
+                "description": "Uses the given idempotency token as-is",
                 "given": {
                     "name": "QueryIdempotencyTokenAutoFill",
                     "http": {
@@ -3237,7 +3641,6 @@
                     },
                     "documentation": "<p>Automatically adds idempotency tokens.</p>"
                 },
-                "description": "Uses the given idempotency token as-is",
                 "params": {
                     "token": "00000000-0000-4000-8000-000000000000"
                 },
@@ -3252,11 +3655,20 @@
     {
         "description": "Test cases for QueryParamsAsStringListMap operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "QueryParamsAsStringListMapInput": {
@@ -3276,6 +3688,12 @@
             "String": {
                 "type": "string"
             },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
             "StringListMap": {
                 "type": "map",
                 "key": {
@@ -3284,17 +3702,12 @@
                 "value": {
                     "shape": "StringList"
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
             }
         },
         "cases": [
             {
                 "id": "RestXmlQueryParamsStringListMap",
+                "description": "Serialize query params from map of list strings",
                 "given": {
                     "name": "QueryParamsAsStringListMap",
                     "http": {
@@ -3306,7 +3719,6 @@
                         "shape": "QueryParamsAsStringListMapInput"
                     }
                 },
-                "description": "Serialize query params from map of list strings",
                 "params": {
                     "qux": "named",
                     "foo": {
@@ -3327,11 +3739,20 @@
     {
         "description": "Test cases for QueryPrecedence operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "QueryPrecedenceInput": {
@@ -3364,6 +3785,7 @@
         "cases": [
             {
                 "id": "RestXmlQueryPrecedence",
+                "description": "Prefer named query parameters when serializing",
                 "given": {
                     "name": "QueryPrecedence",
                     "http": {
@@ -3375,7 +3797,6 @@
                         "shape": "QueryPrecedenceInput"
                     }
                 },
-                "description": "Prefer named query parameters when serializing",
                 "params": {
                     "foo": "named",
                     "baz": {
@@ -3394,21 +3815,22 @@
     {
         "description": "Test cases for RecursiveShapes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "RecursiveShapesRequest": {
-                "type": "structure",
-                "members": {
-                    "nested": {
-                        "shape": "RecursiveShapesInputOutputNested1"
-                    }
-                }
-            },
             "RecursiveShapesInputOutputNested1": {
                 "type": "structure",
                 "members": {
@@ -3420,9 +3842,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveShapesInputOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -3433,11 +3852,23 @@
                         "shape": "RecursiveShapesInputOutputNested1"
                     }
                 }
+            },
+            "RecursiveShapesRequest": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "RecursiveShapesInputOutputNested1"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveShapes",
                     "http": {
@@ -3452,7 +3883,6 @@
                     "documentation": "<p>Recursive shapes</p>",
                     "idempotent": true
                 },
-                "description": "Serializes recursive structures",
                 "params": {
                     "nested": {
                         "foo": "Foo1",
@@ -3481,13 +3911,42 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarPropertiesRequest": {
                 "type": "structure",
                 "members": {
@@ -3528,31 +3987,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "SimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -3566,7 +4006,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "foo": "Foo",
                     "stringValue": "string",
@@ -3584,13 +4023,14 @@
                     "uri": "/SimpleScalarProperties",
                     "body": "<SimpleScalarPropertiesRequest>\n    <stringValue>string</stringValue>\n    <trueBooleanValue>true</trueBooleanValue>\n    <falseBooleanValue>false</falseBooleanValue>\n    <byteValue>1</byteValue>\n    <shortValue>2</shortValue>\n    <integerValue>3</integerValue>\n    <longValue>4</longValue>\n    <floatValue>5.5</floatValue>\n    <DoubleDribble>6.5</DoubleDribble>\n</SimpleScalarPropertiesRequest>\n",
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     }
                 }
             },
             {
                 "id": "SimpleScalarPropertiesWithEscapedCharacter",
+                "description": "Serializes string with escaping",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -3604,7 +4044,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes string with escaping",
                 "params": {
                     "foo": "Foo",
                     "stringValue": "<string>"
@@ -3614,13 +4053,14 @@
                     "uri": "/SimpleScalarProperties",
                     "body": "<SimpleScalarPropertiesRequest>\n    <stringValue>&lt;string&gt;</stringValue>\n</SimpleScalarPropertiesRequest>\n",
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     }
                 }
             },
             {
                 "id": "SimpleScalarPropertiesWithWhiteSpace",
+                "description": "Serializes string containing white space",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -3634,7 +4074,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes string containing white space",
                 "params": {
                     "foo": "Foo",
                     "stringValue": "  string with white    space  "
@@ -3644,13 +4083,14 @@
                     "uri": "/SimpleScalarProperties",
                     "body": "<SimpleScalarPropertiesRequest>\n    <stringValue>  string with white    space  </stringValue>\n</SimpleScalarPropertiesRequest>\n",
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     }
                 }
             },
             {
                 "id": "SimpleScalarPropertiesPureWhiteSpace",
+                "description": "Serializes string containing exclusively whitespace",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -3664,7 +4104,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes string containing exclusively whitespace",
                 "params": {
                     "foo": "Foo",
                     "stringValue": "   "
@@ -3674,13 +4113,14 @@
                     "uri": "/SimpleScalarProperties",
                     "body": "<SimpleScalarPropertiesRequest>\n    <stringValue>   </stringValue>\n</SimpleScalarPropertiesRequest>\n",
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     }
                 }
             },
             {
                 "id": "RestXmlSupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -3694,7 +4134,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling NaN float values.",
                 "params": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -3710,6 +4149,7 @@
             },
             {
                 "id": "RestXmlSupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -3723,7 +4163,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -3739,6 +4178,7 @@
             },
             {
                 "id": "RestXmlSupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -3752,7 +4192,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling -Infinity float values.",
                 "params": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -3771,13 +4210,49 @@
     {
         "description": "Test cases for TimestampFormatHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "TimestampFormatHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -3817,38 +4292,12 @@
                         "locationName": "X-targetDateTime"
                     }
                 }
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "TimestampFormatHeaders",
+                "description": "Tests how timestamp request headers are serialized",
                 "given": {
                     "name": "TimestampFormatHeaders",
                     "http": {
@@ -3861,7 +4310,6 @@
                     },
                     "documentation": "<p>The example tests how timestamp request and response headers are serialized.</p>"
                 },
-                "description": "Tests how timestamp request headers are serialized",
                 "params": {
                     "memberEpochSeconds": 1576540098,
                     "memberHttpDate": 1576540098,
@@ -3876,13 +4324,13 @@
                     "uri": "/TimestampFormatHeaders",
                     "body": "",
                     "headers": {
-                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberDateTime": "2019-12-16T23:48:18Z",
-                        "X-memberEpochSeconds": "1576540098",
+                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-targetDateTime": "2019-12-16T23:48:18Z",
                         "X-targetEpochSeconds": "1576540098",
-                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT"
+                        "X-memberEpochSeconds": "1576540098",
+                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT"
                     }
                 }
             }
@@ -3891,13 +4339,25 @@
     {
         "description": "Test cases for XmlAttributes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "XmlAttributesRequest": {
                 "type": "structure",
                 "members": {
@@ -3910,14 +4370,12 @@
                         "xmlAttribute": true
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlAttributes",
+                "description": "Serializes XML attributes on the synthesized document",
                 "given": {
                     "name": "XmlAttributes",
                     "http": {
@@ -3932,7 +4390,6 @@
                     "documentation": "<p>This example serializes an XML attributes on synthesized document.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes XML attributes on the synthesized document",
                 "params": {
                     "foo": "hi",
                     "attr": "test"
@@ -3948,6 +4405,7 @@
             },
             {
                 "id": "XmlAttributesWithEscaping",
+                "description": "Serializes XML attributes with escaped characters on the synthesized document",
                 "given": {
                     "name": "XmlAttributes",
                     "http": {
@@ -3962,7 +4420,6 @@
                     "documentation": "<p>This example serializes an XML attributes on synthesized document.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes XML attributes with escaped characters on the synthesized document",
                 "params": {
                     "foo": "hi",
                     "attr": "<test&mock>"
@@ -3979,15 +4436,111 @@
         ]
     },
     {
-        "description": "Test cases for XmlAttributesOnPayload operation",
+        "description": "Test cases for XmlAttributesInMiddle operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
+            "XmlAttributesInMiddlePayloadRequest": {
+                "type": "structure",
+                "members": {
+                    "foo": {
+                        "shape": "String"
+                    },
+                    "attr": {
+                        "shape": "String",
+                        "locationName": "test",
+                        "xmlAttribute": true
+                    },
+                    "baz": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "XmlAttributesInMiddleRequest": {
+                "type": "structure",
+                "members": {
+                    "payload": {
+                        "shape": "XmlAttributesInMiddlePayloadRequest",
+                        "locationName": "payload"
+                    }
+                },
+                "payload": "payload"
+            }
+        },
+        "cases": [
+            {
+                "id": "XmlAttributesInMiddle",
+                "description": "Serializes XML attributes on a payload when the xmlAttribute trait targets a member in the middle of the member list",
+                "given": {
+                    "name": "XmlAttributesInMiddle",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/XmlAttributesInMiddle",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "XmlAttributesInMiddleRequest"
+                    },
+                    "documentation": "<p>This example serializes an XML attribute on a payload when it's defined in the middle of the member list. This tests that implementations correctly write attributes immediately after the element start tag, which is critical for languages like C# where attribute writing must happen before child elements.</p>",
+                    "idempotent": true
+                },
+                "params": {
+                    "payload": {
+                        "foo": "Foo",
+                        "attr": "attributeValue",
+                        "baz": "Baz"
+                    }
+                },
+                "serialized": {
+                    "method": "PUT",
+                    "uri": "/XmlAttributesInMiddle",
+                    "body": "<XmlAttributesInMiddlePayloadRequest test=\"attributeValue\">\n    <foo>Foo</foo>\n    <baz>Baz</baz>\n</XmlAttributesInMiddlePayloadRequest>\n",
+                    "headers": {
+                        "Content-Type": "application/xml"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for XmlAttributesOnPayload operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
+            "protocol": "rest-xml",
+            "protocols": [
+                "rest-xml"
+            ],
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
+        },
+        "shapes": {
+            "String": {
+                "type": "string"
+            },
             "XmlAttributesOnPayloadRequest": {
                 "type": "structure",
                 "members": {
@@ -4010,14 +4563,12 @@
                         "xmlAttribute": true
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlAttributesOnPayload",
+                "description": "Serializes XML attributes on the synthesized document",
                 "given": {
                     "name": "XmlAttributesOnPayload",
                     "http": {
@@ -4031,7 +4582,6 @@
                     "documentation": "<p>This example serializes an XML attributes on a document targeted by httpPayload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes XML attributes on the synthesized document",
                 "params": {
                     "payload": {
                         "foo": "hi",
@@ -4052,13 +4602,25 @@
     {
         "description": "Test cases for XmlBlobs operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "XmlBlobsRequest": {
                 "type": "structure",
                 "members": {
@@ -4066,14 +4628,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "XmlBlobs",
+                "description": "Blobs are base64 encoded",
                 "given": {
                     "name": "XmlBlobs",
                     "http": {
@@ -4087,7 +4647,6 @@
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Blobs are base64 encoded",
                 "params": {
                     "data": "value"
                 },
@@ -4105,13 +4664,141 @@
     {
         "description": "Test cases for XmlEmptyLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlEmptyListsRequest": {
                 "type": "structure",
                 "members": {
@@ -4169,130 +4856,12 @@
                         "flattened": true
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "XmlEmptyLists",
+                "description": "Serializes Empty XML lists",
                 "given": {
                     "name": "XmlEmptyLists",
                     "http": {
@@ -4306,7 +4875,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes Empty XML lists",
                 "params": {
                     "stringList": [],
                     "stringSet": []
@@ -4325,13 +4893,33 @@
     {
         "description": "Test cases for XmlEmptyMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlEmptyMapsRequest": {
                 "type": "structure",
                 "members": {
@@ -4348,22 +4936,12 @@
                 "value": {
                     "shape": "GreetingStruct"
                 }
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlEmptyMaps",
+                "description": "Serializes Empty XML maps",
                 "given": {
                     "name": "XmlEmptyMaps",
                     "http": {
@@ -4376,7 +4954,6 @@
                         "locationName": "XmlEmptyMapsRequest"
                     }
                 },
-                "description": "Serializes Empty XML maps",
                 "params": {
                     "myMap": {}
                 },
@@ -4394,13 +4971,25 @@
     {
         "description": "Test cases for XmlEmptyStrings operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "XmlEmptyStringsRequest": {
                 "type": "structure",
                 "members": {
@@ -4408,14 +4997,12 @@
                         "shape": "String"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlEmptyStrings",
+                "description": "Serializes xml empty strings",
                 "given": {
                     "name": "XmlEmptyStrings",
                     "http": {
@@ -4429,7 +5016,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes xml empty strings",
                 "params": {
                     "emptyString": ""
                 },
@@ -4447,13 +5033,56 @@
     {
         "description": "Test cases for XmlEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlEnumsRequest": {
                 "type": "structure",
                 "members": {
@@ -4476,45 +5105,12 @@
                         "shape": "FooEnumMap"
                     }
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlEnums",
                     "http": {
@@ -4529,7 +5125,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -4561,13 +5156,50 @@
     {
         "description": "Test cases for XmlIntEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlIntEnumsRequest": {
                 "type": "structure",
                 "members": {
@@ -4590,39 +5222,12 @@
                         "shape": "IntegerEnumMap"
                     }
                 }
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlIntEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlIntEnums",
                     "http": {
@@ -4637,7 +5242,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "intEnum1": 1,
                     "intEnum2": 2,
@@ -4669,13 +5273,141 @@
     {
         "description": "Test cases for XmlLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlListsRequest": {
                 "type": "structure",
                 "members": {
@@ -4733,130 +5465,12 @@
                         "flattened": true
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "XmlLists",
+                "description": "Tests for XML list serialization",
                 "given": {
                     "name": "XmlLists",
                     "http": {
@@ -4871,7 +5485,6 @@
                     "documentation": "<p>This test case serializes XML lists for the following cases for both input and output:</p> <ol> <li>Normal XML lists.</li> <li>Normal XML sets.</li> <li>XML lists of lists.</li> <li>XML lists with @xmlName on its members</li> <li>Flattened XML lists.</li> <li>Flattened XML lists with @xmlName.</li> <li>Flattened XML lists with @xmlNamespace.</li> <li>Lists of structures.</li> <li>Flattened XML list of structures</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Tests for XML list serialization",
                 "params": {
                     "stringList": [
                         "foo",
@@ -4958,30 +5571,22 @@
     {
         "description": "Test cases for XmlMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlMapsRequest": {
-                "type": "structure",
-                "members": {
-                    "myMap": {
-                        "shape": "XmlMapsInputOutputMap"
-                    }
-                }
-            },
-            "XmlMapsInputOutputMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "GreetingStruct"
-                }
-            },
             "GreetingStruct": {
                 "type": "structure",
                 "members": {
@@ -4992,11 +5597,29 @@
             },
             "String": {
                 "type": "string"
+            },
+            "XmlMapsInputOutputMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "XmlMapsRequest": {
+                "type": "structure",
+                "members": {
+                    "myMap": {
+                        "shape": "XmlMapsInputOutputMap"
+                    }
+                }
             }
         },
         "cases": [
             {
                 "id": "XmlMaps",
+                "description": "Tests for XML map serialization",
                 "given": {
                     "name": "XmlMaps",
                     "http": {
@@ -5010,7 +5633,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Tests for XML map serialization",
                 "params": {
                     "myMap": {
                         "foo": {
@@ -5035,20 +5657,32 @@
     {
         "description": "Test cases for XmlMapsXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlMapsXmlNameRequest": {
+            "GreetingStruct": {
                 "type": "structure",
                 "members": {
-                    "myMap": {
-                        "shape": "XmlMapsXmlNameInputOutputMap"
+                    "hi": {
+                        "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             },
             "XmlMapsXmlNameInputOutputMap": {
                 "type": "map",
@@ -5061,21 +5695,19 @@
                     "locationName": "Setting"
                 }
             },
-            "GreetingStruct": {
+            "XmlMapsXmlNameRequest": {
                 "type": "structure",
                 "members": {
-                    "hi": {
-                        "shape": "String"
+                    "myMap": {
+                        "shape": "XmlMapsXmlNameInputOutputMap"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlMapsXmlName",
+                "description": "Serializes XML maps that have xmlName on members",
                 "given": {
                     "name": "XmlMapsXmlName",
                     "http": {
@@ -5088,7 +5720,6 @@
                         "locationName": "XmlMapsXmlNameRequest"
                     }
                 },
-                "description": "Serializes XML maps that have xmlName on members",
                 "params": {
                     "myMap": {
                         "foo": {
@@ -5113,22 +5744,24 @@
     {
         "description": "Test cases for XmlMapWithXmlNamespace operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlMapWithXmlNamespaceRequest": {
-                "type": "structure",
-                "members": {
-                    "myMap": {
-                        "shape": "XmlMapWithXmlNamespaceInputOutputMap",
-                        "locationName": "KVP",
-                        "xmlNamespace": "https://the-member.example.com"
-                    }
-                }
+            "String": {
+                "type": "string"
             },
             "XmlMapWithXmlNamespaceInputOutputMap": {
                 "type": "map",
@@ -5143,13 +5776,21 @@
                     "xmlNamespace": "https://the-value.example.com"
                 }
             },
-            "String": {
-                "type": "string"
+            "XmlMapWithXmlNamespaceRequest": {
+                "type": "structure",
+                "members": {
+                    "myMap": {
+                        "shape": "XmlMapWithXmlNamespaceInputOutputMap",
+                        "locationName": "KVP",
+                        "xmlNamespace": "https://the-member.example.com"
+                    }
+                }
             }
         },
         "cases": [
             {
                 "id": "RestXmlXmlMapWithXmlNamespace",
+                "description": "Serializes XML maps in requests that have xmlNamespace and xmlName on members",
                 "given": {
                     "name": "XmlMapWithXmlNamespace",
                     "http": {
@@ -5163,7 +5804,6 @@
                     },
                     "documentation": "<p>Maps with @xmlNamespace and @xmlName</p>"
                 },
-                "description": "Serializes XML maps in requests that have xmlNamespace and xmlName on members",
                 "params": {
                     "myMap": {
                         "a": "A",
@@ -5184,21 +5824,24 @@
     {
         "description": "Test cases for XmlNamespaces operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlNamespacesRequest": {
-                "type": "structure",
-                "members": {
-                    "nested": {
-                        "shape": "XmlNamespaceNested"
-                    }
-                },
-                "xmlNamespace": "http://foo.com"
+            "String": {
+                "type": "string"
             },
             "XmlNamespaceNested": {
                 "type": "structure",
@@ -5217,20 +5860,27 @@
                 },
                 "xmlNamespace": "http://foo.com"
             },
-            "String": {
-                "type": "string"
-            },
             "XmlNamespacedList": {
                 "type": "list",
                 "member": {
                     "shape": "String",
                     "xmlNamespace": "http://bux.com"
                 }
+            },
+            "XmlNamespacesRequest": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "XmlNamespaceNested"
+                    }
+                },
+                "xmlNamespace": "http://foo.com"
             }
         },
         "cases": [
             {
                 "id": "XmlNamespaces",
+                "description": "Serializes XML namespaces",
                 "given": {
                     "name": "XmlNamespaces",
                     "http": {
@@ -5243,7 +5893,6 @@
                         "locationName": "XmlNamespacesRequest"
                     }
                 },
-                "description": "Serializes XML namespaces",
                 "params": {
                     "nested": {
                         "foo": "Foo",
@@ -5267,13 +5916,49 @@
     {
         "description": "Test cases for XmlTimestamps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "XmlTimestampsRequest": {
                 "type": "structure",
                 "members": {
@@ -5299,38 +5984,12 @@
                         "shape": "HttpDate"
                     }
                 }
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
             }
         },
         "cases": [
             {
                 "id": "XmlTimestamps",
+                "description": "Tests how normal timestamps are serialized",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -5344,7 +6003,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Tests how normal timestamps are serialized",
                 "params": {
                     "normal": 1398796238
                 },
@@ -5359,6 +6017,7 @@
             },
             {
                 "id": "XmlTimestampsWithDateTimeFormat",
+                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -5372,7 +6031,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "params": {
                     "dateTime": 1398796238
                 },
@@ -5387,6 +6045,7 @@
             },
             {
                 "id": "XmlTimestampsWithDateTimeOnTargetFormat",
+                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -5400,7 +6059,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "params": {
                     "dateTimeOnTarget": 1398796238
                 },
@@ -5415,6 +6073,7 @@
             },
             {
                 "id": "XmlTimestampsWithEpochSecondsFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -5428,7 +6087,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "params": {
                     "epochSeconds": 1398796238
                 },
@@ -5443,6 +6101,7 @@
             },
             {
                 "id": "XmlTimestampsWithEpochSecondsOnTargetFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -5456,7 +6115,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "params": {
                     "epochSecondsOnTarget": 1398796238
                 },
@@ -5471,6 +6129,7 @@
             },
             {
                 "id": "XmlTimestampsWithHttpDateFormat",
+                "description": "Ensures that the timestampFormat of http-date works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -5484,7 +6143,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date works",
                 "params": {
                     "httpDate": 1398796238
                 },
@@ -5499,6 +6157,7 @@
             },
             {
                 "id": "XmlTimestampsWithHttpDateOnTargetFormat",
+                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -5512,7 +6171,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "params": {
                     "httpDateOnTarget": 1398796238
                 },
@@ -5530,18 +6188,71 @@
     {
         "description": "Test cases for XmlUnions operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlUnionsRequest": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "XmlNestedUnionStruct": {
                 "type": "structure",
                 "members": {
-                    "unionValue": {
-                        "shape": "XmlUnionShape"
+                    "stringValue": {
+                        "shape": "String"
+                    },
+                    "booleanValue": {
+                        "shape": "Boolean"
+                    },
+                    "byteValue": {
+                        "shape": "Integer"
+                    },
+                    "shortValue": {
+                        "shape": "Integer"
+                    },
+                    "integerValue": {
+                        "shape": "Integer"
+                    },
+                    "longValue": {
+                        "shape": "Long"
+                    },
+                    "floatValue": {
+                        "shape": "Float"
+                    },
+                    "doubleValue": {
+                        "shape": "Double"
                     }
                 }
             },
@@ -5581,55 +6292,11 @@
                 },
                 "union": true
             },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "XmlNestedUnionStruct": {
+            "XmlUnionsRequest": {
                 "type": "structure",
                 "members": {
-                    "stringValue": {
-                        "shape": "String"
-                    },
-                    "booleanValue": {
-                        "shape": "Boolean"
-                    },
-                    "byteValue": {
-                        "shape": "Integer"
-                    },
-                    "shortValue": {
-                        "shape": "Integer"
-                    },
-                    "integerValue": {
-                        "shape": "Integer"
-                    },
-                    "longValue": {
-                        "shape": "Long"
-                    },
-                    "floatValue": {
-                        "shape": "Float"
-                    },
-                    "doubleValue": {
-                        "shape": "Double"
+                    "unionValue": {
+                        "shape": "XmlUnionShape"
                     }
                 }
             }
@@ -5637,6 +6304,7 @@
         "cases": [
             {
                 "id": "XmlUnionsWithStructMember",
+                "description": "Serializes union struct member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -5650,7 +6318,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes union struct member",
                 "params": {
                     "unionValue": {
                         "structValue": {
@@ -5676,6 +6343,7 @@
             },
             {
                 "id": "XmlUnionsWithStringMember",
+                "description": "serialize union string member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -5689,7 +6357,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "serialize union string member",
                 "params": {
                     "unionValue": {
                         "stringValue": "some string"
@@ -5706,6 +6373,7 @@
             },
             {
                 "id": "XmlUnionsWithBooleanMember",
+                "description": "Serializes union boolean member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -5719,7 +6387,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes union boolean member",
                 "params": {
                     "unionValue": {
                         "booleanValue": true
@@ -5736,6 +6403,7 @@
             },
             {
                 "id": "XmlUnionsWithUnionMember",
+                "description": "Serializes union member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -5749,7 +6417,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes union member",
                 "params": {
                     "unionValue": {
                         "unionValue": {

--- a/tests/unit/protocols/input/smithy-rpc-v2-cbor-non-query-compatible.json
+++ b/tests/unit/protocols/input/smithy-rpc-v2-cbor-non-query-compatible.json
@@ -22,6 +22,7 @@
         "cases": [
             {
                 "id": "NonQueryCompatibleRpcV2CborForbidsQueryModeHeader",
+                "description": "The query mode header MUST NOT be set on non-query-compatible services.",
                 "given": {
                     "name": "NonQueryCompatibleOperation",
                     "http": {
@@ -30,7 +31,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "The query mode header MUST NOT be set on non-query-compatible services.",
                 "params": {},
                 "serialized": {
                     "method": "POST",

--- a/tests/unit/protocols/input/smithy-rpc-v2-cbor-query-compatible.json
+++ b/tests/unit/protocols/input/smithy-rpc-v2-cbor-query-compatible.json
@@ -23,6 +23,7 @@
         "cases": [
             {
                 "id": "QueryCompatibleRpcV2CborSendsQueryModeHeader",
+                "description": "Clients for query-compatible services MUST send the x-amzn-query-mode header.",
                 "given": {
                     "name": "QueryCompatibleOperation",
                     "http": {
@@ -31,15 +32,14 @@
                     },
                     "idempotent": true
                 },
-                "description": "Clients for query-compatible services MUST send the x-amzn-query-mode header.",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/service/QueryCompatibleRpcV2Protocol/operation/QueryCompatibleOperation",
                     "body": "",
                     "headers": {
-                        "Accept": "application/cbor",
                         "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
                         "x-amzn-query-mode": "true"
                     },
                     "forbidHeaders": [

--- a/tests/unit/protocols/input/smithy-rpc-v2-cbor.json
+++ b/tests/unit/protocols/input/smithy-rpc-v2-cbor.json
@@ -2,12 +2,21 @@
     {
         "description": "Test cases for EmptyInputOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "EmptyStructure": {
@@ -18,6 +27,7 @@
         "cases": [
             {
                 "id": "empty_input",
+                "description": "When Input structure is empty we write CBOR equivalent of {}",
                 "given": {
                     "name": "EmptyInputOutput",
                     "http": {
@@ -28,16 +38,15 @@
                         "shape": "EmptyStructure"
                     }
                 },
-                "description": "When Input structure is empty we write CBOR equivalent of {}",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/service/RpcV2Protocol/operation/EmptyInputOutput",
                     "body": "v/8=",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "forbidHeaders": [
                         "X-Amz-Target"
@@ -52,17 +61,27 @@
     {
         "description": "Test cases for NoInputOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "no_input",
+                "description": "Body is empty and no Content-Type header if no input",
                 "given": {
                     "name": "NoInputOutput",
                     "http": {
@@ -70,7 +89,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Body is empty and no Content-Type header if no input",
                 "params": {},
                 "serialized": {
                     "method": "POST",
@@ -91,12 +109,21 @@
     {
         "description": "Test cases for OptionalInputOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "SimpleStructure": {
@@ -114,6 +141,7 @@
         "cases": [
             {
                 "id": "optional_input",
+                "description": "When input is empty we write CBOR equivalent of {}",
                 "given": {
                     "name": "OptionalInputOutput",
                     "http": {
@@ -124,16 +152,15 @@
                         "shape": "SimpleStructure"
                     }
                 },
-                "description": "When input is empty we write CBOR equivalent of {}",
                 "params": {},
                 "serialized": {
                     "method": "POST",
                     "uri": "/service/RpcV2Protocol/operation/OptionalInputOutput",
                     "body": "v/8=",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "forbidHeaders": [
                         "X-Amz-Target"
@@ -145,12 +172,21 @@
     {
         "description": "Test cases for RecursiveShapes operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "RecursiveShapesInputOutput": {
@@ -172,9 +208,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveShapesInputOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -185,11 +218,15 @@
                         "shape": "RecursiveShapesInputOutputNested1"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborRecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveShapes",
                     "http": {
@@ -200,7 +237,6 @@
                         "shape": "RecursiveShapesInputOutput"
                     }
                 },
-                "description": "Serializes recursive structures",
                 "params": {
                     "nested": {
                         "foo": "Foo1",
@@ -220,9 +256,9 @@
                     "uri": "/service/RpcV2Protocol/operation/RecursiveShapes",
                     "body": "v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8=",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -234,14 +270,84 @@
     {
         "description": "Test cases for RpcV2CborDenseMaps operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "DenseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                }
+            },
+            "DenseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                }
+            },
+            "DenseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                }
+            },
+            "DenseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
+            "DenseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
             "RpcV2CborDenseMapsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -262,80 +368,20 @@
                     }
                 }
             },
-            "DenseStructMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "GreetingStruct"
-                }
-            },
-            "DenseNumberMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Integer"
-                }
-            },
-            "DenseBooleanMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Boolean"
-                }
-            },
-            "DenseStringMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "String"
-                }
-            },
-            "DenseSetMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "StringSet"
-                }
+            "String": {
+                "type": "string"
             },
             "StringSet": {
                 "type": "list",
                 "member": {
                     "shape": "String"
                 }
-            },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborMaps",
+                "description": "Serializes maps",
                 "given": {
                     "name": "RpcV2CborDenseMaps",
                     "http": {
@@ -347,7 +393,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Serializes maps",
                 "params": {
                     "denseStructMap": {
                         "foo": {
@@ -363,9 +408,9 @@
                     "uri": "/service/RpcV2Protocol/operation/RpcV2CborDenseMaps",
                     "body": "oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ==",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -374,6 +419,7 @@
             },
             {
                 "id": "RpcV2CborSerializesZeroValuesInMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "given": {
                     "name": "RpcV2CborDenseMaps",
                     "http": {
@@ -385,7 +431,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "params": {
                     "denseNumberMap": {
                         "x": 0
@@ -399,9 +444,9 @@
                     "uri": "/service/RpcV2Protocol/operation/RpcV2CborDenseMaps",
                     "body": "om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A==",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -410,6 +455,7 @@
             },
             {
                 "id": "RpcV2CborSerializesDenseSetMap",
+                "description": "A request that contains a dense map of sets.",
                 "given": {
                     "name": "RpcV2CborDenseMaps",
                     "http": {
@@ -421,7 +467,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "A request that contains a dense map of sets.",
                 "params": {
                     "denseSetMap": {
                         "x": [],
@@ -436,9 +481,9 @@
                     "uri": "/service/RpcV2Protocol/operation/RpcV2CborDenseMaps",
                     "body": "oWtkZW5zZVNldE1hcKJheIBheYJhYWFi",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -450,14 +495,85 @@
     {
         "description": "Test cases for RpcV2CborLists operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "BlobList": {
+                "type": "list",
+                "member": {
+                    "shape": "Blob"
+                }
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
             "RpcV2CborListInputOutput": {
                 "type": "structure",
                 "members": {
@@ -493,6 +609,9 @@
                     }
                 }
             },
+            "String": {
+                "type": "string"
+            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -505,57 +624,11 @@
                     "shape": "String"
                 }
             },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
             "StructureList": {
                 "type": "list",
                 "member": {
                     "shape": "StructureListMember"
                 }
-            },
-            "BlobList": {
-                "type": "list",
-                "member": {
-                    "shape": "Blob"
-                }
-            },
-            "Blob": {
-                "type": "blob"
             },
             "StructureListMember": {
                 "type": "structure",
@@ -568,38 +641,20 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "Timestamp": {
                 "type": "timestamp"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborLists",
+                "description": "Serializes RpcV2 Cbor lists",
                 "given": {
                     "name": "RpcV2CborLists",
                     "http": {
@@ -612,7 +667,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes RpcV2 Cbor lists",
                 "params": {
                     "stringList": [
                         "foo",
@@ -672,9 +726,9 @@
                     "uri": "/service/RpcV2Protocol/operation/RpcV2CborLists",
                     "body": "v2pzdHJpbmdMaXN0gmNmb29jYmFyaXN0cmluZ1NldIJjZm9vY2JhcmtpbnRlZ2VyTGlzdIIBAmtib29sZWFuTGlzdIL19G10aW1lc3RhbXBMaXN0gsH7QdTX+/OAAADB+0HU1/vzgAAAaGVudW1MaXN0gmNGb29hMGtpbnRFbnVtTGlzdIIBAnBuZXN0ZWRTdHJpbmdMaXN0goJjZm9vY2JhcoJjYmF6Y3F1eG1zdHJ1Y3R1cmVMaXN0gqJhYWExYWJhMqJhYWEzYWJhNGhibG9iTGlzdIJDZm9vQ2Jhcv8=",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -683,6 +737,7 @@
             },
             {
                 "id": "RpcV2CborListsEmpty",
+                "description": "Serializes empty JSON lists",
                 "given": {
                     "name": "RpcV2CborLists",
                     "http": {
@@ -695,7 +750,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes empty JSON lists",
                 "params": {
                     "stringList": []
                 },
@@ -704,9 +758,9 @@
                     "uri": "/service/RpcV2Protocol/operation/RpcV2CborLists",
                     "body": "v2pzdHJpbmdMaXN0n///",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -715,6 +769,7 @@
             },
             {
                 "id": "RpcV2CborListsEmptyUsingDefiniteLength",
+                "description": "Serializes empty JSON definite length lists",
                 "given": {
                     "name": "RpcV2CborLists",
                     "http": {
@@ -727,7 +782,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes empty JSON definite length lists",
                 "params": {
                     "stringList": []
                 },
@@ -736,9 +790,314 @@
                     "uri": "/service/RpcV2Protocol/operation/RpcV2CborLists",
                     "body": "oWpzdHJpbmdMaXN0gA==",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for RpcV2CborSparseMaps operation",
+        "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
+        },
+        "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "RpcV2CborSparseMapsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStructMap": {
+                        "shape": "SparseStructMap"
+                    },
+                    "sparseNumberMap": {
+                        "shape": "SparseNumberMap"
+                    },
+                    "sparseBooleanMap": {
+                        "shape": "SparseBooleanMap"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
+                    },
+                    "sparseSetMap": {
+                        "shape": "SparseSetMap"
+                    }
+                }
+            },
+            "SparseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                },
+                "sparse": true
+            },
+            "SparseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                },
+                "sparse": true
+            },
+            "SparseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                },
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "SparseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborSparseMaps",
+                "description": "Serializes sparse maps",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseStructMap": {
+                        "foo": {
+                            "hi": "there"
+                        },
+                        "baz": {
+                            "hi": "bye"
+                        }
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborSparseMaps",
+                    "body": "v29zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb79iaGlldGhlcmX/Y2Jher9iaGljYnll////",
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSerializesNullMapValues",
+                "description": "Serializes null map values in sparse maps",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseBooleanMap": {
+                        "x": null
+                    },
+                    "sparseNumberMap": {
+                        "x": null
+                    },
+                    "sparseStringMap": {
+                        "x": null
+                    },
+                    "sparseStructMap": {
+                        "x": null
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborSparseMaps",
+                    "body": "v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//",
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSerializesSparseSetMap",
+                "description": "A request that contains a sparse map of sets",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ]
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborSparseMaps",
+                    "body": "v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL///8=",
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSerializesSparseSetMapAndRetainsNull",
+                "description": "A request that contains a sparse map of sets.",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ],
+                        "z": null
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborSparseMaps",
+                    "body": "v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL/YXr2//8=",
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSerializesZeroValuesInSparseMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseNumberMap": {
+                        "x": 0
+                    },
+                    "sparseBooleanMap": {
+                        "x": false
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborSparseMaps",
+                    "body": "v29zcGFyc2VOdW1iZXJNYXC/YXgA/3BzcGFyc2VCb29sZWFuTWFwv2F49P//",
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -750,14 +1109,46 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarStructure": {
                 "type": "structure",
                 "members": {
@@ -793,36 +1184,14 @@
                     }
                 }
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
             "String": {
                 "type": "string"
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborSimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -833,7 +1202,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Serializes simple scalar properties",
                 "params": {
                     "byteValue": 5,
                     "doubleValue": 1.889,
@@ -851,9 +1219,9 @@
                     "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
                     "body": "v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w==",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -862,6 +1230,7 @@
             },
             {
                 "id": "RpcV2CborClientDoesntSerializeNullStructureValues",
+                "description": "RpcV2 Cbor should not serialize null structure values",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -872,7 +1241,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "RpcV2 Cbor should not serialize null structure values",
                 "params": {
                     "stringValue": null
                 },
@@ -881,9 +1249,9 @@
                     "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
                     "body": "v/8=",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -892,6 +1260,7 @@
             },
             {
                 "id": "RpcV2CborSupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -902,7 +1271,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "params": {
                     "doubleValue": "NaN",
                     "floatValue": "NaN"
@@ -912,9 +1280,9 @@
                     "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
                     "body": "v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -923,6 +1291,7 @@
             },
             {
                 "id": "RpcV2CborSupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -933,7 +1302,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "doubleValue": "Infinity",
                     "floatValue": "Infinity"
@@ -943,9 +1311,9 @@
                     "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
                     "body": "v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"
@@ -954,6 +1322,7 @@
             },
             {
                 "id": "RpcV2CborSupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -964,7 +1333,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "params": {
                     "doubleValue": "-Infinity",
                     "floatValue": "-Infinity"
@@ -974,9 +1342,128 @@
                     "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
                     "body": "v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/",
                     "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
                         "Accept": "application/cbor",
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "Content-Type": "application/cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SparseNullsOperation operation",
+        "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
+        },
+        "shapes": {
+            "SparseNullsOperationInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStringList": {
+                        "shape": "SparseStringList"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
+                    }
+                }
+            },
+            "SparseStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborSparseMapsSerializeNullValues",
+                "description": "Serializes null values in maps",
+                "given": {
+                    "name": "SparseNullsOperation",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseStringMap": {
+                        "foo": null
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/SparseNullsOperation",
+                    "body": "v29zcGFyc2VTdHJpbmdNYXC/Y2Zvb/b//w==",
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSparseListsSerializeNull",
+                "description": "Serializes null values in lists",
+                "given": {
+                    "name": "SparseNullsOperation",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
+                },
+                "params": {
+                    "sparseStringList": [
+                        null
+                    ]
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/SparseNullsOperation",
+                    "body": "v3BzcGFyc2VTdHJpbmdMaXN0n/b//w==",
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "requireHeaders": [
                         "Content-Length"

--- a/tests/unit/protocols/output/ec2.json
+++ b/tests/unit/protocols/output/ec2.json
@@ -2,13 +2,26 @@
     {
         "description": "Test cases for DatetimeOffsets operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "DatetimeOffsetsOutput": {
                 "type": "structure",
                 "members": {
@@ -16,15 +29,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "Ec2QueryDateTimeWithNegativeOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -35,7 +45,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -49,6 +58,7 @@
             },
             {
                 "id": "Ec2QueryDateTimeWithPositiveOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -59,7 +69,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -76,11 +85,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputOutput": {
@@ -91,6 +109,7 @@
         "cases": [
             {
                 "id": "Ec2QueryEmptyInputAndEmptyOutput",
+                "description": "Empty output",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -102,7 +121,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -117,13 +135,26 @@
     {
         "description": "Test cases for FractionalSeconds operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "FractionalSecondsOutput": {
                 "type": "structure",
                 "members": {
@@ -131,15 +162,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "Ec2QueryDateTimeWithFractionalSeconds",
+                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "given": {
                     "name": "FractionalSeconds",
                     "http": {
@@ -150,7 +178,6 @@
                         "shape": "FractionalSecondsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "result": {
                     "datetime": 9.46845296123E8
                 },
@@ -167,11 +194,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "GreetingWithErrorsOutput": {
@@ -189,6 +225,7 @@
         "cases": [
             {
                 "id": "Ec2GreetingWithErrors",
+                "description": "Ensures that operations with errors successfully know how to deserialize the successful response",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -200,7 +237,6 @@
                     },
                     "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> </ol>"
                 },
-                "description": "Ensures that operations with errors successfully know how to deserialize the successful response",
                 "result": {
                     "greeting": "Hello"
                 },
@@ -217,11 +253,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "InvalidGreeting": {
@@ -241,6 +286,7 @@
         "cases": [
             {
                 "id": "Ec2InvalidGreetingError",
+                "description": "Parses simple XML errors",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -254,7 +300,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple XML errors",
                 "errorCode": "InvalidGreeting",
                 "errorMessage": "Hi",
                 "error": {
@@ -273,11 +318,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "ComplexError": {
@@ -293,9 +347,6 @@
                 "documentation": "<p>This error is thrown when a request is invalid.</p>",
                 "exception": true
             },
-            "String": {
-                "type": "string"
-            },
             "ComplexNestedErrorData": {
                 "type": "structure",
                 "members": {
@@ -303,6 +354,9 @@
                         "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
@@ -341,11 +395,20 @@
     {
         "description": "Test cases for IgnoresWrappingXmlName operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "IgnoresWrappingXmlNameOutput": {
@@ -364,6 +427,7 @@
         "cases": [
             {
                 "id": "Ec2IgnoresWrappingXmlName",
+                "description": "The xmlName trait on the output structure is ignored in the ec2 protocol",
                 "given": {
                     "name": "IgnoresWrappingXmlName",
                     "http": {
@@ -375,7 +439,6 @@
                     },
                     "documentation": "<p>The xmlName trait on the output structure is ignored in AWS Query.</p> <p>The wrapping element is always operation name + &quot;Response&quot;.</p>"
                 },
-                "description": "The xmlName trait on the output structure is ignored in the ec2 protocol",
                 "result": {
                     "foo": "bar"
                 },
@@ -392,11 +455,20 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "NoInputAndOutputOutput": {
@@ -407,6 +479,7 @@
         "cases": [
             {
                 "id": "Ec2QueryNoInputAndOutput",
+                "description": "Empty output",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -418,7 +491,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request payload or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -433,11 +505,20 @@
     {
         "description": "Test cases for RecursiveXmlShapes operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
             "RecursiveXmlShapesOutput": {
@@ -459,9 +540,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveXmlShapesOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -472,11 +550,15 @@
                         "shape": "RecursiveXmlShapesOutputNested1"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "Ec2RecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveXmlShapes",
                     "http": {
@@ -488,7 +570,6 @@
                     },
                     "documentation": "<p>Recursive shapes</p>"
                 },
-                "description": "Serializes recursive structures",
                 "result": {
                     "nested": {
                         "foo": "Foo1",
@@ -516,13 +597,42 @@
     {
         "description": "Test cases for SimpleScalarXmlProperties operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarXmlPropertiesOutput": {
                 "type": "structure",
                 "members": {
@@ -561,31 +671,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "Ec2SimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -596,7 +687,6 @@
                         "shape": "SimpleScalarXmlPropertiesOutput"
                     }
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "stringValue": "string",
                     "emptyStringValue": "",
@@ -619,6 +709,7 @@
             },
             {
                 "id": "Ec2QuerySupportsNaNFloatOutputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -629,7 +720,6 @@
                         "shape": "SimpleScalarXmlPropertiesOutput"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "result": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -644,6 +734,7 @@
             },
             {
                 "id": "Ec2QuerySupportsInfinityFloatOutputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -654,7 +745,6 @@
                         "shape": "SimpleScalarXmlPropertiesOutput"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "result": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -669,6 +759,7 @@
             },
             {
                 "id": "Ec2QuerySupportsNegativeInfinityFloatOutputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -679,7 +770,6 @@
                         "shape": "SimpleScalarXmlPropertiesOutput"
                     }
                 },
-                "description": "Supports handling -Infinity float values.",
                 "result": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -697,13 +787,25 @@
     {
         "description": "Test cases for XmlBlobs operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "XmlBlobsOutput": {
                 "type": "structure",
                 "members": {
@@ -711,14 +813,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlBlobs",
+                "description": "Blobs are base64 encoded",
                 "given": {
                     "name": "XmlBlobs",
                     "http": {
@@ -730,7 +830,6 @@
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Blobs are base64 encoded",
                 "result": {
                     "data": "value"
                 },
@@ -747,13 +846,25 @@
     {
         "description": "Test cases for XmlEmptyBlobs operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "XmlBlobsOutput": {
                 "type": "structure",
                 "members": {
@@ -761,14 +872,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlEmptyBlobs",
+                "description": "Empty blobs are deserialized as empty string",
                 "given": {
                     "name": "XmlEmptyBlobs",
                     "http": {
@@ -779,7 +888,6 @@
                         "shape": "XmlBlobsOutput"
                     }
                 },
-                "description": "Empty blobs are deserialized as empty string",
                 "result": {
                     "data": ""
                 },
@@ -793,6 +901,7 @@
             },
             {
                 "id": "Ec2XmlEmptySelfClosedBlobs",
+                "description": "Empty self closed blobs are deserialized as empty string",
                 "given": {
                     "name": "XmlEmptyBlobs",
                     "http": {
@@ -803,7 +912,6 @@
                         "shape": "XmlBlobsOutput"
                     }
                 },
-                "description": "Empty self closed blobs are deserialized as empty string",
                 "result": {
                     "data": ""
                 },
@@ -820,13 +928,141 @@
     {
         "description": "Test cases for XmlEmptyLists operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlListsOutput": {
                 "type": "structure",
                 "members": {
@@ -880,130 +1116,12 @@
                         "locationName": "myStructureList"
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlEmptyLists",
+                "description": "Deserializes empty XML lists",
                 "given": {
                     "name": "XmlEmptyLists",
                     "http": {
@@ -1014,7 +1132,6 @@
                         "shape": "XmlListsOutput"
                     }
                 },
-                "description": "Deserializes empty XML lists",
                 "result": {
                     "stringList": [],
                     "stringSet": []
@@ -1032,13 +1149,56 @@
     {
         "description": "Test cases for XmlEnums operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlEnumsOutput": {
                 "type": "structure",
                 "members": {
@@ -1061,45 +1221,12 @@
                         "shape": "FooEnumMap"
                     }
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlEnums",
                     "http": {
@@ -1111,7 +1238,6 @@
                     },
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>"
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -1142,13 +1268,50 @@
     {
         "description": "Test cases for XmlIntEnums operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlIntEnumsOutput": {
                 "type": "structure",
                 "members": {
@@ -1171,39 +1334,12 @@
                         "shape": "IntegerEnumMap"
                     }
                 }
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlIntEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlIntEnums",
                     "http": {
@@ -1215,7 +1351,6 @@
                     },
                     "documentation": "<p>This example serializes intEnums as top level properties, in lists, sets, and maps.</p>"
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "intEnum1": 1,
                     "intEnum2": 2,
@@ -1246,13 +1381,141 @@
     {
         "description": "Test cases for XmlLists operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlListsOutput": {
                 "type": "structure",
                 "members": {
@@ -1306,130 +1569,12 @@
                         "locationName": "myStructureList"
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlLists",
+                "description": "Tests for XML list serialization",
                 "given": {
                     "name": "XmlLists",
                     "http": {
@@ -1441,7 +1586,6 @@
                     },
                     "documentation": "<p>This test case serializes XML lists for the following cases for both input and output:</p> <ol> <li>Normal XML lists.</li> <li>Normal XML sets.</li> <li>XML lists of lists.</li> <li>XML lists with @xmlName on its members</li> <li>Flattened XML lists.</li> <li>Flattened XML lists with @xmlName.</li> <li>Flattened XML lists with @xmlNamespace.</li> <li>Lists of structures.</li> </ol>"
                 },
-                "description": "Tests for XML list serialization",
                 "result": {
                     "stringList": [
                         "foo",
@@ -1525,21 +1669,24 @@
     {
         "description": "Test cases for XmlNamespaces operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
-            "XmlNamespacesOutput": {
-                "type": "structure",
-                "members": {
-                    "nested": {
-                        "shape": "XmlNamespaceNested"
-                    }
-                },
-                "xmlNamespace": "http://foo.com"
+            "String": {
+                "type": "string"
             },
             "XmlNamespaceNested": {
                 "type": "structure",
@@ -1558,20 +1705,27 @@
                 },
                 "xmlNamespace": "http://foo.com"
             },
-            "String": {
-                "type": "string"
-            },
             "XmlNamespacedList": {
                 "type": "list",
                 "member": {
                     "shape": "String",
                     "xmlNamespace": "http://bux.com"
                 }
+            },
+            "XmlNamespacesOutput": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "XmlNamespaceNested"
+                    }
+                },
+                "xmlNamespace": "http://foo.com"
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlNamespaces",
+                "description": "Serializes XML namespaces",
                 "given": {
                     "name": "XmlNamespaces",
                     "http": {
@@ -1582,7 +1736,6 @@
                         "shape": "XmlNamespacesOutput"
                     }
                 },
-                "description": "Serializes XML namespaces",
                 "result": {
                     "nested": {
                         "foo": "Foo",
@@ -1605,13 +1758,49 @@
     {
         "description": "Test cases for XmlTimestamps operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsec2",
             "protocol": "ec2",
             "protocols": [
                 "ec2"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsEc2",
+            "serviceId": "EC2 Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsEc2",
+            "uid": "ec2-protocol-2020-01-08"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "XmlTimestampsOutput": {
                 "type": "structure",
                 "members": {
@@ -1637,38 +1826,12 @@
                         "shape": "HttpDate"
                     }
                 }
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
             }
         },
         "cases": [
             {
                 "id": "Ec2XmlTimestamps",
+                "description": "Tests how normal timestamps are serialized",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -1680,7 +1843,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Tests how normal timestamps are serialized",
                 "result": {
                     "normal": 1398796238
                 },
@@ -1694,6 +1856,7 @@
             },
             {
                 "id": "Ec2XmlTimestampsWithDateTimeFormat",
+                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -1705,7 +1868,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "result": {
                     "dateTime": 1398796238
                 },
@@ -1719,6 +1881,7 @@
             },
             {
                 "id": "Ec2XmlTimestampsWithDateTimeOnTargetFormat",
+                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -1730,7 +1893,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "result": {
                     "dateTimeOnTarget": 1398796238
                 },
@@ -1744,6 +1906,7 @@
             },
             {
                 "id": "Ec2XmlTimestampsWithEpochSecondsFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -1755,7 +1918,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "result": {
                     "epochSeconds": 1398796238
                 },
@@ -1769,6 +1931,7 @@
             },
             {
                 "id": "Ec2XmlTimestampsWithEpochSecondsOnTargetFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -1780,7 +1943,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "result": {
                     "epochSecondsOnTarget": 1398796238
                 },
@@ -1794,6 +1956,7 @@
             },
             {
                 "id": "Ec2XmlTimestampsWithHttpDateFormat",
+                "description": "Ensures that the timestampFormat of http-date works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -1805,7 +1968,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date works",
                 "result": {
                     "httpDate": 1398796238
                 },
@@ -1819,6 +1981,7 @@
             },
             {
                 "id": "Ec2XmlTimestampsWithHttpDateOnTargetFormat",
+                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -1830,7 +1993,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "result": {
                     "httpDateOnTarget": 1398796238
                 },

--- a/tests/unit/protocols/output/json.json
+++ b/tests/unit/protocols/output/json.json
@@ -2,15 +2,28 @@
     {
         "description": "Test cases for DatetimeOffsets operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "DatetimeOffsetsOutput": {
                 "type": "structure",
                 "members": {
@@ -18,15 +31,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "AwsJson11DateTimeWithNegativeOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -37,7 +47,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -51,6 +60,7 @@
             },
             {
                 "id": "AwsJson11DateTimeWithPositiveOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -61,7 +71,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -78,18 +87,28 @@
     {
         "description": "Test cases for EmptyOperation operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "handles_empty_output_shape",
+                "description": "When no output is defined, the service is expected to return\nan empty payload, however, client must ignore a JSON payload\nif one is returned. This ensures that if output is added later,\nthen it will not break the client.",
                 "given": {
                     "name": "EmptyOperation",
                     "http": {
@@ -97,7 +116,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "When no output is defined, the service is expected to return\nan empty payload, however, client must ignore a JSON payload\nif one is returned. This ensures that if output is added later,\nthen it will not break the client.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -109,6 +127,7 @@
             },
             {
                 "id": "handles_unexpected_json_output",
+                "description": "This client-only test builds on handles_empty_output_shape,\nby including unexpected fields in the JSON. A client\nneeds to ignore JSON output that is empty or that contains\nJSON object data.",
                 "given": {
                     "name": "EmptyOperation",
                     "http": {
@@ -116,7 +135,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "This client-only test builds on handles_empty_output_shape,\nby including unexpected fields in the JSON. A client\nneeds to ignore JSON output that is empty or that contains\nJSON object data.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -128,6 +146,7 @@
             },
             {
                 "id": "json_1_1_service_responds_with_no_payload",
+                "description": "When no output is defined, the service is expected to return\nan empty payload. Despite the lack of a payload, the service\nis expected to always send a Content-Type header. Clients must\nhandle cases where a service returns a JSON object and where\na service returns no JSON at all.",
                 "given": {
                     "name": "EmptyOperation",
                     "http": {
@@ -135,7 +154,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "When no output is defined, the service is expected to return\nan empty payload. Despite the lack of a payload, the service\nis expected to always send a Content-Type header. Clients must\nhandle cases where a service returns a JSON object and where\na service returns no JSON at all.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -150,15 +168,28 @@
     {
         "description": "Test cases for FractionalSeconds operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "FractionalSecondsOutput": {
                 "type": "structure",
                 "members": {
@@ -166,15 +197,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "AwsJson11DateTimeWithFractionalSeconds",
+                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "given": {
                     "name": "FractionalSeconds",
                     "http": {
@@ -185,7 +213,6 @@
                         "shape": "FractionalSecondsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "result": {
                     "datetime": 9.46845296123E8
                 },
@@ -202,13 +229,22 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "InvalidGreeting": {
@@ -228,6 +264,7 @@
         "cases": [
             {
                 "id": "AwsJson11InvalidGreetingError",
+                "description": "Parses simple JSON errors",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -242,7 +279,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple JSON errors",
                 "errorCode": "InvalidGreeting",
                 "errorMessage": "Hi",
                 "error": {
@@ -261,13 +297,22 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "ComplexError": {
@@ -283,9 +328,6 @@
                 "documentation": "<p>This error is thrown when a request is invalid.</p>",
                 "exception": true
             },
-            "String": {
-                "type": "string"
-            },
             "ComplexNestedErrorData": {
                 "type": "structure",
                 "members": {
@@ -293,11 +335,15 @@
                         "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "AwsJson11ComplexError",
+                "description": "Parses a complex error with no message member",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -312,7 +358,6 @@
                         }
                     ]
                 },
-                "description": "Parses a complex error with no message member",
                 "errorCode": "ComplexError",
                 "error": {
                     "TopLevel": "Top level",
@@ -359,13 +404,22 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "FooError": {
@@ -379,6 +433,7 @@
         "cases": [
             {
                 "id": "AwsJson11FooErrorUsingXAmznErrorType",
+                "description": "Serializes the X-Amzn-ErrorType header. For an example service, see Amazon EKS.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -393,7 +448,6 @@
                         }
                     ]
                 },
-                "description": "Serializes the X-Amzn-ErrorType header. For an example service, see Amazon EKS.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -405,6 +459,7 @@
             },
             {
                 "id": "AwsJson11FooErrorUsingXAmznErrorTypeWithUri",
+                "description": "Some X-Amzn-Errortype headers contain URLs. Clients need to split the URL on ':' and take only the first half of the string. For example, 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'\nis to be interpreted as 'ValidationException'.\n\nFor an example service see Amazon Polly.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -419,7 +474,6 @@
                         }
                     ]
                 },
-                "description": "Some X-Amzn-Errortype headers contain URLs. Clients need to split the URL on ':' and take only the first half of the string. For example, 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'\nis to be interpreted as 'ValidationException'.\n\nFor an example service see Amazon Polly.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -431,6 +485,7 @@
             },
             {
                 "id": "AwsJson11FooErrorUsingXAmznErrorTypeWithUriAndNamespace",
+                "description": "X-Amzn-Errortype might contain a URL and a namespace. Client should extract only the shape name. This is a pathalogical case that might not actually happen in any deployed AWS service.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -445,7 +500,6 @@
                         }
                     ]
                 },
-                "description": "X-Amzn-Errortype might contain a URL and a namespace. Client should extract only the shape name. This is a pathalogical case that might not actually happen in any deployed AWS service.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -457,6 +511,7 @@
             },
             {
                 "id": "AwsJson11FooErrorUsingCode",
+                "description": "This example uses the 'code' property in the output rather than X-Amzn-Errortype. Some services do this though it's preferable to send the X-Amzn-Errortype. Client implementations must first check for the X-Amzn-Errortype and then check for a top-level 'code' property.\n\nFor example service see Amazon S3 Glacier.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -471,7 +526,6 @@
                         }
                     ]
                 },
-                "description": "This example uses the 'code' property in the output rather than X-Amzn-Errortype. Some services do this though it's preferable to send the X-Amzn-Errortype. Client implementations must first check for the X-Amzn-Errortype and then check for a top-level 'code' property.\n\nFor example service see Amazon S3 Glacier.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -484,6 +538,7 @@
             },
             {
                 "id": "AwsJson11FooErrorUsingCodeAndNamespace",
+                "description": "Some services serialize errors using code, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -498,7 +553,6 @@
                         }
                     ]
                 },
-                "description": "Some services serialize errors using code, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -511,6 +565,7 @@
             },
             {
                 "id": "AwsJson11FooErrorUsingCodeUriAndNamespace",
+                "description": "Some services serialize errors using code, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -525,7 +580,6 @@
                         }
                     ]
                 },
-                "description": "Some services serialize errors using code, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -538,6 +592,7 @@
             },
             {
                 "id": "AwsJson11FooErrorWithDunderType",
+                "description": "Some services serialize errors using __type.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -552,7 +607,6 @@
                         }
                     ]
                 },
-                "description": "Some services serialize errors using __type.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -565,6 +619,7 @@
             },
             {
                 "id": "AwsJson11FooErrorWithDunderTypeAndNamespace",
+                "description": "Some services serialize errors using __type, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -579,7 +634,6 @@
                         }
                     ]
                 },
-                "description": "Some services serialize errors using __type, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -592,6 +646,7 @@
             },
             {
                 "id": "AwsJson11FooErrorWithDunderTypeUriAndNamespace",
+                "description": "Some services serialize errors using __type, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -606,7 +661,6 @@
                         }
                     ]
                 },
-                "description": "Some services serialize errors using __type, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
                 "errorCode": "FooError",
                 "error": {},
                 "response": {
@@ -616,21 +670,88 @@
                     },
                     "body": "{\n    \"__type\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
                 }
+            },
+            {
+                "id": "AwsJson11FooErrorWithNestedTypeProperty",
+                "description": "Some services serialize errors using __type, and if the response includes additional shapes that belong to a different namespace there'll be a nested __type property that must not be considered when determining which error to be surfaced.\n\nFor an example service see Amazon DynamoDB.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.1"
+                    },
+                    "body": "{\n    \"__type\": \"aws.protocoltests.restjson#FooError\",\n    \"ErrorDetails\": [\n      {\n          \"__type\": \"com.amazon.internal#ErrorDetails\",\n          \"reason\": \"Some reason\"\n      }\n    ]\n}"
+                }
             }
         ]
     },
     {
         "description": "Test cases for JsonEnums operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "JsonEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -654,37 +775,6 @@
                     }
                 }
             },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -692,6 +782,7 @@
         "cases": [
             {
                 "id": "AwsJson11Enums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "JsonEnums",
                     "http": {
@@ -704,7 +795,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -735,15 +825,49 @@
     {
         "description": "Test cases for JsonIntEnums operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
             "JsonIntEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -767,31 +891,6 @@
                     }
                 }
             },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -799,6 +898,7 @@
         "cases": [
             {
                 "id": "AwsJson11IntEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "JsonIntEnums",
                     "http": {
@@ -811,7 +911,6 @@
                     "documentation": "<p>This example serializes intEnums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "intEnum1": 1,
                     "intEnum2": 2,
@@ -832,8 +931,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.1",
-                        "X-Amz-Target": "JsonProtocol.JsonIntEnums"
+                        "X-Amz-Target": "JsonProtocol.JsonIntEnums",
+                        "Content-Type": "application/x-amz-json-1.1"
                     },
                     "body": "{\n    \"intEnum1\": 1,\n    \"intEnum2\": 2,\n    \"intEnum3\": 3,\n    \"intEnumList\": [\n        1,\n        2\n    ],\n    \"intEnumSet\": [\n        1,\n        2\n    ],\n    \"intEnumMap\": {\n        \"a\": 1,\n        \"b\": 2\n    }\n}"
                 }
@@ -843,23 +942,52 @@
     {
         "description": "Test cases for JsonUnions operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
-            "UnionInputOutput": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "GreetingStruct": {
                 "type": "structure",
                 "members": {
-                    "contents": {
-                        "shape": "MyUnion"
+                    "hi": {
+                        "shape": "String"
                     }
-                },
-                "documentation": "<p>A shared structure that contains a single union member.</p>"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
             },
             "MyUnion": {
                 "type": "structure",
@@ -898,30 +1026,6 @@
             "String": {
                 "type": "string"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -937,18 +1041,23 @@
                     "shape": "String"
                 }
             },
-            "GreetingStruct": {
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "UnionInputOutput": {
                 "type": "structure",
                 "members": {
-                    "hi": {
-                        "shape": "String"
+                    "contents": {
+                        "shape": "MyUnion"
                     }
-                }
+                },
+                "documentation": "<p>A shared structure that contains a single union member.</p>"
             }
         },
         "cases": [
             {
                 "id": "AwsJson11DeserializeStringUnionValue",
+                "description": "Deserializes a string union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -961,7 +1070,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a string union value",
                 "result": {
                     "contents": {
                         "stringValue": "foo"
@@ -977,6 +1085,7 @@
             },
             {
                 "id": "AwsJson11DeserializeBooleanUnionValue",
+                "description": "Deserializes a boolean union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -989,7 +1098,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a boolean union value",
                 "result": {
                     "contents": {
                         "booleanValue": true
@@ -1005,6 +1113,7 @@
             },
             {
                 "id": "AwsJson11DeserializeNumberUnionValue",
+                "description": "Deserializes a number union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1017,7 +1126,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a number union value",
                 "result": {
                     "contents": {
                         "numberValue": 1
@@ -1033,6 +1141,7 @@
             },
             {
                 "id": "AwsJson11DeserializeBlobUnionValue",
+                "description": "Deserializes a blob union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1045,7 +1154,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a blob union value",
                 "result": {
                     "contents": {
                         "blobValue": "foo"
@@ -1061,6 +1169,7 @@
             },
             {
                 "id": "AwsJson11DeserializeTimestampUnionValue",
+                "description": "Deserializes a timestamp union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1073,7 +1182,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a timestamp union value",
                 "result": {
                     "contents": {
                         "timestampValue": 1398796238
@@ -1089,6 +1197,7 @@
             },
             {
                 "id": "AwsJson11DeserializeEnumUnionValue",
+                "description": "Deserializes an enum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1101,7 +1210,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes an enum union value",
                 "result": {
                     "contents": {
                         "enumValue": "Foo"
@@ -1117,6 +1225,7 @@
             },
             {
                 "id": "AwsJson11DeserializeListUnionValue",
+                "description": "Deserializes a list union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1129,7 +1238,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a list union value",
                 "result": {
                     "contents": {
                         "listValue": [
@@ -1148,6 +1256,7 @@
             },
             {
                 "id": "AwsJson11DeserializeMapUnionValue",
+                "description": "Deserializes a map union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1160,7 +1269,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a map union value",
                 "result": {
                     "contents": {
                         "mapValue": {
@@ -1179,6 +1287,7 @@
             },
             {
                 "id": "AwsJson11DeserializeStructureUnionValue",
+                "description": "Deserializes a structure union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1191,7 +1300,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a structure union value",
                 "result": {
                     "contents": {
                         "structureValue": {
@@ -1209,6 +1317,7 @@
             },
             {
                 "id": "AwsJson11DeserializeIgnoreType",
+                "description": "Ignores an unrecognized __type property",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -1221,7 +1330,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Ignores an unrecognized __type property",
                 "result": {
                     "contents": {
                         "structureValue": {
@@ -1242,15 +1350,50 @@
     {
         "description": "Test cases for KitchenSinkOperation operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "EmptyStruct": {
+                "type": "structure",
+                "members": {}
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "JsonValue": {
+                "type": "string"
+            },
             "KitchenSink": {
                 "type": "structure",
                 "members": {
@@ -1335,39 +1478,11 @@
                     }
                 }
             },
-            "Blob": {
-                "type": "blob"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "EmptyStruct": {
-                "type": "structure",
-                "members": {}
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "JsonValue": {
-                "type": "string"
+            "ListOfKitchenSinks": {
+                "type": "list",
+                "member": {
+                    "shape": "KitchenSink"
+                }
             },
             "ListOfListOfStrings": {
                 "type": "list",
@@ -1396,6 +1511,15 @@
             "Long": {
                 "type": "long",
                 "box": true
+            },
+            "MapOfKitchenSinks": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "KitchenSink"
+                }
             },
             "MapOfListsOfStrings": {
                 "type": "map",
@@ -1433,21 +1557,6 @@
                     "shape": "SimpleStruct"
                 }
             },
-            "ListOfKitchenSinks": {
-                "type": "list",
-                "member": {
-                    "shape": "KitchenSink"
-                }
-            },
-            "MapOfKitchenSinks": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "KitchenSink"
-                }
-            },
             "SimpleStruct": {
                 "type": "structure",
                 "members": {
@@ -1467,17 +1576,26 @@
                     }
                 }
             },
-            "Timestamp": {
-                "type": "timestamp"
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
             },
             "SyntheticTimestamp_epoch_seconds": {
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "parses_operations_with_empty_json_bodies",
+                "description": "Parses operations with empty JSON bodies",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1488,7 +1606,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses operations with empty JSON bodies",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -1500,6 +1617,7 @@
             },
             {
                 "id": "parses_string_shapes",
+                "description": "Parses string shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1510,7 +1628,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses string shapes",
                 "result": {
                     "String": "string-value"
                 },
@@ -1524,6 +1641,7 @@
             },
             {
                 "id": "parses_integer_shapes",
+                "description": "Parses integer shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1534,7 +1652,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses integer shapes",
                 "result": {
                     "Integer": 1234
                 },
@@ -1548,6 +1665,7 @@
             },
             {
                 "id": "parses_long_shapes",
+                "description": "Parses long shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1558,7 +1676,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses long shapes",
                 "result": {
                     "Long": 1234567890123456789
                 },
@@ -1572,6 +1689,7 @@
             },
             {
                 "id": "parses_float_shapes",
+                "description": "Parses float shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1582,7 +1700,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses float shapes",
                 "result": {
                     "Float": 1234.5
                 },
@@ -1596,6 +1713,7 @@
             },
             {
                 "id": "parses_double_shapes",
+                "description": "Parses double shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1606,7 +1724,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses double shapes",
                 "result": {
                     "Double": 1.2345678912345679E8
                 },
@@ -1620,6 +1737,7 @@
             },
             {
                 "id": "parses_boolean_shapes_true",
+                "description": "Parses boolean shapes (true)",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1630,7 +1748,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses boolean shapes (true)",
                 "result": {
                     "Boolean": true
                 },
@@ -1644,6 +1761,7 @@
             },
             {
                 "id": "parses_boolean_false",
+                "description": "Parses boolean (false)",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1654,7 +1772,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses boolean (false)",
                 "result": {
                     "Boolean": false
                 },
@@ -1668,6 +1785,7 @@
             },
             {
                 "id": "parses_blob_shapes",
+                "description": "Parses blob shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1678,7 +1796,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses blob shapes",
                 "result": {
                     "Blob": "binary-value"
                 },
@@ -1692,6 +1809,7 @@
             },
             {
                 "id": "parses_timestamp_shapes",
+                "description": "Parses timestamp shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1702,7 +1820,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses timestamp shapes",
                 "result": {
                     "Timestamp": 946845296
                 },
@@ -1716,6 +1833,7 @@
             },
             {
                 "id": "parses_iso8601_timestamps",
+                "description": "Parses iso8601 timestamps",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1726,7 +1844,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses iso8601 timestamps",
                 "result": {
                     "Iso8601Timestamp": 946845296
                 },
@@ -1740,6 +1857,7 @@
             },
             {
                 "id": "parses_httpdate_timestamps",
+                "description": "Parses httpdate timestamps",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1750,7 +1868,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses httpdate timestamps",
                 "result": {
                     "HttpdateTimestamp": 946845296
                 },
@@ -1764,6 +1881,7 @@
             },
             {
                 "id": "parses_list_shapes",
+                "description": "Parses list shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1774,7 +1892,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses list shapes",
                 "result": {
                     "ListOfStrings": [
                         "abc",
@@ -1792,6 +1909,7 @@
             },
             {
                 "id": "parses_list_of_map_shapes",
+                "description": "Parses list of map shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1802,7 +1920,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses list of map shapes",
                 "result": {
                     "ListOfMapsOfStrings": [
                         {
@@ -1823,6 +1940,7 @@
             },
             {
                 "id": "parses_list_of_list_shapes",
+                "description": "Parses list of list shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1833,7 +1951,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses list of list shapes",
                 "result": {
                     "ListOfLists": [
                         [
@@ -1858,6 +1975,7 @@
             },
             {
                 "id": "parses_list_of_structure_shapes",
+                "description": "Parses list of structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1868,7 +1986,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses list of structure shapes",
                 "result": {
                     "ListOfStructs": [
                         {
@@ -1889,6 +2006,7 @@
             },
             {
                 "id": "parses_list_of_recursive_structure_shapes",
+                "description": "Parses list of recursive structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1899,7 +2017,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses list of recursive structure shapes",
                 "result": {
                     "RecursiveList": [
                         {
@@ -1925,6 +2042,7 @@
             },
             {
                 "id": "parses_map_shapes",
+                "description": "Parses map shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1935,7 +2053,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses map shapes",
                 "result": {
                     "MapOfStrings": {
                         "size": "large",
@@ -1952,6 +2069,7 @@
             },
             {
                 "id": "parses_map_of_list_shapes",
+                "description": "Parses map of list shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1962,7 +2080,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses map of list shapes",
                 "result": {
                     "MapOfListsOfStrings": {
                         "sizes": [
@@ -1985,6 +2102,7 @@
             },
             {
                 "id": "parses_map_of_map_shapes",
+                "description": "Parses map of map shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -1995,7 +2113,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses map of map shapes",
                 "result": {
                     "MapOfMaps": {
                         "sizes": {
@@ -2018,6 +2135,7 @@
             },
             {
                 "id": "parses_map_of_structure_shapes",
+                "description": "Parses map of structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -2028,7 +2146,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses map of structure shapes",
                 "result": {
                     "MapOfStructs": {
                         "size": {
@@ -2049,6 +2166,7 @@
             },
             {
                 "id": "parses_map_of_recursive_structure_shapes",
+                "description": "Parses map of recursive structure shapes",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -2059,7 +2177,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses map of recursive structure shapes",
                 "result": {
                     "RecursiveMap": {
                         "key-1": {
@@ -2085,6 +2202,7 @@
             },
             {
                 "id": "parses_the_request_id_from_the_response",
+                "description": "Parses the request id from the response",
                 "given": {
                     "name": "KitchenSinkOperation",
                     "http": {
@@ -2095,7 +2213,6 @@
                         "shape": "KitchenSink"
                     }
                 },
-                "description": "Parses the request id from the response",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -2111,13 +2228,22 @@
     {
         "description": "Test cases for NullOperation operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
             "NullOperationInputOutput": {
@@ -2135,6 +2261,7 @@
         "cases": [
             {
                 "id": "AwsJson11StructuresDontDeserializeNullValues",
+                "description": "Null structure values are dropped",
                 "given": {
                     "name": "NullOperation",
                     "http": {
@@ -2145,7 +2272,6 @@
                         "shape": "NullOperationInputOutput"
                     }
                 },
-                "description": "Null structure values are dropped",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -2160,15 +2286,29 @@
     {
         "description": "Test cases for PutAndGetInlineDocuments operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "PutAndGetInlineDocumentsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2176,16 +2316,12 @@
                         "shape": "Document"
                     }
                 }
-            },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
             }
         },
         "cases": [
             {
                 "id": "PutAndGetInlineDocumentsInput",
+                "description": "Serializes inline documents in a JSON response.",
                 "given": {
                     "name": "PutAndGetInlineDocuments",
                     "http": {
@@ -2197,7 +2333,6 @@
                     },
                     "documentation": "<p>This example serializes an inline document as part of the payload.</p>"
                 },
-                "description": "Serializes inline documents in a JSON response.",
                 "result": {
                     "inlineDocument": {
                         "foo": "bar"
@@ -2216,15 +2351,32 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2018-01-01",
-            "jsonVersion": "1.1",
-            "targetPrefix": "JsonProtocol"
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
         },
         "shapes": {
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "SimpleScalarPropertiesInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2235,19 +2387,12 @@
                         "shape": "Double"
                     }
                 }
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "AwsJson11SupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2258,7 +2403,6 @@
                         "shape": "SimpleScalarPropertiesInputOutput"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "result": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -2273,6 +2417,7 @@
             },
             {
                 "id": "AwsJson11SupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2283,7 +2428,6 @@
                         "shape": "SimpleScalarPropertiesInputOutput"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "result": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -2298,6 +2442,7 @@
             },
             {
                 "id": "AwsJson11SupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2308,7 +2453,6 @@
                         "shape": "SimpleScalarPropertiesInputOutput"
                     }
                 },
-                "description": "Supports handling -Infinity float values.",
                 "result": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -2319,6 +2463,114 @@
                         "Content-Type": "application/x-amz-json-1.1"
                     },
                     "body": "{\n    \"floatValue\": \"-Infinity\",\n    \"doubleValue\": \"-Infinity\"\n}"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SparseNullsOperation operation",
+        "metadata": {
+            "apiVersion": "2018-01-01",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonprotocol",
+            "jsonVersion": "1.1",
+            "protocol": "json",
+            "protocols": [
+                "json"
+            ],
+            "serviceFullName": "JsonProtocol",
+            "serviceId": "Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "JsonProtocol",
+            "targetPrefix": "JsonProtocol",
+            "uid": "json-protocol-2018-01-01"
+        },
+        "shapes": {
+            "SparseNullsOperationInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStringList": {
+                        "shape": "SparseStringList"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
+                    }
+                }
+            },
+            "SparseStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "AwsJson11SparseMapsDeserializeNullValues",
+                "description": "Deserializes null values in maps",
+                "given": {
+                    "name": "SparseNullsOperation",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
+                },
+                "result": {
+                    "sparseStringMap": {
+                        "foo": null
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.1"
+                    },
+                    "body": "{\n    \"sparseStringMap\": {\n        \"foo\": null\n    }\n}"
+                }
+            },
+            {
+                "id": "AwsJson11SparseListsDeserializeNull",
+                "description": "Deserializes null values in lists",
+                "given": {
+                    "name": "SparseNullsOperation",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
+                },
+                "result": {
+                    "sparseStringList": [
+                        null
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.1"
+                    },
+                    "body": "{\n    \"sparseStringList\": [\n        null\n    ]\n}"
                 }
             }
         ]

--- a/tests/unit/protocols/output/json_1_0-query-compatible.json
+++ b/tests/unit/protocols/output/json_1_0-query-compatible.json
@@ -37,6 +37,7 @@
         "cases": [
             {
                 "id": "QueryCompatibleAwsJson10NoCustomCodeError",
+                "description": "Parses simple errors with no query error code",
                 "given": {
                     "name": "QueryCompatibleOperation",
                     "http": {
@@ -50,7 +51,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple errors with no query error code",
                 "errorCode": "NoCustomCodeError",
                 "errorMessage": "Hi",
                 "error": {
@@ -109,6 +109,7 @@
         "cases": [
             {
                 "id": "QueryCompatibleAwsJson10CustomCodeError",
+                "description": "Parses simple errors with query error code",
                 "given": {
                     "name": "QueryCompatibleOperation",
                     "http": {
@@ -122,7 +123,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple errors with query error code",
                 "errorCode": "Customized",
                 "errorMessage": "Hi",
                 "error": {
@@ -131,8 +131,8 @@
                 "response": {
                     "status_code": 400,
                     "headers": {
-                        "Content-Type": "application/x-amz-json-1.0",
-                        "x-amzn-query-error": "Customized;Sender"
+                        "x-amzn-query-error": "Customized;Sender",
+                        "Content-Type": "application/x-amz-json-1.0"
                     },
                     "body": "{\n    \"__type\": \"aws.protocoltests.json10#CustomCodeError\",\n    \"message\": \"Hi\"\n}"
                 }

--- a/tests/unit/protocols/output/json_1_0.json
+++ b/tests/unit/protocols/output/json_1_0.json
@@ -2,13 +2,22 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputOutput": {
@@ -19,6 +28,7 @@
         "cases": [
             {
                 "id": "AwsJson10EmptyInputAndEmptyOutputSendJsonObject",
+                "description": "A service will always return a JSON object for operations with modeled output.",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -30,7 +40,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has an empty input and empty output structure that reuses the same shape. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "A service will always return a JSON object for operations with modeled output.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -45,13 +54,22 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
             "InvalidGreeting": {
@@ -71,6 +89,7 @@
         "cases": [
             {
                 "id": "AwsJson10InvalidGreetingError",
+                "description": "Parses simple JSON errors",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -85,7 +104,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple JSON errors",
                 "errorCode": "InvalidGreeting",
                 "errorMessage": "Hi",
                 "error": {
@@ -104,276 +122,22 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
-        },
-        "shapes": {
-            "FooError": {
-                "type": "structure",
-                "members": {},
-                "documentation": "<p>This error has test cases that test some of the dark corners of Amazon service framework history. It should only be implemented by clients.</p>",
-                "exception": true,
-                "fault": true
-            }
-        },
-        "cases": [
-            {
-                "id": "AwsJson10FooErrorUsingXAmznErrorType",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Serializes the X-Amzn-ErrorType header. For an example service, see Amazon EKS.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "X-Amzn-Errortype": "FooError"
-                    }
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorUsingXAmznErrorTypeWithUri",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some X-Amzn-Errortype headers contain URLs. Clients need to split the URL on ':' and take only the first half of the string. For example, 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'\nis to be interpreted as 'ValidationException'.\n\nFor an example service see Amazon Polly.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "X-Amzn-Errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
-                    }
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorUsingXAmznErrorTypeWithUriAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "X-Amzn-Errortype might contain a URL and a namespace. Client should extract only the shape name. This is a pathalogical case that might not actually happen in any deployed AWS service.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "X-Amzn-Errortype": "aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
-                    }
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorUsingCode",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "This example uses the 'code' property in the output rather than X-Amzn-Errortype. Some services do this though it's preferable to send the X-Amzn-Errortype. Client implementations must first check for the X-Amzn-Errortype and then check for a top-level 'code' property.\n\nFor example service see Amazon S3 Glacier.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/x-amz-json-1.0"
-                    },
-                    "body": "{\n    \"code\": \"FooError\"\n}"
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorUsingCodeAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using code, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/x-amz-json-1.0"
-                    },
-                    "body": "{\n    \"code\": \"aws.protocoltests.json10#FooError\"\n}"
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorUsingCodeUriAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using code, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/x-amz-json-1.0"
-                    },
-                    "body": "{\n    \"code\": \"aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorWithDunderType",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using __type.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/x-amz-json-1.0"
-                    },
-                    "body": "{\n    \"__type\": \"FooError\"\n}"
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorWithDunderTypeAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using __type, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/x-amz-json-1.0"
-                    },
-                    "body": "{\n    \"__type\": \"aws.protocoltests.json10#FooError\"\n}"
-                }
-            },
-            {
-                "id": "AwsJson10FooErrorWithDunderTypeUriAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using __type, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/x-amz-json-1.0"
-                    },
-                    "body": "{\n    \"__type\": \"aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
-                }
-            }
-        ]
-    },
-    {
-        "description": "Test cases for GreetingWithErrors operation",
-        "metadata": {
-            "protocol": "json",
-            "protocols": [
-                "json"
-            ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
             "ComplexError": {
@@ -389,9 +153,6 @@
                 "documentation": "<p>This error is thrown when a request is invalid.</p>",
                 "exception": true
             },
-            "String": {
-                "type": "string"
-            },
             "ComplexNestedErrorData": {
                 "type": "structure",
                 "members": {
@@ -399,11 +160,15 @@
                         "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "AwsJson10ComplexError",
+                "description": "Parses a complex error with no message member",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -418,7 +183,6 @@
                         }
                     ]
                 },
-                "description": "Parses a complex error with no message member",
                 "errorCode": "ComplexError",
                 "error": {
                     "TopLevel": "Top level",
@@ -436,6 +200,7 @@
             },
             {
                 "id": "AwsJson10EmptyComplexError",
+                "description": "Parses a complex error with an empty body",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -450,7 +215,6 @@
                         }
                     ]
                 },
-                "description": "Parses a complex error with an empty body",
                 "errorCode": "ComplexError",
                 "error": {},
                 "response": {
@@ -464,17 +228,358 @@
         ]
     },
     {
-        "description": "Test cases for JsonUnions operation",
+        "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
+            "FooError": {
+                "type": "structure",
+                "members": {},
+                "documentation": "<p>This error has test cases that test some of the dark corners of Amazon service framework history. It should only be implemented by clients.</p>",
+                "exception": true,
+                "fault": true
+            }
+        },
+        "cases": [
+            {
+                "id": "AwsJson10FooErrorUsingXAmznErrorType",
+                "description": "Serializes the X-Amzn-ErrorType header. For an example service, see Amazon EKS.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "X-Amzn-Errortype": "FooError"
+                    }
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorUsingXAmznErrorTypeWithUri",
+                "description": "Some X-Amzn-Errortype headers contain URLs. Clients need to split the URL on ':' and take only the first half of the string. For example, 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'\nis to be interpreted as 'ValidationException'.\n\nFor an example service see Amazon Polly.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "X-Amzn-Errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+                    }
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorUsingXAmznErrorTypeWithUriAndNamespace",
+                "description": "X-Amzn-Errortype might contain a URL and a namespace. Client should extract only the shape name. This is a pathalogical case that might not actually happen in any deployed AWS service.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "X-Amzn-Errortype": "aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+                    }
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorUsingCode",
+                "description": "This example uses the 'code' property in the output rather than X-Amzn-Errortype. Some services do this though it's preferable to send the X-Amzn-Errortype. Client implementations must first check for the X-Amzn-Errortype and then check for a top-level 'code' property.\n\nFor example service see Amazon S3 Glacier.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.0"
+                    },
+                    "body": "{\n    \"code\": \"FooError\"\n}"
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorUsingCodeAndNamespace",
+                "description": "Some services serialize errors using code, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.0"
+                    },
+                    "body": "{\n    \"code\": \"aws.protocoltests.json10#FooError\"\n}"
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorUsingCodeUriAndNamespace",
+                "description": "Some services serialize errors using code, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.0"
+                    },
+                    "body": "{\n    \"code\": \"aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorWithDunderType",
+                "description": "Some services serialize errors using __type.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.0"
+                    },
+                    "body": "{\n    \"__type\": \"FooError\"\n}"
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorWithDunderTypeAndNamespace",
+                "description": "Some services serialize errors using __type, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.0"
+                    },
+                    "body": "{\n    \"__type\": \"aws.protocoltests.json10#FooError\"\n}"
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorWithDunderTypeUriAndNamespace",
+                "description": "Some services serialize errors using __type, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.0"
+                    },
+                    "body": "{\n    \"__type\": \"aws.protocoltests.json10#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
+                }
+            },
+            {
+                "id": "AwsJson10FooErrorWithNestedTypeProperty",
+                "description": "Some services serialize errors using __type, and if the response includes additional shapes that belong to a different namespace there'll be a nested __type property that must not be considered when determining which error to be surfaced.\n\nFor an example service see Amazon DynamoDB.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/x-amz-json-1.0"
+                    },
+                    "body": "{\n    \"__type\": \"aws.protocoltests.json10#FooError\",\n    \"ErrorDetails\": [\n      {\n          \"__type\": \"com.amazon.internal#ErrorDetails\",\n          \"reason\": \"Some reason\"\n      }\n    ]\n}"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for JsonUnions operation",
+        "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
+            "protocol": "json",
+            "protocols": [
+                "json"
+            ],
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
+        },
+        "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
             "JsonUnionsOutput": {
                 "type": "structure",
                 "members": {
@@ -523,34 +628,6 @@
             "String": {
                 "type": "string"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -566,18 +643,14 @@
                     "shape": "String"
                 }
             },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "AwsJson10DeserializeStringUnionValue",
+                "description": "Deserializes a string union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -590,7 +663,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a string union value",
                 "result": {
                     "contents": {
                         "stringValue": "foo"
@@ -606,6 +678,7 @@
             },
             {
                 "id": "AwsJson10DeserializeBooleanUnionValue",
+                "description": "Deserializes a boolean union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -618,7 +691,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a boolean union value",
                 "result": {
                     "contents": {
                         "booleanValue": true
@@ -634,6 +706,7 @@
             },
             {
                 "id": "AwsJson10DeserializeNumberUnionValue",
+                "description": "Deserializes a number union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -646,7 +719,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a number union value",
                 "result": {
                     "contents": {
                         "numberValue": 1
@@ -662,6 +734,7 @@
             },
             {
                 "id": "AwsJson10DeserializeBlobUnionValue",
+                "description": "Deserializes a blob union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -674,7 +747,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a blob union value",
                 "result": {
                     "contents": {
                         "blobValue": "foo"
@@ -690,6 +762,7 @@
             },
             {
                 "id": "AwsJson10DeserializeTimestampUnionValue",
+                "description": "Deserializes a timestamp union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -702,7 +775,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a timestamp union value",
                 "result": {
                     "contents": {
                         "timestampValue": 1398796238
@@ -718,6 +790,7 @@
             },
             {
                 "id": "AwsJson10DeserializeEnumUnionValue",
+                "description": "Deserializes an enum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -730,7 +803,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes an enum union value",
                 "result": {
                     "contents": {
                         "enumValue": "Foo"
@@ -746,6 +818,7 @@
             },
             {
                 "id": "AwsJson10DeserializeIntEnumUnionValue",
+                "description": "Deserializes an intEnum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -758,7 +831,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes an intEnum union value",
                 "result": {
                     "contents": {
                         "intEnumValue": 1
@@ -774,6 +846,7 @@
             },
             {
                 "id": "AwsJson10DeserializeListUnionValue",
+                "description": "Deserializes a list union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -786,7 +859,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a list union value",
                 "result": {
                     "contents": {
                         "listValue": [
@@ -805,6 +877,7 @@
             },
             {
                 "id": "AwsJson10DeserializeMapUnionValue",
+                "description": "Deserializes a map union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -817,7 +890,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a map union value",
                 "result": {
                     "contents": {
                         "mapValue": {
@@ -836,6 +908,7 @@
             },
             {
                 "id": "AwsJson10DeserializeStructureUnionValue",
+                "description": "Deserializes a structure union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -848,7 +921,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a structure union value",
                 "result": {
                     "contents": {
                         "structureValue": {
@@ -866,6 +938,7 @@
             },
             {
                 "id": "AwsJson10DeserializeIgnoreType",
+                "description": "Ignores an unrecognized __type property",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -878,7 +951,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Ignores an unrecognized __type property",
                 "result": {
                     "contents": {
                         "structureValue": {
@@ -896,6 +968,7 @@
             },
             {
                 "id": "AwsJson10DeserializeAllowNulls",
+                "description": "Allows for `: null` to be set for all unset fields",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -908,7 +981,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Allows for `: null` to be set for all unset fields",
                 "result": {
                     "contents": {
                         "structureValue": {
@@ -929,18 +1001,28 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "AwsJson10HandlesEmptyOutputShape",
+                "description": "When no output is defined, the service is expected to return\nan empty payload, however, client must ignore a JSON payload\nif one is returned. This ensures that if output is added later,\nthen it will not break the client.",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -949,7 +1031,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "When no output is defined, the service is expected to return\nan empty payload, however, client must ignore a JSON payload\nif one is returned. This ensures that if output is added later,\nthen it will not break the client.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -961,6 +1042,7 @@
             },
             {
                 "id": "AwsJson10HandlesUnexpectedJsonOutput",
+                "description": "This client-only test builds on handles_empty_output_shape,\nby including unexpected fields in the JSON. A client\nneeds to ignore JSON output that is empty or that contains\nJSON object data.",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -969,7 +1051,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "This client-only test builds on handles_empty_output_shape,\nby including unexpected fields in the JSON. A client\nneeds to ignore JSON output that is empty or that contains\nJSON object data.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -981,6 +1062,7 @@
             },
             {
                 "id": "AwsJson10ServiceRespondsWithNoPayload",
+                "description": "When no output is defined, the service is expected to return\nan empty payload. Despite the lack of a payload, the service\nis expected to always send a Content-Type header. Clients must\nhandle cases where a service returns a JSON object and where\na service returns no JSON at all.",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -989,7 +1071,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "When no output is defined, the service is expected to return\nan empty payload. Despite the lack of a payload, the service\nis expected to always send a Content-Type header. Clients must\nhandle cases where a service returns a JSON object and where\na service returns no JSON at all.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -1004,13 +1085,22 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
             "NoInputAndOutputOutput": {
@@ -1021,6 +1111,7 @@
         "cases": [
             {
                 "id": "AwsJson10NoInputAndOutput",
+                "description": "Empty output always serializes an empty object payload.",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -1032,7 +1123,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input and the output is empty. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output always serializes an empty object payload.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -1047,15 +1137,32 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "jsonrpc10",
+            "jsonVersion": "1.0",
             "protocol": "json",
             "protocols": [
                 "json"
             ],
-            "apiVersion": "2020-07-14",
-            "jsonVersion": "1.0",
-            "targetPrefix": "JsonRpc10"
+            "serviceFullName": "JsonRpc10",
+            "serviceId": "JSON RPC 10",
+            "signatureVersion": "v4",
+            "signingName": "JsonRpc10",
+            "targetPrefix": "JsonRpc10",
+            "uid": "json-rpc-10-2020-07-14"
         },
         "shapes": {
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
             "SimpleScalarPropertiesOutput": {
                 "type": "structure",
                 "members": {
@@ -1066,19 +1173,12 @@
                         "shape": "Double"
                     }
                 }
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "AwsJson10SupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1089,7 +1189,6 @@
                         "shape": "SimpleScalarPropertiesOutput"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "result": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -1104,6 +1203,7 @@
             },
             {
                 "id": "AwsJson10SupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1114,7 +1214,6 @@
                         "shape": "SimpleScalarPropertiesOutput"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "result": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -1129,6 +1228,7 @@
             },
             {
                 "id": "AwsJson10SupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1139,7 +1239,6 @@
                         "shape": "SimpleScalarPropertiesOutput"
                     }
                 },
-                "description": "Supports handling -Infinity float values.",
                 "result": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"

--- a/tests/unit/protocols/output/query.json
+++ b/tests/unit/protocols/output/query.json
@@ -2,13 +2,26 @@
     {
         "description": "Test cases for DatetimeOffsets operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "DatetimeOffsetsOutput": {
                 "type": "structure",
                 "members": {
@@ -16,15 +29,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "AwsQueryDateTimeWithNegativeOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -32,10 +42,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "DatetimeOffsetsOutput"
+                        "shape": "DatetimeOffsetsOutput",
+                        "resultWrapper": "DatetimeOffsetsResult"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -49,6 +59,7 @@
             },
             {
                 "id": "AwsQueryDateTimeWithPositiveOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -56,10 +67,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "DatetimeOffsetsOutput"
+                        "shape": "DatetimeOffsetsOutput",
+                        "resultWrapper": "DatetimeOffsetsResult"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -76,11 +87,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputOutput": {
@@ -91,6 +111,7 @@
         "cases": [
             {
                 "id": "QueryEmptyInputAndEmptyOutput",
+                "description": "Empty output",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -98,11 +119,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "EmptyInputAndEmptyOutputOutput"
+                        "shape": "EmptyInputAndEmptyOutputOutput",
+                        "resultWrapper": "EmptyInputAndEmptyOutputResult"
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output",
                 "result": {},
                 "response": {
                     "status_code": 200
@@ -113,11 +134,20 @@
     {
         "description": "Test cases for FlattenedXmlMap operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "FlattenedXmlMapOutput": {
@@ -127,15 +157,6 @@
                         "shape": "FooEnumMap",
                         "flattened": true
                     }
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
                 }
             },
             "FooEnum": {
@@ -148,6 +169,15 @@
                     "0"
                 ]
             },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
             "String": {
                 "type": "string"
             }
@@ -155,6 +185,7 @@
         "cases": [
             {
                 "id": "QueryQueryFlattenedXmlMap",
+                "description": "Serializes flattened XML maps in responses",
                 "given": {
                     "name": "FlattenedXmlMap",
                     "http": {
@@ -162,11 +193,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "FlattenedXmlMapOutput"
+                        "shape": "FlattenedXmlMapOutput",
+                        "resultWrapper": "FlattenedXmlMapResult"
                     },
                     "documentation": "<p>Flattened maps</p>"
                 },
-                "description": "Serializes flattened XML maps in responses",
                 "result": {
                     "myMap": {
                         "foo": "Foo",
@@ -186,11 +217,20 @@
     {
         "description": "Test cases for FlattenedXmlMapWithXmlName operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "FlattenedXmlMapWithXmlNameOutput": {
@@ -221,6 +261,7 @@
         "cases": [
             {
                 "id": "QueryQueryFlattenedXmlMapWithXmlName",
+                "description": "Serializes flattened XML maps in responses that have xmlName on members",
                 "given": {
                     "name": "FlattenedXmlMapWithXmlName",
                     "http": {
@@ -228,11 +269,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "FlattenedXmlMapWithXmlNameOutput"
+                        "shape": "FlattenedXmlMapWithXmlNameOutput",
+                        "resultWrapper": "FlattenedXmlMapWithXmlNameResult"
                     },
                     "documentation": "<p>Flattened maps with @xmlName</p>"
                 },
-                "description": "Serializes flattened XML maps in responses that have xmlName on members",
                 "result": {
                     "myMap": {
                         "a": "A",
@@ -252,11 +293,20 @@
     {
         "description": "Test cases for FlattenedXmlMapWithXmlNamespace operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "FlattenedXmlMapWithXmlNamespaceOutput": {
@@ -290,6 +340,7 @@
         "cases": [
             {
                 "id": "QueryQueryFlattenedXmlMapWithXmlNamespace",
+                "description": "Serializes flattened XML maps in responses that have xmlNamespace and xmlName on members",
                 "given": {
                     "name": "FlattenedXmlMapWithXmlNamespace",
                     "http": {
@@ -297,11 +348,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "FlattenedXmlMapWithXmlNamespaceOutput"
+                        "shape": "FlattenedXmlMapWithXmlNamespaceOutput",
+                        "resultWrapper": "FlattenedXmlMapWithXmlNamespaceResult"
                     },
                     "documentation": "<p>Flattened maps with @xmlNamespace and @xmlName</p>"
                 },
-                "description": "Serializes flattened XML maps in responses that have xmlNamespace and xmlName on members",
                 "result": {
                     "myMap": {
                         "a": "A",
@@ -321,13 +372,26 @@
     {
         "description": "Test cases for FractionalSeconds operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "FractionalSecondsOutput": {
                 "type": "structure",
                 "members": {
@@ -335,15 +399,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "AwsQueryDateTimeWithFractionalSeconds",
+                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "given": {
                     "name": "FractionalSeconds",
                     "http": {
@@ -351,10 +412,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "FractionalSecondsOutput"
+                        "shape": "FractionalSecondsOutput",
+                        "resultWrapper": "FractionalSecondsResult"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "result": {
                     "datetime": 9.46845296123E8
                 },
@@ -371,11 +432,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "GreetingWithErrorsOutput": {
@@ -393,6 +463,7 @@
         "cases": [
             {
                 "id": "QueryGreetingWithErrors",
+                "description": "Ensures that operations with errors successfully know how to deserialize the successful response",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -400,11 +471,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "GreetingWithErrorsOutput"
+                        "shape": "GreetingWithErrorsOutput",
+                        "resultWrapper": "GreetingWithErrorsResult"
                     },
                     "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> </ol>"
                 },
-                "description": "Ensures that operations with errors successfully know how to deserialize the successful response",
                 "result": {
                     "greeting": "Hello"
                 },
@@ -421,11 +492,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "InvalidGreeting": {
@@ -445,6 +525,7 @@
         "cases": [
             {
                 "id": "QueryInvalidGreetingError",
+                "description": "Parses simple XML errors",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -458,7 +539,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple XML errors",
                 "errorCode": "InvalidGreeting",
                 "errorMessage": "Hi",
                 "error": {
@@ -477,71 +557,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
-        },
-        "shapes": {
-            "CustomCodeError": {
-                "type": "structure",
-                "members": {
-                    "Message": {
-                        "shape": "String"
-                    }
-                },
-                "error": {
-                    "code": "Customized",
-                    "httpStatusCode": 402,
-                    "senderFault": true
-                },
-                "exception": true
-            },
-            "String": {
-                "type": "string"
-            }
-        },
-        "cases": [
-            {
-                "id": "QueryCustomizedError",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> </ol>",
-                    "errors": [
-                        {
-                            "shape": "CustomCodeError"
-                        }
-                    ]
-                },
-                "description": "Parses customized XML errors",
-                "errorCode": "Customized",
-                "errorMessage": "Hi",
-                "error": {
-                    "Message": "Hi"
-                },
-                "response": {
-                    "status_code": 402,
-                    "headers": {
-                        "Content-Type": "text/xml"
-                    },
-                    "body": "<ErrorResponse>\n   <Error>\n      <Type>Sender</Type>\n      <Code>Customized</Code>\n      <Message>Hi</Message>\n   </Error>\n   <RequestId>foo-id</RequestId>\n</ErrorResponse>\n"
-                }
-            }
-        ]
-    },
-    {
-        "description": "Test cases for GreetingWithErrors operation",
-        "metadata": {
-            "protocol": "query",
-            "protocols": [
-                "query"
-            ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "ComplexError": {
@@ -557,9 +586,6 @@
                 "documentation": "<p>This error is thrown when a request is invalid.</p>",
                 "exception": true
             },
-            "String": {
-                "type": "string"
-            },
             "ComplexNestedErrorData": {
                 "type": "structure",
                 "members": {
@@ -567,6 +593,9 @@
                         "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
@@ -603,13 +632,91 @@
         ]
     },
     {
-        "description": "Test cases for IgnoresWrappingXmlName operation",
+        "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
+        },
+        "shapes": {
+            "CustomCodeError": {
+                "type": "structure",
+                "members": {
+                    "Message": {
+                        "shape": "String"
+                    }
+                },
+                "error": {
+                    "code": "Customized",
+                    "httpStatusCode": 402,
+                    "senderFault": true
+                },
+                "exception": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "QueryCustomizedError",
+                "description": "Parses customized XML errors",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> </ol>",
+                    "errors": [
+                        {
+                            "shape": "CustomCodeError"
+                        }
+                    ]
+                },
+                "errorCode": "Customized",
+                "errorMessage": "Hi",
+                "error": {
+                    "Message": "Hi"
+                },
+                "response": {
+                    "status_code": 402,
+                    "headers": {
+                        "Content-Type": "text/xml"
+                    },
+                    "body": "<ErrorResponse>\n   <Error>\n      <Type>Sender</Type>\n      <Code>Customized</Code>\n      <Message>Hi</Message>\n   </Error>\n   <RequestId>foo-id</RequestId>\n</ErrorResponse>\n"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for IgnoresWrappingXmlName operation",
+        "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
+            "protocol": "query",
+            "protocols": [
+                "query"
+            ],
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "IgnoresWrappingXmlNameOutput": {
@@ -628,6 +735,7 @@
         "cases": [
             {
                 "id": "QueryIgnoresWrappingXmlName",
+                "description": "The xmlName trait on the output structure is ignored in AWS Query",
                 "given": {
                     "name": "IgnoresWrappingXmlName",
                     "http": {
@@ -635,11 +743,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "IgnoresWrappingXmlNameOutput"
+                        "shape": "IgnoresWrappingXmlNameOutput",
+                        "resultWrapper": "IgnoresWrappingXmlNameResult"
                     },
                     "documentation": "<p>The xmlName trait on the output structure is ignored in AWS Query.</p> <p>The wrapping element is always operation name + &quot;Response&quot;, and inside of that wrapper is another wrapper named operation name + &quot;Result&quot;.</p>"
                 },
-                "description": "The xmlName trait on the output structure is ignored in AWS Query",
                 "result": {
                     "foo": "bar"
                 },
@@ -656,16 +764,26 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "QueryNoInputAndNoOutput",
+                "description": "Empty output. Note that no assertion is made on the output body itself.",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -674,7 +792,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output. Note that no assertion is made on the output body itself.",
                 "result": {},
                 "response": {
                     "status_code": 200
@@ -685,11 +802,20 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "NoInputAndOutputOutput": {
@@ -700,6 +826,7 @@
         "cases": [
             {
                 "id": "QueryNoInputAndOutput",
+                "description": "Empty output",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -707,11 +834,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "NoInputAndOutputOutput"
+                        "shape": "NoInputAndOutputOutput",
+                        "resultWrapper": "NoInputAndOutputResult"
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request payload or response members.</p> <p>While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output",
                 "result": {},
                 "response": {
                     "status_code": 200
@@ -722,11 +849,20 @@
     {
         "description": "Test cases for RecursiveXmlShapes operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
             "RecursiveXmlShapesOutput": {
@@ -748,9 +884,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveXmlShapesOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -761,11 +894,15 @@
                         "shape": "RecursiveXmlShapesOutputNested1"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "QueryRecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveXmlShapes",
                     "http": {
@@ -773,11 +910,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "RecursiveXmlShapesOutput"
+                        "shape": "RecursiveXmlShapesOutput",
+                        "resultWrapper": "RecursiveXmlShapesResult"
                     },
                     "documentation": "<p>Recursive shapes</p>"
                 },
-                "description": "Serializes recursive structures",
                 "result": {
                     "nested": {
                         "foo": "Foo1",
@@ -805,13 +942,42 @@
     {
         "description": "Test cases for SimpleScalarXmlProperties operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarXmlPropertiesOutput": {
                 "type": "structure",
                 "members": {
@@ -850,31 +1016,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "QuerySimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -882,10 +1029,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "SimpleScalarXmlPropertiesOutput"
+                        "shape": "SimpleScalarXmlPropertiesOutput",
+                        "resultWrapper": "SimpleScalarXmlPropertiesResult"
                     }
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "stringValue": "string",
                     "emptyStringValue": "",
@@ -908,6 +1055,7 @@
             },
             {
                 "id": "AwsQuerySupportsNaNFloatOutputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -915,10 +1063,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "SimpleScalarXmlPropertiesOutput"
+                        "shape": "SimpleScalarXmlPropertiesOutput",
+                        "resultWrapper": "SimpleScalarXmlPropertiesResult"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "result": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -933,6 +1081,7 @@
             },
             {
                 "id": "AwsQuerySupportsInfinityFloatOutputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -940,10 +1089,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "SimpleScalarXmlPropertiesOutput"
+                        "shape": "SimpleScalarXmlPropertiesOutput",
+                        "resultWrapper": "SimpleScalarXmlPropertiesResult"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "result": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -958,6 +1107,7 @@
             },
             {
                 "id": "AwsQuerySupportsNegativeInfinityFloatOutputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarXmlProperties",
                     "http": {
@@ -965,10 +1115,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "SimpleScalarXmlPropertiesOutput"
+                        "shape": "SimpleScalarXmlPropertiesOutput",
+                        "resultWrapper": "SimpleScalarXmlPropertiesResult"
                     }
                 },
-                "description": "Supports handling -Infinity float values.",
                 "result": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -986,13 +1136,25 @@
     {
         "description": "Test cases for XmlBlobs operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "XmlBlobsOutput": {
                 "type": "structure",
                 "members": {
@@ -1000,14 +1162,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlBlobs",
+                "description": "Blobs are base64 encoded",
                 "given": {
                     "name": "XmlBlobs",
                     "http": {
@@ -1015,11 +1175,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlBlobsOutput"
+                        "shape": "XmlBlobsOutput",
+                        "resultWrapper": "XmlBlobsResult"
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Blobs are base64 encoded",
                 "result": {
                     "data": "value"
                 },
@@ -1036,13 +1196,25 @@
     {
         "description": "Test cases for XmlEmptyBlobs operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "XmlBlobsOutput": {
                 "type": "structure",
                 "members": {
@@ -1050,14 +1222,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlEmptyBlobs",
+                "description": "Empty blobs are deserialized as empty string",
                 "given": {
                     "name": "XmlEmptyBlobs",
                     "http": {
@@ -1065,10 +1235,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlBlobsOutput"
+                        "shape": "XmlBlobsOutput",
+                        "resultWrapper": "XmlEmptyBlobsResult"
                     }
                 },
-                "description": "Empty blobs are deserialized as empty string",
                 "result": {
                     "data": ""
                 },
@@ -1082,6 +1252,7 @@
             },
             {
                 "id": "QueryXmlEmptySelfClosedBlobs",
+                "description": "Empty self closed blobs are deserialized as empty string",
                 "given": {
                     "name": "XmlEmptyBlobs",
                     "http": {
@@ -1089,10 +1260,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlBlobsOutput"
+                        "shape": "XmlBlobsOutput",
+                        "resultWrapper": "XmlEmptyBlobsResult"
                     }
                 },
-                "description": "Empty self closed blobs are deserialized as empty string",
                 "result": {
                     "data": ""
                 },
@@ -1109,13 +1280,141 @@
     {
         "description": "Test cases for XmlEmptyLists operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlListsOutput": {
                 "type": "structure",
                 "members": {
@@ -1169,130 +1468,12 @@
                         "locationName": "myStructureList"
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "QueryXmlEmptyLists",
+                "description": "Deserializes empty XML lists",
                 "given": {
                     "name": "XmlEmptyLists",
                     "http": {
@@ -1300,10 +1481,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlListsOutput"
+                        "shape": "XmlListsOutput",
+                        "resultWrapper": "XmlEmptyListsResult"
                     }
                 },
-                "description": "Deserializes empty XML lists",
                 "result": {
                     "stringList": [],
                     "stringSet": []
@@ -1321,13 +1502,33 @@
     {
         "description": "Test cases for XmlEmptyMaps operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlMapsOutput": {
                 "type": "structure",
                 "members": {
@@ -1344,22 +1545,12 @@
                 "value": {
                     "shape": "GreetingStruct"
                 }
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlEmptyMaps",
+                "description": "Deserializes Empty XML maps",
                 "given": {
                     "name": "XmlEmptyMaps",
                     "http": {
@@ -1367,10 +1558,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlMapsOutput"
+                        "shape": "XmlMapsOutput",
+                        "resultWrapper": "XmlEmptyMapsResult"
                     }
                 },
-                "description": "Deserializes Empty XML maps",
                 "result": {
                     "myMap": {}
                 },
@@ -1384,6 +1575,7 @@
             },
             {
                 "id": "QueryXmlEmptySelfClosedMaps",
+                "description": "Deserializes Self-Closed XML maps",
                 "given": {
                     "name": "XmlEmptyMaps",
                     "http": {
@@ -1391,10 +1583,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlMapsOutput"
+                        "shape": "XmlMapsOutput",
+                        "resultWrapper": "XmlEmptyMapsResult"
                     }
                 },
-                "description": "Deserializes Self-Closed XML maps",
                 "result": {
                     "myMap": {}
                 },
@@ -1411,13 +1603,56 @@
     {
         "description": "Test cases for XmlEnums operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlEnumsOutput": {
                 "type": "structure",
                 "members": {
@@ -1440,45 +1675,12 @@
                         "shape": "FooEnumMap"
                     }
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlEnums",
                     "http": {
@@ -1486,11 +1688,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlEnumsOutput"
+                        "shape": "XmlEnumsOutput",
+                        "resultWrapper": "XmlEnumsResult"
                     },
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>"
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -1521,13 +1723,50 @@
     {
         "description": "Test cases for XmlIntEnums operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlIntEnumsOutput": {
                 "type": "structure",
                 "members": {
@@ -1550,39 +1789,12 @@
                         "shape": "IntegerEnumMap"
                     }
                 }
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlIntEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlIntEnums",
                     "http": {
@@ -1590,11 +1802,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlIntEnumsOutput"
+                        "shape": "XmlIntEnumsOutput",
+                        "resultWrapper": "XmlIntEnumsResult"
                     },
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>"
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "intEnum1": 1,
                     "intEnum2": 2,
@@ -1625,13 +1837,141 @@
     {
         "description": "Test cases for XmlLists operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlListsOutput": {
                 "type": "structure",
                 "members": {
@@ -1685,130 +2025,12 @@
                         "locationName": "myStructureList"
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "QueryXmlLists",
+                "description": "Tests for XML list serialization",
                 "given": {
                     "name": "XmlLists",
                     "http": {
@@ -1816,11 +2038,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlListsOutput"
+                        "shape": "XmlListsOutput",
+                        "resultWrapper": "XmlListsResult"
                     },
                     "documentation": "<p>This test case serializes XML lists for the following cases for both input and output:</p> <ol> <li>Normal XML lists.</li> <li>Normal XML sets.</li> <li>XML lists of lists.</li> <li>XML lists with @xmlName on its members</li> <li>Flattened XML lists.</li> <li>Flattened XML lists with @xmlName.</li> <li>Lists of structures.</li> </ol>"
                 },
-                "description": "Tests for XML list serialization",
                 "result": {
                     "stringList": [
                         "foo",
@@ -1904,13 +2126,33 @@
     {
         "description": "Test cases for XmlMaps operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlMapsOutput": {
                 "type": "structure",
                 "members": {
@@ -1927,22 +2169,12 @@
                 "value": {
                     "shape": "GreetingStruct"
                 }
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlMaps",
+                "description": "Tests for XML map serialization",
                 "given": {
                     "name": "XmlMaps",
                     "http": {
@@ -1950,11 +2182,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlMapsOutput"
+                        "shape": "XmlMapsOutput",
+                        "resultWrapper": "XmlMapsResult"
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Tests for XML map serialization",
                 "result": {
                     "myMap": {
                         "foo": {
@@ -1978,13 +2210,33 @@
     {
         "description": "Test cases for XmlMapsXmlName operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlMapsXmlNameOutput": {
                 "type": "structure",
                 "members": {
@@ -2003,22 +2255,12 @@
                     "shape": "GreetingStruct",
                     "locationName": "Setting"
                 }
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "QueryQueryXmlMapsXmlName",
+                "description": "Serializes XML lists",
                 "given": {
                     "name": "XmlMapsXmlName",
                     "http": {
@@ -2026,10 +2268,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlMapsXmlNameOutput"
+                        "shape": "XmlMapsXmlNameOutput",
+                        "resultWrapper": "XmlMapsXmlNameResult"
                     }
                 },
-                "description": "Serializes XML lists",
                 "result": {
                     "myMap": {
                         "foo": {
@@ -2053,21 +2295,24 @@
     {
         "description": "Test cases for XmlNamespaces operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
-            "XmlNamespacesOutput": {
-                "type": "structure",
-                "members": {
-                    "nested": {
-                        "shape": "XmlNamespaceNested"
-                    }
-                },
-                "xmlNamespace": "http://foo.com"
+            "String": {
+                "type": "string"
             },
             "XmlNamespaceNested": {
                 "type": "structure",
@@ -2086,20 +2331,27 @@
                 },
                 "xmlNamespace": "http://boo.com"
             },
-            "String": {
-                "type": "string"
-            },
             "XmlNamespacedList": {
                 "type": "list",
                 "member": {
                     "shape": "String",
                     "xmlNamespace": "http://bux.com"
                 }
+            },
+            "XmlNamespacesOutput": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "XmlNamespaceNested"
+                    }
+                },
+                "xmlNamespace": "http://foo.com"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlNamespaces",
+                "description": "Serializes XML namespaces",
                 "given": {
                     "name": "XmlNamespaces",
                     "http": {
@@ -2107,10 +2359,10 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlNamespacesOutput"
+                        "shape": "XmlNamespacesOutput",
+                        "resultWrapper": "XmlNamespacesResult"
                     }
                 },
-                "description": "Serializes XML namespaces",
                 "result": {
                     "nested": {
                         "foo": "Foo",
@@ -2133,13 +2385,49 @@
     {
         "description": "Test cases for XmlTimestamps operation",
         "metadata": {
+            "apiVersion": "2020-01-08",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "awsquery",
             "protocol": "query",
             "protocols": [
                 "query"
             ],
-            "apiVersion": "2020-01-08"
+            "serviceFullName": "AwsQuery",
+            "serviceId": "Query Protocol",
+            "signatureVersion": "v4",
+            "signingName": "AwsQuery",
+            "uid": "query-protocol-2020-01-08"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "XmlTimestampsOutput": {
                 "type": "structure",
                 "members": {
@@ -2165,38 +2453,12 @@
                         "shape": "HttpDate"
                     }
                 }
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
             }
         },
         "cases": [
             {
                 "id": "QueryXmlTimestamps",
+                "description": "Tests how normal timestamps are serialized",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -2204,11 +2466,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlTimestampsOutput"
+                        "shape": "XmlTimestampsOutput",
+                        "resultWrapper": "XmlTimestampsResult"
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Tests how normal timestamps are serialized",
                 "result": {
                     "normal": 1398796238
                 },
@@ -2222,6 +2484,7 @@
             },
             {
                 "id": "QueryXmlTimestampsWithDateTimeFormat",
+                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -2229,11 +2492,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlTimestampsOutput"
+                        "shape": "XmlTimestampsOutput",
+                        "resultWrapper": "XmlTimestampsResult"
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "result": {
                     "dateTime": 1398796238
                 },
@@ -2247,6 +2510,7 @@
             },
             {
                 "id": "QueryXmlTimestampsWithDateTimeOnTargetFormat",
+                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -2254,11 +2518,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlTimestampsOutput"
+                        "shape": "XmlTimestampsOutput",
+                        "resultWrapper": "XmlTimestampsResult"
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "result": {
                     "dateTimeOnTarget": 1398796238
                 },
@@ -2272,6 +2536,7 @@
             },
             {
                 "id": "QueryXmlTimestampsWithEpochSecondsFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -2279,11 +2544,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlTimestampsOutput"
+                        "shape": "XmlTimestampsOutput",
+                        "resultWrapper": "XmlTimestampsResult"
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "result": {
                     "epochSeconds": 1398796238
                 },
@@ -2297,6 +2562,7 @@
             },
             {
                 "id": "QueryXmlTimestampsWithEpochSecondsOnTargetFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -2304,11 +2570,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlTimestampsOutput"
+                        "shape": "XmlTimestampsOutput",
+                        "resultWrapper": "XmlTimestampsResult"
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "result": {
                     "epochSecondsOnTarget": 1398796238
                 },
@@ -2322,6 +2588,7 @@
             },
             {
                 "id": "QueryXmlTimestampsWithHttpDateFormat",
+                "description": "Ensures that the timestampFormat of http-date works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -2329,11 +2596,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlTimestampsOutput"
+                        "shape": "XmlTimestampsOutput",
+                        "resultWrapper": "XmlTimestampsResult"
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date works",
                 "result": {
                     "httpDate": 1398796238
                 },
@@ -2347,6 +2614,7 @@
             },
             {
                 "id": "QueryXmlTimestampsWithHttpDateOnTargetFormat",
+                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -2354,11 +2622,11 @@
                         "requestUri": "/"
                     },
                     "output": {
-                        "shape": "XmlTimestampsOutput"
+                        "shape": "XmlTimestampsOutput",
+                        "resultWrapper": "XmlTimestampsResult"
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "result": {
                     "httpDateOnTarget": 1398796238
                 },

--- a/tests/unit/protocols/output/rest-json.json
+++ b/tests/unit/protocols/output/rest-json.json
@@ -2,13 +2,26 @@
     {
         "description": "Test cases for DatetimeOffsets operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "DatetimeOffsetsOutput": {
                 "type": "structure",
                 "members": {
@@ -16,15 +29,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RestJsonDateTimeWithNegativeOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -36,7 +46,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -47,6 +56,7 @@
             },
             {
                 "id": "RestJsonDateTimeWithPositiveOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -58,7 +68,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -72,13 +81,27 @@
     {
         "description": "Test cases for DocumentType operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "DocumentTypeInputOutput": {
                 "type": "structure",
                 "members": {
@@ -92,16 +115,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
             }
         },
         "cases": [
             {
                 "id": "DocumentOutput",
+                "description": "Serializes documents as part of the JSON response payload with no escaping.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -115,7 +134,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes documents as part of the JSON response payload with no escaping.",
                 "result": {
                     "stringValue": "string",
                     "documentValue": {
@@ -132,6 +150,7 @@
             },
             {
                 "id": "DocumentOutputString",
+                "description": "Document types can be JSON scalars too.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -145,7 +164,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Document types can be JSON scalars too.",
                 "result": {
                     "stringValue": "string",
                     "documentValue": "hello"
@@ -160,6 +178,7 @@
             },
             {
                 "id": "DocumentOutputNumber",
+                "description": "Document types can be JSON scalars too.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -173,7 +192,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Document types can be JSON scalars too.",
                 "result": {
                     "stringValue": "string",
                     "documentValue": 10
@@ -188,6 +206,7 @@
             },
             {
                 "id": "DocumentOutputBoolean",
+                "description": "Document types can be JSON scalars too.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -201,7 +220,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Document types can be JSON scalars too.",
                 "result": {
                     "stringValue": "string",
                     "documentValue": false
@@ -216,6 +234,7 @@
             },
             {
                 "id": "DocumentOutputArray",
+                "description": "Document types can be JSON arrays.",
                 "given": {
                     "name": "DocumentType",
                     "http": {
@@ -229,7 +248,6 @@
                     "documentation": "<p>This example serializes a document as part of the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Document types can be JSON arrays.",
                 "result": {
                     "stringValue": "string",
                     "documentValue": [
@@ -250,13 +268,27 @@
     {
         "description": "Test cases for DocumentTypeAsMapValue operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "DocumentTypeAsMapValueInputOutput": {
                 "type": "structure",
                 "members": {
@@ -274,11 +306,6 @@
                     "shape": "Document"
                 }
             },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
-            },
             "String": {
                 "type": "string"
             }
@@ -286,6 +313,7 @@
         "cases": [
             {
                 "id": "DocumentTypeAsMapValueOutput",
+                "description": "Serializes a map that uses documents as the value.",
                 "given": {
                     "name": "DocumentTypeAsMapValue",
                     "http": {
@@ -299,7 +327,6 @@
                     "documentation": "<p>This example serializes documents as the value of maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a map that uses documents as the value.",
                 "result": {
                     "docValuedMap": {
                         "foo": {
@@ -327,13 +354,27 @@
     {
         "description": "Test cases for DocumentTypeAsPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Document": {
+                "type": "structure",
+                "members": {},
+                "document": true
+            },
             "DocumentTypeAsPayloadInputOutput": {
                 "type": "structure",
                 "members": {
@@ -342,16 +383,12 @@
                     }
                 },
                 "payload": "documentValue"
-            },
-            "Document": {
-                "type": "structure",
-                "members": {},
-                "document": true
             }
         },
         "cases": [
             {
                 "id": "DocumentTypeAsPayloadOutput",
+                "description": "Serializes a document as the target of the httpPayload trait.",
                 "given": {
                     "name": "DocumentTypeAsPayload",
                     "http": {
@@ -365,7 +402,6 @@
                     "documentation": "<p>This example serializes a document as the entire HTTP payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a document as the target of the httpPayload trait.",
                 "result": {
                     "documentValue": {
                         "foo": "bar"
@@ -381,6 +417,7 @@
             },
             {
                 "id": "DocumentTypeAsPayloadOutputString",
+                "description": "Serializes a document as a payload string.",
                 "given": {
                     "name": "DocumentTypeAsPayload",
                     "http": {
@@ -394,7 +431,6 @@
                     "documentation": "<p>This example serializes a document as the entire HTTP payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a document as a payload string.",
                 "result": {
                     "documentValue": "hello"
                 },
@@ -411,11 +447,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputOutput": {
@@ -426,6 +471,7 @@
         "cases": [
             {
                 "id": "RestJsonEmptyInputAndEmptyOutput",
+                "description": "As of January 2021, server implementations are expected to\nrespond with a JSON object regardless of if the output\nparameters are empty.",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -438,7 +484,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has an empty input and empty output structure that reuses the same shape. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "As of January 2021, server implementations are expected to\nrespond with a JSON object regardless of if the output\nparameters are empty.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -450,6 +495,7 @@
             },
             {
                 "id": "RestJsonEmptyInputAndEmptyOutputJsonObjectOutput",
+                "description": "This test ensures that clients can gracefully handle\nsituations where a service omits a JSON payload entirely.",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -462,7 +508,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has an empty input and empty output structure that reuses the same shape. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "This test ensures that clients can gracefully handle\nsituations where a service omits a JSON payload entirely.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -474,13 +519,26 @@
     {
         "description": "Test cases for FractionalSeconds operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "FractionalSecondsOutput": {
                 "type": "structure",
                 "members": {
@@ -488,15 +546,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RestJsonDateTimeWithFractionalSeconds",
+                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "given": {
                     "name": "FractionalSeconds",
                     "http": {
@@ -508,7 +563,6 @@
                         "shape": "FractionalSecondsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "result": {
                     "datetime": 9.46845296123E8
                 },
@@ -522,11 +576,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "GreetingWithErrorsOutput": {
@@ -546,6 +609,7 @@
         "cases": [
             {
                 "id": "RestJsonGreetingWithErrors",
+                "description": "Ensures that operations with errors successfully know how\nto deserialize a successful response. As of January 2021,\nserver implementations are expected to respond with a\nJSON object regardless of if the output parameters are\nempty.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -559,7 +623,6 @@
                     "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
                     "idempotent": true
                 },
-                "description": "Ensures that operations with errors successfully know how\nto deserialize a successful response. As of January 2021,\nserver implementations are expected to respond with a\nJSON object regardless of if the output parameters are\nempty.",
                 "result": {
                     "greeting": "Hello"
                 },
@@ -573,6 +636,7 @@
             },
             {
                 "id": "RestJsonGreetingWithErrorsNoPayload",
+                "description": "This test is similar to RestJsonGreetingWithErrors, but it\nensures that clients can gracefully deal with a server\nomitting a response payload.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -586,7 +650,6 @@
                     "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
                     "idempotent": true
                 },
-                "description": "This test is similar to RestJsonGreetingWithErrors, but it\nensures that clients can gracefully deal with a server\nomitting a response payload.",
                 "result": {
                     "greeting": "Hello"
                 },
@@ -603,27 +666,44 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
-            "FooError": {
+            "InvalidGreeting": {
                 "type": "structure",
-                "members": {},
-                "documentation": "<p>This error has test cases that test some of the dark corners of Amazon service framework history. It should only be implemented by clients.</p>",
-                "error": {
-                    "httpStatusCode": 500
+                "members": {
+                    "Message": {
+                        "shape": "String"
+                    }
                 },
-                "exception": true,
-                "fault": true
+                "documentation": "<p>This error is thrown when an invalid greeting value is provided.</p>",
+                "error": {
+                    "httpStatusCode": 400,
+                    "senderFault": true
+                },
+                "exception": true
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
-                "id": "RestJsonFooErrorUsingXAmznErrorType",
+                "id": "RestJsonInvalidGreetingError",
+                "description": "Parses simple JSON errors",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -635,240 +715,22 @@
                     "idempotent": true,
                     "errors": [
                         {
-                            "shape": "FooError"
+                            "shape": "InvalidGreeting"
                         }
                     ]
                 },
-                "description": "Serializes the X-Amzn-ErrorType header. For an example service, see Amazon EKS.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "X-Amzn-Errortype": "FooError"
-                    }
-                }
-            },
-            {
-                "id": "RestJsonFooErrorUsingXAmznErrorTypeWithUri",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
+                "errorCode": "InvalidGreeting",
+                "errorMessage": "Hi",
+                "error": {
+                    "Message": "Hi"
                 },
-                "description": "Some X-Amzn-Errortype headers contain URLs. Clients need to split the URL on ':' and take only the first half of the string. For example, 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'\nis to be interpreted as 'ValidationException'.\n\nFor an example service see Amazon Polly.",
-                "errorCode": "FooError",
-                "error": {},
                 "response": {
-                    "status_code": 500,
+                    "status_code": 400,
                     "headers": {
-                        "X-Amzn-Errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
-                    }
-                }
-            },
-            {
-                "id": "RestJsonFooErrorUsingXAmznErrorTypeWithUriAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "X-Amzn-Errortype might contain a URL and a namespace. Client should extract only the shape name. This is a pathalogical case that might not actually happen in any deployed AWS service.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "X-Amzn-Errortype": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
-                    }
-                }
-            },
-            {
-                "id": "RestJsonFooErrorUsingCode",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "This example uses the 'code' property in the output rather than X-Amzn-Errortype. Some services do this though it's preferable to send the X-Amzn-Errortype. Client implementations must first check for the X-Amzn-Errortype and then check for a top-level 'code' property.\n\nFor example service see Amazon S3 Glacier.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
+                        "X-Amzn-Errortype": "InvalidGreeting",
                         "Content-Type": "application/json"
                     },
-                    "body": "{\n    \"code\": \"FooError\"\n}"
-                }
-            },
-            {
-                "id": "RestJsonFooErrorUsingCodeAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using code, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/json"
-                    },
-                    "body": "{\n    \"code\": \"aws.protocoltests.restjson#FooError\"\n}"
-                }
-            },
-            {
-                "id": "RestJsonFooErrorUsingCodeUriAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using code, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/json"
-                    },
-                    "body": "{\n    \"code\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
-                }
-            },
-            {
-                "id": "RestJsonFooErrorWithDunderType",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using __type.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/json"
-                    },
-                    "body": "{\n    \"__type\": \"FooError\"\n}"
-                }
-            },
-            {
-                "id": "RestJsonFooErrorWithDunderTypeAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using __type, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/json"
-                    },
-                    "body": "{\n    \"__type\": \"aws.protocoltests.restjson#FooError\"\n}"
-                }
-            },
-            {
-                "id": "RestJsonFooErrorWithDunderTypeUriAndNamespace",
-                "given": {
-                    "name": "GreetingWithErrors",
-                    "http": {
-                        "method": "PUT",
-                        "requestUri": "/GreetingWithErrors",
-                        "responseCode": 200
-                    },
-                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
-                    "idempotent": true,
-                    "errors": [
-                        {
-                            "shape": "FooError"
-                        }
-                    ]
-                },
-                "description": "Some services serialize errors using __type, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
-                "errorCode": "FooError",
-                "error": {},
-                "response": {
-                    "status_code": 500,
-                    "headers": {
-                        "Content-Type": "application/json"
-                    },
-                    "body": "{\n    \"__type\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
+                    "body": "{\n    \"Message\": \"Hi\"\n}"
                 }
             }
         ]
@@ -876,11 +738,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "ComplexError": {
@@ -905,9 +776,6 @@
                 },
                 "exception": true
             },
-            "String": {
-                "type": "string"
-            },
             "ComplexNestedErrorData": {
                 "type": "structure",
                 "members": {
@@ -916,11 +784,15 @@
                         "locationName": "Fooooo"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonComplexErrorWithNoMessage",
+                "description": "Serializes a complex error with no message member",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -936,7 +808,6 @@
                         }
                     ]
                 },
-                "description": "Serializes a complex error with no message member",
                 "errorCode": "ComplexError",
                 "error": {
                     "Header": "Header",
@@ -948,9 +819,9 @@
                 "response": {
                     "status_code": 403,
                     "headers": {
-                        "Content-Type": "application/json",
                         "X-Amzn-Errortype": "ComplexError",
-                        "X-Header": "Header"
+                        "X-Header": "Header",
+                        "Content-Type": "application/json"
                     },
                     "body": "{\n    \"TopLevel\": \"Top level\",\n    \"Nested\": {\n        \"Fooooo\": \"bar\"\n    }\n}"
                 }
@@ -977,8 +848,8 @@
                 "response": {
                     "status_code": 403,
                     "headers": {
-                        "Content-Type": "application/json",
-                        "X-Amzn-Errortype": "ComplexError"
+                        "X-Amzn-Errortype": "ComplexError",
+                        "Content-Type": "application/json"
                     },
                     "body": "{}"
                 }
@@ -988,34 +859,37 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
-            "InvalidGreeting": {
+            "FooError": {
                 "type": "structure",
-                "members": {
-                    "Message": {
-                        "shape": "String"
-                    }
-                },
-                "documentation": "<p>This error is thrown when an invalid greeting value is provided.</p>",
+                "members": {},
+                "documentation": "<p>This error has test cases that test some of the dark corners of Amazon service framework history. It should only be implemented by clients.</p>",
                 "error": {
-                    "httpStatusCode": 400,
-                    "senderFault": true
+                    "httpStatusCode": 500
                 },
-                "exception": true
-            },
-            "String": {
-                "type": "string"
+                "exception": true,
+                "fault": true
             }
         },
         "cases": [
             {
-                "id": "RestJsonInvalidGreetingError",
+                "id": "RestJsonFooErrorUsingXAmznErrorType",
+                "description": "Serializes the X-Amzn-ErrorType header. For an example service, see Amazon EKS.",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -1027,23 +901,348 @@
                     "idempotent": true,
                     "errors": [
                         {
-                            "shape": "InvalidGreeting"
+                            "shape": "FooError"
                         }
                     ]
                 },
-                "description": "Parses simple JSON errors",
-                "errorCode": "InvalidGreeting",
-                "errorMessage": "Hi",
-                "error": {
-                    "Message": "Hi"
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "X-Amzn-Errortype": "FooError"
+                    }
+                }
+            },
+            {
+                "id": "RestJsonFooErrorUsingXAmznErrorTypeWithUri",
+                "description": "Some X-Amzn-Errortype headers contain URLs. Clients need to split the URL on ':' and take only the first half of the string. For example, 'ValidationException:http://internal.amazon.com/coral/com.amazon.coral.validate/'\nis to be interpreted as 'ValidationException'.\n\nFor an example service see Amazon Polly.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "X-Amzn-Errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+                    }
+                }
+            },
+            {
+                "id": "RestJsonFooErrorUsingXAmznErrorTypeWithUriAndNamespace",
+                "description": "X-Amzn-Errortype might contain a URL and a namespace. Client should extract only the shape name. This is a pathalogical case that might not actually happen in any deployed AWS service.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "X-Amzn-Errortype": "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+                    }
+                }
+            },
+            {
+                "id": "RestJsonFooErrorUsingCode",
+                "description": "This example uses the 'code' property in the output rather than X-Amzn-Errortype. Some services do this though it's preferable to send the X-Amzn-Errortype. Client implementations must first check for the X-Amzn-Errortype and then check for a top-level 'code' property.\n\nFor example service see Amazon S3 Glacier.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"code\": \"FooError\"\n}"
+                }
+            },
+            {
+                "id": "RestJsonFooErrorUsingCodeAndNamespace",
+                "description": "Some services serialize errors using code, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"code\": \"aws.protocoltests.restjson#FooError\"\n}"
+                }
+            },
+            {
+                "id": "RestJsonFooErrorUsingCodeUriAndNamespace",
+                "description": "Some services serialize errors using code, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"code\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
+                }
+            },
+            {
+                "id": "RestJsonFooErrorWithDunderType",
+                "description": "Some services serialize errors using __type.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"__type\": \"FooError\"\n}"
+                }
+            },
+            {
+                "id": "RestJsonFooErrorWithDunderTypeAndNamespace",
+                "description": "Some services serialize errors using __type, and it might contain a namespace. Clients should just take the last part of the string after '#'.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"__type\": \"aws.protocoltests.restjson#FooError\"\n}"
+                }
+            },
+            {
+                "id": "RestJsonFooErrorWithDunderTypeUriAndNamespace",
+                "description": "Some services serialize errors using __type, and it might contain a namespace. It also might contain a URI. Clients should just take the last part of the string after '#' and before \":\". This is a pathalogical case that might not occur in any deployed AWS service.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"__type\": \"aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/\"\n}"
+                }
+            },
+            {
+                "id": "RestJsonFooErrorWithNestedTypeProperty",
+                "description": "Some services serialize errors using __type, and if the response includes additional shapes that belong to a different namespace there'll be a nested __type property that must not be considered when determining which error to be surfaced.\n\nFor an example service see Amazon DynamoDB.",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/GreetingWithErrors",
+                        "responseCode": 200
+                    },
+                    "documentation": "<p>This operation has four possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> <li>A FooError.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "FooError"
+                        }
+                    ]
+                },
+                "errorCode": "FooError",
+                "error": {},
+                "response": {
+                    "status_code": 500,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"__type\": \"aws.protocoltests.restjson#FooError\",\n    \"ErrorDetails\": [\n      {\n          \"__type\": \"com.amazon.internal#ErrorDetails\",\n          \"reason\": \"Some reason\"\n      }\n    ]\n}"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for HttpEmptyPrefixHeaders operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
+            "protocol": "rest-json",
+            "protocols": [
+                "rest-json"
+            ],
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
+        },
+        "shapes": {
+            "HttpEmptyPrefixHeadersOutput": {
+                "type": "structure",
+                "members": {
+                    "prefixHeaders": {
+                        "shape": "StringMap",
+                        "location": "headers",
+                        "locationName": ""
+                    },
+                    "specificHeader": {
+                        "shape": "String",
+                        "location": "header",
+                        "locationName": "hello"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RestJsonHttpEmptyPrefixHeadersResponseClient",
+                "description": "Deserializes all response headers with the same for prefix and specific",
+                "given": {
+                    "name": "HttpEmptyPrefixHeaders",
+                    "http": {
+                        "method": "GET",
+                        "requestUri": "/HttpEmptyPrefixHeaders",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "HttpEmptyPrefixHeadersOutput"
+                    },
+                    "documentation": "<p>Clients that perform this test extract all headers from the response.</p>",
+                    "readonly": true
+                },
+                "result": {
+                    "prefixHeaders": {
+                        "x-foo": "Foo",
+                        "hello": "There"
+                    },
+                    "specificHeader": "There"
                 },
                 "response": {
-                    "status_code": 400,
+                    "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/json",
-                        "X-Amzn-Errortype": "InvalidGreeting"
-                    },
-                    "body": "{\n    \"Message\": \"Hi\"\n}"
+                        "x-foo": "Foo",
+                        "hello": "There"
+                    }
                 }
             }
         ]
@@ -1051,11 +1250,20 @@
     {
         "description": "Test cases for HttpEnumPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "EnumPayloadInput": {
@@ -1104,13 +1312,25 @@
     {
         "description": "Test cases for HttpPayloadTraits operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "HttpPayloadTraitsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -1127,14 +1347,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpPayloadTraitsWithBlob",
+                "description": "Serializes a blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -1147,7 +1365,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no JSON document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes a blob in the HTTP payload",
                 "result": {
                     "foo": "Foo",
                     "blob": "blobby blob blob"
@@ -1162,6 +1379,7 @@
             },
             {
                 "id": "RestJsonHttpPayloadTraitsWithNoBlobBody",
+                "description": "Serializes an empty blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -1174,7 +1392,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no JSON document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes an empty blob in the HTTP payload",
                 "result": {
                     "foo": "Foo"
                 },
@@ -1191,11 +1408,20 @@
     {
         "description": "Test cases for HttpPayloadWithStructure operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithStructureInputOutput": {
@@ -1225,6 +1451,7 @@
         "cases": [
             {
                 "id": "RestJsonHttpPayloadWithStructure",
+                "description": "Serializes a structure in the payload",
                 "given": {
                     "name": "HttpPayloadWithStructure",
                     "http": {
@@ -1238,7 +1465,6 @@
                     "documentation": "<p>This example serializes a structure in the payload.</p> <p>Note that serializing a structure changes the wrapper element name to match the targeted structure.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload",
                 "result": {
                     "nested": {
                         "greeting": "hello",
@@ -1252,17 +1478,50 @@
                     },
                     "body": "{\n    \"greeting\": \"hello\",\n    \"name\": \"Phreddy\"\n}"
                 }
+            },
+            {
+                "id": "RestJsonHttpPayloadWithStructureAndEmptyResponseBody",
+                "description": "Serializes a structure in the payload",
+                "given": {
+                    "name": "HttpPayloadWithStructure",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/HttpPayloadWithStructure",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "HttpPayloadWithStructureInputOutput"
+                    },
+                    "documentation": "<p>This example serializes a structure in the payload.</p> <p>Note that serializing a structure changes the wrapper element name to match the targeted structure.</p>",
+                    "idempotent": true
+                },
+                "result": {
+                    "nested": null
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": ""
+                }
             }
         ]
     },
     {
         "description": "Test cases for HttpPayloadWithUnion operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithUnionInputOutput": {
@@ -1274,6 +1533,9 @@
                 },
                 "payload": "nested"
             },
+            "String": {
+                "type": "string"
+            },
             "UnionPayload": {
                 "type": "structure",
                 "members": {
@@ -1282,14 +1544,12 @@
                     }
                 },
                 "union": true
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonHttpPayloadWithUnion",
+                "description": "Serializes a union in the payload.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -1303,7 +1563,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a union in the payload.",
                 "result": {
                     "nested": {
                         "greeting": "hello"
@@ -1319,6 +1578,7 @@
             },
             {
                 "id": "RestJsonHttpPayloadWithUnsetUnion",
+                "description": "No payload is sent if the union has no value.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -1332,7 +1592,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "No payload is sent if the union has no value.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -1347,11 +1606,20 @@
     {
         "description": "Test cases for HttpPrefixHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPrefixHeadersOutput": {
@@ -1385,6 +1653,7 @@
         "cases": [
             {
                 "id": "RestJsonHttpPrefixHeadersArePresent",
+                "description": "Adds headers by prefix",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1395,9 +1664,9 @@
                     "output": {
                         "shape": "HttpPrefixHeadersOutput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "Adds headers by prefix",
                 "result": {
                     "foo": "Foo",
                     "fooMap": {
@@ -1409,8 +1678,8 @@
                     "status_code": 200,
                     "headers": {
                         "x-foo": "Foo",
-                        "x-foo-abc": "Abc value",
-                        "x-foo-def": "Def value"
+                        "x-foo-def": "Def value",
+                        "x-foo-abc": "Abc value"
                     }
                 }
             }
@@ -1419,11 +1688,20 @@
     {
         "description": "Test cases for HttpPrefixHeadersInResponse operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPrefixHeadersInResponseOutput": {
@@ -1436,6 +1714,9 @@
                     }
                 }
             },
+            "String": {
+                "type": "string"
+            },
             "StringMap": {
                 "type": "map",
                 "key": {
@@ -1444,14 +1725,12 @@
                 "value": {
                     "shape": "String"
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "HttpPrefixHeadersResponse",
+                "description": "(de)serializes all response headers",
                 "given": {
                     "name": "HttpPrefixHeadersInResponse",
                     "http": {
@@ -1462,9 +1741,9 @@
                     "output": {
                         "shape": "HttpPrefixHeadersInResponseOutput"
                     },
-                    "documentation": "<p>Clients that perform this test extract all headers from the response.</p>"
+                    "documentation": "<p>Clients that perform this test extract all headers from the response.</p>",
+                    "readonly": true
                 },
-                "description": "(de)serializes all response headers",
                 "result": {
                     "prefixHeaders": {
                         "x-foo": "Foo",
@@ -1474,8 +1753,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "hello": "Hello",
-                        "x-foo": "Foo"
+                        "x-foo": "Foo",
+                        "hello": "Hello"
                     }
                 }
             }
@@ -1484,11 +1763,20 @@
     {
         "description": "Test cases for HttpResponseCode operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "HttpResponseCodeOutput": {
@@ -1508,6 +1796,7 @@
         "cases": [
             {
                 "id": "RestJsonHttpResponseCode",
+                "description": "Binds the http response code to an output structure. Note that\neven though all members are bound outside of the payload, an\nempty JSON object is serialized in the response. However,\nclients should be able to handle an empty JSON object or an\nempty payload without failing to deserialize a response.",
                 "given": {
                     "name": "HttpResponseCode",
                     "http": {
@@ -1520,7 +1809,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Binds the http response code to an output structure. Note that\neven though all members are bound outside of the payload, an\nempty JSON object is serialized in the response. However,\nclients should be able to handle an empty JSON object or an\nempty payload without failing to deserialize a response.",
                 "result": {
                     "Status": 201
                 },
@@ -1534,6 +1822,7 @@
             },
             {
                 "id": "RestJsonHttpResponseCodeWithNoPayload",
+                "description": "This test ensures that clients gracefully handle cases where\nthe service responds with no payload rather than an empty JSON\nobject.",
                 "given": {
                     "name": "HttpResponseCode",
                     "http": {
@@ -1546,7 +1835,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "This test ensures that clients gracefully handle cases where\nthe service responds with no payload rather than an empty JSON\nobject.",
                 "result": {
                     "Status": 201
                 },
@@ -1560,13 +1848,25 @@
     {
         "description": "Test cases for HttpStringPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "StringPayloadInput": {
                 "type": "structure",
                 "members": {
@@ -1575,9 +1875,6 @@
                     }
                 },
                 "payload": "payload"
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
@@ -1610,11 +1907,20 @@
     {
         "description": "Test cases for IgnoreQueryParamsInResponse operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "IgnoreQueryParamsInResponseOutput": {
@@ -1634,6 +1940,7 @@
         "cases": [
             {
                 "id": "RestJsonIgnoreQueryParamsInResponse",
+                "description": "Query parameters must be ignored when serializing the output\nof an operation. As of January 2021, server implementations\nare expected to respond with a JSON object regardless of\nif the output parameters are empty.",
                 "given": {
                     "name": "IgnoreQueryParamsInResponse",
                     "http": {
@@ -1644,37 +1951,18 @@
                     "output": {
                         "shape": "IgnoreQueryParamsInResponseOutput"
                     },
-                    "documentation": "<p>This example ensures that query string bound request parameters are serialized in the body of responses if the structure is used in both the request and response.</p>"
+                    "documentation": "<p>This example ensures that query string bound request parameters are serialized in the body of responses if the structure is used in both the request and response.</p>",
+                    "readonly": true
                 },
-                "description": "Query parameters must be ignored when serializing the output\nof an operation. As of January 2021, server implementations\nare expected to respond with a JSON object regardless of\nif the output parameters are empty.",
-                "result": {},
+                "result": {
+                    "baz": "bam"
+                },
                 "response": {
                     "status_code": 200,
                     "headers": {
                         "Content-Type": "application/json"
                     },
-                    "body": "{}"
-                }
-            },
-            {
-                "id": "RestJsonIgnoreQueryParamsInResponseNoPayload",
-                "given": {
-                    "name": "IgnoreQueryParamsInResponse",
-                    "http": {
-                        "method": "GET",
-                        "requestUri": "/IgnoreQueryParamsInResponse",
-                        "responseCode": 200
-                    },
-                    "output": {
-                        "shape": "IgnoreQueryParamsInResponseOutput"
-                    },
-                    "documentation": "<p>This example ensures that query string bound request parameters are serialized in the body of responses if the structure is used in both the request and response.</p>"
-                },
-                "description": "This test is similar to RestJsonIgnoreQueryParamsInResponse,\nbut it ensures that clients gracefully handle responses from\nthe server that do not serialize an empty JSON object.",
-                "result": {},
-                "response": {
-                    "status_code": 200,
-                    "body": ""
+                    "body": "{\"baz\":\"bam\"}"
                 }
             }
         ]
@@ -1682,13 +1970,56 @@
     {
         "description": "Test cases for InputAndOutputWithHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "InputAndOutputWithHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -1784,28 +2115,32 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "Integer": {
                 "type": "integer",
                 "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
             },
             "Long": {
                 "type": "long",
                 "box": true
             },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
+            "String": {
+                "type": "string"
             },
             "StringList": {
                 "type": "list",
@@ -1819,57 +2154,20 @@
                     "shape": "String"
                 }
             },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
+            "Timestamp": {
+                "type": "timestamp"
             },
             "TimestampList": {
                 "type": "list",
                 "member": {
                     "shape": "Timestamp"
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "Timestamp": {
-                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "RestJsonInputAndOutputWithStringHeaders",
+                "description": "Tests responses with string header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1882,7 +2180,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with string header bindings",
                 "result": {
                     "headerString": "Hello",
                     "headerStringList": [
@@ -1899,14 +2196,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-String": "Hello",
                         "X-StringList": "a, b, c",
+                        "X-String": "Hello",
                         "X-StringSet": "a, b, c"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithQuotedStringHeaders",
+                "description": "Tests responses with string list header bindings that require quoting",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1919,7 +2217,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with string list header bindings that require quoting",
                 "result": {
                     "headerStringList": [
                         "b,c",
@@ -1936,6 +2233,7 @@
             },
             {
                 "id": "RestJsonInputAndOutputWithNumericHeaders",
+                "description": "Tests responses with numeric header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1948,7 +2246,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with numeric header bindings",
                 "result": {
                     "headerByte": 1,
                     "headerShort": 123,
@@ -1965,18 +2262,19 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
+                        "X-Integer": "123",
+                        "X-Short": "123",
                         "X-Byte": "1",
+                        "X-Long": "123",
                         "X-Double": "1.1",
                         "X-Float": "1.1",
-                        "X-Integer": "123",
-                        "X-IntegerList": "1, 2, 3",
-                        "X-Long": "123",
-                        "X-Short": "123"
+                        "X-IntegerList": "1, 2, 3"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithBooleanHeaders",
+                "description": "Tests responses with boolean header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1989,7 +2287,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with boolean header bindings",
                 "result": {
                     "headerTrueBool": true,
                     "headerFalseBool": false,
@@ -2002,14 +2299,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
+                        "X-BooleanList": "true, false, true",
                         "X-Boolean1": "true",
-                        "X-Boolean2": "false",
-                        "X-BooleanList": "true, false, true"
+                        "X-Boolean2": "false"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithTimestampHeaders",
+                "description": "Tests responses with timestamp header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2022,7 +2320,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with timestamp header bindings",
                 "result": {
                     "headerTimestampList": [
                         1576540098,
@@ -2038,6 +2335,7 @@
             },
             {
                 "id": "RestJsonInputAndOutputWithEnumHeaders",
+                "description": "Tests responses with enum header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2050,7 +2348,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with enum header bindings",
                 "result": {
                     "headerEnum": "Foo",
                     "headerEnumList": [
@@ -2062,13 +2359,14 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Enum": "Foo",
-                        "X-EnumList": "Foo, Bar, Baz"
+                        "X-EnumList": "Foo, Bar, Baz",
+                        "X-Enum": "Foo"
                     }
                 }
             },
             {
                 "id": "RestJsonInputAndOutputWithIntEnumHeaders",
+                "description": "Tests responses with intEnum header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2081,7 +2379,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with intEnum header bindings",
                 "result": {
                     "headerIntegerEnum": 1,
                     "headerIntegerEnumList": [
@@ -2093,13 +2390,14 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-IntegerEnum": "1",
-                        "X-IntegerEnumList": "1, 2, 3"
+                        "X-IntegerEnumList": "1, 2, 3",
+                        "X-IntegerEnum": "1"
                     }
                 }
             },
             {
                 "id": "RestJsonSupportsNaNFloatHeaderOutputs",
+                "description": "Supports handling NaN float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2112,7 +2410,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling NaN float header values.",
                 "result": {
                     "headerFloat": "NaN",
                     "headerDouble": "NaN"
@@ -2120,13 +2417,14 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Double": "NaN",
-                        "X-Float": "NaN"
+                        "X-Float": "NaN",
+                        "X-Double": "NaN"
                     }
                 }
             },
             {
                 "id": "RestJsonSupportsInfinityFloatHeaderOutputs",
+                "description": "Supports handling Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2139,7 +2437,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling Infinity float header values.",
                 "result": {
                     "headerFloat": "Infinity",
                     "headerDouble": "Infinity"
@@ -2147,13 +2444,14 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Double": "Infinity",
-                        "X-Float": "Infinity"
+                        "X-Float": "Infinity",
+                        "X-Double": "Infinity"
                     }
                 }
             },
             {
                 "id": "RestJsonSupportsNegativeInfinityFloatHeaderOutputs",
+                "description": "Supports handling -Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -2166,7 +2464,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling -Infinity float header values.",
                 "result": {
                     "headerFloat": "-Infinity",
                     "headerDouble": "-Infinity"
@@ -2174,8 +2471,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Double": "-Infinity",
-                        "X-Float": "-Infinity"
+                        "X-Float": "-Infinity",
+                        "X-Double": "-Infinity"
                     }
                 }
             }
@@ -2184,13 +2481,25 @@
     {
         "description": "Test cases for JsonBlobs operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "JsonBlobsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2198,14 +2507,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "RestJsonJsonBlobs",
+                "description": "Blobs are base64 encoded",
                 "given": {
                     "name": "JsonBlobs",
                     "http": {
@@ -2218,7 +2525,6 @@
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Blobs are base64 encoded",
                 "result": {
                     "data": "value"
                 },
@@ -2235,13 +2541,53 @@
     {
         "description": "Test cases for JsonEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "JsonEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2265,37 +2611,6 @@
                     }
                 }
             },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -2303,6 +2618,7 @@
         "cases": [
             {
                 "id": "RestJsonJsonEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "JsonEnums",
                     "http": {
@@ -2316,7 +2632,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -2347,13 +2662,47 @@
     {
         "description": "Test cases for JsonIntEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
             "JsonIntEnumsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2377,31 +2726,6 @@
                     }
                 }
             },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
             "String": {
                 "type": "string"
             }
@@ -2409,6 +2733,7 @@
         "cases": [
             {
                 "id": "RestJsonJsonIntEnums",
+                "description": "Serializes intEnums as integers",
                 "given": {
                     "name": "JsonIntEnums",
                     "http": {
@@ -2422,7 +2747,6 @@
                     "documentation": "<p>This example serializes intEnums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes intEnums as integers",
                 "result": {
                     "integerEnum1": 1,
                     "integerEnum2": 2,
@@ -2454,13 +2778,68 @@
     {
         "description": "Test cases for JsonLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
             "JsonListsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2494,6 +2873,16 @@
                     }
                 }
             },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "String": {
+                "type": "string"
+            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -2505,43 +2894,6 @@
                 "member": {
                     "shape": "String"
                 }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
             },
             "StructureList": {
                 "type": "list",
@@ -2562,38 +2914,20 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "Timestamp": {
                 "type": "timestamp"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
             }
         },
         "cases": [
             {
                 "id": "RestJsonLists",
+                "description": "Serializes JSON lists",
                 "given": {
                     "name": "JsonLists",
                     "http": {
@@ -2607,7 +2941,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal JSON lists.</li> <li>Normal JSON sets.</li> <li>JSON lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes JSON lists",
                 "result": {
                     "stringList": [
                         "foo",
@@ -2668,6 +3001,7 @@
             },
             {
                 "id": "RestJsonListsEmpty",
+                "description": "Serializes empty JSON lists",
                 "given": {
                     "name": "JsonLists",
                     "http": {
@@ -2681,7 +3015,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal JSON lists.</li> <li>Normal JSON sets.</li> <li>JSON lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes empty JSON lists",
                 "result": {
                     "stringList": []
                 },
@@ -2698,13 +3031,83 @@
     {
         "description": "Test cases for JsonMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "DenseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                }
+            },
+            "DenseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                }
+            },
+            "DenseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                }
+            },
+            "DenseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
+            "DenseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
             "JsonMapsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2725,80 +3128,20 @@
                     }
                 }
             },
-            "DenseStructMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "GreetingStruct"
-                }
-            },
-            "DenseNumberMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Integer"
-                }
-            },
-            "DenseBooleanMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Boolean"
-                }
-            },
-            "DenseStringMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "String"
-                }
-            },
-            "DenseSetMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "StringSet"
-                }
+            "String": {
+                "type": "string"
             },
             "StringSet": {
                 "type": "list",
                 "member": {
                     "shape": "String"
                 }
-            },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
             }
         },
         "cases": [
             {
                 "id": "RestJsonJsonMaps",
+                "description": "Deserializes JSON maps",
                 "given": {
                     "name": "JsonMaps",
                     "http": {
@@ -2811,7 +3154,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Deserializes JSON maps",
                 "result": {
                     "denseStructMap": {
                         "foo": {
@@ -2832,6 +3174,7 @@
             },
             {
                 "id": "RestJsonDeserializesZeroValuesInMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "given": {
                     "name": "JsonMaps",
                     "http": {
@@ -2844,7 +3187,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "result": {
                     "denseNumberMap": {
                         "x": 0
@@ -2863,6 +3205,7 @@
             },
             {
                 "id": "RestJsonDeserializesDenseSetMap",
+                "description": "A response that contains a dense map of sets.",
                 "given": {
                     "name": "JsonMaps",
                     "http": {
@@ -2875,7 +3218,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "A response that contains a dense map of sets.",
                 "result": {
                     "denseSetMap": {
                         "x": [],
@@ -2892,51 +3234,40 @@
                     },
                     "body": "{\n    \"denseSetMap\": {\n        \"x\": [],\n        \"y\": [\"a\", \"b\"]\n    }\n}"
                 }
-            },
-            {
-                "id": "RestJsonDeserializesDenseSetMapAndSkipsNull",
-                "given": {
-                    "name": "JsonMaps",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/JsonMaps",
-                        "responseCode": 200
-                    },
-                    "output": {
-                        "shape": "JsonMapsInputOutput"
-                    },
-                    "documentation": "<p>The example tests basic map serialization.</p>"
-                },
-                "description": "Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD\ndrop the null key-value pair.",
-                "result": {
-                    "denseSetMap": {
-                        "x": [],
-                        "y": [
-                            "a",
-                            "b"
-                        ]
-                    }
-                },
-                "response": {
-                    "status_code": 200,
-                    "headers": {
-                        "Content-Type": "application/json"
-                    },
-                    "body": "{\n    \"denseSetMap\": {\n        \"x\": [],\n        \"y\": [\"a\", \"b\"],\n        \"z\": null\n    }\n}"
-                }
             }
         ]
     },
     {
         "description": "Test cases for JsonTimestamps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
             "JsonTimestampsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -2963,14 +3294,7 @@
                     }
                 }
             },
-            "Timestamp": {
-                "type": "timestamp"
-            },
             "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "DateTime": {
                 "type": "timestamp",
                 "timestampFormat": "iso8601"
             },
@@ -2978,22 +3302,18 @@
                 "type": "timestamp",
                 "timestampFormat": "unixTimestamp"
             },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
             "SyntheticTimestamp_http_date": {
                 "type": "timestamp",
                 "timestampFormat": "rfc822"
             },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
+            "Timestamp": {
+                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "RestJsonJsonTimestamps",
+                "description": "Tests how normal timestamps are serialized",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3006,7 +3326,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Tests how normal timestamps are serialized",
                 "result": {
                     "normal": 1398796238
                 },
@@ -3020,6 +3339,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithDateTimeFormat",
+                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3032,7 +3352,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "result": {
                     "dateTime": 1398796238
                 },
@@ -3046,6 +3365,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
+                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3058,7 +3378,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "result": {
                     "dateTimeOnTarget": 1398796238
                 },
@@ -3072,6 +3391,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithEpochSecondsFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3084,7 +3404,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "result": {
                     "epochSeconds": 1398796238
                 },
@@ -3098,6 +3417,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3110,7 +3430,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "result": {
                     "epochSecondsOnTarget": 1398796238
                 },
@@ -3124,6 +3443,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithHttpDateFormat",
+                "description": "Ensures that the timestampFormat of http-date works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3136,7 +3456,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date works",
                 "result": {
                     "httpDate": 1398796238
                 },
@@ -3150,6 +3469,7 @@
             },
             {
                 "id": "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
+                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "given": {
                     "name": "JsonTimestamps",
                     "http": {
@@ -3162,7 +3482,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "result": {
                     "httpDateOnTarget": 1398796238
                 },
@@ -3179,21 +3498,50 @@
     {
         "description": "Test cases for JsonUnions operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
-            "UnionInputOutput": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "GreetingStruct": {
                 "type": "structure",
                 "members": {
-                    "contents": {
-                        "shape": "MyUnion"
+                    "hi": {
+                        "shape": "String"
                     }
-                },
-                "documentation": "<p>A shared structure that contains a single union member.</p>"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
             },
             "MyUnion": {
                 "type": "structure",
@@ -3232,32 +3580,16 @@
                 "documentation": "<p>A union with a representative set of types for members.</p>",
                 "union": true
             },
+            "RenamedGreeting": {
+                "type": "structure",
+                "members": {
+                    "salutation": {
+                        "shape": "String"
+                    }
+                }
+            },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Blob": {
-                "type": "blob"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
             },
             "StringList": {
                 "type": "list",
@@ -3274,26 +3606,23 @@
                     "shape": "String"
                 }
             },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
+            "Timestamp": {
+                "type": "timestamp"
             },
-            "RenamedGreeting": {
+            "UnionInputOutput": {
                 "type": "structure",
                 "members": {
-                    "salutation": {
-                        "shape": "String"
+                    "contents": {
+                        "shape": "MyUnion"
                     }
-                }
+                },
+                "documentation": "<p>A shared structure that contains a single union member.</p>"
             }
         },
         "cases": [
             {
                 "id": "RestJsonDeserializeStringUnionValue",
+                "description": "Deserializes a string union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3307,7 +3636,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a string union value",
                 "result": {
                     "contents": {
                         "stringValue": "foo"
@@ -3323,6 +3651,7 @@
             },
             {
                 "id": "RestJsonDeserializeBooleanUnionValue",
+                "description": "Deserializes a boolean union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3336,7 +3665,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a boolean union value",
                 "result": {
                     "contents": {
                         "booleanValue": true
@@ -3352,6 +3680,7 @@
             },
             {
                 "id": "RestJsonDeserializeNumberUnionValue",
+                "description": "Deserializes a number union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3365,7 +3694,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a number union value",
                 "result": {
                     "contents": {
                         "numberValue": 1
@@ -3381,6 +3709,7 @@
             },
             {
                 "id": "RestJsonDeserializeBlobUnionValue",
+                "description": "Deserializes a blob union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3394,7 +3723,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a blob union value",
                 "result": {
                     "contents": {
                         "blobValue": "foo"
@@ -3410,6 +3738,7 @@
             },
             {
                 "id": "RestJsonDeserializeTimestampUnionValue",
+                "description": "Deserializes a timestamp union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3423,7 +3752,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a timestamp union value",
                 "result": {
                     "contents": {
                         "timestampValue": 1398796238
@@ -3439,6 +3767,7 @@
             },
             {
                 "id": "RestJsonDeserializeEnumUnionValue",
+                "description": "Deserializes an enum union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3452,7 +3781,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes an enum union value",
                 "result": {
                     "contents": {
                         "enumValue": "Foo"
@@ -3468,6 +3796,7 @@
             },
             {
                 "id": "RestJsonDeserializeListUnionValue",
+                "description": "Deserializes a list union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3481,7 +3810,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a list union value",
                 "result": {
                     "contents": {
                         "listValue": [
@@ -3500,6 +3828,7 @@
             },
             {
                 "id": "RestJsonDeserializeMapUnionValue",
+                "description": "Deserializes a map union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3513,7 +3842,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a map union value",
                 "result": {
                     "contents": {
                         "mapValue": {
@@ -3532,6 +3860,7 @@
             },
             {
                 "id": "RestJsonDeserializeStructureUnionValue",
+                "description": "Deserializes a structure union value",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3545,7 +3874,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Deserializes a structure union value",
                 "result": {
                     "contents": {
                         "structureValue": {
@@ -3563,6 +3891,7 @@
             },
             {
                 "id": "RestJsonDeserializeIgnoreType",
+                "description": "Ignores an unrecognized __type property",
                 "given": {
                     "name": "JsonUnions",
                     "http": {
@@ -3576,7 +3905,6 @@
                     "documentation": "<p>This operation uses unions for inputs and outputs.</p>",
                     "idempotent": true
                 },
-                "description": "Ignores an unrecognized __type property",
                 "result": {
                     "contents": {
                         "structureValue": {
@@ -3597,13 +3925,25 @@
     {
         "description": "Test cases for MediaTypeHeader operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "JsonValue": {
+                "type": "string"
+            },
             "MediaTypeHeaderOutput": {
                 "type": "structure",
                 "members": {
@@ -3614,14 +3954,12 @@
                         "locationName": "X-Json"
                     }
                 }
-            },
-            "JsonValue": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "MediaTypeHeaderOutputBase64",
+                "description": "Headers that target strings with a mediaType are base64 encoded",
                 "given": {
                     "name": "MediaTypeHeader",
                     "http": {
@@ -3632,9 +3970,9 @@
                     "output": {
                         "shape": "MediaTypeHeaderOutput"
                     },
-                    "documentation": "<p>This example ensures that mediaType strings are base64 encoded in headers.</p>"
+                    "documentation": "<p>This example ensures that mediaType strings are base64 encoded in headers.</p>",
+                    "readonly": true
                 },
-                "description": "Headers that target strings with a mediaType are base64 encoded",
                 "result": {
                     "json": "true"
                 },
@@ -3650,16 +3988,26 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonNoInputAndNoOutput",
+                "description": "When an operation does not define output, the service will respond\nwith an empty payload, and may optionally include the content-type\nheader.",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -3669,7 +4017,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "When an operation does not define output, the service will respond\nwith an empty payload, and may optionally include the content-type\nheader.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -3681,11 +4028,20 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "NoInputAndOutputOutput": {
@@ -3696,6 +4052,7 @@
         "cases": [
             {
                 "id": "RestJsonNoInputAndOutputWithJson",
+                "description": "Operations that define output and do not bind anything to\nthe payload return a JSON object in the response.",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -3708,7 +4065,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input and the output is empty. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Operations that define output and do not bind anything to\nthe payload return a JSON object in the response.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -3720,6 +4076,7 @@
             },
             {
                 "id": "RestJsonNoInputAndOutputNoPayload",
+                "description": "This test is similar to RestJsonNoInputAndOutputWithJson, but\nit ensures that clients can gracefully handle responses that\nomit a JSON payload.",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -3732,7 +4089,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input and the output is empty. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "This test is similar to RestJsonNoInputAndOutputWithJson, but\nit ensures that clients can gracefully handle responses that\nomit a JSON payload.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -3744,11 +4100,20 @@
     {
         "description": "Test cases for PostUnionWithJsonName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "PostUnionWithJsonNameOutput": {
@@ -3761,6 +4126,9 @@
                         "shape": "UnionWithJsonName"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             },
             "UnionWithJsonName": {
                 "type": "structure",
@@ -3778,14 +4146,12 @@
                     }
                 },
                 "union": true
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "PostUnionWithJsonNameResponse1",
+                "description": "Tests that jsonName works with union members.",
                 "given": {
                     "name": "PostUnionWithJsonName",
                     "http": {
@@ -3798,7 +4164,6 @@
                     },
                     "documentation": "<p>This operation defines a union that uses jsonName on some members.</p>"
                 },
-                "description": "Tests that jsonName works with union members.",
                 "result": {
                     "value": {
                         "foo": "hi"
@@ -3814,6 +4179,7 @@
             },
             {
                 "id": "PostUnionWithJsonNameResponse2",
+                "description": "Tests that jsonName works with union members.",
                 "given": {
                     "name": "PostUnionWithJsonName",
                     "http": {
@@ -3826,7 +4192,6 @@
                     },
                     "documentation": "<p>This operation defines a union that uses jsonName on some members.</p>"
                 },
-                "description": "Tests that jsonName works with union members.",
                 "result": {
                     "value": {
                         "baz": "hi"
@@ -3842,6 +4207,7 @@
             },
             {
                 "id": "PostUnionWithJsonNameResponse3",
+                "description": "Tests that jsonName works with union members.",
                 "given": {
                     "name": "PostUnionWithJsonName",
                     "http": {
@@ -3854,7 +4220,6 @@
                     },
                     "documentation": "<p>This operation defines a union that uses jsonName on some members.</p>"
                 },
-                "description": "Tests that jsonName works with union members.",
                 "result": {
                     "value": {
                         "bar": "hi"
@@ -3873,11 +4238,20 @@
     {
         "description": "Test cases for RecursiveShapes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
             "RecursiveShapesInputOutput": {
@@ -3899,9 +4273,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveShapesInputOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -3912,11 +4283,15 @@
                         "shape": "RecursiveShapesInputOutputNested1"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestJsonRecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveShapes",
                     "http": {
@@ -3930,7 +4305,6 @@
                     "documentation": "<p>Recursive shapes</p>",
                     "idempotent": true
                 },
-                "description": "Serializes recursive structures",
                 "result": {
                     "nested": {
                         "foo": "Foo1",
@@ -3958,13 +4332,42 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarPropertiesInputOutput": {
                 "type": "structure",
                 "members": {
@@ -4005,31 +4408,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "RestJsonSimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -4042,7 +4426,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "foo": "Foo",
                     "stringValue": "string",
@@ -4058,14 +4441,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/json",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/json"
                     },
                     "body": "{\n    \"stringValue\": \"string\",\n    \"trueBooleanValue\": true,\n    \"falseBooleanValue\": false,\n    \"byteValue\": 1,\n    \"shortValue\": 2,\n    \"integerValue\": 3,\n    \"longValue\": 4,\n    \"floatValue\": 5.5,\n    \"DoubleDribble\": 6.5\n}"
                 }
             },
             {
                 "id": "RestJsonDoesntDeserializeNullStructureValues",
+                "description": "Rest Json should not deserialize null structure values",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -4078,7 +4462,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Rest Json should not deserialize null structure values",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -4090,6 +4473,7 @@
             },
             {
                 "id": "RestJsonSupportsNaNFloatInputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -4102,7 +4486,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling NaN float values.",
                 "result": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -4117,6 +4500,7 @@
             },
             {
                 "id": "RestJsonSupportsInfinityFloatInputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -4129,7 +4513,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling Infinity float values.",
                 "result": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -4144,6 +4527,7 @@
             },
             {
                 "id": "RestJsonSupportsNegativeInfinityFloatInputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -4156,7 +4540,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling -Infinity float values.",
                 "result": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -4172,15 +4555,423 @@
         ]
     },
     {
-        "description": "Test cases for TimestampFormatHeaders operation",
+        "description": "Test cases for SparseJsonLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "SparseJsonListsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStringList": {
+                        "shape": "SparseStringList"
+                    },
+                    "sparseShortList": {
+                        "shape": "SparseShortList"
+                    }
+                }
+            },
+            "SparseShortList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                },
+                "sparse": true
+            },
+            "SparseStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "RestJsonSparseListsSerializeNull",
+                "description": "Serializes null values in sparse lists",
+                "given": {
+                    "name": "SparseJsonLists",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/SparseJsonLists",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "SparseJsonListsInputOutput"
+                    },
+                    "idempotent": true
+                },
+                "result": {
+                    "sparseStringList": [
+                        null,
+                        "hi"
+                    ],
+                    "sparseShortList": [
+                        null,
+                        2
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"sparseStringList\": [\n        null,\n        \"hi\"\n    ],\n    \"sparseShortList\": [\n        null,\n        2\n    ]\n}"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SparseJsonMaps operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
+            "protocol": "rest-json",
+            "protocols": [
+                "rest-json"
+            ],
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
+        },
+        "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "SparseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                },
+                "sparse": true
+            },
+            "SparseJsonMapsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStructMap": {
+                        "shape": "SparseStructMap"
+                    },
+                    "sparseNumberMap": {
+                        "shape": "SparseNumberMap"
+                    },
+                    "sparseBooleanMap": {
+                        "shape": "SparseBooleanMap"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
+                    },
+                    "sparseSetMap": {
+                        "shape": "SparseSetMap"
+                    }
+                }
+            },
+            "SparseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                },
+                "sparse": true
+            },
+            "SparseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                },
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "SparseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RestJsonSparseJsonMaps",
+                "description": "Deserializes JSON maps",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "result": {
+                    "sparseStructMap": {
+                        "foo": {
+                            "hi": "there"
+                        },
+                        "baz": {
+                            "hi": "bye"
+                        }
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"sparseStructMap\": {\n        \"foo\": {\n            \"hi\": \"there\"\n        },\n        \"baz\": {\n            \"hi\": \"bye\"\n        }\n   }\n}"
+                }
+            },
+            {
+                "id": "RestJsonDeserializesSparseNullMapValues",
+                "description": "Deserializes null JSON map values",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "result": {
+                    "sparseBooleanMap": {
+                        "x": null
+                    },
+                    "sparseNumberMap": {
+                        "x": null
+                    },
+                    "sparseStringMap": {
+                        "x": null
+                    },
+                    "sparseStructMap": {
+                        "x": null
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"sparseBooleanMap\": {\n        \"x\": null\n    },\n    \"sparseNumberMap\": {\n        \"x\": null\n    },\n    \"sparseStringMap\": {\n        \"x\": null\n    },\n    \"sparseStructMap\": {\n        \"x\": null\n    }\n}"
+                }
+            },
+            {
+                "id": "RestJsonDeserializesZeroValuesInSparseMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "result": {
+                    "sparseNumberMap": {
+                        "x": 0
+                    },
+                    "sparseBooleanMap": {
+                        "x": false
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"sparseNumberMap\": {\n        \"x\": 0\n    },\n    \"sparseBooleanMap\": {\n        \"x\": false\n    }\n}"
+                }
+            },
+            {
+                "id": "RestJsonDeserializesSparseSetMap",
+                "description": "A response that contains a sparse map of sets",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "result": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ]
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"sparseSetMap\": {\n        \"x\": [],\n        \"y\": [\"a\", \"b\"]\n    }\n}"
+                }
+            },
+            {
+                "id": "RestJsonDeserializesSparseSetMapAndRetainsNull",
+                "description": "A response that contains a sparse map of sets.",
+                "given": {
+                    "name": "SparseJsonMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/SparseJsonMaps",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "SparseJsonMapsInputOutput"
+                    },
+                    "documentation": "<p>This example tests sparse map serialization.</p>"
+                },
+                "result": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ],
+                        "z": null
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/json"
+                    },
+                    "body": "{\n    \"sparseSetMap\": {\n        \"x\": [],\n        \"y\": [\"a\", \"b\"],\n        \"z\": null\n    }\n}"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for TimestampFormatHeaders operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
+            "protocol": "rest-json",
+            "protocols": [
+                "rest-json"
+            ],
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
+        },
+        "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "TimestampFormatHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -4220,38 +5011,12 @@
                         "locationName": "X-targetDateTime"
                     }
                 }
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RestJsonTimestampFormatHeaders",
+                "description": "Tests how timestamp response headers are serialized",
                 "given": {
                     "name": "TimestampFormatHeaders",
                     "http": {
@@ -4264,7 +5029,6 @@
                     },
                     "documentation": "<p>This example tests how timestamp request and response headers are serialized.</p>"
                 },
-                "description": "Tests how timestamp response headers are serialized",
                 "result": {
                     "memberEpochSeconds": 1576540098,
                     "memberHttpDate": 1576540098,
@@ -4277,13 +5041,13 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberDateTime": "2019-12-16T23:48:18Z",
-                        "X-memberEpochSeconds": "1576540098",
+                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-targetDateTime": "2019-12-16T23:48:18Z",
                         "X-targetEpochSeconds": "1576540098",
-                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT"
+                        "X-memberEpochSeconds": "1576540098",
+                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT"
                     }
                 }
             }
@@ -4292,16 +5056,26 @@
     {
         "description": "Test cases for UnitInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restjson",
             "protocol": "rest-json",
             "protocols": [
                 "rest-json"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestJson",
+            "serviceId": "Rest Json Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestJson",
+            "uid": "rest-json-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "RestJsonUnitInputAndOutputNoOutput",
+                "description": "When an operation defines Unit output, the service will respond\nwith an empty payload, and may optionally include the content-type\nheader.",
                 "given": {
                     "name": "UnitInputAndOutput",
                     "http": {
@@ -4311,7 +5085,6 @@
                     },
                     "documentation": "<p>This test is similar to NoInputAndNoOutput, but uses explicit Unit types.</p>"
                 },
-                "description": "When an operation defines Unit output, the service will respond\nwith an empty payload, and may optionally include the content-type\nheader.",
                 "result": {},
                 "response": {
                     "status_code": 200,

--- a/tests/unit/protocols/output/rest-xml.json
+++ b/tests/unit/protocols/output/rest-xml.json
@@ -2,11 +2,20 @@
     {
         "description": "Test cases for BodyWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "BodyWithXmlNameInputOutput": {
@@ -34,6 +43,7 @@
         "cases": [
             {
                 "id": "BodyWithXmlName",
+                "description": "Serializes a payload using a wrapper name based on the xmlName",
                 "given": {
                     "name": "BodyWithXmlName",
                     "http": {
@@ -47,7 +57,6 @@
                     "documentation": "<p>The following example serializes a body that uses an XML name, changing the wrapper name.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a payload using a wrapper name based on the xmlName",
                 "result": {
                     "nested": {
                         "name": "Phreddy"
@@ -66,13 +75,26 @@
     {
         "description": "Test cases for DatetimeOffsets operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "DatetimeOffsetsOutput": {
                 "type": "structure",
                 "members": {
@@ -80,15 +102,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RestXmlDateTimeWithNegativeOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -100,7 +119,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -114,6 +132,7 @@
             },
             {
                 "id": "RestXmlDateTimeWithPositiveOffset",
+                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "given": {
                     "name": "DatetimeOffsets",
                     "http": {
@@ -125,7 +144,6 @@
                         "shape": "DatetimeOffsetsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime (timestamps) with offsets",
                 "result": {
                     "datetime": 1576540098
                 },
@@ -142,11 +160,20 @@
     {
         "description": "Test cases for EmptyInputAndEmptyOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "EmptyInputAndEmptyOutputOutput": {
@@ -157,6 +184,7 @@
         "cases": [
             {
                 "id": "EmptyInputAndEmptyOutput",
+                "description": "Empty output serializes no payload",
                 "given": {
                     "name": "EmptyInputAndEmptyOutput",
                     "http": {
@@ -169,7 +197,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has an empty input and empty output structure that reuses the same shape. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output serializes no payload",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -181,11 +208,20 @@
     {
         "description": "Test cases for FlattenedXmlMap operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "FlattenedXmlMapResponse": {
@@ -195,15 +231,6 @@
                         "shape": "FooEnumMap",
                         "flattened": true
                     }
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
                 }
             },
             "FooEnum": {
@@ -216,6 +243,15 @@
                     "0"
                 ]
             },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
             "String": {
                 "type": "string"
             }
@@ -223,6 +259,7 @@
         "cases": [
             {
                 "id": "FlattenedXmlMap",
+                "description": "Serializes flattened XML maps in responses",
                 "given": {
                     "name": "FlattenedXmlMap",
                     "http": {
@@ -235,7 +272,6 @@
                     },
                     "documentation": "<p>Flattened maps</p>"
                 },
-                "description": "Serializes flattened XML maps in responses",
                 "result": {
                     "myMap": {
                         "foo": "Foo",
@@ -255,23 +291,22 @@
     {
         "description": "Test cases for FlattenedXmlMapWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "FlattenedXmlMapWithXmlNameResponse": {
-                "type": "structure",
-                "members": {
-                    "myMap": {
-                        "shape": "FlattenedXmlMapWithXmlNameInputOutputMap",
-                        "flattened": true,
-                        "locationName": "KVP"
-                    }
-                }
-            },
             "FlattenedXmlMapWithXmlNameInputOutputMap": {
                 "type": "map",
                 "key": {
@@ -283,6 +318,16 @@
                     "locationName": "V"
                 }
             },
+            "FlattenedXmlMapWithXmlNameResponse": {
+                "type": "structure",
+                "members": {
+                    "myMap": {
+                        "shape": "FlattenedXmlMapWithXmlNameInputOutputMap",
+                        "flattened": true,
+                        "locationName": "KVP"
+                    }
+                }
+            },
             "String": {
                 "type": "string"
             }
@@ -290,6 +335,7 @@
         "cases": [
             {
                 "id": "FlattenedXmlMapWithXmlName",
+                "description": "Serializes flattened XML maps in responses that have xmlName on members",
                 "given": {
                     "name": "FlattenedXmlMapWithXmlName",
                     "http": {
@@ -302,7 +348,6 @@
                     },
                     "documentation": "<p>Flattened maps with @xmlName</p>"
                 },
-                "description": "Serializes flattened XML maps in responses that have xmlName on members",
                 "result": {
                     "myMap": {
                         "a": "A",
@@ -322,11 +367,20 @@
     {
         "description": "Test cases for FlattenedXmlMapWithXmlNamespace operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "FlattenedXmlMapWithXmlNamespaceOutput": {
@@ -360,6 +414,7 @@
         "cases": [
             {
                 "id": "RestXmlFlattenedXmlMapWithXmlNamespace",
+                "description": "Serializes flattened XML maps in responses that have xmlNamespace and xmlName on members",
                 "given": {
                     "name": "FlattenedXmlMapWithXmlNamespace",
                     "http": {
@@ -372,7 +427,6 @@
                     },
                     "documentation": "<p>Flattened maps with @xmlNamespace and @xmlName</p>"
                 },
-                "description": "Serializes flattened XML maps in responses that have xmlNamespace and xmlName on members",
                 "result": {
                     "myMap": {
                         "a": "A",
@@ -392,13 +446,26 @@
     {
         "description": "Test cases for FractionalSeconds operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "FractionalSecondsOutput": {
                 "type": "structure",
                 "members": {
@@ -406,15 +473,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RestXmlDateTimeWithFractionalSeconds",
+                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "given": {
                     "name": "FractionalSeconds",
                     "http": {
@@ -426,7 +490,6 @@
                         "shape": "FractionalSecondsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse datetime timestamps with fractional seconds",
                 "result": {
                     "datetime": 9.46845296123E8
                 },
@@ -443,11 +506,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "GreetingWithErrorsOutput": {
@@ -467,6 +539,7 @@
         "cases": [
             {
                 "id": "GreetingWithErrors",
+                "description": "Ensures that operations with errors successfully know how to deserialize the successful response",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -480,7 +553,6 @@
                     "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A BadRequest error.</li> </ol> <p>Implementations must be able to successfully take a response and properly (de)serialize successful and error responses based on the the presence of the</p>",
                     "idempotent": true
                 },
-                "description": "Ensures that operations with errors successfully know how to deserialize the successful response",
                 "result": {
                     "greeting": "Hello"
                 },
@@ -497,11 +569,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "InvalidGreeting": {
@@ -525,6 +606,7 @@
         "cases": [
             {
                 "id": "InvalidGreetingError",
+                "description": "Parses simple XML errors",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -540,7 +622,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple XML errors",
                 "errorCode": "InvalidGreeting",
                 "errorMessage": "Hi",
                 "error": {
@@ -559,11 +640,20 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "ComplexError": {
@@ -588,9 +678,6 @@
                 },
                 "exception": true
             },
-            "String": {
-                "type": "string"
-            },
             "ComplexNestedErrorData": {
                 "type": "structure",
                 "members": {
@@ -598,6 +685,9 @@
                         "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
@@ -638,13 +728,103 @@
         ]
     },
     {
-        "description": "Test cases for HttpEnumPayload operation",
+        "description": "Test cases for HttpEmptyPrefixHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
+        },
+        "shapes": {
+            "HttpEmptyPrefixHeadersOutput": {
+                "type": "structure",
+                "members": {
+                    "prefixHeaders": {
+                        "shape": "StringMap",
+                        "location": "headers",
+                        "locationName": ""
+                    },
+                    "specificHeader": {
+                        "shape": "String",
+                        "location": "header",
+                        "locationName": "hello"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "HttpEmptyPrefixHeadersResponseClient",
+                "description": "Deserializes all response headers with the same for prefix and specific",
+                "given": {
+                    "name": "HttpEmptyPrefixHeaders",
+                    "http": {
+                        "method": "GET",
+                        "requestUri": "/HttpEmptyPrefixHeaders",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "HttpEmptyPrefixHeadersOutput"
+                    },
+                    "documentation": "<p>Clients that perform this test extract all headers from the response.</p>",
+                    "readonly": true
+                },
+                "result": {
+                    "prefixHeaders": {
+                        "x-foo": "Foo",
+                        "hello": "There"
+                    },
+                    "specificHeader": "There"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "x-foo": "Foo",
+                        "hello": "There"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for HttpEnumPayload operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
+            "protocol": "rest-xml",
+            "protocols": [
+                "rest-xml"
+            ],
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "EnumPayloadInput": {
@@ -693,13 +873,25 @@
     {
         "description": "Test cases for HttpPayloadTraits operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "HttpPayloadTraitsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -716,14 +908,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "HttpPayloadTraitsWithBlob",
+                "description": "Serializes a blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -736,7 +926,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no XML document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes a blob in the HTTP payload",
                 "result": {
                     "foo": "Foo",
                     "blob": "blobby blob blob"
@@ -751,6 +940,7 @@
             },
             {
                 "id": "HttpPayloadTraitsWithNoBlobBody",
+                "description": "Serializes an empty blob in the HTTP payload",
                 "given": {
                     "name": "HttpPayloadTraits",
                     "http": {
@@ -763,7 +953,6 @@
                     },
                     "documentation": "<p>This example serializes a blob shape in the payload.</p> <p>In this example, no XML document is synthesized because the payload is not a structure or a union type.</p>"
                 },
-                "description": "Serializes an empty blob in the HTTP payload",
                 "result": {
                     "foo": "Foo"
                 },
@@ -780,11 +969,20 @@
     {
         "description": "Test cases for HttpPayloadWithMemberXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithMemberXmlNameInputOutput": {
@@ -813,6 +1011,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithMemberXmlName",
+                "description": "Serializes a structure in the payload using a wrapper name based on member xmlName",
                 "given": {
                     "name": "HttpPayloadWithMemberXmlName",
                     "http": {
@@ -826,7 +1025,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML name on the member, changing the wrapper name.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper name based on member xmlName",
                 "result": {
                     "nested": {
                         "name": "Phreddy"
@@ -845,11 +1043,20 @@
     {
         "description": "Test cases for HttpPayloadWithStructure operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithStructureInputOutput": {
@@ -880,6 +1087,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithStructure",
+                "description": "Serializes a structure in the payload",
                 "given": {
                     "name": "HttpPayloadWithStructure",
                     "http": {
@@ -893,7 +1101,6 @@
                     "documentation": "<p>This example serializes a structure in the payload.</p> <p>Note that serializing a structure changes the wrapper element name to match the targeted structure.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload",
                 "result": {
                     "nested": {
                         "greeting": "hello",
@@ -913,11 +1120,20 @@
     {
         "description": "Test cases for HttpPayloadWithUnion operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithUnionInputOutput": {
@@ -930,6 +1146,9 @@
                 },
                 "payload": "nested"
             },
+            "String": {
+                "type": "string"
+            },
             "UnionPayload": {
                 "type": "structure",
                 "members": {
@@ -938,14 +1157,12 @@
                     }
                 },
                 "union": true
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RestXmlHttpPayloadWithUnion",
+                "description": "Serializes a union in the payload.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -959,7 +1176,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a union in the payload.",
                 "result": {
                     "nested": {
                         "greeting": "hello"
@@ -975,6 +1191,7 @@
             },
             {
                 "id": "RestXmlHttpPayloadWithUnsetUnion",
+                "description": "No payload is sent if the union has no value.",
                 "given": {
                     "name": "HttpPayloadWithUnion",
                     "http": {
@@ -988,7 +1205,6 @@
                     "documentation": "<p>This example serializes a union in the payload.</p>",
                     "idempotent": true
                 },
-                "description": "No payload is sent if the union has no value.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -1003,11 +1219,20 @@
     {
         "description": "Test cases for HttpPayloadWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithXmlNameInputOutput": {
@@ -1036,6 +1261,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithXmlName",
+                "description": "Serializes a structure in the payload using a wrapper name based on xmlName",
                 "given": {
                     "name": "HttpPayloadWithXmlName",
                     "http": {
@@ -1049,7 +1275,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML name, changing the wrapper name.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper name based on xmlName",
                 "result": {
                     "nested": {
                         "name": "Phreddy"
@@ -1068,11 +1293,20 @@
     {
         "description": "Test cases for HttpPayloadWithXmlNamespace operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithXmlNamespaceInputOutput": {
@@ -1101,6 +1335,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithXmlNamespace",
+                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "given": {
                     "name": "HttpPayloadWithXmlNamespace",
                     "http": {
@@ -1114,7 +1349,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML namespace.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "result": {
                     "nested": {
                         "name": "Phreddy"
@@ -1133,11 +1367,20 @@
     {
         "description": "Test cases for HttpPayloadWithXmlNamespaceAndPrefix operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpPayloadWithXmlNamespaceAndPrefixInputOutput": {
@@ -1169,6 +1412,7 @@
         "cases": [
             {
                 "id": "HttpPayloadWithXmlNamespaceAndPrefix",
+                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "given": {
                     "name": "HttpPayloadWithXmlNamespaceAndPrefix",
                     "http": {
@@ -1182,7 +1426,6 @@
                     "documentation": "<p>The following example serializes a payload that uses an XML namespace.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes a structure in the payload using a wrapper with an XML namespace",
                 "result": {
                     "nested": {
                         "name": "Phreddy"
@@ -1201,13 +1444,31 @@
     {
         "description": "Test cases for HttpPrefixHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "FooPrefixHeaders": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
             "HttpPrefixHeadersInputOutput": {
                 "type": "structure",
                 "members": {
@@ -1225,20 +1486,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "FooPrefixHeaders": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "String"
-                }
             }
         },
         "cases": [
             {
                 "id": "HttpPrefixHeadersArePresent",
+                "description": "Adds headers by prefix",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1249,9 +1502,9 @@
                     "output": {
                         "shape": "HttpPrefixHeadersInputOutput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "Adds headers by prefix",
                 "result": {
                     "foo": "Foo",
                     "fooMap": {
@@ -1263,14 +1516,15 @@
                     "status_code": 200,
                     "headers": {
                         "x-foo": "Foo",
-                        "x-foo-abc": "Abc value",
-                        "x-foo-def": "Def value"
+                        "x-foo-def": "Def value",
+                        "x-foo-abc": "Abc value"
                     },
                     "body": ""
                 }
             },
             {
                 "id": "HttpPrefixHeadersAreNotPresent",
+                "description": "No prefix headers are serialized because the value is empty",
                 "given": {
                     "name": "HttpPrefixHeaders",
                     "http": {
@@ -1281,9 +1535,9 @@
                     "output": {
                         "shape": "HttpPrefixHeadersInputOutput"
                     },
-                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>"
+                    "documentation": "<p>This examples adds headers to the input of a request and response by prefix.</p>",
+                    "readonly": true
                 },
-                "description": "No prefix headers are serialized because the value is empty",
                 "result": {
                     "foo": "Foo",
                     "fooMap": {}
@@ -1301,11 +1555,20 @@
     {
         "description": "Test cases for HttpResponseCode operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "HttpResponseCodeOutput": {
@@ -1325,6 +1588,7 @@
         "cases": [
             {
                 "id": "RestXmlHttpResponseCode",
+                "description": "Binds the http response code to an output structure.",
                 "given": {
                     "name": "HttpResponseCode",
                     "http": {
@@ -1337,7 +1601,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Binds the http response code to an output structure.",
                 "result": {
                     "Status": 201
                 },
@@ -1354,13 +1617,25 @@
     {
         "description": "Test cases for HttpStringPayload operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "StringPayloadInput": {
                 "type": "structure",
                 "members": {
@@ -1369,9 +1644,6 @@
                     }
                 },
                 "payload": "payload"
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
@@ -1404,11 +1676,20 @@
     {
         "description": "Test cases for IgnoreQueryParamsInResponse operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "IgnoreQueryParamsInResponseOutput": {
@@ -1428,6 +1709,7 @@
         "cases": [
             {
                 "id": "IgnoreQueryParamsInResponse",
+                "description": "Query parameters must be ignored when serializing the output of an operation",
                 "given": {
                     "name": "IgnoreQueryParamsInResponse",
                     "http": {
@@ -1438,9 +1720,9 @@
                     "output": {
                         "shape": "IgnoreQueryParamsInResponseOutput"
                     },
-                    "documentation": "<p>This example ensures that query string bound request parameters are serialized in the body of responses if the structure is used in both the request and response.</p>"
+                    "documentation": "<p>This example ensures that query string bound request parameters are serialized in the body of responses if the structure is used in both the request and response.</p>",
+                    "readonly": true
                 },
-                "description": "Query parameters must be ignored when serializing the output of an operation",
                 "result": {
                     "baz": "bam"
                 },
@@ -1457,13 +1739,56 @@
     {
         "description": "Test cases for InputAndOutputWithHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
             "InputAndOutputWithHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -1549,28 +1874,22 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "Integer": {
                 "type": "integer",
                 "box": true
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
             },
             "Long": {
                 "type": "long",
                 "box": true
             },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
+            "String": {
+                "type": "string"
             },
             "StringList": {
                 "type": "list",
@@ -1584,47 +1903,20 @@
                     "shape": "String"
                 }
             },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
+            "Timestamp": {
+                "type": "timestamp"
             },
             "TimestampList": {
                 "type": "list",
                 "member": {
                     "shape": "Timestamp"
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "Timestamp": {
-                "type": "timestamp"
             }
         },
         "cases": [
             {
                 "id": "InputAndOutputWithStringHeaders",
+                "description": "Tests responses with string header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1637,7 +1929,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with string header bindings",
                 "result": {
                     "headerString": "Hello",
                     "headerStringList": [
@@ -1654,8 +1945,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-String": "Hello",
                         "X-StringList": "a, b, c",
+                        "X-String": "Hello",
                         "X-StringSet": "a, b, c"
                     },
                     "body": ""
@@ -1663,6 +1954,7 @@
             },
             {
                 "id": "InputAndOutputWithNumericHeaders",
+                "description": "Tests responses with numeric header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1675,7 +1967,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with numeric header bindings",
                 "result": {
                     "headerByte": 1,
                     "headerShort": 123,
@@ -1692,19 +1983,20 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
+                        "X-Integer": "123",
+                        "X-Short": "123",
                         "X-Byte": "1",
+                        "X-Long": "123",
                         "X-Double": "1.1",
                         "X-Float": "1.1",
-                        "X-Integer": "123",
-                        "X-IntegerList": "1, 2, 3",
-                        "X-Long": "123",
-                        "X-Short": "123"
+                        "X-IntegerList": "1, 2, 3"
                     },
                     "body": ""
                 }
             },
             {
                 "id": "InputAndOutputWithBooleanHeaders",
+                "description": "Tests responses with boolean header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1717,7 +2009,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with boolean header bindings",
                 "result": {
                     "headerTrueBool": true,
                     "headerFalseBool": false,
@@ -1730,15 +2021,16 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
+                        "X-BooleanList": "true, false, true",
                         "X-Boolean1": "true",
-                        "X-Boolean2": "false",
-                        "X-BooleanList": "true, false, true"
+                        "X-Boolean2": "false"
                     },
                     "body": ""
                 }
             },
             {
                 "id": "InputAndOutputWithTimestampHeaders",
+                "description": "Tests responses with timestamp header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1751,7 +2043,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with timestamp header bindings",
                 "result": {
                     "headerTimestampList": [
                         1576540098,
@@ -1768,6 +2059,7 @@
             },
             {
                 "id": "InputAndOutputWithEnumHeaders",
+                "description": "Tests responses with enum header bindings",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1780,7 +2072,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Tests responses with enum header bindings",
                 "result": {
                     "headerEnum": "Foo",
                     "headerEnumList": [
@@ -1792,14 +2083,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Enum": "Foo",
-                        "X-EnumList": "Foo, Bar, Baz"
+                        "X-EnumList": "Foo, Bar, Baz",
+                        "X-Enum": "Foo"
                     },
                     "body": ""
                 }
             },
             {
                 "id": "RestXmlSupportsNaNFloatHeaderOutputs",
+                "description": "Supports handling NaN float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1812,7 +2104,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling NaN float header values.",
                 "result": {
                     "headerFloat": "NaN",
                     "headerDouble": "NaN"
@@ -1820,14 +2111,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Double": "NaN",
-                        "X-Float": "NaN"
+                        "X-Float": "NaN",
+                        "X-Double": "NaN"
                     },
                     "body": ""
                 }
             },
             {
                 "id": "RestXmlSupportsInfinityFloatHeaderOutputs",
+                "description": "Supports handling Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1840,7 +2132,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling Infinity float header values.",
                 "result": {
                     "headerFloat": "Infinity",
                     "headerDouble": "Infinity"
@@ -1848,14 +2139,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Double": "Infinity",
-                        "X-Float": "Infinity"
+                        "X-Float": "Infinity",
+                        "X-Double": "Infinity"
                     },
                     "body": ""
                 }
             },
             {
                 "id": "RestXmlSupportsNegativeInfinityFloatHeaderOutputs",
+                "description": "Supports handling -Infinity float header values.",
                 "given": {
                     "name": "InputAndOutputWithHeaders",
                     "http": {
@@ -1868,7 +2160,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there is no input or output payload but there are HTTP header bindings.</p>"
                 },
-                "description": "Supports handling -Infinity float header values.",
                 "result": {
                     "headerFloat": "-Infinity",
                     "headerDouble": "-Infinity"
@@ -1876,8 +2167,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-Double": "-Infinity",
-                        "X-Float": "-Infinity"
+                        "X-Float": "-Infinity",
+                        "X-Double": "-Infinity"
                     },
                     "body": ""
                 }
@@ -1887,13 +2178,50 @@
     {
         "description": "Test cases for NestedXmlMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "NestedMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnumMap"
+                }
+            },
             "NestedXmlMapsResponse": {
                 "type": "structure",
                 "members": {
@@ -1906,34 +2234,6 @@
                     }
                 }
             },
-            "NestedMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnumMap"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "String": {
                 "type": "string"
             }
@@ -1941,6 +2241,7 @@
         "cases": [
             {
                 "id": "NestedXmlMapResponse",
+                "description": "Tests responses with nested maps.",
                 "given": {
                     "name": "NestedXmlMaps",
                     "http": {
@@ -1952,7 +2253,6 @@
                         "shape": "NestedXmlMapsResponse"
                     }
                 },
-                "description": "Tests responses with nested maps.",
                 "result": {
                     "nestedMap": {
                         "foo": {
@@ -1970,6 +2270,7 @@
             },
             {
                 "id": "FlatNestedXmlMapResponse",
+                "description": "Tests responses with nested flat maps. Since maps can only be\nflattened when they're structure members, only the outer map is flat.",
                 "given": {
                     "name": "NestedXmlMaps",
                     "http": {
@@ -1981,7 +2282,6 @@
                         "shape": "NestedXmlMapsResponse"
                     }
                 },
-                "description": "Tests responses with nested flat maps. Since maps can only be\nflattened when they're structure members, only the outer map is flat.",
                 "result": {
                     "flatNestedMap": {
                         "foo": {
@@ -2002,19 +2302,31 @@
     {
         "description": "Test cases for NestedXmlMapWithXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "NestedXmlMapWithXmlNameInputOutput": {
-                "type": "structure",
-                "members": {
-                    "nestedXmlMapWithXmlNameMap": {
-                        "shape": "NestedXmlMapWithXmlNameMap"
-                    }
+            "NestedXmlMapWithXmlNameInnerMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String",
+                    "locationName": "InnerKey"
+                },
+                "value": {
+                    "shape": "String",
+                    "locationName": "InnerValue"
                 }
             },
             "NestedXmlMapWithXmlNameMap": {
@@ -2027,15 +2339,12 @@
                     "shape": "NestedXmlMapWithXmlNameInnerMap"
                 }
             },
-            "NestedXmlMapWithXmlNameInnerMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String",
-                    "locationName": "InnerKey"
-                },
-                "value": {
-                    "shape": "String",
-                    "locationName": "InnerValue"
+            "NestedXmlMapWithXmlNameResponse": {
+                "type": "structure",
+                "members": {
+                    "nestedXmlMapWithXmlNameMap": {
+                        "shape": "NestedXmlMapWithXmlNameMap"
+                    }
                 }
             },
             "String": {
@@ -2045,6 +2354,7 @@
         "cases": [
             {
                 "id": "NestedXmlMapWithXmlNameDeserializes",
+                "description": "Serializes nested XML maps in responses that have xmlName on members",
                 "given": {
                     "name": "NestedXmlMapWithXmlName",
                     "http": {
@@ -2053,11 +2363,10 @@
                         "responseCode": 200
                     },
                     "output": {
-                        "shape": "NestedXmlMapWithXmlNameInputOutput"
+                        "shape": "NestedXmlMapWithXmlNameResponse"
                     },
                     "documentation": "<p>Nested Xml Maps with key/values with @xmlName</p>"
                 },
-                "description": "Serializes nested XML maps in responses that have xmlName on members",
                 "result": {
                     "nestedXmlMapWithXmlNameMap": {
                         "foo": {
@@ -2075,7 +2384,7 @@
                     "headers": {
                         "Content-Type": "application/xml"
                     },
-                    "body": "    <NestedXmlMapWithXmlNameInputOutput>\n        <nestedXmlMapWithXmlNameMap>\n            <entry>\n                <OuterKey>foo</OuterKey>\n                <value>\n                    <entry>\n                        <InnerKey>bar</InnerKey>\n                        <InnerValue>Baz</InnerValue>\n                    </entry>\n                    <entry>\n                        <InnerKey>fizz</InnerKey>\n                        <InnerValue>Buzz</InnerValue>\n                    </entry>\n                </value>\n            </entry>\n            <entry>\n                <OuterKey>qux</OuterKey>\n                <value>\n                    <entry>\n                        <InnerKey>foobar</InnerKey>\n                        <InnerValue>Bar</InnerValue>\n                    </entry>\n                    <entry>\n                        <InnerKey>fizzbuzz</InnerKey>\n                        <InnerValue>Buzz</InnerValue>\n                    </entry>\n                </value>\n            </entry>\n        </nestedXmlMapWithXmlNameMap>\n    </NestedXmlMapWithXmlNameInputOutput>\n"
+                    "body": "    <NestedXmlMapWithXmlNameResponse>\n        <nestedXmlMapWithXmlNameMap>\n            <entry>\n                <OuterKey>foo</OuterKey>\n                <value>\n                    <entry>\n                        <InnerKey>bar</InnerKey>\n                        <InnerValue>Baz</InnerValue>\n                    </entry>\n                    <entry>\n                        <InnerKey>fizz</InnerKey>\n                        <InnerValue>Buzz</InnerValue>\n                    </entry>\n                </value>\n            </entry>\n            <entry>\n                <OuterKey>qux</OuterKey>\n                <value>\n                    <entry>\n                        <InnerKey>foobar</InnerKey>\n                        <InnerValue>Bar</InnerValue>\n                    </entry>\n                    <entry>\n                        <InnerKey>fizzbuzz</InnerKey>\n                        <InnerValue>Buzz</InnerValue>\n                    </entry>\n                </value>\n            </entry>\n        </nestedXmlMapWithXmlNameMap>\n    </NestedXmlMapWithXmlNameResponse>\n"
                 }
             }
         ]
@@ -2083,16 +2392,26 @@
     {
         "description": "Test cases for NoInputAndNoOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "NoInputAndNoOutput",
+                "description": "No output serializes no payload",
                 "given": {
                     "name": "NoInputAndNoOutput",
                     "http": {
@@ -2102,7 +2421,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input or output. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "No output serializes no payload",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -2114,11 +2432,20 @@
     {
         "description": "Test cases for NoInputAndOutput operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
             "NoInputAndOutputOutput": {
@@ -2129,6 +2456,7 @@
         "cases": [
             {
                 "id": "NoInputAndOutput",
+                "description": "Empty output serializes no payload",
                 "given": {
                     "name": "NoInputAndOutput",
                     "http": {
@@ -2141,7 +2469,6 @@
                     },
                     "documentation": "<p>The example tests how requests and responses are serialized when there's no request or response payload because the operation has no input and the output is empty. While this should be rare, code generators must support this.</p>"
                 },
-                "description": "Empty output serializes no payload",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -2153,21 +2480,22 @@
     {
         "description": "Test cases for RecursiveShapes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "RecursiveShapesResponse": {
-                "type": "structure",
-                "members": {
-                    "nested": {
-                        "shape": "RecursiveShapesInputOutputNested1"
-                    }
-                }
-            },
             "RecursiveShapesInputOutputNested1": {
                 "type": "structure",
                 "members": {
@@ -2179,9 +2507,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveShapesInputOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -2192,11 +2517,23 @@
                         "shape": "RecursiveShapesInputOutputNested1"
                     }
                 }
+            },
+            "RecursiveShapesResponse": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "RecursiveShapesInputOutputNested1"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveShapes",
                     "http": {
@@ -2210,7 +2547,6 @@
                     "documentation": "<p>Recursive shapes</p>",
                     "idempotent": true
                 },
-                "description": "Serializes recursive structures",
                 "result": {
                     "nested": {
                         "foo": "Foo1",
@@ -2238,13 +2574,42 @@
     {
         "description": "Test cases for SimpleScalarProperties operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarPropertiesResponse": {
                 "type": "structure",
                 "members": {
@@ -2285,31 +2650,12 @@
             },
             "String": {
                 "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "SimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2322,7 +2668,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "foo": "Foo",
                     "stringValue": "string",
@@ -2338,14 +2683,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     },
                     "body": "<SimpleScalarPropertiesResponse>\n    <stringValue>string</stringValue>\n    <trueBooleanValue>true</trueBooleanValue>\n    <falseBooleanValue>false</falseBooleanValue>\n    <byteValue>1</byteValue>\n    <shortValue>2</shortValue>\n    <integerValue>3</integerValue>\n    <longValue>4</longValue>\n    <floatValue>5.5</floatValue>\n    <DoubleDribble>6.5</DoubleDribble>\n</SimpleScalarPropertiesResponse>\n"
                 }
             },
             {
                 "id": "SimpleScalarPropertiesComplexEscapes",
+                "description": "Serializes string with escaping.\n\nThis validates the three escape types: literal, decimal and hexadecimal. It also validates that unescaping properly\nhandles the case where unescaping an & produces a newly formed escape sequence (this should not be re-unescaped).\n\nServers may produce different output, this test is designed different unescapes clients must handle\n",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2358,7 +2704,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes string with escaping.\n\nThis validates the three escape types: literal, decimal and hexadecimal. It also validates that unescaping properly\nhandles the case where unescaping an & produces a newly formed escape sequence (this should not be re-unescaped).\n\nServers may produce different output, this test is designed different unescapes clients must handle\n",
                 "result": {
                     "foo": "Foo",
                     "stringValue": "escaped data: &lt;\r\n"
@@ -2366,14 +2711,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     },
                     "body": "<SimpleScalarPropertiesResponse>\n    <stringValue>escaped data: &amp;lt;&#xD;&#10;</stringValue>\n</SimpleScalarPropertiesResponse>\n"
                 }
             },
             {
                 "id": "SimpleScalarPropertiesWithEscapedCharacter",
+                "description": "Serializes string with escaping",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2386,7 +2732,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes string with escaping",
                 "result": {
                     "foo": "Foo",
                     "stringValue": "<string>"
@@ -2394,14 +2739,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     },
                     "body": "<SimpleScalarPropertiesResponse>\n    <stringValue>&lt;string&gt;</stringValue>\n</SimpleScalarPropertiesResponse>\n"
                 }
             },
             {
                 "id": "SimpleScalarPropertiesWithXMLPreamble",
+                "description": "Serializes simple scalar properties with xml preamble, comments and CDATA",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2414,7 +2760,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties with xml preamble, comments and CDATA",
                 "result": {
                     "foo": "Foo",
                     "stringValue": "string"
@@ -2422,14 +2767,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     },
                     "body": "<?xml version = \"1.0\" encoding = \"UTF-8\"?>\n<SimpleScalarPropertiesResponse>\n    <![CDATA[characters representing CDATA]]>\n    <stringValue>string</stringValue>\n    <!--xml comment-->\n</SimpleScalarPropertiesResponse>\n"
                 }
             },
             {
                 "id": "SimpleScalarPropertiesWithWhiteSpace",
+                "description": "Serializes string containing white space",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2442,7 +2788,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes string containing white space",
                 "result": {
                     "foo": "Foo",
                     "stringValue": " string with white    space "
@@ -2450,14 +2795,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     },
                     "body": "<?xml version = \"1.0\" encoding = \"UTF-8\"?>\n<SimpleScalarPropertiesResponse>\n    <stringValue> string with white    space </stringValue>\n</SimpleScalarPropertiesResponse>\n"
                 }
             },
             {
                 "id": "SimpleScalarPropertiesPureWhiteSpace",
+                "description": "Serializes string containing white space",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2470,7 +2816,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes string containing white space",
                 "result": {
                     "foo": "Foo",
                     "stringValue": "  "
@@ -2478,14 +2823,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/xml",
-                        "X-Foo": "Foo"
+                        "X-Foo": "Foo",
+                        "Content-Type": "application/xml"
                     },
                     "body": "<?xml version = \"1.0\" encoding = \"UTF-8\"?>\n<SimpleScalarPropertiesResponse>\n    <stringValue>  </stringValue>\n</SimpleScalarPropertiesResponse>\n"
                 }
             },
             {
                 "id": "RestXmlSupportsNaNFloatOutputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2498,7 +2844,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling NaN float values.",
                 "result": {
                     "floatValue": "NaN",
                     "doubleValue": "NaN"
@@ -2513,6 +2858,7 @@
             },
             {
                 "id": "RestXmlSupportsInfinityFloatOutputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2525,7 +2871,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling Infinity float values.",
                 "result": {
                     "floatValue": "Infinity",
                     "doubleValue": "Infinity"
@@ -2540,6 +2885,7 @@
             },
             {
                 "id": "RestXmlSupportsNegativeInfinityFloatOutputs",
+                "description": "Supports handling -Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -2552,7 +2898,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Supports handling -Infinity float values.",
                 "result": {
                     "floatValue": "-Infinity",
                     "doubleValue": "-Infinity"
@@ -2570,13 +2915,49 @@
     {
         "description": "Test cases for TimestampFormatHeaders operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "TimestampFormatHeadersIO": {
                 "type": "structure",
                 "members": {
@@ -2616,38 +2997,12 @@
                         "locationName": "X-targetDateTime"
                     }
                 }
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "TimestampFormatHeaders",
+                "description": "Tests how timestamp response headers are serialized",
                 "given": {
                     "name": "TimestampFormatHeaders",
                     "http": {
@@ -2660,7 +3015,6 @@
                     },
                     "documentation": "<p>The example tests how timestamp request and response headers are serialized.</p>"
                 },
-                "description": "Tests how timestamp response headers are serialized",
                 "result": {
                     "memberEpochSeconds": 1576540098,
                     "memberHttpDate": 1576540098,
@@ -2673,13 +3027,13 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberDateTime": "2019-12-16T23:48:18Z",
-                        "X-memberEpochSeconds": "1576540098",
+                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-memberHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT",
                         "X-targetDateTime": "2019-12-16T23:48:18Z",
                         "X-targetEpochSeconds": "1576540098",
-                        "X-targetHttpDate": "Mon, 16 Dec 2019 23:48:18 GMT"
+                        "X-memberEpochSeconds": "1576540098",
+                        "X-defaultFormat": "Mon, 16 Dec 2019 23:48:18 GMT"
                     },
                     "body": ""
                 }
@@ -2689,13 +3043,25 @@
     {
         "description": "Test cases for XmlAttributes operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "XmlAttributesResponse": {
                 "type": "structure",
                 "members": {
@@ -2708,14 +3074,12 @@
                         "xmlAttribute": true
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlAttributes",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlAttributes",
                     "http": {
@@ -2729,7 +3093,6 @@
                     "documentation": "<p>This example serializes an XML attributes on synthesized document.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "foo": "hi",
                     "attr": "test"
@@ -2745,15 +3108,109 @@
         ]
     },
     {
-        "description": "Test cases for XmlAttributesOnPayload operation",
+        "description": "Test cases for XmlAttributesInMiddle operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
+            "XmlAttributesInMiddlePayloadResponse": {
+                "type": "structure",
+                "members": {
+                    "foo": {
+                        "shape": "String"
+                    },
+                    "attr": {
+                        "shape": "String",
+                        "locationName": "test",
+                        "xmlAttribute": true
+                    },
+                    "baz": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "XmlAttributesInMiddleResponse": {
+                "type": "structure",
+                "members": {
+                    "payload": {
+                        "shape": "XmlAttributesInMiddlePayloadResponse"
+                    }
+                },
+                "payload": "payload"
+            }
+        },
+        "cases": [
+            {
+                "id": "XmlAttributesInMiddle",
+                "description": "Deserializes XML attributes on a payload when the xmlAttribute trait targets a member in the middle of the member list",
+                "given": {
+                    "name": "XmlAttributesInMiddle",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/XmlAttributesInMiddle",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "XmlAttributesInMiddleResponse"
+                    },
+                    "documentation": "<p>This example serializes an XML attribute on a payload when it's defined in the middle of the member list. This tests that implementations correctly write attributes immediately after the element start tag, which is critical for languages like C# where attribute writing must happen before child elements.</p>",
+                    "idempotent": true
+                },
+                "result": {
+                    "payload": {
+                        "foo": "Foo",
+                        "attr": "attributeValue",
+                        "baz": "Baz"
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/xml"
+                    },
+                    "body": "<XmlAttributesInMiddlePayloadResponse test=\"attributeValue\">\n    <foo>Foo</foo>\n    <baz>Baz</baz>\n</XmlAttributesInMiddlePayloadResponse>\n"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for XmlAttributesOnPayload operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
+            "protocol": "rest-xml",
+            "protocols": [
+                "rest-xml"
+            ],
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
+        },
+        "shapes": {
+            "String": {
+                "type": "string"
+            },
             "XmlAttributesOnPayloadResponse": {
                 "type": "structure",
                 "members": {
@@ -2775,14 +3232,12 @@
                         "xmlAttribute": true
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlAttributesOnPayload",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlAttributesOnPayload",
                     "http": {
@@ -2796,7 +3251,6 @@
                     "documentation": "<p>This example serializes an XML attributes on a document targeted by httpPayload.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "payload": {
                         "foo": "hi",
@@ -2816,13 +3270,25 @@
     {
         "description": "Test cases for XmlBlobs operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "XmlBlobsResponse": {
                 "type": "structure",
                 "members": {
@@ -2830,14 +3296,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "XmlBlobs",
+                "description": "Blobs are base64 encoded",
                 "given": {
                     "name": "XmlBlobs",
                     "http": {
@@ -2850,7 +3314,6 @@
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Blobs are base64 encoded",
                 "result": {
                     "data": "value"
                 },
@@ -2867,13 +3330,25 @@
     {
         "description": "Test cases for XmlEmptyBlobs operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
             "XmlEmptyBlobsResponse": {
                 "type": "structure",
                 "members": {
@@ -2881,14 +3356,12 @@
                         "shape": "Blob"
                     }
                 }
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "XmlEmptyBlobs",
+                "description": "Empty blobs are deserialized as empty string",
                 "given": {
                     "name": "XmlEmptyBlobs",
                     "http": {
@@ -2901,7 +3374,6 @@
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Empty blobs are deserialized as empty string",
                 "result": {
                     "data": ""
                 },
@@ -2915,6 +3387,7 @@
             },
             {
                 "id": "XmlEmptySelfClosedBlobs",
+                "description": "Empty self closed blobs are deserialized as empty string",
                 "given": {
                     "name": "XmlEmptyBlobs",
                     "http": {
@@ -2927,7 +3400,6 @@
                     },
                     "documentation": "<p>Blobs are base64 encoded</p>"
                 },
-                "description": "Empty self closed blobs are deserialized as empty string",
                 "result": {
                     "data": ""
                 },
@@ -2944,13 +3416,141 @@
     {
         "description": "Test cases for XmlEmptyLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlEmptyListsResponse": {
                 "type": "structure",
                 "members": {
@@ -3008,130 +3608,12 @@
                         "flattened": true
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "XmlEmptyLists",
+                "description": "Deserializes Empty XML lists",
                 "given": {
                     "name": "XmlEmptyLists",
                     "http": {
@@ -3144,7 +3626,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Deserializes Empty XML lists",
                 "result": {
                     "stringList": [],
                     "stringSet": []
@@ -3162,13 +3643,33 @@
     {
         "description": "Test cases for XmlEmptyMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlEmptyMapsResponse": {
                 "type": "structure",
                 "members": {
@@ -3185,22 +3686,12 @@
                 "value": {
                     "shape": "GreetingStruct"
                 }
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlEmptyMaps",
+                "description": "Deserializes Empty XML maps",
                 "given": {
                     "name": "XmlEmptyMaps",
                     "http": {
@@ -3212,7 +3703,6 @@
                         "shape": "XmlEmptyMapsResponse"
                     }
                 },
-                "description": "Deserializes Empty XML maps",
                 "result": {
                     "myMap": {}
                 },
@@ -3226,6 +3716,7 @@
             },
             {
                 "id": "XmlEmptySelfClosedMaps",
+                "description": "Deserializes Empty Self-closed XML maps",
                 "given": {
                     "name": "XmlEmptyMaps",
                     "http": {
@@ -3237,7 +3728,6 @@
                         "shape": "XmlEmptyMapsResponse"
                     }
                 },
-                "description": "Deserializes Empty Self-closed XML maps",
                 "result": {
                     "myMap": {}
                 },
@@ -3254,13 +3744,25 @@
     {
         "description": "Test cases for XmlEmptyStrings operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "String": {
+                "type": "string"
+            },
             "XmlEmptyStringsResponse": {
                 "type": "structure",
                 "members": {
@@ -3268,14 +3770,12 @@
                         "shape": "String"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlEmptyStrings",
+                "description": "Deserializes xml empty strings",
                 "given": {
                     "name": "XmlEmptyStrings",
                     "http": {
@@ -3288,7 +3788,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Deserializes xml empty strings",
                 "result": {
                     "emptyString": ""
                 },
@@ -3302,6 +3801,7 @@
             },
             {
                 "id": "XmlEmptySelfClosedStrings",
+                "description": "Empty self closed string are deserialized as empty string",
                 "given": {
                     "name": "XmlEmptyStrings",
                     "http": {
@@ -3314,7 +3814,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Empty self closed string are deserialized as empty string",
                 "result": {
                     "emptyString": ""
                 },
@@ -3331,13 +3830,56 @@
     {
         "description": "Test cases for XmlEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "FooEnum"
+                }
+            },
+            "FooEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlEnumsResponse": {
                 "type": "structure",
                 "members": {
@@ -3360,45 +3902,12 @@
                         "shape": "FooEnumMap"
                     }
                 }
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "FooEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "FooEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlEnums",
                     "http": {
@@ -3412,7 +3921,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "fooEnum1": "Foo",
                     "fooEnum2": "0",
@@ -3443,13 +3951,50 @@
     {
         "description": "Test cases for XmlIntEnums operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerEnumSet": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
             "XmlIntEnumsResponse": {
                 "type": "structure",
                 "members": {
@@ -3472,39 +4017,12 @@
                         "shape": "IntegerEnumMap"
                     }
                 }
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumSet": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "IntegerEnumMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlIntEnums",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "XmlIntEnums",
                     "http": {
@@ -3518,7 +4036,6 @@
                     "documentation": "<p>This example serializes enums as top level properties, in lists, sets, and maps.</p>",
                     "idempotent": true
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "intEnum1": 1,
                     "intEnum2": 2,
@@ -3549,13 +4066,141 @@
     {
         "description": "Test cases for XmlLists operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "ListWithMemberNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "xmlNamespace": "https://xml-member.example.com"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "ListWithNamespace": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                },
+                "xmlNamespace": "https://xml-list.example.com"
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "RenamedListMembers": {
+                "type": "list",
+                "member": {
+                    "shape": "String",
+                    "locationName": "item"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember",
+                    "locationName": "item"
+                }
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String",
+                        "locationName": "value"
+                    },
+                    "b": {
+                        "shape": "String",
+                        "locationName": "other"
+                    }
+                }
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
             "XmlListsResponse": {
                 "type": "structure",
                 "members": {
@@ -3613,130 +4258,12 @@
                         "flattened": true
                     }
                 }
-            },
-            "StringList": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "StringSet": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                }
-            },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
-            "RenamedListMembers": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "locationName": "item"
-                }
-            },
-            "ListWithMemberNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String",
-                    "xmlNamespace": "https://xml-member.example.com"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "ListWithNamespace": {
-                "type": "list",
-                "member": {
-                    "shape": "String"
-                },
-                "xmlNamespace": "https://xml-list.example.com"
-            },
-            "StructureList": {
-                "type": "list",
-                "member": {
-                    "shape": "StructureListMember",
-                    "locationName": "item"
-                }
-            },
-            "StructureListMember": {
-                "type": "structure",
-                "members": {
-                    "a": {
-                        "shape": "String",
-                        "locationName": "value"
-                    },
-                    "b": {
-                        "shape": "String",
-                        "locationName": "other"
-                    }
-                }
-            },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "XmlLists",
+                "description": "Tests for XML list serialization",
                 "given": {
                     "name": "XmlLists",
                     "http": {
@@ -3750,7 +4277,6 @@
                     "documentation": "<p>This test case serializes XML lists for the following cases for both input and output:</p> <ol> <li>Normal XML lists.</li> <li>Normal XML sets.</li> <li>XML lists of lists.</li> <li>XML lists with @xmlName on its members</li> <li>Flattened XML lists.</li> <li>Flattened XML lists with @xmlName.</li> <li>Flattened XML lists with @xmlNamespace.</li> <li>Lists of structures.</li> <li>Flattened XML list of structures</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Tests for XML list serialization",
                 "result": {
                     "stringList": [
                         "foo",
@@ -3844,30 +4370,22 @@
     {
         "description": "Test cases for XmlMaps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlMapsResponse": {
-                "type": "structure",
-                "members": {
-                    "myMap": {
-                        "shape": "XmlMapsInputOutputMap"
-                    }
-                }
-            },
-            "XmlMapsInputOutputMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "GreetingStruct"
-                }
-            },
             "GreetingStruct": {
                 "type": "structure",
                 "members": {
@@ -3878,11 +4396,29 @@
             },
             "String": {
                 "type": "string"
+            },
+            "XmlMapsInputOutputMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "XmlMapsResponse": {
+                "type": "structure",
+                "members": {
+                    "myMap": {
+                        "shape": "XmlMapsInputOutputMap"
+                    }
+                }
             }
         },
         "cases": [
             {
                 "id": "XmlMaps",
+                "description": "Tests for XML map serialization",
                 "given": {
                     "name": "XmlMaps",
                     "http": {
@@ -3895,7 +4431,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Tests for XML map serialization",
                 "result": {
                     "myMap": {
                         "foo": {
@@ -3919,20 +4454,32 @@
     {
         "description": "Test cases for XmlMapsXmlName operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlMapsXmlNameResponse": {
+            "GreetingStruct": {
                 "type": "structure",
                 "members": {
-                    "myMap": {
-                        "shape": "XmlMapsXmlNameInputOutputMap"
+                    "hi": {
+                        "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             },
             "XmlMapsXmlNameInputOutputMap": {
                 "type": "map",
@@ -3945,21 +4492,19 @@
                     "locationName": "Setting"
                 }
             },
-            "GreetingStruct": {
+            "XmlMapsXmlNameResponse": {
                 "type": "structure",
                 "members": {
-                    "hi": {
-                        "shape": "String"
+                    "myMap": {
+                        "shape": "XmlMapsXmlNameInputOutputMap"
                     }
                 }
-            },
-            "String": {
-                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "XmlMapsXmlName",
+                "description": "Serializes XML lists",
                 "given": {
                     "name": "XmlMapsXmlName",
                     "http": {
@@ -3971,7 +4516,6 @@
                         "shape": "XmlMapsXmlNameResponse"
                     }
                 },
-                "description": "Serializes XML lists",
                 "result": {
                     "myMap": {
                         "foo": {
@@ -3995,22 +4539,24 @@
     {
         "description": "Test cases for XmlMapWithXmlNamespace operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlMapWithXmlNamespaceResponse": {
-                "type": "structure",
-                "members": {
-                    "myMap": {
-                        "shape": "XmlMapWithXmlNamespaceInputOutputMap",
-                        "locationName": "KVP",
-                        "xmlNamespace": "https://the-member.example.com"
-                    }
-                }
+            "String": {
+                "type": "string"
             },
             "XmlMapWithXmlNamespaceInputOutputMap": {
                 "type": "map",
@@ -4025,13 +4571,21 @@
                     "xmlNamespace": "https://the-value.example.com"
                 }
             },
-            "String": {
-                "type": "string"
+            "XmlMapWithXmlNamespaceResponse": {
+                "type": "structure",
+                "members": {
+                    "myMap": {
+                        "shape": "XmlMapWithXmlNamespaceInputOutputMap",
+                        "locationName": "KVP",
+                        "xmlNamespace": "https://the-member.example.com"
+                    }
+                }
             }
         },
         "cases": [
             {
                 "id": "RestXmlXmlMapWithXmlNamespace",
+                "description": "Serializes XML maps in responses that have xmlNamespace and xmlName on members",
                 "given": {
                     "name": "XmlMapWithXmlNamespace",
                     "http": {
@@ -4044,7 +4598,6 @@
                     },
                     "documentation": "<p>Maps with @xmlNamespace and @xmlName</p>"
                 },
-                "description": "Serializes XML maps in responses that have xmlNamespace and xmlName on members",
                 "result": {
                     "myMap": {
                         "a": "A",
@@ -4064,21 +4617,24 @@
     {
         "description": "Test cases for XmlNamespaces operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlNamespacesResponse": {
-                "type": "structure",
-                "members": {
-                    "nested": {
-                        "shape": "XmlNamespaceNested"
-                    }
-                },
-                "xmlNamespace": "http://foo.com"
+            "String": {
+                "type": "string"
             },
             "XmlNamespaceNested": {
                 "type": "structure",
@@ -4097,20 +4653,27 @@
                 },
                 "xmlNamespace": "http://foo.com"
             },
-            "String": {
-                "type": "string"
-            },
             "XmlNamespacedList": {
                 "type": "list",
                 "member": {
                     "shape": "String",
                     "xmlNamespace": "http://bux.com"
                 }
+            },
+            "XmlNamespacesResponse": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "XmlNamespaceNested"
+                    }
+                },
+                "xmlNamespace": "http://foo.com"
             }
         },
         "cases": [
             {
                 "id": "XmlNamespaces",
+                "description": "Serializes XML namespaces",
                 "given": {
                     "name": "XmlNamespaces",
                     "http": {
@@ -4122,7 +4685,6 @@
                         "shape": "XmlNamespacesResponse"
                     }
                 },
-                "description": "Serializes XML namespaces",
                 "result": {
                     "nested": {
                         "foo": "Foo",
@@ -4145,13 +4707,49 @@
     {
         "description": "Test cases for XmlTimestamps operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "EpochSeconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "HttpDate": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "SyntheticTimestamp_date_time": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
+            "SyntheticTimestamp_epoch_seconds": {
+                "type": "timestamp",
+                "timestampFormat": "unixTimestamp"
+            },
+            "SyntheticTimestamp_http_date": {
+                "type": "timestamp",
+                "timestampFormat": "rfc822"
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
             "XmlTimestampsResponse": {
                 "type": "structure",
                 "members": {
@@ -4177,38 +4775,12 @@
                         "shape": "HttpDate"
                     }
                 }
-            },
-            "Timestamp": {
-                "type": "timestamp"
-            },
-            "SyntheticTimestamp_date_time": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
-            },
-            "SyntheticTimestamp_epoch_seconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "EpochSeconds": {
-                "type": "timestamp",
-                "timestampFormat": "unixTimestamp"
-            },
-            "SyntheticTimestamp_http_date": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
-            },
-            "HttpDate": {
-                "type": "timestamp",
-                "timestampFormat": "rfc822"
             }
         },
         "cases": [
             {
                 "id": "XmlTimestamps",
+                "description": "Tests how normal timestamps are serialized",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -4221,7 +4793,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Tests how normal timestamps are serialized",
                 "result": {
                     "normal": 1398796238
                 },
@@ -4235,6 +4806,7 @@
             },
             {
                 "id": "XmlTimestampsWithDateTimeFormat",
+                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -4247,7 +4819,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time works like normal timestamps",
                 "result": {
                     "dateTime": 1398796238
                 },
@@ -4261,6 +4832,7 @@
             },
             {
                 "id": "XmlTimestampsWithDateTimeOnTargetFormat",
+                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -4273,7 +4845,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of date-time on the target shape works like normal timestamps",
                 "result": {
                     "dateTimeOnTarget": 1398796238
                 },
@@ -4287,6 +4858,7 @@
             },
             {
                 "id": "XmlTimestampsWithEpochSecondsFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -4299,7 +4871,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds works",
                 "result": {
                     "epochSeconds": 1398796238
                 },
@@ -4313,6 +4884,7 @@
             },
             {
                 "id": "XmlTimestampsWithEpochSecondsOnTargetFormat",
+                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -4325,7 +4897,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of epoch-seconds on the target shape works",
                 "result": {
                     "epochSecondsOnTarget": 1398796238
                 },
@@ -4339,6 +4910,7 @@
             },
             {
                 "id": "XmlTimestampsWithHttpDateFormat",
+                "description": "Ensures that the timestampFormat of http-date works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -4351,7 +4923,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date works",
                 "result": {
                     "httpDate": 1398796238
                 },
@@ -4365,6 +4936,7 @@
             },
             {
                 "id": "XmlTimestampsWithHttpDateOnTargetFormat",
+                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "given": {
                     "name": "XmlTimestamps",
                     "http": {
@@ -4377,7 +4949,6 @@
                     },
                     "documentation": "<p>This tests how timestamps are serialized, including using the default format of date-time and various @timestampFormat trait values.</p>"
                 },
-                "description": "Ensures that the timestampFormat of http-date on the target shape works",
                 "result": {
                     "httpDateOnTarget": 1398796238
                 },
@@ -4394,18 +4965,71 @@
     {
         "description": "Test cases for XmlUnions operation",
         "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
             "protocol": "rest-xml",
             "protocols": [
                 "rest-xml"
             ],
-            "apiVersion": "2019-12-16"
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
         },
         "shapes": {
-            "XmlUnionsResponse": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "XmlNestedUnionStruct": {
                 "type": "structure",
                 "members": {
-                    "unionValue": {
-                        "shape": "XmlUnionShape"
+                    "stringValue": {
+                        "shape": "String"
+                    },
+                    "booleanValue": {
+                        "shape": "Boolean"
+                    },
+                    "byteValue": {
+                        "shape": "Integer"
+                    },
+                    "shortValue": {
+                        "shape": "Integer"
+                    },
+                    "integerValue": {
+                        "shape": "Integer"
+                    },
+                    "longValue": {
+                        "shape": "Long"
+                    },
+                    "floatValue": {
+                        "shape": "Float"
+                    },
+                    "doubleValue": {
+                        "shape": "Double"
                     }
                 }
             },
@@ -4445,55 +5069,11 @@
                 },
                 "union": true
             },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "XmlNestedUnionStruct": {
+            "XmlUnionsResponse": {
                 "type": "structure",
                 "members": {
-                    "stringValue": {
-                        "shape": "String"
-                    },
-                    "booleanValue": {
-                        "shape": "Boolean"
-                    },
-                    "byteValue": {
-                        "shape": "Integer"
-                    },
-                    "shortValue": {
-                        "shape": "Integer"
-                    },
-                    "integerValue": {
-                        "shape": "Integer"
-                    },
-                    "longValue": {
-                        "shape": "Long"
-                    },
-                    "floatValue": {
-                        "shape": "Float"
-                    },
-                    "doubleValue": {
-                        "shape": "Double"
+                    "unionValue": {
+                        "shape": "XmlUnionShape"
                     }
                 }
             }
@@ -4501,6 +5081,7 @@
         "cases": [
             {
                 "id": "XmlUnionsWithStructMember",
+                "description": "Serializes union struct member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -4513,7 +5094,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes union struct member",
                 "result": {
                     "unionValue": {
                         "structValue": {
@@ -4538,6 +5118,7 @@
             },
             {
                 "id": "XmlUnionsWithStringMember",
+                "description": "Serializes union string member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -4550,7 +5131,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes union string member",
                 "result": {
                     "unionValue": {
                         "stringValue": "some string"
@@ -4566,6 +5146,7 @@
             },
             {
                 "id": "XmlUnionsWithBooleanMember",
+                "description": "Serializes union boolean member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -4578,7 +5159,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes union boolean member",
                 "result": {
                     "unionValue": {
                         "booleanValue": true
@@ -4594,6 +5174,7 @@
             },
             {
                 "id": "XmlUnionsWithUnionMember",
+                "description": "Serializes union member",
                 "given": {
                     "name": "XmlUnions",
                     "http": {
@@ -4606,7 +5187,6 @@
                     },
                     "idempotent": true
                 },
-                "description": "Serializes union member",
                 "result": {
                     "unionValue": {
                         "unionValue": {

--- a/tests/unit/protocols/output/smithy-rpc-v2-cbor-query-compatible.json
+++ b/tests/unit/protocols/output/smithy-rpc-v2-cbor-query-compatible.json
@@ -36,6 +36,7 @@
         "cases": [
             {
                 "id": "QueryCompatibleRpcV2CborNoCustomCodeError",
+                "description": "Parses simple RpcV2 CBOR errors with no query error code",
                 "given": {
                     "name": "QueryCompatibleOperation",
                     "http": {
@@ -49,7 +50,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple RpcV2 CBOR errors with no query error code",
                 "errorCode": "NoCustomCodeError",
                 "errorMessage": "Hi",
                 "error": {
@@ -58,8 +58,8 @@
                 "response": {
                     "status_code": 400,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "uQACZl9fdHlwZXgtYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI05vQ3VzdG9tQ29kZUVycm9yZ21lc3NhZ2ViSGk="
                 }
@@ -108,6 +108,7 @@
         "cases": [
             {
                 "id": "QueryCompatibleRpcV2CborCustomCodeError",
+                "description": "Parses simple RpcV2 CBOR errors with query error code",
                 "given": {
                     "name": "QueryCompatibleOperation",
                     "http": {
@@ -121,7 +122,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple RpcV2 CBOR errors with query error code",
                 "errorCode": "Customized",
                 "errorMessage": "Hi",
                 "error": {
@@ -130,9 +130,9 @@
                 "response": {
                     "status_code": 400,
                     "headers": {
-                        "Content-Type": "application/cbor",
+                        "x-amzn-query-error": "Customized;Sender",
                         "smithy-protocol": "rpc-v2-cbor",
-                        "x-amzn-query-error": "Customized;Sender"
+                        "Content-Type": "application/cbor"
                     },
                     "body": "uQACZl9fdHlwZXgrYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI0N1c3RvbUNvZGVFcnJvcmdtZXNzYWdlYkhp"
                 }

--- a/tests/unit/protocols/output/smithy-rpc-v2-cbor.json
+++ b/tests/unit/protocols/output/smithy-rpc-v2-cbor.json
@@ -2,12 +2,21 @@
     {
         "description": "Test cases for EmptyInputOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "EmptyStructure": {
@@ -18,6 +27,7 @@
         "cases": [
             {
                 "id": "empty_output",
+                "description": "When output structure is empty we write CBOR equivalent of {}",
                 "given": {
                     "name": "EmptyInputOutput",
                     "http": {
@@ -28,19 +38,19 @@
                         "shape": "EmptyStructure"
                     }
                 },
-                "description": "When output structure is empty we write CBOR equivalent of {}",
                 "result": {},
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v/8="
                 }
             },
             {
                 "id": "empty_output_no_body",
+                "description": "When output structure is empty the client should accept an empty body",
                 "given": {
                     "name": "EmptyInputOutput",
                     "http": {
@@ -51,13 +61,12 @@
                         "shape": "EmptyStructure"
                     }
                 },
-                "description": "When output structure is empty the client should accept an empty body",
                 "result": {},
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": ""
                 }
@@ -67,14 +76,27 @@
     {
         "description": "Test cases for Float16 operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "Double": {
+                "type": "double",
+                "box": true
+            },
             "Float16Output": {
                 "type": "structure",
                 "members": {
@@ -82,15 +104,12 @@
                         "shape": "Double"
                     }
                 }
-            },
-            "Double": {
-                "type": "double",
-                "box": true
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborFloat16Inf",
+                "description": "Ensures that clients can correctly parse float16 +Inf.",
                 "given": {
                     "name": "Float16",
                     "http": {
@@ -101,21 +120,21 @@
                         "shape": "Float16Output"
                     }
                 },
-                "description": "Ensures that clients can correctly parse float16 +Inf.",
                 "result": {
                     "value": "Infinity"
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWV2YWx1Zfl8AA=="
                 }
             },
             {
                 "id": "RpcV2CborFloat16NegInf",
+                "description": "Ensures that clients can correctly parse float16 -Inf.",
                 "given": {
                     "name": "Float16",
                     "http": {
@@ -126,21 +145,21 @@
                         "shape": "Float16Output"
                     }
                 },
-                "description": "Ensures that clients can correctly parse float16 -Inf.",
                 "result": {
                     "value": "-Infinity"
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWV2YWx1Zfn8AA=="
                 }
             },
             {
                 "id": "RpcV2CborFloat16LSBNaN",
+                "description": "Ensures that clients can correctly parse float16 NaN with high LSB.",
                 "given": {
                     "name": "Float16",
                     "http": {
@@ -151,21 +170,21 @@
                         "shape": "Float16Output"
                     }
                 },
-                "description": "Ensures that clients can correctly parse float16 NaN with high LSB.",
                 "result": {
                     "value": "NaN"
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWV2YWx1Zfl8AQ=="
                 }
             },
             {
                 "id": "RpcV2CborFloat16MSBNaN",
+                "description": "Ensures that clients can correctly parse float16 NaN with high MSB.",
                 "given": {
                     "name": "Float16",
                     "http": {
@@ -176,21 +195,21 @@
                         "shape": "Float16Output"
                     }
                 },
-                "description": "Ensures that clients can correctly parse float16 NaN with high MSB.",
                 "result": {
                     "value": "NaN"
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWV2YWx1Zfl+AA=="
                 }
             },
             {
                 "id": "RpcV2CborFloat16Subnormal",
+                "description": "Ensures that clients can correctly parse a subnormal float16.",
                 "given": {
                     "name": "Float16",
                     "http": {
@@ -201,15 +220,14 @@
                         "shape": "Float16Output"
                     }
                 },
-                "description": "Ensures that clients can correctly parse a subnormal float16.",
                 "result": {
                     "value": 4.76837158203125E-6
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWV2YWx1ZfkAUA=="
                 }
@@ -219,14 +237,27 @@
     {
         "description": "Test cases for FractionalSeconds operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            },
             "FractionalSecondsOutput": {
                 "type": "structure",
                 "members": {
@@ -234,15 +265,12 @@
                         "shape": "DateTime"
                     }
                 }
-            },
-            "DateTime": {
-                "type": "timestamp",
-                "timestampFormat": "iso8601"
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborDateTimeWithFractionalSeconds",
+                "description": "Ensures that clients can correctly parse timestamps with fractional seconds",
                 "given": {
                     "name": "FractionalSeconds",
                     "http": {
@@ -253,15 +281,14 @@
                         "shape": "FractionalSecondsOutput"
                     }
                 },
-                "description": "Ensures that clients can correctly parse timestamps with fractional seconds",
                 "result": {
                     "datetime": 9.46845296123E8
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2hkYXRldGltZcH7Qcw32zgPvnf/"
                 }
@@ -271,12 +298,21 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "InvalidGreeting": {
@@ -296,6 +332,7 @@
         "cases": [
             {
                 "id": "RpcV2CborInvalidGreetingError",
+                "description": "Parses simple RpcV2 Cbor errors",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -310,7 +347,6 @@
                         }
                     ]
                 },
-                "description": "Parses simple RpcV2 Cbor errors",
                 "errorCode": "InvalidGreeting",
                 "errorMessage": "Hi",
                 "error": {
@@ -319,8 +355,8 @@
                 "response": {
                     "status_code": 400,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2ZfX3R5cGV4LnNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNJbnZhbGlkR3JlZXRpbmdnTWVzc2FnZWJIaf8="
                 }
@@ -330,12 +366,21 @@
     {
         "description": "Test cases for GreetingWithErrors operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "ComplexError": {
@@ -351,9 +396,6 @@
                 "documentation": "<p>This error is thrown when a request is invalid.</p>",
                 "exception": true
             },
-            "String": {
-                "type": "string"
-            },
             "ComplexNestedErrorData": {
                 "type": "structure",
                 "members": {
@@ -361,11 +403,15 @@
                         "shape": "String"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborComplexError",
+                "description": "Parses a complex error with no message member",
                 "given": {
                     "name": "GreetingWithErrors",
                     "http": {
@@ -380,7 +426,6 @@
                         }
                     ]
                 },
-                "description": "Parses a complex error with no message member",
                 "errorCode": "ComplexError",
                 "error": {
                     "TopLevel": "Top level",
@@ -391,8 +436,8 @@
                 "response": {
                     "status_code": 400,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3JoVG9wTGV2ZWxpVG9wIGxldmVsZk5lc3RlZL9jRm9vY2Jhcv//"
                 }
@@ -418,8 +463,8 @@
                 "response": {
                     "status_code": 400,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3L/"
                 }
@@ -429,17 +474,27 @@
     {
         "description": "Test cases for NoInputOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {},
         "cases": [
             {
                 "id": "no_output",
+                "description": "A `Content-Type` header should not be set if the response body is empty.",
                 "given": {
                     "name": "NoInputOutput",
                     "http": {
@@ -447,7 +502,6 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "A `Content-Type` header should not be set if the response body is empty.",
                 "result": {},
                 "response": {
                     "status_code": 200,
@@ -459,6 +513,7 @@
             },
             {
                 "id": "NoOutputClientAllowsEmptyCbor",
+                "description": "Clients should accept a CBOR empty struct if there is no output.",
                 "given": {
                     "name": "NoInputOutput",
                     "http": {
@@ -466,19 +521,19 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Clients should accept a CBOR empty struct if there is no output.",
                 "result": {},
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v/8="
                 }
             },
             {
                 "id": "NoOutputClientAllowsEmptyBody",
+                "description": "Clients should accept an empty body if there is no output and\nshould not raise an error if the `Content-Type` header is set.",
                 "given": {
                     "name": "NoInputOutput",
                     "http": {
@@ -486,13 +541,12 @@
                         "requestUri": "/"
                     }
                 },
-                "description": "Clients should accept an empty body if there is no output and\nshould not raise an error if the `Content-Type` header is set.",
                 "result": {},
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": ""
                 }
@@ -502,12 +556,21 @@
     {
         "description": "Test cases for OptionalInputOutput operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "SimpleStructure": {
@@ -525,6 +588,7 @@
         "cases": [
             {
                 "id": "optional_output",
+                "description": "When output is empty we write CBOR equivalent of {}",
                 "given": {
                     "name": "OptionalInputOutput",
                     "http": {
@@ -535,13 +599,12 @@
                         "shape": "SimpleStructure"
                     }
                 },
-                "description": "When output is empty we write CBOR equivalent of {}",
                 "result": {},
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v/8="
                 }
@@ -551,12 +614,21 @@
     {
         "description": "Test cases for RecursiveShapes operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
             "RecursiveShapesInputOutput": {
@@ -578,9 +650,6 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
             "RecursiveShapesInputOutputNested2": {
                 "type": "structure",
                 "members": {
@@ -591,11 +660,15 @@
                         "shape": "RecursiveShapesInputOutputNested1"
                     }
                 }
+            },
+            "String": {
+                "type": "string"
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborRecursiveShapes",
+                "description": "Serializes recursive structures",
                 "given": {
                     "name": "RecursiveShapes",
                     "http": {
@@ -606,7 +679,6 @@
                         "shape": "RecursiveShapesInputOutput"
                     }
                 },
-                "description": "Serializes recursive structures",
                 "result": {
                     "nested": {
                         "foo": "Foo1",
@@ -624,14 +696,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8="
                 }
             },
             {
                 "id": "RpcV2CborRecursiveShapesUsingDefiniteLength",
+                "description": "Deserializes recursive structures encoded using a map with definite length",
                 "given": {
                     "name": "RecursiveShapes",
                     "http": {
@@ -642,7 +715,6 @@
                         "shape": "RecursiveShapesInputOutput"
                     }
                 },
-                "description": "Deserializes recursive structures encoded using a map with definite length",
                 "result": {
                     "nested": {
                         "foo": "Foo1",
@@ -660,8 +732,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWZuZXN0ZWSiY2Zvb2RGb28xZm5lc3RlZKJjYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyomNmb29kRm9vMmZuZXN0ZWShY2JhcmRCYXIy"
                 }
@@ -671,14 +743,84 @@
     {
         "description": "Test cases for RpcV2CborDenseMaps operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "DenseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                }
+            },
+            "DenseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                }
+            },
+            "DenseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                }
+            },
+            "DenseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
+            "DenseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
             "RpcV2CborDenseMapsInputOutput": {
                 "type": "structure",
                 "members": {
@@ -699,80 +841,20 @@
                     }
                 }
             },
-            "DenseStructMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "GreetingStruct"
-                }
-            },
-            "DenseNumberMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Integer"
-                }
-            },
-            "DenseBooleanMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "Boolean"
-                }
-            },
-            "DenseStringMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "String"
-                }
-            },
-            "DenseSetMap": {
-                "type": "map",
-                "key": {
-                    "shape": "String"
-                },
-                "value": {
-                    "shape": "StringSet"
-                }
+            "String": {
+                "type": "string"
             },
             "StringSet": {
                 "type": "list",
                 "member": {
                     "shape": "String"
                 }
-            },
-            "String": {
-                "type": "string"
-            },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "GreetingStruct": {
-                "type": "structure",
-                "members": {
-                    "hi": {
-                        "shape": "String"
-                    }
-                }
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborMaps",
+                "description": "Deserializes maps",
                 "given": {
                     "name": "RpcV2CborDenseMaps",
                     "http": {
@@ -784,7 +866,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Deserializes maps",
                 "result": {
                     "denseStructMap": {
                         "foo": {
@@ -798,14 +879,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ=="
                 }
             },
             {
                 "id": "RpcV2CborDeserializesZeroValuesInMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "given": {
                     "name": "RpcV2CborDenseMaps",
                     "http": {
@@ -817,7 +899,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
                 "result": {
                     "denseNumberMap": {
                         "x": 0
@@ -829,14 +910,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A=="
                 }
             },
             {
                 "id": "RpcV2CborDeserializesDenseSetMap",
+                "description": "A response that contains a dense map of sets",
                 "given": {
                     "name": "RpcV2CborDenseMaps",
                     "http": {
@@ -848,7 +930,6 @@
                     },
                     "documentation": "<p>The example tests basic map serialization.</p>"
                 },
-                "description": "A response that contains a dense map of sets",
                 "result": {
                     "denseSetMap": {
                         "x": [],
@@ -861,42 +942,10 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWtkZW5zZVNldE1hcKJheIBheYJhYWFi"
-                }
-            },
-            {
-                "id": "RpcV2CborDeserializesDenseSetMapAndSkipsNull",
-                "given": {
-                    "name": "RpcV2CborDenseMaps",
-                    "http": {
-                        "method": "POST",
-                        "requestUri": "/"
-                    },
-                    "output": {
-                        "shape": "RpcV2CborDenseMapsInputOutput"
-                    },
-                    "documentation": "<p>The example tests basic map serialization.</p>"
-                },
-                "description": "Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD\ndrop the null key-value pair.",
-                "result": {
-                    "denseSetMap": {
-                        "x": [],
-                        "y": [
-                            "a",
-                            "b"
-                        ]
-                    }
-                },
-                "response": {
-                    "status_code": 200,
-                    "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
-                    },
-                    "body": "oWtkZW5zZVNldE1hcKNheIBheYJhYWFiYXr2"
                 }
             }
         ]
@@ -904,14 +953,85 @@
     {
         "description": "Test cases for RpcV2CborLists operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "BlobList": {
+                "type": "list",
+                "member": {
+                    "shape": "Blob"
+                }
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
             "RpcV2CborListInputOutput": {
                 "type": "structure",
                 "members": {
@@ -947,6 +1067,9 @@
                     }
                 }
             },
+            "String": {
+                "type": "string"
+            },
             "StringList": {
                 "type": "list",
                 "member": {
@@ -959,57 +1082,11 @@
                     "shape": "String"
                 }
             },
-            "IntegerList": {
-                "type": "list",
-                "member": {
-                    "shape": "Integer"
-                }
-            },
-            "BooleanList": {
-                "type": "list",
-                "member": {
-                    "shape": "Boolean"
-                }
-            },
-            "TimestampList": {
-                "type": "list",
-                "member": {
-                    "shape": "Timestamp"
-                }
-            },
-            "FooEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "FooEnum"
-                }
-            },
-            "IntegerEnumList": {
-                "type": "list",
-                "member": {
-                    "shape": "IntegerEnum"
-                }
-            },
-            "NestedStringList": {
-                "type": "list",
-                "member": {
-                    "shape": "StringList"
-                },
-                "documentation": "<p>A list of lists of strings.</p>"
-            },
             "StructureList": {
                 "type": "list",
                 "member": {
                     "shape": "StructureListMember"
                 }
-            },
-            "BlobList": {
-                "type": "list",
-                "member": {
-                    "shape": "Blob"
-                }
-            },
-            "Blob": {
-                "type": "blob"
             },
             "StructureListMember": {
                 "type": "structure",
@@ -1022,38 +1099,20 @@
                     }
                 }
             },
-            "String": {
-                "type": "string"
-            },
-            "IntegerEnum": {
-                "type": "integer",
-                "box": true
-            },
-            "FooEnum": {
-                "type": "string",
-                "enum": [
-                    "Foo",
-                    "Baz",
-                    "Bar",
-                    "1",
-                    "0"
-                ]
-            },
             "Timestamp": {
                 "type": "timestamp"
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborLists",
+                "description": "Serializes RpcV2 Cbor lists",
                 "given": {
                     "name": "RpcV2CborLists",
                     "http": {
@@ -1066,7 +1125,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes RpcV2 Cbor lists",
                 "result": {
                     "stringList": [
                         "foo",
@@ -1124,14 +1182,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2pzdHJpbmdMaXN0n2Nmb29jYmFy/2lzdHJpbmdTZXSfY2Zvb2NiYXL/a2ludGVnZXJMaXN0nwEC/2tib29sZWFuTGlzdJ/19P9tdGltZXN0YW1wTGlzdJ/B+0HU1/vzgAAAwftB1Nf784AAAP9oZW51bUxpc3SfY0Zvb2Ew/2tpbnRFbnVtTGlzdJ8BAv9wbmVzdGVkU3RyaW5nTGlzdJ+fY2Zvb2NiYXL/n2NiYXpjcXV4//9tc3RydWN0dXJlTGlzdJ+/YWFhMWFiYTL/v2FhYTNhYmE0//9oYmxvYkxpc3SfQ2Zvb0NiYXL//w=="
                 }
             },
             {
                 "id": "RpcV2CborListsEmpty",
+                "description": "Serializes empty RpcV2 Cbor lists",
                 "given": {
                     "name": "RpcV2CborLists",
                     "http": {
@@ -1144,21 +1203,21 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Serializes empty RpcV2 Cbor lists",
                 "result": {
                     "stringList": []
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2pzdHJpbmdMaXN0n///"
                 }
             },
             {
                 "id": "RpcV2CborIndefiniteStringInsideIndefiniteListCanDeserialize",
+                "description": "Can deserialize indefinite length text strings inside an indefinite length list",
                 "given": {
                     "name": "RpcV2CborLists",
                     "http": {
@@ -1171,7 +1230,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Can deserialize indefinite length text strings inside an indefinite length list",
                 "result": {
                     "stringList": [
                         "An example indefinite string, which will be chunked, on each comma",
@@ -1182,14 +1240,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2pzdHJpbmdMaXN0n394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n//8="
                 }
             },
             {
                 "id": "RpcV2CborIndefiniteStringInsideDefiniteListCanDeserialize",
+                "description": "Can deserialize indefinite length text strings inside a definite length list",
                 "given": {
                     "name": "RpcV2CborLists",
                     "http": {
@@ -1202,7 +1261,6 @@
                     "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
                     "idempotent": true
                 },
-                "description": "Can deserialize indefinite length text strings inside a definite length list",
                 "result": {
                     "stringList": [
                         "An example indefinite string, which will be chunked, on each comma",
@@ -1213,8 +1271,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "oWpzdHJpbmdMaXN0g394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n"
                 }
@@ -1222,16 +1280,328 @@
         ]
     },
     {
-        "description": "Test cases for SimpleScalarProperties operation",
+        "description": "Test cases for RpcV2CborSparseMaps operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "RpcV2CborSparseMapsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "sparseStructMap": {
+                        "shape": "SparseStructMap"
+                    },
+                    "sparseNumberMap": {
+                        "shape": "SparseNumberMap"
+                    },
+                    "sparseBooleanMap": {
+                        "shape": "SparseBooleanMap"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
+                    },
+                    "sparseSetMap": {
+                        "shape": "SparseSetMap"
+                    }
+                }
+            },
+            "SparseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                },
+                "sparse": true
+            },
+            "SparseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                },
+                "sparse": true
+            },
+            "SparseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                },
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
+            },
+            "SparseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                },
+                "sparse": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborSparseJsonMaps",
+                "description": "Deserializes sparse maps",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "result": {
+                    "sparseStructMap": {
+                        "foo": {
+                            "hi": "there"
+                        },
+                        "baz": {
+                            "hi": "bye"
+                        }
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "body": "v29zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb79iaGlldGhlcmX/Y2Jher9iaGljYnll////"
+                }
+            },
+            {
+                "id": "RpcV2CborDeserializesNullMapValues",
+                "description": "Deserializes null map values",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "result": {
+                    "sparseBooleanMap": {
+                        "x": null
+                    },
+                    "sparseNumberMap": {
+                        "x": null
+                    },
+                    "sparseStringMap": {
+                        "x": null
+                    },
+                    "sparseStructMap": {
+                        "x": null
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "body": "v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//"
+                }
+            },
+            {
+                "id": "RpcV2CborDeserializesSparseSetMap",
+                "description": "A response that contains a sparse map of sets",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "result": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ]
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "body": "v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8="
+                }
+            },
+            {
+                "id": "RpcV2CborDeserializesSparseSetMapAndRetainsNull",
+                "description": "A response that contains a sparse map of sets with a null",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "result": {
+                    "sparseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ],
+                        "z": null
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "body": "v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL/YXr2//8="
+                }
+            },
+            {
+                "id": "RpcV2CborDeserializesZeroValuesInSparseMaps",
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
+                "given": {
+                    "name": "RpcV2CborSparseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborSparseMapsInputOutput"
+                    }
+                },
+                "result": {
+                    "sparseNumberMap": {
+                        "x": 0
+                    },
+                    "sparseBooleanMap": {
+                        "x": false
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "body": "v29zcGFyc2VOdW1iZXJNYXC/YXgA/3BzcGFyc2VCb29sZWFuTWFwv2F49P//"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SimpleScalarProperties operation",
+        "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
+        },
+        "shapes": {
+            "Blob": {
+                "type": "blob"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
             "SimpleScalarStructure": {
                 "type": "structure",
                 "members": {
@@ -1267,36 +1637,14 @@
                     }
                 }
             },
-            "Boolean": {
-                "type": "boolean",
-                "box": true
-            },
-            "Integer": {
-                "type": "integer",
-                "box": true
-            },
-            "Double": {
-                "type": "double",
-                "box": true
-            },
-            "Float": {
-                "type": "float",
-                "box": true
-            },
-            "Long": {
-                "type": "long",
-                "box": true
-            },
             "String": {
                 "type": "string"
-            },
-            "Blob": {
-                "type": "blob"
             }
         },
         "cases": [
             {
                 "id": "RpcV2CborSimpleScalarProperties",
+                "description": "Serializes simple scalar properties",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1307,7 +1655,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Serializes simple scalar properties",
                 "result": {
                     "trueBooleanValue": true,
                     "falseBooleanValue": false,
@@ -1322,14 +1669,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v3B0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb2//"
                 }
             },
             {
                 "id": "RpcV2CborSimpleScalarPropertiesUsingDefiniteLength",
+                "description": "Deserializes simple scalar properties encoded using a map with definite length",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1340,7 +1688,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Deserializes simple scalar properties encoded using a map with definite length",
                 "result": {
                     "trueBooleanValue": true,
                     "falseBooleanValue": false,
@@ -1355,14 +1702,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "qXB0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb28="
                 }
             },
             {
                 "id": "RpcV2CborClientDoesntDeserializeNullStructureValues",
+                "description": "RpcV2 Cbor should not deserialize null structure values",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1373,19 +1721,19 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "RpcV2 Cbor should not deserialize null structure values",
                 "result": {},
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2tzdHJpbmdWYWx1Zfb/"
                 }
             },
             {
                 "id": "RpcV2CborSupportsNaNFloatOutputs",
+                "description": "Supports handling NaN float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1396,7 +1744,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Supports handling NaN float values.",
                 "result": {
                     "doubleValue": "NaN",
                     "floatValue": "NaN"
@@ -1404,14 +1751,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/"
                 }
             },
             {
                 "id": "RpcV2CborSupportsInfinityFloatOutputs",
+                "description": "Supports handling Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1422,7 +1770,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Supports handling Infinity float values.",
                 "result": {
                     "doubleValue": "Infinity",
                     "floatValue": "Infinity"
@@ -1430,14 +1777,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/"
                 }
             },
             {
                 "id": "RpcV2CborSupportsNegativeInfinityFloatOutputs",
+                "description": "Supports handling Negative Infinity float values.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1448,7 +1796,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Supports handling Negative Infinity float values.",
                 "result": {
                     "doubleValue": "-Infinity",
                     "floatValue": "-Infinity"
@@ -1456,14 +1803,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/"
                 }
             },
             {
                 "id": "RpcV2CborSupportsUpcastingDataOnDeserialize",
+                "description": "Supports upcasting from a smaller byte representation of the same data type.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1474,7 +1822,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "Supports upcasting from a smaller byte representation of the same data type.",
                 "result": {
                     "doubleValue": 1.5,
                     "floatValue": 7.625,
@@ -1485,14 +1832,15 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2tkb3VibGVWYWx1Zfk+AGpmbG9hdFZhbHVl+UegbGludGVnZXJWYWx1ZRg4aWxvbmdWYWx1ZRkBAGpzaG9ydFZhbHVlCv8="
                 }
             },
             {
                 "id": "RpcV2CborExtraFieldsInTheBodyShouldBeSkippedByClients",
+                "description": "The client should skip over additional fields that are not part of the structure. This allows a\nclient generated against an older Smithy model to be able to communicate with a server that is\ngenerated against a newer Smithy model.",
                 "given": {
                     "name": "SimpleScalarProperties",
                     "http": {
@@ -1503,7 +1851,6 @@
                         "shape": "SimpleScalarStructure"
                     }
                 },
-                "description": "The client should skip over additional fields that are not part of the structure. This allows a\nclient generated against an older Smithy model to be able to communicate with a server that is\ngenerated against a newer Smithy model.",
                 "result": {
                     "byteValue": 5,
                     "doubleValue": 1.889,
@@ -1519,8 +1866,8 @@
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
                     "body": "v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABrZXh0cmFPYmplY3S/c2luZGVmaW5pdGVMZW5ndGhNYXC/a3dpdGhBbkFycmF5nwECA///cWRlZmluaXRlTGVuZ3RoTWFwo3J3aXRoQURlZmluaXRlQXJyYXmDAQIDeB1hbmRTb21lSW5kZWZpbml0ZUxlbmd0aFN0cmluZ3gfdGhhdCBoYXMsIGJlZW4gY2h1bmtlZCBvbiBjb21tYWxub3JtYWxTdHJpbmdjZm9vanNob3J0VmFsdWUZJw9uc29tZU90aGVyRmllbGR2dGhpcyBzaG91bGQgYmUgc2tpcHBlZP9saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w=="
                 }
@@ -1528,33 +1875,52 @@
         ]
     },
     {
-        "description": "Test cases for HttpPayloadWithUnion operation",
+        "description": "Test cases for SparseNullsOperation operation",
         "metadata": {
+            "apiVersion": "2020-07-14",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "rpcv2protocol",
             "protocol": "smithy-rpc-v2-cbor",
             "protocols": [
                 "smithy-rpc-v2-cbor"
             ],
-            "apiVersion": "2020-07-14",
-            "targetPrefix": "RpcV2Protocol"
+            "serviceFullName": "RpcV2Protocol",
+            "serviceId": "RpcV2Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RpcV2Protocol",
+            "targetPrefix": "RpcV2Protocol",
+            "uid": "rpcv2protocol-2020-07-14"
         },
         "shapes": {
-            "HttpPayloadWithUnionInputOutput": {
+            "SparseNullsOperationInputOutput": {
                 "type": "structure",
                 "members": {
-                    "nested": {
-                        "shape": "UnionPayload"
+                    "sparseStringList": {
+                        "shape": "SparseStringList"
+                    },
+                    "sparseStringMap": {
+                        "shape": "SparseStringMap"
                     }
-                },
-                "payload": "nested"
+                }
             },
-            "UnionPayload": {
-                "type": "structure",
-                "members": {
-                    "greeting": {
-                        "shape": "String"
-                    }
+            "SparseStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
                 },
-                "union": true
+                "sparse": true
+            },
+            "SparseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                },
+                "sparse": true
             },
             "String": {
                 "type": "string"
@@ -1562,57 +1928,57 @@
         },
         "cases": [
             {
-                "id": "RpcV2CborPayloadWithUnion",
+                "id": "RpcV2CborSparseMapsDeserializeNullValues",
+                "description": "Deserializes null values in maps",
                 "given": {
-                    "name": "HttpPayloadWithUnion",
+                    "name": "SparseNullsOperation",
                     "http": {
-                        "method": "PUT",
-                        "requestUri": "/HttpPayloadWithUnion",
-                        "responseCode": 200
+                        "method": "POST",
+                        "requestUri": "/"
                     },
                     "output": {
-                        "shape": "HttpPayloadWithUnionInputOutput"
-                    },
-                    "documentation": "<p>This example serializes a union in the payload.</p>",
-                    "idempotent": true
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
                 },
-                "description": "Serializes a union in the payload.",
                 "result": {
-                    "nested": {
-                        "greeting": "hello"
+                    "sparseStringMap": {
+                        "foo": null
                     }
                 },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Type": "application/cbor",
-                        "smithy-protocol": "rpc-v2-cbor"                    },
-                    "body": "oWZuZXN0ZWShaGdyZWV0aW5nZWhlbGxv"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
+                    },
+                    "body": "v29zcGFyc2VTdHJpbmdNYXC/Y2Zvb/b//w=="
                 }
             },
             {
-                "id": "RpcV2CborPayloadWithUnsetUnion",
+                "id": "RpcV2CborSparseListsDeserializeNull",
+                "description": "Deserializes null values in lists",
                 "given": {
-                    "name": "HttpPayloadWithUnion",
+                    "name": "SparseNullsOperation",
                     "http": {
-                        "method": "PUT",
-                        "requestUri": "/HttpPayloadWithUnion",
-                        "responseCode": 200
+                        "method": "POST",
+                        "requestUri": "/"
                     },
                     "output": {
-                        "shape": "HttpPayloadWithUnionInputOutput"
-                    },
-                    "documentation": "<p>This example serializes a union in the payload.</p>",
-                    "idempotent": true
+                        "shape": "SparseNullsOperationInputOutput"
+                    }
                 },
-                "description": "No payload is sent if the union has no value.",
-                "result": {},
+                "result": {
+                    "sparseStringList": [
+                        null
+                    ]
+                },
                 "response": {
                     "status_code": 200,
                     "headers": {
-                        "Content-Length": "0"
+                        "smithy-protocol": "rpc-v2-cbor",
+                        "Content-Type": "application/cbor"
                     },
-                    "body": "v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/"
+                    "body": "v3BzcGFyc2VTdHJpbmdMaXN0n/b//w=="
                 }
             }
         ]

--- a/tests/unit/protocols/protocol-tests-ignore-list.json
+++ b/tests/unit/protocols/protocol-tests-ignore-list.json
@@ -1,6 +1,6 @@
 {
   "general": {
-     "input": {
+    "input": {
       "suites": [
         "Test cases for PutWithContentEncoding operation",
         "Test cases for QueryIdempotencyTokenAutoFill operation",
@@ -10,7 +10,7 @@
     }
   },
   "protocols": {
-    "query" : {
+    "query": {
       "input": {
         "cases": [
           "QueryFlattenedListArgWithXmlName"
@@ -19,12 +19,14 @@
       "output": {
         "cases": [
           "QueryXmlLists",
-          "QueryComplexError"
+          "QueryComplexError",
+          "QueryEmptyInputAndEmptyOutput",
+          "QueryNoInputAndOutput"
         ]
       }
     },
-    "ec2" : {
-      "input" : {
+    "ec2": {
+      "input": {
         "cases": [
           "Ec2QueryEndpointTraitWithHostLabel",
           "Ec2Lists",
@@ -38,13 +40,13 @@
         ]
       }
     },
-    "json" : {
+    "json": {
       "input": {
         "cases": [
           "AwsJson11StructuresDontSerializeNullValues"
         ]
       },
-      "output" : {
+      "output": {
         "cases": [
           "AwsJson11FooErrorUsingXAmznErrorType",
           "AwsJson11FooErrorUsingXAmznErrorTypeWithUri",
@@ -55,8 +57,8 @@
         ]
       }
     },
-    "json_1_0" : {
-      "output" : {
+    "json_1_0": {
+      "output": {
         "cases": [
           "AwsJson10FooErrorUsingXAmznErrorType",
           "AwsJson10FooErrorUsingXAmznErrorTypeWithUri",
@@ -67,8 +69,8 @@
         ]
       }
     },
-    "rest-json" : {
-      "input" : {
+    "rest-json": {
+      "input": {
         "cases": [
           "MediaTypeHeaderInputBase64",
           "RestJsonHttpChecksumRequired",
@@ -79,7 +81,7 @@
           "DocumentTypeAsPayloadInput"
         ]
       },
-      "output" : {
+      "output": {
         "cases": [
           "RestJsonFooErrorUsingXAmznErrorType",
           "RestJsonFooErrorUsingXAmznErrorTypeWithUri",
@@ -89,7 +91,8 @@
           "RestJsonInputAndOutputWithTimestampHeaders",
           "RestJsonInputAndOutputWithQuotedStringHeaders",
           "RestJsonDeserializesDenseSetMapAndSkipsNull",
-          "MediaTypeHeaderOutputBase64"
+          "MediaTypeHeaderOutputBase64",
+          "RestJsonHttpPayloadWithStructureAndEmptyResponseBody"
         ]
       }
     },
@@ -102,6 +105,7 @@
           "HttpPayloadWithXmlNamespace",
           "HttpPayloadWithXmlNamespaceAndPrefix",
           "XmlAttributesOnPayload",
+          "XmlAttributesInMiddle",
           "NullAndEmptyHeaders",
           "RestXmlQueryPrecedence"
         ]
@@ -113,7 +117,8 @@
           "HttpPayloadTraitsWithNoBlobBody",
           "ComplexError",
           "BodyWithXmlName",
-          "XmlLists"
+          "XmlLists",
+          "IgnoreQueryParamsInResponse"
         ]
       }
     },


### PR DESCRIPTION
Backport of [aws/aws-cli#10177](https://github.com/aws/aws-cli/pull/10177).

In this PR:

- JSON and CBOR serializers now handle None values in sparse map and list inputs, same pattern that [#3618](https://github.com/boto/botocore/pull/3618) added for list parsing
- CBOR map parser was silently dropping null values (0xf6) instead of preserving them as None in the resulting dict. This aligns CBOR map parsing with how `_parse_array` already handles nulls, and with the new JSON parser behavior
- Updated protocol tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
