### PR TITLE
create the credential cache directory with 0700 in JSONFileCache

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3589,7 +3589,7 @@ class JSONFileCache:
                 f"Value cannot be cached, must be JSON serializable: {value}"
             )
         if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir, exist_ok=True)
+            os.makedirs(self._working_dir, mode=0o700, exist_ok=True)
 
         temp_fd, temp_path = tempfile.mkstemp(
             dir=self._working_dir, suffix='.tmp'

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,7 +15,9 @@ import datetime
 import io
 import operator
 import os
+import platform
 import shutil
+import stat
 import tempfile
 from contextlib import contextmanager
 from sys import getrefcount
@@ -3809,3 +3811,18 @@ class TestJSONFileCacheAtomicWrites(unittest.TestCase):
         self.assertEqual(
             len(temp_files), 0, f'Temp files not cleaned: {temp_files}'
         )
+
+    @unittest.skipIf(
+        platform.system() == 'Windows', 'POSIX permissions not applicable'
+    )
+    def test_creates_working_dir_with_restricted_permissions(self):
+        working_dir = os.path.join(self.temp_dir, 'sso', 'cache')
+        cache = JSONFileCache(working_dir=working_dir)
+        original_umask = os.umask(0o000)
+        try:
+            cache['token'] = {'accessToken': 'secret'}
+        finally:
+            os.umask(original_umask)
+
+        mode = stat.S_IMODE(os.stat(working_dir).st_mode)
+        self.assertEqual(mode, 0o700, f'Cache dir is {oct(mode)}')


### PR DESCRIPTION
JSONFileCache creates its working directory with os.makedirs and no mode, so it lands at 0o777 & ~umask. That directory backs `~/.aws/sso/cache` (SSO access and refresh tokens) and `~/.aws/boto/cache` (cached assume-role credentials); the entries themselves are already 0600 since they come from mkstemp and os.replace keeps the mode, but under umask 000, which is easy to hit in containers and in systemd units with no UMask=, the directory is world-writable and another local user can unlink an entry and drop in their own for botocore to load back. Passing mode=0o700 lines this up with what the CLI does for the directories it creates, and I added a regression test alongside the existing atomic-write ones.