### PR TITLE
Raise error on empty CA bundle value

### DIFF
--- a/.changes/next-release/bugfix-TLS-2331.json
+++ b/.changes/next-release/bugfix-TLS-2331.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "TLS",
+  "description": "Raise a configuration error when the CA bundle value (ca_bundle, AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or the client verify parameter) resolves to an empty string."
+}

--- a/.changes/next-release/bugfix-TLS-2331.json
+++ b/.changes/next-release/bugfix-TLS-2331.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "TLS",
-  "description": "Raise a configuration error when the CA bundle value (ca_bundle, AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or the client verify parameter) resolves to an empty string."
+  "description": "Raise a configuration error when the CA bundle value (ca_bundle, AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or the client verify parameter) resolves to an empty or whitespace-only string."
 }

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -451,13 +451,13 @@ class EndpointCreator:
         )
 
     def _validate_verify_value(self, verify):
-        if isinstance(verify, str) and not verify:
+        if isinstance(verify, str) and not verify.strip():
             raise InvalidConfigError(
                 error_msg=(
                     'Invalid CA bundle: the configured value (ca_bundle, '
                     'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
-                    'to an empty string. Provide a valid path to a CA bundle '
-                    'file.'
+                    'to an empty or whitespace-only string. Provide a valid '
+                    'path to a CA bundle file.'
                 )
             )
         return verify

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -22,7 +22,7 @@ import uuid
 from botocore import parsers
 from botocore.awsrequest import create_request_object
 from botocore.compat import get_current_datetime
-from botocore.exceptions import HTTPClientError
+from botocore.exceptions import HTTPClientError, InvalidConfigError
 from botocore.history import get_global_history_recorder
 from botocore.hooks import first_non_none_response
 from botocore.httpchecksum import handle_checksum_body
@@ -443,7 +443,21 @@ class EndpointCreator:
         # First, if verify is not None, then the user explicitly specified
         # a value so this automatically wins.
         if verify is not None:
-            return verify
+            return self._validate_verify_value(verify)
         # Otherwise use the value from REQUESTS_CA_BUNDLE, or default to
         # True if the env var does not exist.
-        return os.environ.get('REQUESTS_CA_BUNDLE', True)
+        return self._validate_verify_value(
+            os.environ.get('REQUESTS_CA_BUNDLE', True)
+        )
+
+    def _validate_verify_value(self, verify):
+        if isinstance(verify, str) and not verify:
+            raise InvalidConfigError(
+                error_msg=(
+                    'Invalid CA bundle: the configured value (ca_bundle, '
+                    'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
+                    'to an empty string. Provide a valid path to a CA bundle '
+                    'file.'
+                )
+            )
+        return verify

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -476,6 +476,16 @@ class TestEndpointCreator(unittest.TestCase):
                 http_session_cls=self.mock_session,
             )
 
+    def test_whitespace_verify_value_raises(self):
+        with self.assertRaises(InvalidConfigError):
+            self.creator.create_endpoint(
+                self.service_model,
+                region_name='us-west-2',
+                endpoint_url='https://example.com',
+                verify='   ',
+                http_session_cls=self.mock_session,
+            )
+
     def test_empty_cert_bundle_env_var_raises(self):
         self.environ['REQUESTS_CA_BUNDLE'] = ''
         with self.assertRaises(InvalidConfigError):

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -19,7 +19,7 @@ import pytest
 import botocore.endpoint
 from botocore.config import Config
 from botocore.endpoint import DEFAULT_TIMEOUT, Endpoint, EndpointCreator
-from botocore.exceptions import HTTPClientError
+from botocore.exceptions import HTTPClientError, InvalidConfigError
 from botocore.httpsession import URLLib3Session
 from botocore.model import (
     OperationModel,
@@ -465,6 +465,26 @@ class TestEndpointCreator(unittest.TestCase):
         session_args = self.mock_session.call_args[1]
         # /path/cacerts.pem wins over the value from the env var.
         self.assertEqual(session_args.get('verify'), '/path/cacerts.pem')
+
+    def test_empty_verify_value_raises(self):
+        with self.assertRaises(InvalidConfigError):
+            self.creator.create_endpoint(
+                self.service_model,
+                region_name='us-west-2',
+                endpoint_url='https://example.com',
+                verify='',
+                http_session_cls=self.mock_session,
+            )
+
+    def test_empty_cert_bundle_env_var_raises(self):
+        self.environ['REQUESTS_CA_BUNDLE'] = ''
+        with self.assertRaises(InvalidConfigError):
+            self.creator.create_endpoint(
+                self.service_model,
+                region_name='us-west-2',
+                endpoint_url='https://example.com',
+                http_session_cls=self.mock_session,
+            )
 
     def test_can_specify_max_pool_conns(self):
         self.creator.create_endpoint(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a CA bundle value (`ca_bundle`, `AWS_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, or the client `verify` parameter) resolved to an empty string, botocore will now raise an error.

An empty string is not a valid value for these settings, which are defined as paths to a CA bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
