### PR TITLE
Add CODEOWNERS file for team review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Python SDK core team - all PRs require team review
+* @boto/sync-team-aws-sdk-python


### PR DESCRIPTION
## Summary
Add `.github/CODEOWNERS` to require team review on all PRs to the develop branch.

This is part of aligning GitHub repository permissions with OSPO guidance (Python-8717).

## Changes
- Added `.github/CODEOWNERS` with `* @boto/sync-team-aws-sdk-python` to ensure all PRs require approval from the Python SDK core team.