### PR TITLE
Document policyDocumentShape for iam operations as a dict

### DIFF
--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -205,6 +205,76 @@ class AppendParamDocumentation:
             description_section.writeln(self._doc_string)
 
 
+class DocumentModifiedShape:
+    """Modifies the documentation for a shape to reflect runtime transformations.
+
+    This is used when a handler transforms a shape's value at runtime
+    (e.g., decoding a JSON string into a dict) and the documentation
+    needs to reflect the actual Python type returned rather than the
+    modeled type.
+    """
+
+    def __init__(
+        self, shape_name, new_type, new_description, new_example_value
+    ):
+        self._shape_name = shape_name
+        self._new_type = new_type
+        self._new_description = new_description
+        self._new_example_value = new_example_value
+
+    def replace_documentation_for_matching_shape(
+        self, event_name, section, **kwargs
+    ):
+        if self._shape_name == section.context.get('shape'):
+            self._replace_documentation(event_name, section)
+        for section_name in section.available_sections:
+            sub_section = section.get_section(section_name)
+            if self._shape_name == sub_section.context.get('shape'):
+                self._replace_documentation(event_name, sub_section)
+            else:
+                self.replace_documentation_for_matching_shape(
+                    event_name, sub_section
+                )
+
+    def _replace_documentation(self, event_name, section):
+        if event_name.startswith(
+            'docs.request-example'
+        ) or event_name.startswith('docs.response-example'):
+            section.remove_all_sections()
+            section.clear_text()
+            section.write(self._new_example_value)
+
+        if event_name.startswith(
+            'docs.request-params'
+        ) or event_name.startswith('docs.response-params'):
+            allowed_sections = (
+                'param-name',
+                'param-documentation',
+                'end-structure',
+                'param-type',
+                'end-param',
+            )
+            for section_name in section.available_sections:
+                # Delete any extra members as a new shape is being
+                # used.
+                if section_name not in allowed_sections:
+                    section.delete_section(section_name)
+
+            # Update the documentation
+            description_section = section.get_section('param-documentation')
+            description_section.clear_text()
+            description_section.write(self._new_description)
+
+            # Update the param type
+            type_section = section.get_section('param-type')
+            if type_section.getvalue().decode('utf-8').startswith(':type'):
+                type_section.clear_text()
+                type_section.write(f':type {section.name}: {self._new_type}')
+            else:
+                type_section.clear_text()
+                type_section.style.italics(f'({self._new_type}) -- ')
+
+
 _CONTROLS = {
     '\n': '\\n',
     '\r': '\\r',

--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -287,7 +287,8 @@ class DocumentModifiedShape:
                 type_section.write(f':type {section.name}: {self._new_type}')
             else:
                 type_section.clear_text()
-                type_section.style.italics(f'({self._new_type}) -- ')
+                type_section.style.italics(f'({self._new_type}) --')
+                type_section.write(' ')
 
 
 _CONTROLS = {

--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -220,13 +220,11 @@ class DocumentModifiedShape:
         new_type,
         new_description,
         new_example_value,
-        append_description=False,
     ):
         self._shape_name = shape_name
         self._new_type = new_type
         self._new_description = new_description
         self._new_example_value = new_example_value
-        self._append_description = append_description
 
     def replace_documentation_for_matching_shape(
         self, event_name, section, **kwargs
@@ -274,11 +272,8 @@ class DocumentModifiedShape:
                 description_section = section.get_section(
                     'param-documentation'
                 )
-                if self._append_description:
-                    description_section.write(self._new_description)
-                else:
-                    description_section.clear_text()
-                    description_section.write(self._new_description)
+                description_section.clear_text()
+                description_section.write(self._new_description)
 
             # Update the param type
             type_section = section.get_section('param-type')

--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -267,7 +267,10 @@ class DocumentModifiedShape:
                     section.delete_section(section_name)
 
             # Update the documentation.
-            if self._new_description is not None:
+            if (
+                self._new_description is not None
+                and 'param-documentation' in section.available_sections
+            ):
                 description_section = section.get_section(
                     'param-documentation'
                 )

--- a/botocore/docs/utils.py
+++ b/botocore/docs/utils.py
@@ -215,12 +215,18 @@ class DocumentModifiedShape:
     """
 
     def __init__(
-        self, shape_name, new_type, new_description, new_example_value
+        self,
+        shape_name,
+        new_type,
+        new_description,
+        new_example_value,
+        append_description=False,
     ):
         self._shape_name = shape_name
         self._new_type = new_type
         self._new_description = new_description
         self._new_example_value = new_example_value
+        self._append_description = append_description
 
     def replace_documentation_for_matching_shape(
         self, event_name, section, **kwargs
@@ -260,10 +266,16 @@ class DocumentModifiedShape:
                 if section_name not in allowed_sections:
                     section.delete_section(section_name)
 
-            # Update the documentation
-            description_section = section.get_section('param-documentation')
-            description_section.clear_text()
-            description_section.write(self._new_description)
+            # Update the documentation.
+            if self._new_description is not None:
+                description_section = section.get_section(
+                    'param-documentation'
+                )
+                if self._append_description:
+                    description_section.write(self._new_description)
+                else:
+                    description_section.clear_text()
+                    description_section.write(self._new_description)
 
             # Update the param type
             type_section = section.get_section('param-type')

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1545,10 +1545,11 @@ BUILTIN_HANDLERS = [
             'policyDocumentType',
             new_type='dict',
             new_description=(
-                'The policy document as a URL-encoded JSON-decoded dict. '
-                'This is automatically decoded from the original JSON string.'
+                ' This value is automatically parsed from the'
+                ' JSON string returned by the service.'
             ),
             new_example_value='{}',
+            append_description=True,
         ).replace_documentation_for_matching_shape,
     ),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -50,6 +50,7 @@ from botocore.compat import (
 from botocore.docs.utils import (
     AppendParamDocumentation,
     AutoPopulatedParam,
+    DocumentModifiedShape,
     HideParamFromOperations,
 )
 from botocore.endpoint_provider import VALID_HOST_LABEL_RE
@@ -1538,6 +1539,18 @@ BUILTIN_HANDLERS = [
         enable_millisecond_timestamp_precision,
     ),
     ('after-call.iam', json_decode_policies),
+    (
+        'docs.*.iam.*.complete-section',
+        DocumentModifiedShape(
+            'policyDocumentType',
+            new_type='dict',
+            new_description=(
+                'The policy document as a URL-encoded JSON-decoded dict. '
+                'This is automatically decoded from the original JSON string.'
+            ),
+            new_example_value='{}',
+        ).replace_documentation_for_matching_shape,
+    ),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),
     ('after-call.cloudformation.GetTemplate', json_decode_template_body),
     ('after-call.s3.GetBucketLocation', parse_get_bucket_location),

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1544,12 +1544,8 @@ BUILTIN_HANDLERS = [
         DocumentModifiedShape(
             'policyDocumentType',
             new_type='dict',
-            new_description=(
-                ' This value is automatically parsed from the'
-                ' JSON string returned by the service.'
-            ),
+            new_description=None,
             new_example_value='{}',
-            append_description=True,
         ).replace_documentation_for_matching_shape,
     ),
     ('after-call.ec2.GetConsoleOutput', decode_console_output),


### PR DESCRIPTION
*Issue #, if available:*

* https://github.com/boto/boto3/issues/229
* Resolves D95731475 (internal)

*Notes:*

* botocore has a built-in handler that automatically converts all `policyDocumentType` shapes for the `iam` service from a string to a dict, using JSON decoding. However, the boto3 docs describes fields with this type as a string, because it is unaware of the runtime transformation. This bugfix updates the documented type to match the runtime type, performing similar transformation logic to the documented type. There is existing precedent for this in boto3 for DynamoDB.
* Must be sim-shipped with https://github.com/boto/boto3/pull/4795.

*Description of changes:*

* Port `DocumentModifiedShape` class from `boto3`, with the following changes:
  * Class-level documentation comments.
  * When `new_description` is `None`, the description is unmodified.
* Add built-in handler that updates the documented type of all `iam` service `policyDocumentType` shapes. These shapes are auto-converted to a dict; the new handler auto-converts their documented type to match the runtime type.

*Description of tests:*

* Successfully pass all tests (see GitHub Actions).
* Ran the following script and observed expected behavior:

```python
import botocore.session
from botocore.docs.bcdoc.restdoc import DocumentStructure
from botocore.docs.method import document_model_driven_method

session = botocore.session.get_session()
client = session.create_client('iam', region_name='us-east-1')
op_model = client.meta.service_model.operation_model('GetRole')

doc = DocumentStructure('test', target='html')
section = doc.add_new_section('method')
document_model_driven_method(
    section, 'get_role', op_model,
    event_emitter=client.meta.events,
    example_prefix='response = client.get_role',
)

content = doc.flush_structure().decode('utf-8')
assert "'AssumeRolePolicyDocument': {}" in content
assert '*(dict) --*' in content or '(*dict*) --' in content
print("PASS: AssumeRolePolicyDocument documented as dict")
```

* Connected local boto3 to a modified botocore with the changes in this PR. Then, I rebuilt the docs, and verified the HTML looks correct:

<img width="752" height="217" alt="image" src="https://github.com/user-attachments/assets/9c218463-9a53-4189-a759-56aa6c944a90" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
