### PR TITLE
docs: Fix missing comma before coordinating conjunction in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ For more information, see this `blog post <https://aws.amazon.com/blogs/develope
 
 Getting Started
 ---------------
-Assuming that you have Python and ``virtualenv`` installed, set up your environment and install the required dependencies like this or you can install the library using ``pip``:
+Assuming that you have Python and ``virtualenv`` installed, set up your environment and install the required dependencies like this, or you can install the library using ``pip``:
 
 .. code-block:: sh
 


### PR DESCRIPTION
Fixes a missing comma before the coordinating conjunction in the Getting Started section of the README.