### PR TITLE
feat(credentials): support web identity duration seconds

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -1957,6 +1957,13 @@ class AssumeRoleWithWebIdentityProvider(CredentialProvider):
         if role_session_name is not None:
             extra_args['RoleSessionName'] = role_session_name
 
+        duration_seconds = self._get_profile_config('duration_seconds')
+        if duration_seconds is not None:
+            try:
+                extra_args['DurationSeconds'] = int(duration_seconds)
+            except ValueError:
+                pass
+
         fetcher = AssumeRoleWithWebIdentityCredentialFetcher(
             client_creator=self._client_creator,
             web_identity_token_loader=token_loader,

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1131,6 +1131,36 @@ class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
             WebIdentityToken='totally.a.token',
         )
 
+    def test_duration_seconds_provided(self):
+        self.config['duration_seconds'] = '7200'
+        response = {
+            'Credentials': {
+                'AccessKeyId': 'foo',
+                'SecretAccessKey': 'bar',
+                'SessionToken': 'baz',
+                'Expiration': self.some_future_time().isoformat(),
+            },
+        }
+        client_creator = self.create_client_creator(with_response=response)
+        mock_loader_cls = self._mock_loader_cls('totally.a.token')
+        provider = credentials.AssumeRoleWithWebIdentityProvider(
+            load_config=self._load_config,
+            client_creator=client_creator,
+            cache={},
+            profile_name=self.profile_name,
+            token_loader_cls=mock_loader_cls,
+        )
+
+        provider.load().get_frozen_credentials()
+
+        client = client_creator.return_value
+        client.assume_role_with_web_identity.assert_called_with(
+            RoleArn='arn:aws:iam::123:role/role-name',
+            DurationSeconds=7200,
+            RoleSessionName=mock.ANY,
+            WebIdentityToken='totally.a.token',
+        )
+
     def test_role_arn_not_set(self):
         del self.config['role_arn']
         client_creator = self.create_client_creator(with_response={})


### PR DESCRIPTION
Fixes #3411

## Summary
This lets the assume-role-with-web-identity provider read `duration_seconds` from profile config and pass it as `DurationSeconds` to STS.

## Why
The regular assume role provider already supports this config, but the web identity provider ignored it. That made web identity sessions keep the default STS duration even when a profile requested a longer session.

## Test plan
- `.venv/bin/python -m pytest tests/unit/test_credentials.py::TestAssumeRoleWithWebIdentityCredentialProvider`
