### PR TITLE
Add new refresh window defaults

### DIFF
--- a/botocore/client.py
+++ b/botocore/client.py
@@ -27,7 +27,11 @@ from botocore.awsrequest import prepare_request_dict
 from botocore.compress import maybe_compress_request
 from botocore.config import Config
 from botocore.context import with_current_context
-from botocore.credentials import RefreshableCredentials
+from botocore.credentials import (
+    DEFAULT_NEW_CREDENTIAL_REFRESH,
+    RefreshableCredentials,
+    _StrictRefreshableCredentials,
+)
 from botocore.discovery import (
     EndpointDiscoveryHandler,
     EndpointDiscoveryManager,
@@ -389,7 +393,14 @@ class ClientCreator:
     ):
         if client.meta.service_model.service_name != 's3':
             return
-        S3ExpressIdentityResolver(client, RefreshableCredentials).register()
+        if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+            S3ExpressIdentityResolver(
+                client, RefreshableCredentials
+            ).register()
+            return
+        S3ExpressIdentityResolver(
+            client, _StrictRefreshableCredentials
+        ).register()
 
     def _register_s3_events(
         self,

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -17,6 +17,7 @@ import getpass
 import json
 import logging
 import os
+import random
 import subprocess
 import threading
 import time
@@ -69,6 +70,17 @@ from botocore.utils import (
     parse_key_val_file,
     resolve_imds_endpoint_mode,
 )
+
+try:
+    # This is not a public interface and is subject to abrupt breaking changes.
+    # Currently, it's only available to internal users for testing and validation
+    # of the new credential refresh behavior. Any usage is not advised or
+    # supported in external code bases.
+    from botocore.customizations.credentials import (
+        DEFAULT_NEW_CREDENTIAL_REFRESH,
+    )
+except ImportError:
+    DEFAULT_NEW_CREDENTIAL_REFRESH = False
 
 logger = logging.getLogger(__name__)
 ReadOnlyCredentials = namedtuple(
@@ -428,6 +440,7 @@ class RefreshableCredentials(Credentials):
         self._expiry_time = expiry_time
         self._time_fetcher = time_fetcher
         self._refresh_lock = threading.Lock()
+        self._refresh_blocked_until = None
         self.method = method
         self._frozen_credentials = ReadOnlyCredentials(
             access_key, secret_key, token, account_id
@@ -563,7 +576,125 @@ class RefreshableCredentials(Credentials):
         # Checks if the current credentials are expired.
         return self.refresh_needed(refresh_in=0)
 
+    def _in_refresh_backoff(self):
+        if self._refresh_blocked_until is None:
+            return False
+        return self._time_fetcher() < self._refresh_blocked_until
+
+    def _enter_refresh_backoff(self):
+        # Apply a jittered 5-10 minute backoff after a failed refresh to avoid
+        # overwhelming the credential source during an outage.
+        backoff = random.uniform(300, 600)
+        now = self._time_fetcher()
+        self._refresh_blocked_until = now + datetime.timedelta(seconds=backoff)
+        return backoff
+
     def _refresh(self):
+        if DEFAULT_NEW_CREDENTIAL_REFRESH:
+            return self._refresh_with_backoff()
+        return self._refresh_legacy()
+
+    def _refresh_with_backoff(self):
+        # In the common case where we don't need a refresh, we
+        # can immediately exit and not require acquiring the
+        # refresh lock.
+        if not self.refresh_needed(self._advisory_refresh_timeout):
+            return
+
+        # A previous refresh attempt failed; wait before attempting
+        # another refresh.
+        if self._in_refresh_backoff():
+            return
+
+        # acquire() doesn't accept kwargs, but False is indicating
+        # that we should not block if we can't acquire the lock.
+        # If we aren't able to acquire the lock, we'll trigger
+        # the else clause.
+        if self._refresh_lock.acquire(False):
+            try:
+                if not self.refresh_needed(self._advisory_refresh_timeout):
+                    return
+                self._protected_refresh_with_backoff()
+                return
+            finally:
+                self._refresh_lock.release()
+        elif self.refresh_needed(self._mandatory_refresh_timeout):
+            # If we're within the mandatory refresh window,
+            # we must block until we get refreshed credentials.
+            with self._refresh_lock:
+                if not self.refresh_needed(self._mandatory_refresh_timeout):
+                    return
+                self._protected_refresh_with_backoff()
+
+    def _protected_refresh_with_backoff(self):
+        # precondition: this method should only be called if you've acquired
+        # the self._refresh_lock.
+        if self._in_refresh_backoff():
+            # Another caller entered refresh backoff while we were waiting
+            # for the lock. Skip the refresh attempt.
+            return
+        try:
+            metadata = self._refresh_using()
+        except Exception as e:
+            self._handle_refresh_failure(e)
+            return
+        error = self._validate_data(metadata)
+        if error is not None:
+            self._handle_refresh_failure(error)
+            return
+        self._set_from_validated_data(metadata)
+        self._refresh_blocked_until = None
+        self._frozen_credentials = ReadOnlyCredentials(
+            self._access_key, self._secret_key, self._token, self._account_id
+        )
+
+    def _set_from_validated_data(self, data):
+        # Only called once the data has passed ``_validate_data``, so we never
+        # cache missing or expired credentials.
+        self.access_key = data['access_key']
+        self.secret_key = data['secret_key']
+        self.token = data['token']
+        self._expiry_time = parse(data['expiry_time'])
+        self.account_id = data.get('account_id')
+        logger.debug(
+            "Retrieved credentials will expire at: %s", self._expiry_time
+        )
+        self._normalize()
+
+    def _validate_data(self, data):
+        expected_keys = ['access_key', 'secret_key', 'token', 'expiry_time']
+        if not data:
+            missing_keys = expected_keys
+        else:
+            missing_keys = [k for k in expected_keys if k not in data]
+
+        if missing_keys:
+            return (
+                "credential refresh failed, response did not contain: "
+                f"{', '.join(missing_keys)}"
+            )
+
+        if parse(data['expiry_time']) <= self._time_fetcher():
+            return "credential source returned expired credentials"
+        return None
+
+    def _handle_refresh_failure(self, error):
+        if self._frozen_credentials is None:
+            # No credentials have been successfully obtained yet, so we
+            # have nothing to fall back to.
+            raise CredentialRetrievalError(
+                provider=self.method, error_msg=str(error)
+            )
+        backoff = self._enter_refresh_backoff()
+        logger.warning(
+            "Credential refresh failed: %s. The SDK will continue using "
+            "cached credentials. A refresh of these credentials will be "
+            "attempted again after %.0f seconds.",
+            error,
+            backoff,
+        )
+
+    def _refresh_legacy(self):
         # In the common case where we don't need a refresh, we
         # can immediately exit and not require acquiring the
         # refresh lock.
@@ -713,6 +844,7 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         self._expiry_time = None
         self._time_fetcher = time_fetcher
         self._refresh_lock = threading.Lock()
+        self._refresh_blocked_until = None
         self.method = method
         self._frozen_credentials = None
 

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -591,8 +591,9 @@ class RefreshableCredentials(Credentials):
 
     def _refresh(self):
         if DEFAULT_NEW_CREDENTIAL_REFRESH:
-            return self._refresh_with_backoff()
-        return self._refresh_legacy()
+            self._refresh_with_backoff()
+        else:
+            self._refresh_legacy()
 
     def _refresh_with_backoff(self):
         # In the common case where we don't need a refresh, we

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -663,7 +663,7 @@ class RefreshableCredentials(Credentials):
                 if not self.refresh_needed():
                     return
                 is_mandatory_refresh = self.refresh_needed(
-                    self._mandatory_refresh_timeout
+                    self._resolve_mandatory_refresh_timeout()
                 )
                 self._protected_refresh(is_mandatory=is_mandatory_refresh)
                 return

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -686,12 +686,6 @@ class RefreshableCredentials(Credentials):
         return None
 
     def _handle_refresh_failure(self, error):
-        if self._frozen_credentials is None:
-            # No credentials have been successfully obtained yet, so we
-            # have nothing to fall back to.
-            raise CredentialRetrievalError(
-                provider=self.method, error_msg=str(error)
-            )
         backoff = self._enter_refresh_backoff()
         logger.warning(
             "Credential refresh failed: %s. The SDK will continue using "
@@ -859,6 +853,15 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         if self._frozen_credentials is None:
             return True
         return super().refresh_needed(refresh_in)
+
+    def _handle_refresh_failure(self, error):
+        if self._frozen_credentials is None:
+            # No credentials have been successfully obtained yet, so we
+            # have nothing to fall back to.
+            raise CredentialRetrievalError(
+                provider=self.method, error_msg=str(error)
+            )
+        super()._handle_refresh_failure(error)
 
 
 class CachedCredentialFetcher:

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -605,6 +605,12 @@ class RefreshableCredentials(Credentials):
         # A previous refresh attempt failed; wait before attempting
         # another refresh.
         if self._in_refresh_backoff():
+            logger.debug(
+                "Credential refresh is in backoff following a failed attempt. "
+                "Using cached credentials. The next refresh attempt is allowed "
+                "at %s.",
+                self._refresh_blocked_until,
+            )
             return
 
         # acquire() doesn't accept kwargs, but False is indicating

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -581,21 +581,25 @@ class RefreshableCredentials(Credentials):
             return False
         return self._time_fetcher() < self._refresh_blocked_until
 
-    def _enter_refresh_backoff(self):
+    def _enter_refresh_backoff(self, error):
         # Apply a jittered 5-10 minute backoff after a failed refresh to avoid
         # overwhelming the credential source during an outage.
         backoff = random.uniform(300, 600)
         now = self._time_fetcher()
         self._refresh_blocked_until = now + datetime.timedelta(seconds=backoff)
-        return backoff
+        logger.warning(
+            "Credential refresh failed: %s. The SDK will continue using "
+            "cached credentials. A refresh of these credentials will be "
+            "attempted again after %.0f seconds.",
+            error,
+            backoff,
+        )
 
     def _refresh(self):
-        if DEFAULT_NEW_CREDENTIAL_REFRESH:
-            self._refresh_with_backoff()
-        else:
+        if not DEFAULT_NEW_CREDENTIAL_REFRESH:
             self._refresh_legacy()
+            return
 
-    def _refresh_with_backoff(self):
         # In the common case where we don't need a refresh, we
         # can immediately exit and not require acquiring the
         # refresh lock.
@@ -621,7 +625,10 @@ class RefreshableCredentials(Credentials):
             try:
                 if not self.refresh_needed(self._advisory_refresh_timeout):
                     return
-                self._protected_refresh_with_backoff()
+                is_mandatory_refresh = self.refresh_needed(
+                    self._mandatory_refresh_timeout
+                )
+                self._protected_refresh(is_mandatory=is_mandatory_refresh)
                 return
             finally:
                 self._refresh_lock.release()
@@ -631,9 +638,9 @@ class RefreshableCredentials(Credentials):
             with self._refresh_lock:
                 if not self.refresh_needed(self._mandatory_refresh_timeout):
                     return
-                self._protected_refresh_with_backoff()
+                self._protected_refresh(is_mandatory=True)
 
-    def _protected_refresh_with_backoff(self):
+    def _protected_refresh(self, is_mandatory):
         # precondition: this method should only be called if you've acquired
         # the self._refresh_lock.
         if self._in_refresh_backoff():
@@ -643,11 +650,11 @@ class RefreshableCredentials(Credentials):
         try:
             metadata = self._refresh_using()
         except Exception as e:
-            self._handle_refresh_failure(e)
+            self._handle_refresh_exception(e)
             return
         error = self._validate_data(metadata)
         if error is not None:
-            self._handle_refresh_failure(error)
+            self._handle_invalid_refresh_response(error)
             return
         self._set_from_validated_data(metadata)
         self._refresh_blocked_until = None
@@ -676,24 +683,17 @@ class RefreshableCredentials(Credentials):
             missing_keys = [k for k in expected_keys if k not in data]
 
         if missing_keys:
-            return (
-                "credential refresh failed, response did not contain: "
-                f"{', '.join(missing_keys)}"
-            )
+            return f"Response did not contain: {', '.join(missing_keys)}"
 
         if parse(data['expiry_time']) <= self._time_fetcher():
-            return "credential source returned expired credentials"
+            return "Credential source returned expired credentials"
         return None
 
-    def _handle_refresh_failure(self, error):
-        backoff = self._enter_refresh_backoff()
-        logger.warning(
-            "Credential refresh failed: %s. The SDK will continue using "
-            "cached credentials. A refresh of these credentials will be "
-            "attempted again after %.0f seconds.",
-            error,
-            backoff,
-        )
+    def _handle_refresh_exception(self, error):
+        self._enter_refresh_backoff(error)
+
+    def _handle_invalid_refresh_response(self, error):
+        self._enter_refresh_backoff(error)
 
     def _refresh_legacy(self):
         # In the common case where we don't need a refresh, we
@@ -713,7 +713,9 @@ class RefreshableCredentials(Credentials):
                 is_mandatory_refresh = self.refresh_needed(
                     self._mandatory_refresh_timeout
                 )
-                self._protected_refresh(is_mandatory=is_mandatory_refresh)
+                self._protected_refresh_legacy(
+                    is_mandatory=is_mandatory_refresh
+                )
                 return
             finally:
                 self._refresh_lock.release()
@@ -723,9 +725,9 @@ class RefreshableCredentials(Credentials):
             with self._refresh_lock:
                 if not self.refresh_needed(self._mandatory_refresh_timeout):
                     return
-                self._protected_refresh(is_mandatory=True)
+                self._protected_refresh_legacy(is_mandatory=True)
 
-    def _protected_refresh(self, is_mandatory):
+    def _protected_refresh_legacy(self, is_mandatory):
         # precondition: this method should only be called if you've acquired
         # the self._refresh_lock.
         try:
@@ -830,6 +832,54 @@ class RefreshableCredentials(Credentials):
         return self._frozen_credentials
 
 
+class _StrictRefreshableCredentials(RefreshableCredentials):
+    """Refreshable credentials that surface refresh failures to the caller
+    instead of falling back to the cached credentials.
+    """
+
+    def _in_refresh_backoff(self):
+        return False
+
+    def _protected_refresh(self, is_mandatory):
+        # precondition: this method should only be called if you've acquired
+        # the self._refresh_lock.
+        try:
+            metadata = self._refresh_using()
+        except Exception:
+            period_name = 'mandatory' if is_mandatory else 'advisory'
+            logger.warning(
+                "Refreshing temporary credentials failed "
+                "during %s refresh period.",
+                period_name,
+                exc_info=True,
+            )
+            if is_mandatory:
+                # If this is a mandatory refresh, then
+                # all errors that occur when we attempt to refresh
+                # credentials are propagated back to the user.
+                raise
+            # Otherwise we'll just return.
+            # The end result will be that we'll use the current
+            # set of temporary credentials we have.
+            return
+        self._set_from_data(metadata)
+        self._frozen_credentials = ReadOnlyCredentials(
+            self._access_key, self._secret_key, self._token, self._account_id
+        )
+        if self._is_expired():
+            # We successfully refreshed credentials but for whatever
+            # reason, our refreshing function returned credentials
+            # that are still expired.  In this scenario, the only
+            # thing we can do is let the user know and raise
+            # an exception.
+            msg = (
+                "Credentials were refreshed, but the "
+                "refreshed credentials are still expired."
+            )
+            logger.warning(msg)
+            raise RuntimeError(msg)
+
+
 class DeferredRefreshableCredentials(RefreshableCredentials):
     """Refreshable credentials that don't require initial credentials.
 
@@ -854,14 +904,19 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
             return True
         return super().refresh_needed(refresh_in)
 
-    def _handle_refresh_failure(self, error):
+    # Before the first successful deferred fetch, there are no cached
+    # credentials to fall back to, so initial failures must be surfaced.
+    def _handle_refresh_exception(self, error):
         if self._frozen_credentials is None:
-            # No credentials have been successfully obtained yet, so we
-            # have nothing to fall back to.
+            raise error
+        super()._handle_refresh_exception(error)
+
+    def _handle_invalid_refresh_response(self, error):
+        if self._frozen_credentials is None:
             raise CredentialRetrievalError(
                 provider=self.method, error_msg=str(error)
             )
-        super()._handle_refresh_failure(error)
+        super()._handle_invalid_refresh_response(error)
 
 
 class CachedCredentialFetcher:
@@ -1226,7 +1281,15 @@ class ProcessProvider(CredentialProvider):
         creds_dict = self._retrieve_credentials_using(credential_process)
         register_feature_id('CREDENTIALS_PROCESS')
         if creds_dict.get('expiry_time') is not None:
-            return RefreshableCredentials.create_from_metadata(
+            if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+                return RefreshableCredentials.create_from_metadata(
+                    creds_dict,
+                    lambda: self._retrieve_credentials_using(
+                        credential_process
+                    ),
+                    self.METHOD,
+                )
+            return _StrictRefreshableCredentials.create_from_metadata(
                 creds_dict,
                 lambda: self._retrieve_credentials_using(credential_process),
                 self.METHOD,
@@ -1399,7 +1462,17 @@ class EnvProvider(CredentialProvider):
             expiry_time = credentials['expiry_time']
             if expiry_time is not None:
                 expiry_time = parse(expiry_time)
-                return RefreshableCredentials(
+                if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+                    return RefreshableCredentials(
+                        credentials['access_key'],
+                        credentials['secret_key'],
+                        credentials['token'],
+                        expiry_time,
+                        refresh_using=fetcher,
+                        method=self.METHOD,
+                        account_id=credentials['account_id'],
+                    )
+                return _StrictRefreshableCredentials(
                     credentials['access_key'],
                     credentials['secret_key'],
                     credentials['token'],

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -91,6 +91,7 @@ ReadOnlyCredentials = namedtuple(
 
 _DEFAULT_MANDATORY_REFRESH_TIMEOUT = 10 * 60  # 10 min
 _DEFAULT_ADVISORY_REFRESH_TIMEOUT = 15 * 60  # 15 min
+_DEFAULT_MANDATORY_REFRESH_TIMEOUT_V2 = 1 * 60  # 1 min
 
 
 def create_credential_resolver(session, cache=None, region_name=None):
@@ -446,10 +447,19 @@ class RefreshableCredentials(Credentials):
             access_key, secret_key, token, account_id
         )
         self._normalize()
+        self._explicit_advisory_refresh_timeout = advisory_timeout
+        self._explicit_mandatory_refresh_timeout = mandatory_timeout
         if advisory_timeout is not None:
             self._advisory_refresh_timeout = advisory_timeout
         if mandatory_timeout is not None:
             self._mandatory_refresh_timeout = mandatory_timeout
+        self._effective_advisory_refresh_timeout = None
+        if DEFAULT_NEW_CREDENTIAL_REFRESH and self._expiry_time is not None:
+            # Set the effective advisory refresh timeout for the initial
+            # credential set.
+            self._effective_advisory_refresh_timeout = (
+                self._compute_effective_advisory_refresh_timeout()
+            )
 
     def _normalize(self):
         self._access_key = botocore.compat.ensure_unicode(self._access_key)
@@ -543,8 +553,8 @@ class RefreshableCredentials(Credentials):
 
         A refresh is needed if the expiry time associated
         with the temporary credentials is less than the
-        provided ``refresh_in``.  If ``time_delta`` is not
-        provided, ``self.advisory_refresh_needed`` will be used.
+        provided ``refresh_in``. If ``refresh_in`` is not
+        provided, the default advisory refresh timeout will be used.
 
         For example, if your temporary credentials expire
         in 10 minutes and the provided ``refresh_in`` is
@@ -563,9 +573,9 @@ class RefreshableCredentials(Credentials):
             return False
 
         if refresh_in is None:
-            refresh_in = self._advisory_refresh_timeout
+            refresh_in = self._resolve_advisory_refresh_timeout()
         # The credentials should be refreshed if they're going to expire
-        # in less than 5 minutes.
+        # within the requested refresh window.
         if self._seconds_remaining() >= refresh_in:
             # There's enough time left. Don't refresh.
             return False
@@ -595,6 +605,33 @@ class RefreshableCredentials(Credentials):
             backoff,
         )
 
+    def _resolve_advisory_refresh_timeout(self):
+        if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+            return self._advisory_refresh_timeout
+        if self._explicit_advisory_refresh_timeout is not None:
+            return self._explicit_advisory_refresh_timeout
+        return self._effective_advisory_refresh_timeout
+
+    def _resolve_mandatory_refresh_timeout(self):
+        if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+            return self._mandatory_refresh_timeout
+        if self._explicit_mandatory_refresh_timeout is not None:
+            return self._explicit_mandatory_refresh_timeout
+        return _DEFAULT_MANDATORY_REFRESH_TIMEOUT_V2
+
+    def _compute_effective_advisory_refresh_timeout(self):
+        # Compute the effective advisory refresh timeout from the credential
+        # lifetime at the time the credential set is created or refreshed:
+        # <= 20 min -> 5 min
+        # > 20 min and < 90 min -> 15 min
+        # >= 90 min -> 60 min
+        lifetime = total_seconds(self._expiry_time - self._time_fetcher())
+        if lifetime <= 20 * 60:
+            return 5 * 60
+        if lifetime < 90 * 60:
+            return 15 * 60
+        return 60 * 60
+
     def _refresh(self):
         if not DEFAULT_NEW_CREDENTIAL_REFRESH:
             self._refresh_legacy()
@@ -603,7 +640,7 @@ class RefreshableCredentials(Credentials):
         # In the common case where we don't need a refresh, we
         # can immediately exit and not require acquiring the
         # refresh lock.
-        if not self.refresh_needed(self._advisory_refresh_timeout):
+        if not self.refresh_needed():
             return
 
         # A previous refresh attempt failed; wait before attempting
@@ -623,7 +660,7 @@ class RefreshableCredentials(Credentials):
         # the else clause.
         if self._refresh_lock.acquire(False):
             try:
-                if not self.refresh_needed(self._advisory_refresh_timeout):
+                if not self.refresh_needed():
                     return
                 is_mandatory_refresh = self.refresh_needed(
                     self._mandatory_refresh_timeout
@@ -632,11 +669,13 @@ class RefreshableCredentials(Credentials):
                 return
             finally:
                 self._refresh_lock.release()
-        elif self.refresh_needed(self._mandatory_refresh_timeout):
+        elif self.refresh_needed(self._resolve_mandatory_refresh_timeout()):
             # If we're within the mandatory refresh window,
             # we must block until we get refreshed credentials.
             with self._refresh_lock:
-                if not self.refresh_needed(self._mandatory_refresh_timeout):
+                if not self.refresh_needed(
+                    self._resolve_mandatory_refresh_timeout()
+                ):
                     return
                 self._protected_refresh(is_mandatory=True)
 
@@ -674,6 +713,11 @@ class RefreshableCredentials(Credentials):
             "Retrieved credentials will expire at: %s", self._expiry_time
         )
         self._normalize()
+        # Update the effective advisory refresh timeout for the refreshed
+        # credential set.
+        self._effective_advisory_refresh_timeout = (
+            self._compute_effective_advisory_refresh_timeout()
+        )
 
     def _validate_data(self, data):
         expected_keys = ['access_key', 'secret_key', 'token', 'expiry_time']
@@ -898,6 +942,9 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         self._refresh_blocked_until = None
         self.method = method
         self._frozen_credentials = None
+        self._explicit_advisory_refresh_timeout = None
+        self._explicit_mandatory_refresh_timeout = None
+        self._effective_advisory_refresh_timeout = None
 
     def refresh_needed(self, refresh_in=None):
         if self._frozen_credentials is None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -348,12 +348,17 @@ class IntegerRefresher(credentials.RefreshableCredentials):
         if refresh_function is None:
             refresh_function = self._do_refresh
         super().__init__(
-            '0', '0', '0', expires_in, refresh_function, 'INTREFRESH'
+            '0',
+            '0',
+            '0',
+            expires_in,
+            refresh_function,
+            'INTREFRESH',
+            advisory_timeout=advisory_refresh,
+            mandatory_timeout=mandatory_refresh,
         )
         self.creds_last_for = creds_last_for
         self.refresh_counter = 0
-        self._advisory_refresh_timeout = advisory_refresh
-        self._mandatory_refresh_timeout = mandatory_refresh
 
     def _do_refresh(self):
         self.refresh_counter += 1

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -1,0 +1,329 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Temporary test suite for updated credential refresh behavior.
+
+These tests validate the updated credential refresh behavior, which is
+currently gated behind the DEFAULT_NEW_CREDENTIAL_REFRESH flag and not
+yet available to external users. Once the changes are validated
+internally and released publicly, the classes below will replace the
+corresponding classes in test_credentials.py and the standalone tests
+will be added to test_credentials.py. This file will then be removed.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from dateutil.tz import tzlocal
+
+from botocore import credentials
+from botocore.exceptions import CredentialRetrievalError
+from tests import BaseEnvVar, IntegerRefresher, mock, unittest
+
+# ---------------------------------------------------------------------------
+# Replacement classes: these mirror the classes in test_credentials.py with
+# assertions updated for the new credential refresh behavior.
+# ---------------------------------------------------------------------------
+
+
+@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+class TestRefreshableCredentials(BaseEnvVar):
+    def setUp(self):
+        super().setUp()
+        self.refresher = mock.Mock()
+        self.future_time = datetime.now(tzlocal()) + timedelta(hours=24)
+        self.expiry_time = datetime.now(tzlocal()) - timedelta(minutes=30)
+        self.metadata = {
+            'access_key': 'NEW-ACCESS',
+            'secret_key': 'NEW-SECRET',
+            'token': 'NEW-TOKEN',
+            'expiry_time': self.future_time.isoformat(),
+            'role_name': 'rolename',
+        }
+        self.refresher.return_value = self.metadata
+        self.mock_time = mock.Mock()
+        self.creds = credentials.RefreshableCredentials(
+            'ORIGINAL-ACCESS',
+            'ORIGINAL-SECRET',
+            'ORIGINAL-TOKEN',
+            self.expiry_time,
+            self.refresher,
+            'iam-role',
+            time_fetcher=self.mock_time,
+        )
+
+    def test_refresh_needed(self):
+        # The expiry time was set for 30 minutes ago, so if we
+        # say the current time is now(), then we should need
+        # a refresh.
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        # We should refresh creds, if we try to access "access_key"
+        # or any of the cred vars.
+        self.assertEqual(self.creds.access_key, 'NEW-ACCESS')
+        self.assertEqual(self.creds.secret_key, 'NEW-SECRET')
+        self.assertEqual(self.creds.token, 'NEW-TOKEN')
+
+    def test_no_expiration(self):
+        creds = credentials.RefreshableCredentials(
+            'ORIGINAL-ACCESS',
+            'ORIGINAL-SECRET',
+            'ORIGINAL-TOKEN',
+            None,
+            self.refresher,
+            'iam-role',
+            time_fetcher=self.mock_time,
+        )
+        self.assertFalse(creds.refresh_needed())
+
+    def test_no_refresh_needed(self):
+        # The expiry time was 30 minutes ago, let's say it's an hour
+        # ago currently.  That would mean we don't need a refresh.
+        self.mock_time.return_value = datetime.now(tzlocal()) - timedelta(
+            minutes=60
+        )
+        self.assertTrue(not self.creds.refresh_needed())
+
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(self.creds.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(self.creds.token, 'ORIGINAL-TOKEN')
+
+    def test_get_credentials_set(self):
+        # We need to return a consistent set of credentials to use during the
+        # signing process.
+        self.mock_time.return_value = datetime.now(tzlocal()) - timedelta(
+            minutes=60
+        )
+        self.assertTrue(not self.creds.refresh_needed())
+        credential_set = self.creds.get_frozen_credentials()
+        self.assertEqual(credential_set.access_key, 'ORIGINAL-ACCESS')
+        self.assertEqual(credential_set.secret_key, 'ORIGINAL-SECRET')
+        self.assertEqual(credential_set.token, 'ORIGINAL-TOKEN')
+
+    def test_refresh_returns_empty_dict(self):
+        # An empty dict from the source is treated as a failed refresh
+        # and we fall back to cached credentials.
+        self.refresher.return_value = {}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertTrue(self.refresher.called)
+
+    def test_refresh_returns_none(self):
+        # None from the source is treated as a failed refresh and we fall
+        # back to cached credentials.
+        self.refresher.return_value = None
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertTrue(self.refresher.called)
+
+    def test_refresh_returns_partial_credentials(self):
+        # Partial credentials from the source are treated as a failed
+        # refresh and we fall back to cached credentials.
+        self.refresher.return_value = {'access_key': 'akid'}
+        self.mock_time.return_value = datetime.now(tzlocal())
+        self.assertTrue(self.creds.refresh_needed())
+        self.assertEqual(self.creds.access_key, 'ORIGINAL-ACCESS')
+        self.assertTrue(self.refresher.called)
+
+
+@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+class TestRefreshLogic(unittest.TestCase):
+    def test_mandatory_refresh_needed(self):
+        creds = IntegerRefresher(
+            # These values will immediately trigger
+            # a mandatory refresh.
+            creds_last_for=2,
+            mandatory_refresh=3,
+            advisory_refresh=3,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('1', '1', '1'))
+
+    def test_advisory_refresh_needed(self):
+        creds = IntegerRefresher(
+            # These values will immediately trigger
+            # a mandatory refresh.
+            creds_last_for=4,
+            mandatory_refresh=2,
+            advisory_refresh=5,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('1', '1', '1'))
+
+    def test_refresh_fails_is_not_an_error_during_advisory_period(self):
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            creds_last_for=5,
+            advisory_refresh=7,
+            mandatory_refresh=3,
+            refresh_function=fail_refresh,
+        )
+        temp = creds.get_frozen_credentials()
+        # We should have called the refresh function.
+        self.assertTrue(fail_refresh.called)
+        # The fail_refresh function will raise an exception.
+        # Because we're in the advisory period we'll not propogate
+        # the exception and return the current set of credentials
+        # (generation '0').
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+    def test_exception_not_propogated_on_error_during_mandatory_period(self):
+        # Refresh failures in the mandatory window fall back to cached
+        # credentials instead of propagating.
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            creds_last_for=5,
+            advisory_refresh=10,
+            # Note we're in the mandatory period now (5 < 7 < 10).
+            mandatory_refresh=7,
+            refresh_function=fail_refresh,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertTrue(fail_refresh.called)
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+    def test_exception_not_propogated_on_expired_credentials(self):
+        # Even with fully expired credentials, a refresh failure returns
+        # the cached credentials.
+        fail_refresh = mock.Mock(side_effect=Exception("refresh failed"))
+        creds = IntegerRefresher(
+            # Setting this to 0 means the credentials are immediately
+            # expired.
+            creds_last_for=0,
+            advisory_refresh=10,
+            mandatory_refresh=7,
+            refresh_function=fail_refresh,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertTrue(fail_refresh.called)
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+    def test_refresh_giving_expired_credentials_returns_cached(self):
+        # This verifies an edge case where refreshed credentials
+        # still give expired credentials:
+        # 1. We see credentials are expired.
+        # 2. We try to refresh the credentials.
+        # 3. The "refreshed" credentials are still expired.
+        #
+        # In this case, we treat it as a failed refresh and fall back
+        # to the cached credentials.
+        creds = IntegerRefresher(
+            # Negative number indicates that the credentials
+            # have already been expired for 2 seconds, even
+            # on refresh.
+            creds_last_for=-2,
+        )
+        temp = creds.get_frozen_credentials()
+        self.assertEqual(temp, credentials.ReadOnlyCredentials('0', '0', '0'))
+
+
+# ---------------------------------------------------------------------------
+# Net-new tests: these cover backoff behavior that has no counterpart in the
+# legacy code path. At GA they will be added to test_credentials.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _enable_new_credential_refresh(monkeypatch):
+    monkeypatch.setattr(credentials, 'DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+
+
+@pytest.fixture
+def refresher():
+    return mock.Mock()
+
+
+@pytest.fixture
+def mock_time():
+    return mock.Mock(return_value=datetime.now(tzlocal()))
+
+
+@pytest.fixture
+def creds(refresher, mock_time):
+    # The expiry time is in the past so that accessing the credentials
+    # triggers a refresh.
+    return credentials.RefreshableCredentials(
+        'ORIGINAL-ACCESS',
+        'ORIGINAL-SECRET',
+        'ORIGINAL-TOKEN',
+        datetime.now(tzlocal()) - timedelta(minutes=30),
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+
+
+def _valid_metadata(mock_time, expires_in=timedelta(hours=24)):
+    expiry_time = mock_time() + expires_in
+    return {
+        'access_key': 'NEW-ACCESS',
+        'secret_key': 'NEW-SECRET',
+        'token': 'NEW-TOKEN',
+        'expiry_time': expiry_time.isoformat(),
+    }
+
+
+def test_refresh_failure_returns_cached(creds, refresher):
+    # When the source fails, we keep serving the cached credentials instead
+    # of raising.
+    refresher.side_effect = Exception("source down")
+    frozen = creds.get_frozen_credentials()
+    assert frozen.access_key == 'ORIGINAL-ACCESS'
+    assert frozen.secret_key == 'ORIGINAL-SECRET'
+    assert frozen.token == 'ORIGINAL-TOKEN'
+
+
+def test_failed_refresh_is_not_retried_immediately(creds, refresher):
+    # After a failed refresh, accessing the credentials again keeps using the
+    # cached credentials and does not call the source a second time.
+    refresher.side_effect = Exception("source down")
+    creds.get_frozen_credentials()
+    assert refresher.call_count == 1
+    frozen = creds.get_frozen_credentials()
+    assert refresher.call_count == 1
+    assert frozen.access_key == 'ORIGINAL-ACCESS'
+
+
+def test_refresh_is_retried_after_backoff(creds, refresher, mock_time):
+    # The first refresh fails and the source is not contacted again right
+    # away. Once enough time has passed, the next access retries the source
+    # and picks up the new credentials.
+    refresher.side_effect = [
+        Exception("source down"),
+        _valid_metadata(mock_time),
+    ]
+    creds.get_frozen_credentials()
+    assert refresher.call_count == 1
+
+    # Advance time past the maximum backoff window (10 minutes) so the next
+    # access is allowed to retry.
+    mock_time.return_value = datetime.now(tzlocal()) + timedelta(minutes=11)
+    frozen = creds.get_frozen_credentials()
+    assert refresher.call_count == 2
+    assert frozen.access_key == 'NEW-ACCESS'
+
+
+def test_refresh_failure_without_cached_creds_raises(mock_time):
+    # If we've never successfully fetched credentials, a refresh failure has
+    # nothing to fall back to and must be surfaced.
+    refresher = mock.Mock(side_effect=Exception("source down"))
+    creds = credentials.DeferredRefreshableCredentials(
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+    with pytest.raises(CredentialRetrievalError):
+        creds.get_frozen_credentials()

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -155,7 +155,7 @@ class TestRefreshLogic(unittest.TestCase):
     def test_advisory_refresh_needed(self):
         creds = IntegerRefresher(
             # These values will immediately trigger
-            # a mandatory refresh.
+            # an advisory refresh.
             creds_last_for=4,
             mandatory_refresh=2,
             advisory_refresh=5,

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -325,13 +325,13 @@ def _assert_refresh_boundary(
 ):
     expiry_time = issued_at + expires_in
 
-    # Just outside the window: no refresh yet.
+    # 1 second outside the window: no refresh yet.
     mock_time.return_value = expiry_time - timedelta(
         seconds=refresh_window + 1
     )
     assert creds.refresh_needed() is False
 
-    # Just inside the window: refresh needed.
+    # 1 second inside the window: refresh needed.
     mock_time.return_value = expiry_time - timedelta(
         seconds=refresh_window - 1
     )
@@ -420,13 +420,31 @@ def test_effective_advisory_window_not_recomputed_on_failure(
     assert creds.refresh_needed() is True
 
 
-def test_new_path_uses_one_minute_mandatory_window_by_default(mock_time):
-    creds = _create_refreshable_credentials(mock_time)
+def test_mandatory_refresh_boundary_is_one_minute(mock_time):
+    issued_at = mock_time()
+    expires_in = timedelta(minutes=30)
+    creds = _create_refreshable_credentials(
+        mock_time,
+        expires_in=expires_in,
+    )
+    expiry_time = issued_at + expires_in
 
-    assert creds._resolve_mandatory_refresh_timeout() == 60
+    # RefreshableCredentials does not branch on is_mandatory directly, but
+    # _refresh() still computes it and _StrictRefreshableCredentials depends
+    # on the mandatory-window classification.
+    mock_time.return_value = expiry_time - timedelta(seconds=61)
+    with mock.patch.object(creds, '_protected_refresh') as protected_refresh:
+        creds.get_frozen_credentials()
+    protected_refresh.assert_called_once_with(is_mandatory=False)
+
+    # Inside the 60-second mandatory window.
+    mock_time.return_value = expiry_time - timedelta(seconds=59)
+    with mock.patch.object(creds, '_protected_refresh') as protected_refresh:
+        creds.get_frozen_credentials()
+    protected_refresh.assert_called_once_with(is_mandatory=True)
 
 
-def test_explicit_refresh_windows_are_preserved_on_new_path(mock_time):
+def test_explicit_refresh_windows_are_preserved(mock_time):
     issued_at = mock_time()
     expires_in = timedelta(minutes=2)
     creds = _create_refreshable_credentials(
@@ -435,9 +453,21 @@ def test_explicit_refresh_windows_are_preserved_on_new_path(mock_time):
         advisory_timeout=45,
         mandatory_timeout=10,
     )
+    expiry_time = issued_at + expires_in
 
     _assert_refresh_boundary(creds, mock_time, issued_at, expires_in, 45)
-    assert creds._resolve_mandatory_refresh_timeout() == 10
+
+    # Outside the explicit 10-second mandatory window.
+    mock_time.return_value = expiry_time - timedelta(seconds=11)
+    with mock.patch.object(creds, '_protected_refresh') as protected_refresh:
+        creds.get_frozen_credentials()
+    protected_refresh.assert_called_once_with(is_mandatory=False)
+
+    # Inside the explicit 10-second mandatory window.
+    mock_time.return_value = expiry_time - timedelta(seconds=9)
+    with mock.patch.object(creds, '_protected_refresh') as protected_refresh:
+        creds.get_frozen_credentials()
+    protected_refresh.assert_called_once_with(is_mandatory=True)
 
 
 def test_deferred_first_fetch_uses_recomputed_advisory_window(mock_time):

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -30,6 +30,18 @@ from dateutil.tz import tzlocal
 from botocore import credentials
 from botocore.exceptions import CredentialRetrievalError
 from tests import BaseEnvVar, IntegerRefresher, mock, unittest
+from tests.unit.test_credentials import (
+    TestEnvVar as _TestEnvVar,
+)
+from tests.unit.test_credentials import (
+    TestProcessProvider as _TestProcessProvider,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_new_credential_refresh(monkeypatch):
+    monkeypatch.setattr(credentials, 'DEFAULT_NEW_CREDENTIAL_REFRESH', True)
+
 
 # ---------------------------------------------------------------------------
 # Replacement classes: these mirror the classes in test_credentials.py with
@@ -37,7 +49,6 @@ from tests import BaseEnvVar, IntegerRefresher, mock, unittest
 # ---------------------------------------------------------------------------
 
 
-@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
 class TestRefreshableCredentials(BaseEnvVar):
     def setUp(self):
         super().setUp()
@@ -139,7 +150,6 @@ class TestRefreshableCredentials(BaseEnvVar):
         self.assertTrue(self.refresher.called)
 
 
-@mock.patch('botocore.credentials.DEFAULT_NEW_CREDENTIAL_REFRESH', True)
 class TestRefreshLogic(unittest.TestCase):
     def test_mandatory_refresh_needed(self):
         creds = IntegerRefresher(
@@ -231,14 +241,22 @@ class TestRefreshLogic(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Mirrored provider suites: these reuse the existing Env and Process provider
+# tests with the flag enabled. Because these providers are out of scope for
+# static stability, their provider behavior should remain unchanged.
+# ---------------------------------------------------------------------------
+class TestEnvVarFlagOn(_TestEnvVar):
+    pass
+
+
+class TestProcessProviderFlagOn(_TestProcessProvider):
+    pass
+
+
+# ---------------------------------------------------------------------------
 # Net-new tests: these cover backoff behavior that has no counterpart in the
 # legacy code path. At GA they will be added to test_credentials.py.
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-def _enable_new_credential_refresh(monkeypatch):
-    monkeypatch.setattr(credentials, 'DEFAULT_NEW_CREDENTIAL_REFRESH', True)
 
 
 @pytest.fixture
@@ -325,5 +343,18 @@ def test_refresh_failure_without_cached_creds_raises(mock_time):
         'iam-role',
         time_fetcher=mock_time,
     )
-    with pytest.raises(CredentialRetrievalError):
+    with pytest.raises(Exception, match='source down'):
+        creds.get_frozen_credentials()
+
+
+def test_invalid_refresh_data_without_cached_creds_raises(mock_time):
+    refresher = mock.Mock(return_value={})
+    creds = credentials.DeferredRefreshableCredentials(
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+    with pytest.raises(
+        CredentialRetrievalError, match='Response did not contain'
+    ):
         creds.get_frozen_credentials()

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -63,7 +63,7 @@ class TestRefreshableCredentials(BaseEnvVar):
             'role_name': 'rolename',
         }
         self.refresher.return_value = self.metadata
-        self.mock_time = mock.Mock()
+        self.mock_time = mock.Mock(return_value=datetime.now(tzlocal()))
         self.creds = credentials.RefreshableCredentials(
             'ORIGINAL-ACCESS',
             'ORIGINAL-SECRET',
@@ -292,6 +292,178 @@ def _valid_metadata(mock_time, expires_in=timedelta(hours=24)):
         'token': 'NEW-TOKEN',
         'expiry_time': expiry_time.isoformat(),
     }
+
+
+def _create_refreshable_credentials(
+    mock_time,
+    refresher=None,
+    expires_in=timedelta(hours=24),
+    **kwargs,
+):
+    if refresher is None:
+        refresher = mock.Mock()
+    return credentials.RefreshableCredentials(
+        'ORIGINAL-ACCESS',
+        'ORIGINAL-SECRET',
+        'ORIGINAL-TOKEN',
+        mock_time() + expires_in,
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Refresh-window tests: these cover the advisory/mandatory defaults and their
+# interactions with successful and failed refreshes.
+# ---------------------------------------------------------------------------
+
+
+def _assert_refresh_boundary(
+    creds, mock_time, issued_at, expires_in, refresh_window
+):
+    expiry_time = issued_at + expires_in
+
+    # Just outside the window: no refresh yet.
+    mock_time.return_value = expiry_time - timedelta(
+        seconds=refresh_window + 1
+    )
+    assert creds.refresh_needed() is False
+
+    # Just inside the window: refresh needed.
+    mock_time.return_value = expiry_time - timedelta(
+        seconds=refresh_window - 1
+    )
+    assert creds.refresh_needed() is True
+
+
+def test_15_minute_credentials_do_not_refresh_immediately(mock_time):
+    creds = _create_refreshable_credentials(
+        mock_time, expires_in=timedelta(minutes=15)
+    )
+
+    assert creds.refresh_needed() is False
+
+
+@pytest.mark.parametrize(
+    "expires_in, expected_timeout",
+    [
+        (timedelta(minutes=20), 5 * 60),
+        (timedelta(minutes=20, seconds=1), 15 * 60),
+        (timedelta(minutes=89, seconds=59), 15 * 60),
+        (timedelta(minutes=90), 60 * 60),
+    ],
+)
+def test_effective_advisory_window_tier_boundaries(
+    mock_time, expires_in, expected_timeout
+):
+    issued_at = mock_time()
+    creds = _create_refreshable_credentials(mock_time, expires_in=expires_in)
+
+    _assert_refresh_boundary(
+        creds, mock_time, issued_at, expires_in, expected_timeout
+    )
+
+
+def test_effective_advisory_window_uses_lifetime_at_set_time(mock_time):
+    issued_at = mock_time()
+    creds = _create_refreshable_credentials(
+        mock_time,
+        expires_in=timedelta(hours=2),
+    )
+
+    mock_time.return_value = issued_at + timedelta(minutes=70)
+
+    assert creds.refresh_needed() is True
+
+
+def test_effective_advisory_window_recomputed_after_successful_refresh(
+    mock_time, refresher
+):
+    issued_at = mock_time()
+    refresher.return_value = _valid_metadata(
+        mock_time, expires_in=timedelta(hours=6)
+    )
+    creds = _create_refreshable_credentials(
+        mock_time,
+        refresher=refresher,
+        expires_in=timedelta(seconds=30),
+    )
+
+    frozen = creds.get_frozen_credentials()
+
+    assert frozen.access_key == 'NEW-ACCESS'
+    _assert_refresh_boundary(
+        creds, mock_time, issued_at, timedelta(hours=6), 60 * 60
+    )
+
+
+def test_effective_advisory_window_not_recomputed_on_failure(
+    mock_time, refresher
+):
+    issued_at = mock_time()
+    creds = _create_refreshable_credentials(
+        mock_time,
+        refresher=refresher,
+        expires_in=timedelta(minutes=30),
+    )
+
+    refresher.side_effect = Exception("source down")
+    mock_time.return_value = issued_at + timedelta(minutes=16)
+
+    assert creds.refresh_needed() is True
+
+    frozen = creds.get_frozen_credentials()
+
+    assert frozen.access_key == 'ORIGINAL-ACCESS'
+    assert creds.refresh_needed() is True
+
+
+def test_new_path_uses_one_minute_mandatory_window_by_default(mock_time):
+    creds = _create_refreshable_credentials(mock_time)
+
+    assert creds._resolve_mandatory_refresh_timeout() == 60
+
+
+def test_explicit_refresh_windows_are_preserved_on_new_path(mock_time):
+    issued_at = mock_time()
+    expires_in = timedelta(minutes=2)
+    creds = _create_refreshable_credentials(
+        mock_time,
+        expires_in=expires_in,
+        advisory_timeout=45,
+        mandatory_timeout=10,
+    )
+
+    _assert_refresh_boundary(creds, mock_time, issued_at, expires_in, 45)
+    assert creds._resolve_mandatory_refresh_timeout() == 10
+
+
+def test_deferred_first_fetch_uses_recomputed_advisory_window(mock_time):
+    issued_at = mock_time()
+    refresher = mock.Mock(
+        return_value=_valid_metadata(mock_time, expires_in=timedelta(hours=6))
+    )
+    creds = credentials.DeferredRefreshableCredentials(
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+
+    frozen = creds.get_frozen_credentials()
+
+    assert frozen.access_key == 'NEW-ACCESS'
+    assert refresher.call_count == 1
+    _assert_refresh_boundary(
+        creds, mock_time, issued_at, timedelta(hours=6), 60 * 60
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backoff tests: these cover behavior that has no counterpart in the legacy
+# code path.
+# ---------------------------------------------------------------------------
 
 
 def test_refresh_failure_returns_cached(creds, refresher):


### PR DESCRIPTION
*Issue #, if available:*
Python-8913

*Description of changes:*
### Overview
This PR updates the flag-gated the credential refresh path to use the new refresh window defaults. The legacy path is unchanged and all behavior changes here are scoped to  `DEFAULT_NEW_CREDENTIAL_REFRESH`.

### What changed

 #### Mandatory refresh window
The new refresh path now uses a 1-minute mandatory refresh window.

 #### Advisory refresh window
On the new refresh path, the effective advisory refresh window is selected dynamically from the credential lifetime (`Expiration - now`) when a new credential set is obtained:
- `<= 20 minutes` -> `5 minutes`
- `> 20 minutes and < 90 minutes` -> `15 minutes`
- `>= 90 minutes` -> `60 minutes`
That window stays fixed for the current credential set, is recomputed only after a successful refresh, and is not recomputed after a failed refresh.

#### Internal override behavior
- Preserves explicitly passed internal refresh windows on the new path instead of replacing them with computed defaults.
- This keeps existing internal callers such as S3 Express on their explicit windows.

#### New path refresh flow
- Advisory refresh checks on the new path now use the effective advisory window for the current credential set.
- Deferred credentials continue to fetch on first use and compute their advisory window once a credential set is successfully obtained.

### Tests
The flag-on coverage lives in `tests/unit/test_credential_refresh.py` for now. At GA, that coverage will be folded into `tests/unit/test_credentials.py` and the temporary file will be removed.

### Notes
- The legacy refresh path is unchanged, including the existing 15-minute advisory and 10-minute mandatory defaults.
- S3 Express behavior is unchanged since it is out of scope for this work.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
