### PR TITLE
Add static stability to credential refresh

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -27,7 +27,11 @@ from botocore.awsrequest import prepare_request_dict
 from botocore.compress import maybe_compress_request
 from botocore.config import Config
 from botocore.context import with_current_context
-from botocore.credentials import RefreshableCredentials
+from botocore.credentials import (
+    DEFAULT_NEW_CREDENTIAL_REFRESH,
+    RefreshableCredentials,
+    _StrictRefreshableCredentials,
+)
 from botocore.discovery import (
     EndpointDiscoveryHandler,
     EndpointDiscoveryManager,
@@ -389,7 +393,14 @@ class ClientCreator:
     ):
         if client.meta.service_model.service_name != 's3':
             return
-        S3ExpressIdentityResolver(client, RefreshableCredentials).register()
+        if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+            S3ExpressIdentityResolver(
+                client, RefreshableCredentials
+            ).register()
+            return
+        S3ExpressIdentityResolver(
+            client, _StrictRefreshableCredentials
+        ).register()
 
     def _register_s3_events(
         self,

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -17,6 +17,7 @@ import getpass
 import json
 import logging
 import os
+import random
 import subprocess
 import threading
 import time
@@ -69,6 +70,17 @@ from botocore.utils import (
     parse_key_val_file,
     resolve_imds_endpoint_mode,
 )
+
+try:
+    # This is not a public interface and is subject to abrupt breaking changes.
+    # Currently, it's only available to internal users for testing and validation
+    # of the new credential refresh behavior. Any usage is not advised or
+    # supported in external code bases.
+    from botocore.customizations.credentials import (
+        DEFAULT_NEW_CREDENTIAL_REFRESH,
+    )
+except ImportError:
+    DEFAULT_NEW_CREDENTIAL_REFRESH = False
 
 logger = logging.getLogger(__name__)
 ReadOnlyCredentials = namedtuple(
@@ -428,6 +440,7 @@ class RefreshableCredentials(Credentials):
         self._expiry_time = expiry_time
         self._time_fetcher = time_fetcher
         self._refresh_lock = threading.Lock()
+        self._refresh_blocked_until = None
         self.method = method
         self._frozen_credentials = ReadOnlyCredentials(
             access_key, secret_key, token, account_id
@@ -563,7 +576,125 @@ class RefreshableCredentials(Credentials):
         # Checks if the current credentials are expired.
         return self.refresh_needed(refresh_in=0)
 
+    def _in_refresh_backoff(self):
+        if self._refresh_blocked_until is None:
+            return False
+        return self._time_fetcher() < self._refresh_blocked_until
+
+    def _enter_refresh_backoff(self):
+        # Apply a jittered 5-10 minute backoff after a failed refresh to avoid
+        # overwhelming the credential source during an outage.
+        backoff = random.uniform(300, 600)
+        now = self._time_fetcher()
+        self._refresh_blocked_until = now + datetime.timedelta(seconds=backoff)
+        return backoff
+
     def _refresh(self):
+        if DEFAULT_NEW_CREDENTIAL_REFRESH:
+            return self._refresh_with_backoff()
+        return self._refresh_legacy()
+
+    def _refresh_with_backoff(self):
+        # In the common case where we don't need a refresh, we
+        # can immediately exit and not require acquiring the
+        # refresh lock.
+        if not self.refresh_needed(self._advisory_refresh_timeout):
+            return
+
+        # A previous refresh attempt failed; wait before attempting
+        # another refresh.
+        if self._in_refresh_backoff():
+            return
+
+        # acquire() doesn't accept kwargs, but False is indicating
+        # that we should not block if we can't acquire the lock.
+        # If we aren't able to acquire the lock, we'll trigger
+        # the else clause.
+        if self._refresh_lock.acquire(False):
+            try:
+                if not self.refresh_needed(self._advisory_refresh_timeout):
+                    return
+                self._protected_refresh_with_backoff()
+                return
+            finally:
+                self._refresh_lock.release()
+        elif self.refresh_needed(self._mandatory_refresh_timeout):
+            # If we're within the mandatory refresh window,
+            # we must block until we get refreshed credentials.
+            with self._refresh_lock:
+                if not self.refresh_needed(self._mandatory_refresh_timeout):
+                    return
+                self._protected_refresh_with_backoff()
+
+    def _protected_refresh_with_backoff(self):
+        # precondition: this method should only be called if you've acquired
+        # the self._refresh_lock.
+        if self._in_refresh_backoff():
+            # Another caller entered refresh backoff while we were waiting
+            # for the lock. Skip the refresh attempt.
+            return
+        try:
+            metadata = self._refresh_using()
+        except Exception as e:
+            self._handle_refresh_failure(e)
+            return
+        error = self._validate_data(metadata)
+        if error is not None:
+            self._handle_refresh_failure(error)
+            return
+        self._set_from_validated_data(metadata)
+        self._refresh_blocked_until = None
+        self._frozen_credentials = ReadOnlyCredentials(
+            self._access_key, self._secret_key, self._token, self._account_id
+        )
+
+    def _set_from_validated_data(self, data):
+        # Only called once the data has passed ``_validate_data``, so we never
+        # cache missing or expired credentials.
+        self.access_key = data['access_key']
+        self.secret_key = data['secret_key']
+        self.token = data['token']
+        self._expiry_time = parse(data['expiry_time'])
+        self.account_id = data.get('account_id')
+        logger.debug(
+            "Retrieved credentials will expire at: %s", self._expiry_time
+        )
+        self._normalize()
+
+    def _validate_data(self, data):
+        expected_keys = ['access_key', 'secret_key', 'token', 'expiry_time']
+        if not data:
+            missing_keys = expected_keys
+        else:
+            missing_keys = [k for k in expected_keys if k not in data]
+
+        if missing_keys:
+            return (
+                "credential refresh failed, response did not contain: "
+                f"{', '.join(missing_keys)}"
+            )
+
+        if parse(data['expiry_time']) <= self._time_fetcher():
+            return "credential source returned expired credentials"
+        return None
+
+    def _handle_refresh_failure(self, error):
+        if self._frozen_credentials is None:
+            # No credentials have been successfully obtained yet, so we
+            # have nothing to fall back to.
+            raise CredentialRetrievalError(
+                provider=self.method, error_msg=str(error)
+            )
+        backoff = self._enter_refresh_backoff()
+        logger.warning(
+            "Credential refresh failed: %s. The SDK will continue using "
+            "cached credentials. A refresh of these credentials will be "
+            "attempted again after %.0f seconds.",
+            error,
+            backoff,
+        )
+
+    def _refresh_legacy(self):
         # In the common case where we don't need a refresh, we
         # can immediately exit and not require acquiring the
         # refresh lock.
@@ -713,6 +844,7 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         self._expiry_time = None
         self._time_fetcher = time_fetcher
         self._refresh_lock = threading.Lock()
+        self._refresh_blocked_until = None
         self.method = method
         self._frozen_credentials = None
 

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -591,8 +591,9 @@ class RefreshableCredentials(Credentials):
 
     def _refresh(self):
         if DEFAULT_NEW_CREDENTIAL_REFRESH:
-            return self._refresh_with_backoff()
-        return self._refresh_legacy()
+            self._refresh_with_backoff()
+        else:
+            self._refresh_legacy()
 
     def _refresh_with_backoff(self):
         # In the common case where we don't need a refresh, we

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -686,12 +686,6 @@ class RefreshableCredentials(Credentials):
         return None
 
     def _handle_refresh_failure(self, error):
-        if self._frozen_credentials is None:
-            # No credentials have been successfully obtained yet, so we
-            # have nothing to fall back to.
-            raise CredentialRetrievalError(
-                provider=self.method, error_msg=str(error)
-            )
         backoff = self._enter_refresh_backoff()
         logger.warning(
             "Credential refresh failed: %s. The SDK will continue using "
@@ -859,6 +853,15 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         if self._frozen_credentials is None:
             return True
         return super().refresh_needed(refresh_in)
+
+    def _handle_refresh_failure(self, error):
+        if self._frozen_credentials is None:
+            # No credentials have been successfully obtained yet, so we
+            # have nothing to fall back to.
+            raise CredentialRetrievalError(
+                provider=self.method, error_msg=str(error)
+            )
+        super()._handle_refresh_failure(error)
 
 
 class CachedCredentialFetcher:

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -605,6 +605,12 @@ class RefreshableCredentials(Credentials):
         # A previous refresh attempt failed; wait before attempting
         # another refresh.
         if self._in_refresh_backoff():
+            logger.debug(
+                "Credential refresh is in backoff following a failed attempt. "
+                "Using cached credentials. The next refresh attempt is allowed "
+                "at %s.",
+                self._refresh_blocked_until,
+            )
             return
 
         # acquire() doesn't accept kwargs, but False is indicating

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -581,21 +581,25 @@ class RefreshableCredentials(Credentials):
             return False
         return self._time_fetcher() < self._refresh_blocked_until
 
-    def _enter_refresh_backoff(self):
+    def _enter_refresh_backoff(self, error):
         # Apply a jittered 5-10 minute backoff after a failed refresh to avoid
         # overwhelming the credential source during an outage.
         backoff = random.uniform(300, 600)
         now = self._time_fetcher()
         self._refresh_blocked_until = now + datetime.timedelta(seconds=backoff)
-        return backoff
+        logger.warning(
+            "Credential refresh failed: %s. The SDK will continue using "
+            "cached credentials. A refresh of these credentials will be "
+            "attempted again after %.0f seconds.",
+            error,
+            backoff,
+        )
 
     def _refresh(self):
-        if DEFAULT_NEW_CREDENTIAL_REFRESH:
-            self._refresh_with_backoff()
-        else:
+        if not DEFAULT_NEW_CREDENTIAL_REFRESH:
             self._refresh_legacy()
+            return
 
-    def _refresh_with_backoff(self):
         # In the common case where we don't need a refresh, we
         # can immediately exit and not require acquiring the
         # refresh lock.
@@ -621,7 +625,10 @@ class RefreshableCredentials(Credentials):
             try:
                 if not self.refresh_needed(self._advisory_refresh_timeout):
                     return
-                self._protected_refresh_with_backoff()
+                is_mandatory_refresh = self.refresh_needed(
+                    self._mandatory_refresh_timeout
+                )
+                self._protected_refresh(is_mandatory=is_mandatory_refresh)
                 return
             finally:
                 self._refresh_lock.release()
@@ -631,9 +638,9 @@ class RefreshableCredentials(Credentials):
             with self._refresh_lock:
                 if not self.refresh_needed(self._mandatory_refresh_timeout):
                     return
-                self._protected_refresh_with_backoff()
+                self._protected_refresh(is_mandatory=True)
 
-    def _protected_refresh_with_backoff(self):
+    def _protected_refresh(self, is_mandatory):
         # precondition: this method should only be called if you've acquired
         # the self._refresh_lock.
         if self._in_refresh_backoff():
@@ -643,11 +650,11 @@ class RefreshableCredentials(Credentials):
         try:
             metadata = self._refresh_using()
         except Exception as e:
-            self._handle_refresh_failure(e)
+            self._handle_refresh_exception(e)
             return
         error = self._validate_data(metadata)
         if error is not None:
-            self._handle_refresh_failure(error)
+            self._handle_invalid_refresh_response(error)
             return
         self._set_from_validated_data(metadata)
         self._refresh_blocked_until = None
@@ -676,24 +683,17 @@ class RefreshableCredentials(Credentials):
             missing_keys = [k for k in expected_keys if k not in data]
 
         if missing_keys:
-            return (
-                "credential refresh failed, response did not contain: "
-                f"{', '.join(missing_keys)}"
-            )
+            return f"Response did not contain: {', '.join(missing_keys)}"
 
         if parse(data['expiry_time']) <= self._time_fetcher():
-            return "credential source returned expired credentials"
+            return "Credential source returned expired credentials"
         return None
 
-    def _handle_refresh_failure(self, error):
-        backoff = self._enter_refresh_backoff()
-        logger.warning(
-            "Credential refresh failed: %s. The SDK will continue using "
-            "cached credentials. A refresh of these credentials will be "
-            "attempted again after %.0f seconds.",
-            error,
-            backoff,
-        )
+    def _handle_refresh_exception(self, error):
+        self._enter_refresh_backoff(error)
+
+    def _handle_invalid_refresh_response(self, error):
+        self._enter_refresh_backoff(error)
 
     def _refresh_legacy(self):
         # In the common case where we don't need a refresh, we
@@ -713,7 +713,9 @@ class RefreshableCredentials(Credentials):
                 is_mandatory_refresh = self.refresh_needed(
                     self._mandatory_refresh_timeout
                 )
-                self._protected_refresh(is_mandatory=is_mandatory_refresh)
+                self._protected_refresh_legacy(
+                    is_mandatory=is_mandatory_refresh
+                )
                 return
             finally:
                 self._refresh_lock.release()
@@ -723,9 +725,9 @@ class RefreshableCredentials(Credentials):
             with self._refresh_lock:
                 if not self.refresh_needed(self._mandatory_refresh_timeout):
                     return
-                self._protected_refresh(is_mandatory=True)
+                self._protected_refresh_legacy(is_mandatory=True)
 
-    def _protected_refresh(self, is_mandatory):
+    def _protected_refresh_legacy(self, is_mandatory):
         # precondition: this method should only be called if you've acquired
         # the self._refresh_lock.
         try:
@@ -830,6 +832,54 @@ class RefreshableCredentials(Credentials):
         return self._frozen_credentials
 
 
+class _StrictRefreshableCredentials(RefreshableCredentials):
+    """Refreshable credentials that surface refresh failures to the caller
+    instead of falling back to the cached credentials.
+    """
+
+    def _in_refresh_backoff(self):
+        return False
+
+    def _protected_refresh(self, is_mandatory):
+        # precondition: this method should only be called if you've acquired
+        # the self._refresh_lock.
+        try:
+            metadata = self._refresh_using()
+        except Exception:
+            period_name = 'mandatory' if is_mandatory else 'advisory'
+            logger.warning(
+                "Refreshing temporary credentials failed "
+                "during %s refresh period.",
+                period_name,
+                exc_info=True,
+            )
+            if is_mandatory:
+                # If this is a mandatory refresh, then
+                # all errors that occur when we attempt to refresh
+                # credentials are propagated back to the user.
+                raise
+            # Otherwise we'll just return.
+            # The end result will be that we'll use the current
+            # set of temporary credentials we have.
+            return
+        self._set_from_data(metadata)
+        self._frozen_credentials = ReadOnlyCredentials(
+            self._access_key, self._secret_key, self._token, self._account_id
+        )
+        if self._is_expired():
+            # We successfully refreshed credentials but for whatever
+            # reason, our refreshing function returned credentials
+            # that are still expired.  In this scenario, the only
+            # thing we can do is let the user know and raise
+            # an exception.
+            msg = (
+                "Credentials were refreshed, but the "
+                "refreshed credentials are still expired."
+            )
+            logger.warning(msg)
+            raise RuntimeError(msg)
+
+
 class DeferredRefreshableCredentials(RefreshableCredentials):
     """Refreshable credentials that don't require initial credentials.
 
@@ -854,14 +904,19 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
             return True
         return super().refresh_needed(refresh_in)
 
-    def _handle_refresh_failure(self, error):
+    # Before the first successful deferred fetch, there are no cached
+    # credentials to fall back to, so initial failures must be surfaced.
+    def _handle_refresh_exception(self, error):
         if self._frozen_credentials is None:
-            # No credentials have been successfully obtained yet, so we
-            # have nothing to fall back to.
+            raise error
+        super()._handle_refresh_exception(error)
+
+    def _handle_invalid_refresh_response(self, error):
+        if self._frozen_credentials is None:
             raise CredentialRetrievalError(
                 provider=self.method, error_msg=str(error)
             )
-        super()._handle_refresh_failure(error)
+        super()._handle_invalid_refresh_response(error)
 
 
 class CachedCredentialFetcher:
@@ -1226,7 +1281,15 @@ class ProcessProvider(CredentialProvider):
         creds_dict = self._retrieve_credentials_using(credential_process)
         register_feature_id('CREDENTIALS_PROCESS')
         if creds_dict.get('expiry_time') is not None:
-            return RefreshableCredentials.create_from_metadata(
+            if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+                return RefreshableCredentials.create_from_metadata(
+                    creds_dict,
+                    lambda: self._retrieve_credentials_using(
+                        credential_process
+                    ),
+                    self.METHOD,
+                )
+            return _StrictRefreshableCredentials.create_from_metadata(
                 creds_dict,
                 lambda: self._retrieve_credentials_using(credential_process),
                 self.METHOD,
@@ -1399,7 +1462,17 @@ class EnvProvider(CredentialProvider):
             expiry_time = credentials['expiry_time']
             if expiry_time is not None:
                 expiry_time = parse(expiry_time)
-                return RefreshableCredentials(
+                if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+                    return RefreshableCredentials(
+                        credentials['access_key'],
+                        credentials['secret_key'],
+                        credentials['token'],
+                        expiry_time,
+                        refresh_using=fetcher,
+                        method=self.METHOD,
+                        account_id=credentials['account_id'],
+                    )
+                return _StrictRefreshableCredentials(
                     credentials['access_key'],
                     credentials['secret_key'],
                     credentials['token'],

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -1,0 +1,329 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Temporary test suite for updated credential refresh behavior.
+
+These tests validate the updated credential refresh behavior, which is
+currently gated behind the DEFAULT_NEW_CREDENTIAL_REFRESH flag and not
+yet available to external users. Once the changes are validated
+internally and released publicly, the classes below will replace the
+corresponding classes in test_credentials.py and the standalone tests
+will be added to test_credentials.py. This file will then be removed.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from dateutil.tz import tzlocal
+
+from botocore import credentials
+from botocore.exceptions import CredentialRetrievalError
+from tests import BaseEnvVar, IntegerRefresher, mock, unittest
+
+# ---------------------------------------------------------------------------
+# Replacement classes: these mirror the classes in test_credentials.py with
+# assertions updated for the new credential refresh behavior.
+# ---------------------------------------------------------------------------
+
+
+@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+class TestRefreshableCredentials(BaseEnvVar):
+    def setUp(self):
+        super().setUp()
+        self.refresher = mock.Mock()
+        self.future_time = datetime.now(tzlocal()) + timedelta(hours=24)
+        self.expiry_time = datetime.now(tzlocal()) - timedelta(minutes=30)
+        self.metadata = {
+            'access_key': 'NEW-ACCESS',
+            'secret_key': 'NEW-SECRET',
+            'token': 'NEW-TOKEN',
+            'expiry_time': self.future_time.isoformat(),
+            'role_name': 'rolename',
+        }
+        self.refresher.return_value = self.metadata
+        self.mock_time = mock.Mock()
+        self.creds = credentials.RefreshableCredentials(
+            'ORIGINAL-ACCESS',
+            'ORIGINAL-SECRET',
+            'ORIGINAL-TOKEN',
+            self.expiry_time,
+            self.refresher,
+            'iam-role',
+            time_fetcher=self.mock_time,
+        )
+
+    def test_refresh_needed(self):
+        # The expiry time was set for 30 minutes ago, so if we
+        # say the current time is now(), then we should need
+        # a refresh.
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        # We should refresh creds, if we try to access "access_key"
+        # or any of the cred vars.
+        self.assertEqual(self.creds.access_key, 'NEW-ACCESS')
+        self.assertEqual(self.creds.secret_key, 'NEW-SECRET')
+        self.assertEqual(self.creds.token, 'NEW-TOKEN')
+
+    def test_no_expiration(self):
+        creds = credentials.RefreshableCredentials(
+            'ORIGINAL-ACCESS',
+            'ORIGINAL-SECRET',
+            'ORIGINAL-TOKEN',
+            None,
+            self.refresher,
+            'iam-role',
+            time_fetcher=self.mock_time,
+        )
+        self.assertFalse(creds.refresh_needed())
+
+    def test_no_refresh_needed(self):
+        # The expiry time was 30 minutes ago, let's say it's an hour
+        # ago currently.  That would mean we don't need a refresh.
+        self.mock_time.return_value = datetime.now(tzlocal()) - timedelta(
+            minutes=60
+        )
+        self.assertTrue(not self.creds.refresh_needed())
+
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(self.creds.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(self.creds.token, 'ORIGINAL-TOKEN')
+
+    def test_get_credentials_set(self):
+        # We need to return a consistent set of credentials to use during the
+        # signing process.
+        self.mock_time.return_value = datetime.now(tzlocal()) - timedelta(
+            minutes=60
+        )
+        self.assertTrue(not self.creds.refresh_needed())
+        credential_set = self.creds.get_frozen_credentials()
+        self.assertEqual(credential_set.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(credential_set.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(credential_set.token, 'ORIGINAL-TOKEN')
+
+    def test_refresh_returns_empty_dict(self):
+        # An empty dict from the source is treated as a failed refresh
+        # and we fall back to cached credentials.
+        self.refresher.return_value = {}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertTrue(self.refresher.called)
+
+    def test_refresh_returns_none(self):
+        # None from the source is treated as a failed refresh and we fall
+        # back to cached credentials.
+        self.refresher.return_value = None
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertTrue(self.refresher.called)
+
+    def test_refresh_returns_partial_credentials(self):
+        # Partial credentials from the source are treated as a failed
+        # refresh and we fall back to cached credentials.
+        self.refresher.return_value = {'access_key': 'akid'}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertTrue(self.refresher.called)
+
+
+@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+class TestRefreshLogic(unittest.TestCase):
+    def test_mandatory_refresh_needed(self):
+        creds = IntegerRefresher(
+            # These values will immediately trigger
+            # a mandatory refresh.
+            creds_last_for=2,
+            mandatory_refresh=3,
+            advisory_refresh=3,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('1', '1', '1'))
+
+    def test_advisory_refresh_needed(self):
+        creds = IntegerRefresher(
+            # These values will immediately trigger
+            # a mandatory refresh.
+            creds_last_for=4,
+            mandatory_refresh=2,
+            advisory_refresh=5,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('1', '1', '1'))
+
+    def test_refresh_fails_is_not_an_error_during_advisory_period(self):
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            creds_last_for=5,
+            advisory_refresh=7,
+            mandatory_refresh=3,
+            refresh_function=fail_refresh,
+        )
+        temp = creds.get_frozen_credentials()
+        # We should have called the refresh function.
+        self.assertTrue(fail_refresh.called)
+        # The fail_refresh function will raise an exception.
+        # Because we're in the advisory period we'll not propogate
+        # the exception and return the current set of credentials
+        # (generation '0').
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+    def test_exception_not_propogated_on_error_during_mandatory_period(self):
+        # Refresh failures in the mandatory window fall back to cached
+        # credentials instead of propagating.
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            creds_last_for=5,
+            advisory_refresh=10,
+            # Note we're in the mandatory period now (5 < 7 < 10).
+            mandatory_refresh=7,
+            refresh_function=fail_refresh,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertTrue(fail_refresh.called)
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+    def test_exception_not_propogated_on_expired_credentials(self):
+        # Even with fully expired credentials, a refresh failure returns
+        # the cached credentials.
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            # Setting this to 0 means the credentials are immediately
+            # expired.
+            creds_last_for=0,
+            advisory_refresh=10,
+            mandatory_refresh=7,
+            refresh_function=fail_refresh,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertTrue(fail_refresh.called)
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+    def test_refresh_giving_expired_credentials_returns_cached(self):
+        # This verifies an edge case where refreshed credentials
+        # still give expired credentials:
+        # 1. We see credentials are expired.
+        # 2. We try to refresh the credentials.
+        # 3. The "refreshed" credentials are still expired.
+        #
+        # In this case, we treat it as a failed refresh and fall back
+        # to the cached credentials.
+        creds = IntegerRefresher(
+            # Negative number indicates that the credentials
+            # have already been expired for 2 seconds, even
+            # on refresh.
+            creds_last_for=-2,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+
+# ---------------------------------------------------------------------------
+# Net-new tests: these cover backoff behavior that has no counterpart in the
+# legacy code path. At GA they will be added to test_credentials.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _enable_new_credential_refresh(monkeypatch):
+    monkeypatch.setattr(credentials, 'DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+
+
+@pytest.fixture
+def refresher():
+    return mock.Mock()
+
+
+@pytest.fixture
+def mock_time():
+    return mock.Mock(return_value=datetime.now(tzlocal()))
+
+
+@pytest.fixture
+def creds(refresher, mock_time):
+    # The expiry time is in the past so that accessing the credentials
+    # triggers a refresh.
+    return credentials.RefreshableCredentials(
+        'ORIGINAL-ACCESS',
+        'ORIGINAL-SECRET',
+        'ORIGINAL-TOKEN',
+        datetime.now(tzlocal()) - timedelta(minutes=30),
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+
+
+def _valid_metadata(mock_time, expires_in=timedelta(hours=24)):
+    expiry_time = mock_time() + expires_in
+    return {
+        'access_key': 'NEW-ACCESS',
+        'secret_key': 'NEW-SECRET',
+        'token': 'NEW-TOKEN',
+        'expiry_time': expiry_time.isoformat(),
+    }
+
+
+def test_refresh_failure_returns_cached(creds, refresher):
+    # When the source fails, we keep serving the cached credentials instead
+    # of raising.
+    refresher.side_effect = Exception("source down")
+    frozen = creds.get_frozen_credentials()
+    assert frozen.access_key == 'ORIGINAL-ACCESS'
+    assert frozen.secret_key == 'ORIGINAL-SECRET'
+    assert frozen.token == 'ORIGINAL-TOKEN'
+
+
+def test_failed_refresh_is_not_retried_immediately(creds, refresher):
+    # After a failed refresh, accessing the credentials again keeps using the
+    # cached credentials and does not call the source a second time.
+    refresher.side_effect = Exception("source down")
+    creds.get_frozen_credentials()
+    assert refresher.call_count == 1
+    frozen = creds.get_frozen_credentials()
+    assert refresher.call_count == 1
+    assert frozen.access_key == 'ORIGINAL-ACCESS'
+
+
+def test_refresh_is_retried_after_backoff(creds, refresher, mock_time):
+    # The first refresh fails and the source is not contacted again right
+    # away. Once enough time has passed, the next access retries the source
+    # and picks up the new credentials.
+    refresher.side_effect = [
+        Exception("source down"),
+        _valid_metadata(mock_time),
+    ]
+    creds.get_frozen_credentials()
+    assert refresher.call_count == 1
+
+    # Advance time past the maximum backoff window (10 minutes) so the next
+    # access is allowed to retry.
+    mock_time.return_value = datetime.now(tzlocal()) + timedelta(minutes=11)
+    frozen = creds.get_frozen_credentials()
+    assert refresher.call_count == 2
+    assert frozen.access_key == 'NEW-ACCESS'
+
+
+def test_refresh_failure_without_cached_creds_raises(mock_time):
+    # If we've never successfully fetched credentials, a refresh failure has
+    # nothing to fall back to and must be surfaced.
+    refresher = mock.Mock(side_effect=Exception("source down"))
+    creds = credentials.DeferredRefreshableCredentials(
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+    with pytest.raises(CredentialRetrievalError):
+        creds.get_frozen_credentials()

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -155,7 +155,7 @@ class TestRefreshLogic(unittest.TestCase):
     def test_advisory_refresh_needed(self):
         creds = IntegerRefresher(
             # These values will immediately trigger
-            # a mandatory refresh.
+            # an advisory refresh.
             creds_last_for=4,
             mandatory_refresh=2,
             advisory_refresh=5,

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -30,6 +30,18 @@ from dateutil.tz import tzlocal
 from botocore import credentials
 from botocore.exceptions import CredentialRetrievalError
 from tests import BaseEnvVar, IntegerRefresher, mock, unittest
+from tests.unit.test_credentials import (
+    TestEnvVar as _TestEnvVar,
+)
+from tests.unit.test_credentials import (
+    TestProcessProvider as _TestProcessProvider,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_new_credential_refresh(monkeypatch):
+    monkeypatch.setattr(credentials, 'DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+
 
 # ---------------------------------------------------------------------------
 # Replacement classes: these mirror the classes in test_credentials.py with
@@ -37,7 +49,6 @@ from tests import BaseEnvVar, IntegerRefresher, mock, unittest
 # ---------------------------------------------------------------------------
 
 
-@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
 class TestRefreshableCredentials(BaseEnvVar):
     def setUp(self):
         super().setUp()
@@ -139,7 +150,6 @@ class TestRefreshableCredentials(BaseEnvVar):
         self.assertTrue(self.refresher.called)
 
 
-@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
 class TestRefreshLogic(unittest.TestCase):
     def test_mandatory_refresh_needed(self):
         creds = IntegerRefresher(
@@ -231,14 +241,22 @@ class TestRefreshLogic(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Mirrored provider suites: these reuse the existing Env and Process provider
+# tests with the flag enabled. Because these providers are out of scope for
+# static stability, their provider behavior should remain unchanged.
+# ---------------------------------------------------------------------------
+class TestEnvVarFlagOn(_TestEnvVar):
+    pass
+
+
+class TestProcessProviderFlagOn(_TestProcessProvider):
+    pass
+
+
+# ---------------------------------------------------------------------------
 # Net-new tests: these cover backoff behavior that has no counterpart in the
 # legacy code path. At GA they will be added to test_credentials.py.
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-def _enable_new_credential_refresh(monkeypatch):
-    monkeypatch.setattr(credentials, 'DEFAULT_NEW_CREDENTIAL_REFRESH', True)
 
 
 @pytest.fixture
@@ -325,5 +343,18 @@ def test_refresh_failure_without_cached_creds_raises(mock_time):
         'iam-role',
         time_fetcher=mock_time,
     )
-    with pytest.raises(CredentialRetrievalError):
+    with pytest.raises(Exception, match='source down'):
+        creds.get_frozen_credentials()
+
+
+def test_invalid_refresh_data_without_cached_creds_raises(mock_time):
+    refresher = mock.Mock(return_value={})
+    creds = credentials.DeferredRefreshableCredentials(
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+    with pytest.raises(
+        CredentialRetrievalError, match='Response did not contain'
+    ):
         creds.get_frozen_credentials()


### PR DESCRIPTION
*Issue #, if available:*
Python-8911

### Overview
This PR adds static stability to credential refresh in `RefreshableCredentials`. When a credential source fails during refresh (outage, exception, missing keys, or expired response), the SDK now falls back to the most recently cached credentials and enters a jittered backoff window (5-10 minutes) instead of raising or hammering the source. If no cached credentials exist yet (e.g. `DeferredRefreshableCredentials` on first fetch), the error is still surfaced.

The new behavior is gated behind `DEFAULT_NEW_CREDENTIAL_REFRESH`, a flag that defaults to `False` in the public distribution. External users are unaffected until GA, at which point the flag and legacy path will be removed.

### Implementation

The new behavior lives in `_refresh_with_backoff` and its helpers. The legacy path (`_protected_refresh`, `_set_from_data`) is unchanged and kept under `_refresh_legacy`. A flag check in `_refresh` routes between the two. Credentials are validated before being cached so we never store missing or expired data.

### Testing
Following the same pattern as [test_standard_retry_v2_1.py](https://github.com/boto/botocore/blob/develop/tests/unit/retries/test_standard_retry_v2_1.py) from the retries internal release.

The file contains full copies of `TestRefreshableCredentials` and `TestRefreshLogic` with the flag forced on. Tests that change behavior have updated assertions (refresh failures return cached creds instead of raising). Unchanged tests are included so the full class can be swapped in at GA without cherry-picking individual methods.

The standalone pytest functions at the bottom cover backoff-specific behavior that does not exist in the legacy path (retry timing, not re-hitting the source immediately after failure, first-fetch failure raising).

At GA this file gets folded into `test_credentials.py` and removed.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
