### PR TITLE
percent-encode IMDS role name before building credentials url

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -645,8 +645,13 @@ class InstanceMetadataFetcher(IMDSFetcher):
         ).text
 
     def _get_credentials(self, role_name, token=None):
+        # role_name is read from the IMDS response body in _get_iam_role, so
+        # percent-encode it before splicing it into the path. The safe set keeps
+        # every character that is legal in an IAM role name unchanged while
+        # encoding separators like '/', '?' and '#' that would otherwise let the
+        # response redirect the credentials request to a different resource.
         r = self._get_request(
-            url_path=self._URL_PATH + role_name,
+            url_path=self._URL_PATH + quote(role_name, safe='+=,.@-'),
             retry_func=self._needs_retry_for_credentials,
             token=token,
         )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3147,6 +3147,30 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
         ).retrieve_iam_role_credentials()
         self.assertEqual(result, self._expected_creds)
 
+    def test_role_name_is_percent_encoded_in_credentials_url(self):
+        # The role name is read from the IMDS response body and appended to the
+        # credentials URL. A value with path separators must not be able to
+        # point the credentials request at a different metadata resource.
+        requested_urls = []
+        get_imds_response = self.get_imds_response
+
+        def record_url(request):
+            requested_urls.append(request.url)
+            return get_imds_response(request)
+
+        self._send.side_effect = record_url
+        self.add_get_token_imds_response(token='token')
+        self.add_get_role_name_imds_response(
+            role_name='../../../../latest/meta-data/iam/info'
+        )
+        self.add_get_credentials_imds_response()
+
+        InstanceMetadataFetcher(num_attempts=1).retrieve_iam_role_credentials()
+
+        creds_url = requested_urls[-1]
+        self.assertNotIn('security-credentials/../', creds_url)
+        self.assertIn('security-credentials/..%2F', creds_url)
+
     def test_exhaust_retries_on_role_name_request(self):
         self.add_get_token_imds_response(token='token')
         self.add_imds_response(status_code=400, body=b'')


### PR DESCRIPTION
InstanceMetadataFetcher._get_credentials appends the role name straight onto the security-credentials path, and that role name is the raw response body returned by _get_iam_role over IMDS, so a value containing separators like `../`, `?` or `#` rewrites which resource the credentials request lands on. I ran a small fetcher test with a role-name body of `../../../../latest/meta-data/iam/info` and the credentials GET went to `.../security-credentials/../../../../latest/meta-data/iam/info`. Encoding the segment with quote and a safe set of the characters legal in an IAM role name keeps valid names byte-identical while neutralizing the separators.