### PR TITLE
feat(credentials): allow docker host metadata URI

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3075,6 +3075,7 @@ class ContainerMetadataFetcher:
         '169.254.170.23',
         'fd00:ec2::23',
         'localhost',
+        'host.docker.internal',
     ]
 
     def __init__(self, session=None, sleep=time.sleep):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2775,6 +2775,11 @@ class TestContainerMetadataFetcher(unittest.TestCase):
     def test_localhost_with_port_http_is_allowed(self):
         self.assert_can_retrieve_metadata_from('http://localhost:8000/foo')
 
+    def test_docker_host_http_is_allowed(self):
+        self.assert_can_retrieve_metadata_from(
+            'http://host.docker.internal/foo'
+        )
+
     def test_localhost_https_is_allowed(self):
         self.assert_can_retrieve_metadata_from('https://localhost/foo')
 


### PR DESCRIPTION
Fixes #2515

## Summary
This adds `host.docker.internal` to the allowed hosts for container metadata full URI retrieval.

## Why
Docker Desktop exposes the host machine through `host.docker.internal`. Without this allowlist entry, containerized local/test setups cannot point `AWS_CONTAINER_CREDENTIALS_FULL_URI` at a metadata endpoint running on the host over HTTP.

## Test plan
- `.venv/bin/python -m pytest tests/unit/test_utils.py::TestContainerMetadataFetcher`