### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,7 @@ universal = 0
 requires_dist =
     jmespath>=0.7.1,<2.0.0
     python-dateutil>=2.1,<3.0.0
-    urllib3>=1.25.4,<1.27; python_version<"3.10"
-    urllib3>=1.25.4,!=2.2.0,<3; python_version>="3.10"
+    urllib3>=1.25.4,!=2.2.0,<3
 
 [options.extras_require]
 crt = awscrt==0.32.2


### PR DESCRIPTION
*Issue #, if available:*
Small cleanup from the 3.9 deprecation missed in https://github.com/boto/botocore/pull/3679

*Description of changes:*
Removes the conditional urllib3 version based on the python version in setup.cfg that was already removed in setup.py.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
