### PR TITLE
Fix user agent header assertion in tests

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3058,8 +3058,8 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
         ).retrieve_iam_role_credentials()
 
         self.assertEqual(self._send.call_count, 3)
-        for call in self._send.calls:
-            self.assertTrue(call[0][0].headers['User-Agent'], user_agent)
+        for call in self._send.call_args_list:
+            self.assertEqual(call[0][0].headers['User-Agent'], user_agent)
 
     def test_non_200_response_for_role_name_is_retried(self):
         # Response for role name that have a non 200 status code should


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Originally this was accessing Mock().calls which is

```
>>> import unittest.mock
>>> unittest.mock.Mock().calls
<Mock name='mock.calls' id='137384355252176'>
```

so this test wasn't asserting anything



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
