### PR TITLE
mask proxy credentials by rebuilding netloc, not substring replace

### DIFF
--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -210,13 +210,17 @@ def mask_proxy_url(proxy_url):
 
     :return: Masked proxy url, i.e. https://***:***@proxy.com
     """
-    mask = '*' * 3
     parsed_url = urlparse(proxy_url)
-    if parsed_url.username:
-        proxy_url = proxy_url.replace(parsed_url.username, mask, 1)
-    if parsed_url.password:
-        proxy_url = proxy_url.replace(parsed_url.password, mask, 1)
-    return proxy_url
+    if not parsed_url.username:
+        return proxy_url
+    mask = '*' * 3
+    # Rebuild the netloc from the parsed userinfo/host so only the credential
+    # fields are masked. A substring replace can spend the mask on an earlier
+    # occurrence of the credential value (e.g. in the scheme or host) and leave
+    # the real secret in place.
+    _, _, host = parsed_url.netloc.rpartition('@')
+    userinfo = f'{mask}:{mask}' if parsed_url.password else mask
+    return parsed_url._replace(netloc=f'{userinfo}@{host}').geturl()
 
 
 def _is_ipaddress(host):

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -95,6 +95,13 @@ class TestHttpSessionUtils(unittest.TestCase):
         ('http://user:pass@192.168.1.1', 'http://***:***@192.168.1.1'),
         ('http://user:pass@[::1]', 'http://***:***@[::1]'),
         ('http://user:pass@[::1]:80', 'http://***:***@[::1]:80'),
+        # credential value also appears earlier in the url
+        (
+            'https://user:https@proxy.example.com',
+            'https://***:***@proxy.example.com',
+        ),
+        ('http://ttp:secret@host.com', 'http://***:***@host.com'),
+        ('http://myproxy.amazonaws.com', 'http://myproxy.amazonaws.com'),
     ),
 )
 def test_mask_proxy_url(proxy_url, expected_mask_url):


### PR DESCRIPTION
mask_proxy_url masks the userinfo with proxy_url.replace(username, mask, 1) and the same for the password, but str.replace swaps the first occurrence of that substring anywhere in the url, so when the credential value also appears earlier (in the scheme or host) the mask lands there and the real secret survives in the string that gets logged through ProxyConnectionError. for instance https://user:https@proxy.example.com masks to https://***:https@proxy.example.com with the password still visible. rebuilding the netloc from the parsed userinfo and host masks only the actual credential fields.