### PR TITLE
anchor host label validators with \Z to reject trailing newline

### DIFF
--- a/botocore/endpoint_provider.py
+++ b/botocore/endpoint_provider.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 TEMPLATE_STRING_RE = re.compile(r"\{[a-zA-Z#]+\}")
 GET_ATTR_RE = re.compile(r"(\w*)\[(\d+)\]")
 VALID_HOST_LABEL_RE = re.compile(
-    r"^(?!-)[a-zA-Z\d-]{1,63}(?<!-)$",
+    r"^(?!-)[a-zA-Z\d-]{1,63}(?<!-)\Z",
 )
 CACHE_SIZE = 100
 # S3 endpoint ruleset parameters that are defined but not currently referenced.

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -1003,7 +1003,7 @@ class ClientMethodAlias:
 class HeaderToHostHoister:
     """Takes a header and moves it to the front of the hoststring."""
 
-    _VALID_HOSTNAME = re.compile(r'(?!-)[a-z\d-]{1,63}(?<!-)$', re.IGNORECASE)
+    _VALID_HOSTNAME = re.compile(r'(?!-)[a-z\d-]{1,63}(?<!-)\Z', re.IGNORECASE)
 
     def __init__(self, header_name):
         self._header_name = header_name

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -64,7 +64,7 @@ DEFAULT_TIMESTAMP_FORMAT = 'iso8601'
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 # Same as ISO8601, but with microsecond precision.
 ISO8601_MICRO = '%Y-%m-%dT%H:%M:%S.%fZ'
-HOST_PREFIX_RE = re.compile(r"^[A-Za-z0-9\.\-]+$")
+HOST_PREFIX_RE = re.compile(r"^[A-Za-z0-9\.\-]+\Z")
 
 TIMESTAMP_PRECISION_DEFAULT = 'default'
 TIMESTAMP_PRECISION_MILLISECOND = 'millisecond'

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1335,7 +1335,9 @@ def validate_region_name(region_name):
     """Provided region_name must be a valid host label."""
     if region_name is None:
         return
-    valid_host_label = re.compile(r'^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$')
+    valid_host_label = re.compile(
+        r'^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)\Z'
+    )
     valid = valid_host_label.match(region_name)
     if not valid:
         raise InvalidRegionError(region_name=region_name)
@@ -2644,7 +2646,7 @@ class S3EndpointSetter:
 class S3ControlEndpointSetter:
     _DEFAULT_PARTITION = 'aws'
     _DEFAULT_DNS_SUFFIX = 'amazonaws.com'
-    _HOST_LABEL_REGEX = re.compile(r'^[a-zA-Z0-9\-]{1,63}$')
+    _HOST_LABEL_REGEX = re.compile(r'^[a-zA-Z0-9\-]{1,63}\Z')
 
     def __init__(
         self,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2207,6 +2207,19 @@ class TestS3RegionRedirector(unittest.TestCase):
         with self.assertRaises(InvalidRegionError):
             self.redirector.get_bucket_region('foo', response)
 
+    def test_get_region_rejects_region_with_trailing_newline(self):
+        response = (
+            None,
+            {
+                'Error': {'Code': 'PermanentRedirect'},
+                'ResponseMetadata': {
+                    'HTTPHeaders': {'x-amz-bucket-region': 'us-west-2\n'}
+                },
+            },
+        )
+        with self.assertRaises(InvalidRegionError):
+            self.redirector.get_bucket_region('foo', response)
+
 
 class TestArnParser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
several host and host-label validators anchor with `$`, which in python also matches just before a trailing newline, so a value like `us-west-2\n` slips through unchanged. that matters because these values are interpolated into the request hostname. validate_region_name gates the region taken from the `x-amz-bucket-region` response header (or the error body) in S3RegionRedirectorv2.get_bucket_region before it is used to re-resolve the endpoint, and the same shape guards the sigv host prefix in serialize (HOST_PREFIX_RE), the hoisted host header in HeaderToHostHoister, the s3-control arn host labels in S3ControlEndpointSetter, and the ruleset host-label check in endpoint_provider. switching the end anchor to `\Z` rejects the trailing newline and leaves every valid label matching as before. added a regression test that feeds a trailing newline through the redirector's response-header path.
