### PR TITLE
Update awscrt version to 0.36.0

### DIFF
--- a/.changes/next-release/enhancement-awscrt-55348.json
+++ b/.changes/next-release/enhancement-awscrt-55348.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "AWSCRT",
+  "description": "Update awscrt version to 0.36.0"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ requires_dist =
     urllib3>=1.25.4,!=2.2.0,<3
 
 [options.extras_require]
-crt = awscrt==0.32.2
+crt = awscrt==0.36.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requires = [
 ]
 
 extras_require = {
-    'crt': ['awscrt==0.32.2'],
+    'crt': ['awscrt==0.36.0'],
 }
 
 setup(


### PR DESCRIPTION
Updates botocore's dependency on the AWS Common Runtime (CRT) to use the latest version `awscrt-0.36.0`.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
