### PR TITLE
Fix CloudFront signer wildcard question mark handling

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -443,8 +443,12 @@ class CloudFrontSigner:
         return self._build_url(url, params)
 
     def _build_url(self, base_url, extra_params):
-        separator = '&' if '?' in base_url else '?'
+        separator = '&' if self._has_query_string(base_url) else '?'
         return base_url + separator + '&'.join(extra_params)
+
+    def _has_query_string(self, url):
+        _, marker, query = url.rpartition('?')
+        return bool(marker and ('=' in query or '&' in query))
 
     def build_policy(
         self, resource, date_less_than, date_greater_than=None, ip_address=None

--- a/tests/unit/test_signers.py
+++ b/tests/unit/test_signers.py
@@ -644,6 +644,17 @@ class TestCloudfrontSigner(BaseSignerTest):
         )
         assert_url_equal(signed_url, expected)
 
+    def test_generate_presign_url_with_wildcard_question_mark(self):
+        signed_url = self.signer.generate_presigned_url(
+            'http://test.com/example_202?.zip',
+            date_less_than=datetime.datetime(2016, 1, 1),
+        )
+        expected = (
+            'http://test.com/example_202?.zip?Expires=1451606400'
+            '&Signature=c2lnbmVk&Key-Pair-Id=MY_KEY_ID'
+        )
+        self.assertEqual(signed_url, expected)
+
     def test_generate_presign_url_with_custom_policy(self):
         policy = self.signer.build_policy(
             'foo',


### PR DESCRIPTION
Fixes #3377

## Summary
This fixes CloudFront signed URL generation for resource URLs that use `?` as a CloudFront wildcard instead of a query-string separator.

## Why
Before this change, `_build_url()` checked only whether `?` existed anywhere in the URL. A resource like `http://test.com/example_202?.zip` was treated as if it already had query parameters, so signing parameters were appended with `&` and produced an invalid URL.

## Test plan
- `.venv/bin/python -m pytest tests/unit/test_signers.py::TestCloudfrontSigner`
- `.venv/bin/python -m black --check botocore/signers.py tests/unit/test_signers.py`
