### PR TITLE
reject trailing newline in host label validators

### DIFF
--- a/.changes/next-release/bugfix-validators-newline.json
+++ b/.changes/next-release/bugfix-validators-newline.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Validators",
+  "description": "Anchor the host label, region, bucket name and host prefix validators with ``\\Z`` so a value with a trailing newline is rejected instead of slipping through ``$`` into the request host."
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -88,7 +88,7 @@ REGISTER_LAST = object()
 # to be as long as 255 characters, and bucket names can contain any
 # combination of uppercase letters, lowercase letters, numbers, periods
 # (.), hyphens (-), and underscores (_).
-VALID_BUCKET = re.compile(r'^[a-zA-Z0-9.\-_]{1,255}$')
+VALID_BUCKET = re.compile(r'^[a-zA-Z0-9.\-_]{1,255}\Z')
 _ACCESSPOINT_ARN = (
     r'^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:]'
     r'[a-zA-Z0-9\-.]{1,63}$'
@@ -1002,7 +1002,7 @@ class ClientMethodAlias:
 class HeaderToHostHoister:
     """Takes a header and moves it to the front of the hoststring."""
 
-    _VALID_HOSTNAME = re.compile(r'(?!-)[a-z\d-]{1,63}(?<!-)$', re.IGNORECASE)
+    _VALID_HOSTNAME = re.compile(r'(?!-)[a-z\d-]{1,63}(?<!-)\Z', re.IGNORECASE)
 
     def __init__(self, header_name):
         self._header_name = header_name

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -64,7 +64,7 @@ DEFAULT_TIMESTAMP_FORMAT = 'iso8601'
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 # Same as ISO8601, but with microsecond precision.
 ISO8601_MICRO = '%Y-%m-%dT%H:%M:%S.%fZ'
-HOST_PREFIX_RE = re.compile(r"^[A-Za-z0-9\.\-]+$")
+HOST_PREFIX_RE = re.compile(r"^[A-Za-z0-9\.\-]+\Z")
 
 TIMESTAMP_PRECISION_DEFAULT = 'default'
 TIMESTAMP_PRECISION_MILLISECOND = 'millisecond'

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1335,7 +1335,7 @@ def validate_region_name(region_name):
     """Provided region_name must be a valid host label."""
     if region_name is None:
         return
-    valid_host_label = re.compile(r'^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$')
+    valid_host_label = re.compile(r'^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)\Z')
     valid = valid_host_label.match(region_name)
     if not valid:
         raise InvalidRegionError(region_name=region_name)
@@ -2644,7 +2644,7 @@ class S3EndpointSetter:
 class S3ControlEndpointSetter:
     _DEFAULT_PARTITION = 'aws'
     _DEFAULT_DNS_SUFFIX = 'amazonaws.com'
-    _HOST_LABEL_REGEX = re.compile(r'^[a-zA-Z0-9\-]{1,63}$')
+    _HOST_LABEL_REGEX = re.compile(r'^[a-zA-Z0-9\-]{1,63}\Z')
 
     def __init__(
         self,

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -793,6 +793,15 @@ class TestHandlers(BaseSessionTest):
         with self.assertRaises(ParamValidationError):
             handlers.validate_bucket_name(params)
 
+    def test_trailing_newline_in_bucket_raises_exception(self):
+        params = {
+            'Bucket': 'my-bucket-name\n',
+            'Key': 'foo',
+            'Body': b'asdf',
+        }
+        with self.assertRaises(ParamValidationError):
+            handlers.validate_bucket_name(params)
+
     def test_not_dns_compat_but_still_valid_bucket_name(self):
         params = {
             'Bucket': 'foasdf......bar--baz-a_b_CD10',
@@ -1622,6 +1631,10 @@ class TestPrependToHost(unittest.TestCase):
     def test_does_validate_host_with_illegal_char(self):
         with self.assertRaises(ParamValidationError):
             self._prepend_to_host('https://example.com/path', 'host#name')
+
+    def test_does_validate_host_with_trailing_newline(self):
+        with self.assertRaises(ParamValidationError):
+            self._prepend_to_host('https://example.com/path', 'host\n')
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -102,6 +102,7 @@ from botocore.utils import (
     switch_host_s3_accelerate,
     switch_to_virtual_host_style,
     validate_jmespath_for_set,
+    validate_region_name,
 )
 from tests import FreezeTime, RawResponse, create_session, mock, unittest
 
@@ -999,6 +1000,22 @@ class TestIsValidEndpointURL(unittest.TestCase):
 
     def test_hostname_no_dots(self):
         self.assertTrue(is_valid_endpoint_url('https://foo/'))
+
+
+class TestValidateRegionName(unittest.TestCase):
+    def test_valid_region(self):
+        self.assertIsNone(validate_region_name('us-east-1'))
+
+    def test_none_is_allowed(self):
+        self.assertIsNone(validate_region_name(None))
+
+    def test_trailing_newline_is_rejected(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('us-east-1\n')
+
+    def test_embedded_newline_is_rejected(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('us-east\n-1')
 
 
 class TestFixS3Host(unittest.TestCase):


### PR DESCRIPTION
botocore's host label validators all anchor with `$`, which in Python also matches just before a trailing newline, so a value such as `us-east-1\n`, `mybucket\n` or a `data\n` host prefix passes validation and the unchanged string is then used to build the request host. `validate_region_name` even documents that its argument must be a valid host label, yet it accepts the newline, and the same gap exists in `validate_bucket_name`, the `HeaderToHostHoister` hostname check, the `S3ControlEndpointSetter` host label check and the serialiser host prefix check. The region case is the most exposed because that value can be sourced from an S3 cross-region redirect response and then feeds endpoint resolution and the SigV4 signing scope. `is_valid_endpoint_url` already screens for `\t\r\n` through `UNSAFE_URL_CHARS`, so these label validators are the remaining place a control character can slip past. I moved the trailing anchor to `\Z` in each one so a match has to reach the actual end of the string, and left the ARN and resource regexes alone since those re-extract a clean label and never carry a newline through. Valid regions, bucket names and host labels behave exactly as before.