### PR TITLE
fix(auth): warn on empty bearer token env var

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3630,7 +3630,14 @@ def get_token_from_environment(signing_name, environ=None):
     if environ is None:
         environ = os.environ
     env_var = _get_bearer_env_var_name(signing_name)
-    return environ.get(env_var)
+    token = environ.get(env_var)
+    if token == '':
+        logger.warning(
+            "%s is set to an empty value; requests using bearer "
+            "authentication may fail",
+            env_var,
+        )
+    return token
 
 
 def _get_bearer_env_var_name(signing_name):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,6 +13,7 @@
 import copy
 import datetime
 import io
+import logging
 import operator
 import os
 import shutil
@@ -3724,6 +3725,14 @@ def test_get_token_from_environment_returns_token(
 ):
     monkeypatch.setenv(env_var, token)
     assert get_token_from_environment(signing_name) == token
+
+
+def test_get_token_from_environment_warns_for_empty_token(monkeypatch, caplog):
+    monkeypatch.setenv("AWS_BEARER_TOKEN_MY_SERVICE", "")
+    caplog.set_level(logging.WARNING, logger="botocore.utils")
+
+    assert get_token_from_environment("my-service") == ""
+    assert "AWS_BEARER_TOKEN_MY_SERVICE is set to an empty value" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #3603

## Summary
This logs a warning when a bearer token environment variable is set to an empty string.

## Why
An empty bearer token is still treated as configured today, which matches the current environment-variable behavior. The hard part for users is diagnosing it: requests can fail later with confusing service-side auth errors. This warning makes the bad configuration visible without changing token resolution semantics.

## Test plan
- `.venv/bin/python -m pytest tests/unit/test_utils.py::test_get_token_from_environment_warns_for_empty_token tests/unit/test_utils.py::test_get_token_from_environment_returns_token tests/unit/test_utils.py::test_get_token_from_environment_returns_none`
- `git diff --check`
