### PR TITLE
validate region from S3 redirect response in S3RegionRedirector

### DIFF
--- a/.changes/next-release/bugfix-s3-42137.json
+++ b/.changes/next-release/bugfix-s3-42137.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Validate the bucket region sourced from S3 redirect responses in the deprecated ``S3RegionRedirector``, matching ``S3RegionRedirectorv2``."
+}

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -2077,21 +2077,20 @@ class S3RegionRedirector:
         service_response = response[1]
         response_headers = service_response['ResponseMetadata']['HTTPHeaders']
         if 'x-amz-bucket-region' in response_headers:
-            return response_headers['x-amz-bucket-region']
-
+            region = response_headers['x-amz-bucket-region']
         # Next, check the error body
-        region = service_response.get('Error', {}).get('Region', None)
-        if region is not None:
-            return region
+        elif r := service_response.get('Error', {}).get('Region', None):
+            region = r
+        else:
+            # Finally, HEAD the bucket. No other choice sadly.
+            try:
+                response = self._client.head_bucket(Bucket=bucket)
+                headers = response['ResponseMetadata']['HTTPHeaders']
+            except ClientError as e:
+                headers = e.response['ResponseMetadata']['HTTPHeaders']
 
-        # Finally, HEAD the bucket. No other choice sadly.
-        try:
-            response = self._client.head_bucket(Bucket=bucket)
-            headers = response['ResponseMetadata']['HTTPHeaders']
-        except ClientError as e:
-            headers = e.response['ResponseMetadata']['HTTPHeaders']
-
-        region = headers.get('x-amz-bucket-region', None)
+            region = headers.get('x-amz-bucket-region', None)
+        validate_region_name(region)
         return region
 
     def set_request_url(self, params, context, **kwargs):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,6 +17,7 @@ import operator
 import os
 import shutil
 import tempfile
+import warnings
 from contextlib import contextmanager
 from sys import getrefcount
 
@@ -66,6 +67,7 @@ from botocore.utils import (
     JSONFileCache,
     S3ArnParamHandler,
     S3EndpointSetter,
+    S3RegionRedirector,
     S3RegionRedirectorv2,
     SSOTokenLoader,
     _get_bearer_env_var_name,
@@ -2196,6 +2198,61 @@ class TestS3RegionRedirector(unittest.TestCase):
     def test_get_region_validates_region_from_head_bucket(self):
         self.set_client_response_headers(
             {'x-amz-bucket-region': 'invalid region!'}
+        )
+        response = (
+            None,
+            {
+                'Error': {'Code': 'PermanentRedirect'},
+                'ResponseMetadata': {'HTTPHeaders': {}},
+            },
+        )
+        with self.assertRaises(InvalidRegionError):
+            self.redirector.get_bucket_region('foo', response)
+
+
+class TestDeprecatedS3RegionRedirector(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', FutureWarning)
+            self.redirector = S3RegionRedirector(mock.Mock(), self.client)
+
+    def test_get_region_validates_region_from_header(self):
+        response = (
+            None,
+            {
+                'Error': {'Code': 'PermanentRedirect'},
+                'ResponseMetadata': {
+                    'HTTPHeaders': {'x-amz-bucket-region': 'invalid region!'}
+                },
+            },
+        )
+        with self.assertRaises(InvalidRegionError):
+            self.redirector.get_bucket_region('foo', response)
+
+    def test_get_region_validates_region_from_error_body(self):
+        response = (
+            None,
+            {
+                'Error': {
+                    'Code': 'PermanentRedirect',
+                    'Region': 'invalid region!',
+                },
+                'ResponseMetadata': {'HTTPHeaders': {}},
+            },
+        )
+        with self.assertRaises(InvalidRegionError):
+            self.redirector.get_bucket_region('foo', response)
+
+    def test_get_region_validates_region_from_head_bucket(self):
+        self.client.head_bucket.side_effect = ClientError(
+            {
+                'Error': {'Code': '', 'Message': ''},
+                'ResponseMetadata': {
+                    'HTTPHeaders': {'x-amz-bucket-region': 'invalid region!'}
+                },
+            },
+            'HeadBucket',
         )
         response = (
             None,


### PR DESCRIPTION
**Unvalidated bucket region in S3RegionRedirector**

The deprecated `S3RegionRedirector.get_bucket_region` returns the region taken from a redirect response (the `x-amz-bucket-region` header, the error body `Region`, or the HeadBucket fallback) as-is, whereas its replacement `S3RegionRedirectorv2` already runs `validate_region_name` on the same value. The two classes therefore disagree on whether a server-supplied region is checked. That region then feeds endpoint resolution, the rewritten request URL and the SigV4 signing region, so an untrusted or misbehaving endpoint can push an arbitrary string through this path. I have kept the change to the v2 behaviour and applied the same `validate_region_name` call; nothing else in the flow changes. Added unit cover for the three sources. The class is deprecated, but it is still importable and used by third parties, so bringing it in line seems worthwhile.