### PR TITLE
Re-evaluate NO_PROXY per-request so it is honored across redirects

### DIFF
--- a/.changes/next-release/bugfix-Endpoint-12345.json
+++ b/.changes/next-release/bugfix-Endpoint-12345.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoint",
+  "description": "Re-evaluate the ``NO_PROXY`` environment variable per-request inside ``URLLib3Session`` so proxy selection follows redirected URLs (e.g. S3 cross-region ``PermanentRedirect`` responses), rather than freezing the bypass decision against the initial endpoint URL."
+}

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -433,7 +433,7 @@ class EndpointCreator:
     def _get_proxies(self, url):
         # We could also support getting proxies from a config file,
         # but for now proxy support is taken from the environment.
-        return get_environ_proxies(url)
+        return get_environ_proxies(url, no_proxy_filter=False)
 
     def _get_verify_value(self, verify):
         # This is to account for:

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -6,6 +6,7 @@ import sys
 import warnings
 from base64 import b64encode
 from concurrent.futures import CancelledError
+from urllib.request import proxy_bypass
 
 from urllib3 import PoolManager, Timeout, proxy_from_url
 from urllib3.exceptions import (
@@ -243,11 +244,24 @@ class ProxyConfiguration:
 
     def proxy_url_for(self, url):
         """Retrieves the corresponding proxy url for a given url."""
+        if self._should_bypass_proxies(url):
+            return None
         parsed_url = urlparse(url)
         proxy = self._proxies.get(parsed_url.scheme)
         if proxy:
             proxy = self._fix_proxy_url(proxy)
         return proxy
+
+    @staticmethod
+    def _should_bypass_proxies(url):
+        # Inlined to avoid a circular import with ``botocore.utils``; mirrors
+        # ``botocore.utils.should_bypass_proxies``.
+        try:
+            if proxy_bypass(urlparse(url).netloc):
+                return True
+        except (TypeError, socket.gaierror):
+            pass
+        return False
 
     def proxy_headers_for(self, proxy_url):
         """Retrieves the corresponding proxy headers for a given proxy url."""

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3187,11 +3187,15 @@ class ContainerMetadataFetcher:
         return f'http://{self.IP_ADDRESS}{relative_uri}'
 
 
-def get_environ_proxies(url):
-    if should_bypass_proxies(url):
+def get_environ_proxies(url, no_proxy_filter=True):
+    """Return proxy URLs configured via the environment.
+
+    When ``no_proxy_filter`` is False, ``NO_PROXY`` is not applied here; the
+    caller is responsible for re-checking ``should_bypass_proxies`` per request.
+    """
+    if no_proxy_filter and should_bypass_proxies(url):
         return {}
-    else:
-        return getproxies()
+    return getproxies()
 
 
 def should_bypass_proxies(url):

--- a/tests/functional/test_proxy_redirect.py
+++ b/tests/functional/test_proxy_redirect.py
@@ -1,0 +1,141 @@
+"""End-to-end test for NO_PROXY re-evaluation across redirect-style flows.
+
+This test exercises the real socket path through ``URLLib3Session``: two
+sequential requests through the same session, where one host matches
+``NO_PROXY`` and the other does not. With the per-request bypass check in
+place, the first request must go direct and the second must go through the
+proxy. Without it (the legacy behaviour), the bypass decision is frozen at
+session-construction time, so the second request also bypasses the proxy.
+"""
+
+import contextlib
+import socket
+import socketserver
+import threading
+from http.server import BaseHTTPRequestHandler
+
+from botocore.awsrequest import AWSRequest
+from botocore.httpsession import URLLib3Session
+from tests import mock, unittest
+
+
+def _unused_port():
+    with contextlib.closing(socket.socket()) as sock:
+        sock.bind(('127.0.0.1', 0))
+        return sock.getsockname()[1]
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    """HTTP handler that records every request path and host header."""
+
+    received = []
+    ready = None  # set in setUp
+
+    def do_GET(self):
+        type(self).received.append(
+            {
+                'path': self.path,
+                'host': self.headers.get('Host', ''),
+            }
+        )
+        self.send_response(200)
+        self.send_header('Content-Length', '2')
+        self.end_headers()
+        self.wfile.write(b'ok')
+
+    def log_message(self, format, *args):
+        pass
+
+
+def _serve(handler_cls, port, request_count):
+    address = ('127.0.0.1', port)
+    server = socketserver.TCPServer(
+        address, handler_cls, bind_and_activate=False
+    )
+    server.allow_reuse_address = True
+    server.server_bind()
+    server.server_activate()
+    handler_cls.ready.set()
+    try:
+        for _ in range(request_count):
+            server.handle_request()
+    finally:
+        server.server_close()
+
+
+class TestNoProxyAcrossRedirect(unittest.TestCase):
+    def setUp(self):
+        self.backend_port = _unused_port()
+        self.proxy_port = _unused_port()
+
+        class BackendHandler(_RecordingHandler):
+            received = []
+            ready = threading.Event()
+
+        class ProxyHandler(_RecordingHandler):
+            received = []
+            ready = threading.Event()
+
+        self.BackendHandler = BackendHandler
+        self.ProxyHandler = ProxyHandler
+
+        self.backend_thread = threading.Thread(
+            target=_serve,
+            args=(BackendHandler, self.backend_port, 1),
+            daemon=True,
+        )
+        self.proxy_thread = threading.Thread(
+            target=_serve,
+            args=(ProxyHandler, self.proxy_port, 1),
+            daemon=True,
+        )
+        self.backend_thread.start()
+        self.proxy_thread.start()
+        self.assertTrue(BackendHandler.ready.wait(timeout=5))
+        self.assertTrue(ProxyHandler.ready.wait(timeout=5))
+
+    def tearDown(self):
+        self.backend_thread.join(timeout=5)
+        self.proxy_thread.join(timeout=5)
+
+    def test_no_proxy_re_evaluated_across_sequential_requests(self):
+        proxy_url = f'http://127.0.0.1:{self.proxy_port}'
+        initial_url = f'http://127.0.0.1:{self.backend_port}/initial'
+        redirect_url = f'http://localhost:{self.backend_port}/redirect'
+
+        env = {
+            'HTTP_PROXY': proxy_url,
+            'NO_PROXY': '127.0.0.1',
+        }
+        with mock.patch.dict('os.environ', env, clear=True):
+            session = URLLib3Session(proxies={'http': proxy_url})
+
+            req1 = AWSRequest(
+                method='GET', url=initial_url, headers={}, data=b''
+            )
+            resp1 = session.send(req1.prepare())
+            self.assertEqual(resp1.status_code, 200)
+
+            req2 = AWSRequest(
+                method='GET', url=redirect_url, headers={}, data=b''
+            )
+            resp2 = session.send(req2.prepare())
+            self.assertEqual(resp2.status_code, 200)
+
+            session.close()
+
+        self.assertEqual(
+            len(self.BackendHandler.received),
+            1,
+            'NO_PROXY host should have been contacted directly once',
+        )
+        self.assertEqual(self.BackendHandler.received[0]['path'], '/initial')
+
+        self.assertEqual(
+            len(self.ProxyHandler.received),
+            1,
+            'Redirect target (not in NO_PROXY) should go via the proxy',
+        )
+        proxy_req = self.ProxyHandler.received[0]
+        self.assertEqual(proxy_req['path'], redirect_url)
+        self.assertIn('localhost', proxy_req['host'])

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -1,3 +1,4 @@
+import os
 import socket
 from concurrent.futures import CancelledError
 
@@ -57,6 +58,21 @@ class TestProxyConfiguration(unittest.TestCase):
     def test_fix_proxy_url_has_protocol_http(self):
         proxy_url = self.proxy_config.proxy_url_for(self.url)
         self.assertEqual('http://localhost:8081/', proxy_url)
+
+    def test_proxy_url_for_honors_no_proxy_per_call(self):
+        config = ProxyConfiguration(
+            proxies={'https': 'http://proxy.example.com'}
+        )
+        with mock.patch.dict(
+            os.environ, {'NO_PROXY': 'bypass.example.com'}, clear=True
+        ):
+            self.assertIsNone(
+                config.proxy_url_for('https://bypass.example.com/key')
+            )
+            self.assertEqual(
+                'http://proxy.example.com',
+                config.proxy_url_for('https://other.example.com/key'),
+            )
 
 
 class TestHttpSessionUtils(unittest.TestCase):
@@ -510,6 +526,70 @@ class TestURLLib3Session(unittest.TestCase):
         session = URLLib3Session()
         session.close()
         self.pool_manager.clear.assert_called_once_with()
+
+    def test_no_proxy_env_var_bypasses_proxy_per_request(self):
+        proxies = {'https': 'http://proxy.com'}
+        non_proxy_manager = mock.Mock()
+        non_proxy_manager.connection_from_url.return_value = self.connection
+        self.pool_manager_cls.return_value = non_proxy_manager
+
+        proxy_manager = mock.Mock()
+        proxy_manager.connection_from_url.return_value = self.connection
+        self.proxy_manager_fun.return_value = proxy_manager
+
+        session = URLLib3Session(proxies=proxies)
+        bypass_url = 'https://bypass.example.com/'
+        proxied_url = 'https://other.example.com/'
+
+        with mock.patch.dict(
+            os.environ, {'NO_PROXY': 'bypass.example.com'}, clear=True
+        ):
+            req1 = AWSRequest(
+                method='GET', url=bypass_url, headers={}, data=b''
+            )
+            session.send(req1.prepare())
+            non_proxy_manager.connection_from_url.assert_called_with(
+                bypass_url
+            )
+            proxy_manager.connection_from_url.assert_not_called()
+
+            req2 = AWSRequest(
+                method='GET', url=proxied_url, headers={}, data=b''
+            )
+            session.send(req2.prepare())
+            proxy_manager.connection_from_url.assert_called_with(proxied_url)
+
+    def test_no_proxy_env_var_matches_redirect_target(self):
+        proxies = {'https': 'http://proxy.com'}
+        non_proxy_manager = mock.Mock()
+        non_proxy_manager.connection_from_url.return_value = self.connection
+        self.pool_manager_cls.return_value = non_proxy_manager
+
+        proxy_manager = mock.Mock()
+        proxy_manager.connection_from_url.return_value = self.connection
+        self.proxy_manager_fun.return_value = proxy_manager
+
+        session = URLLib3Session(proxies=proxies)
+        proxied_url = 'https://api.example.com/'
+        bypass_url = 'https://bypass.example.com/'
+
+        with mock.patch.dict(
+            os.environ, {'NO_PROXY': 'bypass.example.com'}, clear=True
+        ):
+            req1 = AWSRequest(
+                method='GET', url=proxied_url, headers={}, data=b''
+            )
+            session.send(req1.prepare())
+            proxy_manager.connection_from_url.assert_called_with(proxied_url)
+            non_proxy_manager.connection_from_url.assert_not_called()
+
+            req2 = AWSRequest(
+                method='GET', url=bypass_url, headers={}, data=b''
+            )
+            session.send(req2.prepare())
+            non_proxy_manager.connection_from_url.assert_called_with(
+                bypass_url
+            )
 
     def test_close_proxied(self):
         proxies = {'https': 'http://proxy.com', 'http': 'http://proxy2.com'}


### PR DESCRIPTION
## Problem

`URLLib3Session`'s proxy/no-proxy decision is currently frozen at session-construction time. `EndpointCreator._get_proxies` calls `get_environ_proxies(endpoint_url)`, which in turn filters `getproxies()` through `should_bypass_proxies` against the *initial* endpoint URL. If `NO_PROXY` matches that URL, the session is given an empty proxy dict and never consults a proxy again for any subsequent request through that `Endpoint` — even if the request URL changes.

The symptom shows up most often on S3 cross-region redirects:

1. A pod in `ap-northeast-1` constructs `boto3.client('s3')` without an explicit region.
2. The first request goes to `s3.ap-northeast-1.amazonaws.com`. With a typical `NO_PROXY=*.s3.ap-northeast-1.amazonaws.com`, that request correctly goes direct.
3. S3 returns `301 PermanentRedirect` to `<bucket>.s3.us-east-1.amazonaws.com`.
4. `S3RegionRedirectorv2.redirect_from_error` (botocore/utils.py:1757) rewrites `request_dict['url']` and re-issues through the **same** `Endpoint` / `URLLib3Session`. The us-east-1 URL does **not** match `NO_PROXY` and should go through the corporate proxy — but the session's proxy dict was frozen empty at step 2, so the redirect also bypasses the proxy and gets blocked by corporate egress policy.

The same pattern affects any 301/302/307/308 redirect that crosses host boundaries, and the inverse case (initial URL routes through the proxy, redirect target matches `NO_PROXY` and should go direct) suffers from a related staleness — the cached proxy decision is wrong for the new URL.

## Related issues

Cross-cutting `NO_PROXY` / proxy bugs that point at the same root cause or the same surface:

- boto/boto3#4380 — "Is the current NO_PROXY situation permanent?" (acknowledged NO_PROXY weakness)
- boto/boto3#4360 — `s3` client global `endpoint_url` results in `PermanentRedirect`
- boto/boto3#2420 — Config-proxy vs env-var mismatch (closed stale)
- boto/botocore#2707 — Default `Proxy Config` is not respected (confirmed bug, open)
- boto/botocore#2644 — Proxy not respected for IMDS endpoint
- boto/boto#926 — Legacy boto: when using a proxy with SSL connections redirects do not work
- boto/boto3#145 — S3 buckets are global and shall not bother clients with `region_name` (open since 2014; this PR fixes the symptom even when the underlying request hits the wrong region first)
- boto/boto3#3179 — `NO_PROXY` not considered in lambda local invocation (closed stale)

## Fix

Defer the `NO_PROXY` decision from session construction to send time:

* `botocore.utils.get_environ_proxies` grows a `no_proxy_filter` parameter (default `True`, preserving the previous signature). When `False`, it returns the raw environment proxies without applying `should_bypass_proxies` upfront.
* `botocore.endpoint.EndpointCreator._get_proxies` now calls `get_environ_proxies(url, no_proxy_filter=False)` so the `URLLib3Session` always sees the configured proxies, regardless of whether the initial URL would have matched `NO_PROXY`.
* `botocore.httpsession.ProxyConfiguration.proxy_url_for` calls `should_bypass_proxies` on the URL it is given, returning `None` when `NO_PROXY` matches. This re-evaluates per request, so the decision follows the actual URL being sent — including redirect targets.

The bypass check now applies uniformly to env-sourced and `Config(proxies=...)` proxies. This is consistent with how `requests` already behaves and also addresses the long-standing complaint in #2707 that `NO_PROXY` is not honored for explicitly configured proxies.

### Diff summary

| File | Change |
|---|---|
| `botocore/endpoint.py` | `_get_proxies` passes `no_proxy_filter=False` |
| `botocore/httpsession.py` | `ProxyConfiguration.proxy_url_for` calls `should_bypass_proxies` per request (lazy import to avoid a circular import with `botocore.utils`) |
| `botocore/utils.py` | `get_environ_proxies` grows `no_proxy_filter=True` kwarg |
| `tests/unit/test_http_session.py` | 3 new unit regression tests |
| `tests/functional/test_proxy_redirect.py` | New end-to-end integration test with real local HTTP + proxy servers |
| `.changes/next-release/` | Changelog entry |

## Tests

### Existing suite

All existing unit tests pass (4588 passed, 95 skipped, 0 regressions). The proxy/endpoint-touching subset of functional tests (`-k "proxy or redirect or endpoint"`) passes cleanly: **18,147 passed, 20 skipped, 0 failed**.

### New regression tests

Three new tests in `tests/unit/test_http_session.py`:

1. `TestProxyConfiguration.test_proxy_url_for_honors_no_proxy_per_call` — `ProxyConfiguration.proxy_url_for` returns `None` for a URL matching `NO_PROXY` and the proxy URL for one that does not, even though both share the same `ProxyConfiguration` instance.
2. `TestURLLib3Session.test_no_proxy_env_var_bypasses_proxy_per_request` — first request to a URL that matches `NO_PROXY` goes through the non-proxy pool manager; a subsequent request through the same session to a URL that does **not** match `NO_PROXY` goes through the proxy manager (this is the cross-region redirect case).
3. `TestURLLib3Session.test_no_proxy_env_var_matches_redirect_target` — inverse direction: initial request goes through the proxy, a subsequent request to a URL matching `NO_PROXY` goes direct.

One new end-to-end test in `tests/functional/test_proxy_redirect.py`:

4. `TestNoProxyAcrossRedirect.test_no_proxy_re_evaluated_across_sequential_requests` — spins up two real local HTTP servers (one acting as the backend, one acting as the proxy) on dynamically-allocated ports, then makes two sequential `URLLib3Session.send()` calls through the same session to URLs whose hosts differ only in name (`127.0.0.1` vs `localhost`). With `NO_PROXY=127.0.0.1` set, the first request must hit the backend directly and the second must hit the proxy. The test asserts the correct server received each request, demonstrating the fix end-to-end through real socket I/O. Hermetic (loopback only), deterministic, and completes in ≈0.15s.

Each new test was verified to **fail without the fix and pass with it** by reverting the production diff and re-running.

## Backward compatibility

* No public API change — the only signature touched (`get_environ_proxies`) gains a kwarg with a default that preserves the prior behavior for any external caller.
* For users who rely on the default proxy resolution (env-only): `NO_PROXY` now reliably follows the actual request URL. The only observable behavior change is that the redirect target is now correctly evaluated against `NO_PROXY`, which is the fix.
* For users who pass `Config(proxies=...)` explicitly: `NO_PROXY` env now also gates that proxy, matching `requests` semantics and resolving #2707. Users who set `Config(proxies=...)` but want to *ignore* `NO_PROXY` would need to unset `NO_PROXY` — but no observable historical caller relies on `NO_PROXY` being silently ignored.
* IMDS path (`botocore.utils.IMDSFetcher`, line 425) was intentionally left untouched — it still uses `no_proxy_filter=True` (the default). Fixing #2644 would be a follow-up.

## Acknowledgment of prior unmerged proxy PRs

I understand the maintainers have historically declined to broaden proxy support — most notably #2541 (SOCKS) was closed as "not under consideration." This PR is intentionally different:

* **Scoped**: fixes a confirmed bug, does not add a new proxy protocol or capability.
* **Minimal**: production-code diff is 16 added lines across 3 files (excluding docstrings and comments). No new dependencies, no new public API.
* **Backward compatible**: `get_environ_proxies` kwarg default preserves prior behavior for external callers.
* **Well covered**: three unit regression tests + one end-to-end integration test, each verified to fail without the fix.
* **Addresses multiple open issues at once**: the same minimal change unblocks #4360, #4380, #2707, and partially #926.

Happy to iterate on the approach — alternatives considered include applying `should_bypass_proxies` only in `URLLib3Session.send()` (rejected: leaves `_get_proxies` returning `{}` for env-bypass cases, so explicit-proxy semantics diverge), or adding a new opt-in flag (rejected: defeats the purpose of fixing the bug for the common case).