### PR TITLE
Fix AttributeError in fix_route53_ids when Route53 ID parameter is not a string

### DIFF
--- a/.changes/next-release/bugfix-Route53-3033.json
+++ b/.changes/next-release/bugfix-Route53-3033.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Route53",
+  "description": "Fixed AttributeError in fix_route53_ids when a Route53 resource ID parameter (e.g. HostedZoneId) is None. Non-string values are now passed through to normal parameter validation."
+}

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -694,7 +694,7 @@ def fix_route53_ids(params, model, **kwargs):
     ]
 
     for name in members:
-        if name in params:
+        if name in params and isinstance(params[name], str):
             orig_value = params[name]
             params[name] = orig_value.split('/')[-1]
             logger.debug('%s %s -> %s', name, orig_value, params[name])

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -585,6 +585,29 @@ class TestHandlers(BaseSessionTest):
 
         self.assertEqual(params['HostedZoneId'], '/hostedzone/ABC123')
 
+    def test_route53_resource_id_non_string_left_alone(self):
+        event = 'before-parameter-build.route53.GetHostedZone'
+        params = {'HostedZoneId': None}
+        operation_def = {
+            'name': 'GetHostedZone',
+            'input': {'shape': 'GetHostedZoneInput'},
+        }
+        service_def = {
+            'metadata': {},
+            'shapes': {
+                'GetHostedZoneInput': {
+                    'type': 'structure',
+                    'members': {
+                        'HostedZoneId': {'shape': 'ResourceId'},
+                    },
+                },
+                'ResourceId': {'type': 'string'},
+            },
+        }
+        model = OperationModel(operation_def, ServiceModel(service_def))
+        self.session.emit(event, params=params, model=model)
+        self.assertIsNone(params['HostedZoneId'])
+
     def test_run_instances_userdata(self):
         user_data = 'This is a test'
         b64_user_data = base64.b64encode(user_data.encode('latin-1')).decode(


### PR DESCRIPTION
*Issue #, if available:*

#3033

*Description of changes:*

`fix_route53_ids` calls `.split('/')` on each matching Route53 resource ID parameter but does not guard against non-string values. Passing `HostedZoneId=None` triggers this handler before `ParamValidator` runs and raises an `AttributeError` with no useful context. Adding an `isinstance(params[name], str)` guard lets non-string values pass through to normal parameter validation, which produces a clear `ParamValidationError`.

generated by AI tools, reviewed by enlorik