### PR TITLE
Include max attempts in the amz-sdk-request header on the initial attempt

### DIFF
--- a/.changes/next-release/bugfix-retries-59262.json
+++ b/.changes/next-release/bugfix-retries-59262.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "retries",
+  "description": "Include the resolved max attempts in the ``amz-sdk-request`` header on the initial attempt"
+}

--- a/botocore/retries/standard.py
+++ b/botocore/retries/standard.py
@@ -65,8 +65,10 @@ def register_retry_handler(client, max_attempts=None):
         # The ``max`` token of the ``amz-sdk-request`` header is otherwise
         # only populated once a retry is attempted, so it's missing from
         # the initial attempt.  Seeding it here ensures that it's present
-        # on every attempt.  This is registered first so that it runs before
-        # ``add_retry_headers`` builds the header.
+        # on every attempt. This handler runs before ``add_retry_headers``
+        # because the emitter invokes more specific events first, and
+        # ``add_retry_headers`` is registered on the generic
+        # ``request-created``.
         client.meta.events.register(
             f'request-created.{service_event_name}',
             MaxAttemptsSeeder(max_attempts).seed_max_attempts,

--- a/botocore/retries/standard.py
+++ b/botocore/retries/standard.py
@@ -62,6 +62,16 @@ def register_retry_handler(client, max_attempts=None):
             max_attempts = _SERVICE_MAX_ATTEMPTS[service_event_name]
         elif max_attempts is None:
             max_attempts = DEFAULT_MAX_ATTEMPTS
+        # The ``max`` token of the ``amz-sdk-request`` header is otherwise
+        # only populated once a retry is attempted, so it's missing from
+        # the initial attempt.  Seeding it here ensures that it's present
+        # on every attempt.  This is registered first so that it runs before
+        # ``add_retry_headers`` builds the header.
+        client.meta.events.register(
+            f'request-created.{service_event_name}',
+            MaxAttemptsSeeder(max_attempts).seed_max_attempts,
+            unique_id=f'seed-max-attempts-{service_event_name}',
+        )
         throttling_detector = ThrottlingErrorDetector(retry_event_adapter)
         retry_quota = RetryQuotaChecker(
             quota.RetryQuota(), throttling_detector
@@ -103,6 +113,23 @@ def register_retry_handler(client, max_attempts=None):
         unique_id=unique_id,
     )
     return handler
+
+
+class MaxAttemptsSeeder:
+    """Adds the resolved max attempts to the retries context.
+
+    The ``max`` value is otherwise only added to the retries context by
+    ``MaxAttemptsChecker`` when a retry is evaluated, which means it's
+    absent from the initial attempt's ``amz-sdk-request`` header.
+
+    """
+
+    def __init__(self, max_attempts):
+        self._max_attempts = max_attempts
+
+    def seed_max_attempts(self, request, **kwargs):
+        retries_context = request.context.setdefault('retries', {})
+        retries_context['max'] = self._max_attempts
 
 
 class RetryHandler:

--- a/tests/unit/retries/test_standard_retry_v2_1.py
+++ b/tests/unit/retries/test_standard_retry_v2_1.py
@@ -12,10 +12,17 @@ from collections import Counter
 import pytest
 
 from botocore import configprovider
-from botocore.awsrequest import AWSResponse
+from botocore.awsrequest import AWSRequest, AWSResponse
+from botocore.config import Config
 from botocore.exceptions import ReadTimeoutError
 from botocore.retries import quota, standard
-from tests import BaseEnvVar, mock, unittest
+from tests import (
+    BaseEnvVar,
+    ClientHTTPStubber,
+    mock,
+    unittest,
+)
+from tests.functional.test_retry import BaseRetryTest
 
 
 @mock.patch('botocore.retries.standard.NEW_RETRIES_ENABLED', True)
@@ -437,3 +444,54 @@ class TestNewRetriesEnvironmentVariable(BaseEnvVar):
 
     def test_no_env_var_uses_default(self):
         self.assertFalse(configprovider._resolve_new_retries())
+
+
+@mock.patch('botocore.retries.standard.NEW_RETRIES_ENABLED', True)
+class TestMaxAttemptsInRequestHeader(BaseRetryTest):
+    """The resolved max attempts must appear on the initial attempt.
+
+    ``max`` is seeded into the request context at creation time, so the
+    very first ``amz-sdk-request`` header carries it. Previously it only
+    showed up from the second attempt onward.
+    """
+
+    def _sdk_request_headers(self, client_config, responses):
+        client = self.session.create_client(
+            'dynamodb', self.region, config=client_config
+        )
+        with ClientHTTPStubber(client) as http_stubber:
+            for status in responses:
+                http_stubber.add_response(status=status, body=b'{}')
+            client.list_tables()
+            return [
+                r.headers['amz-sdk-request'] for r in http_stubber.requests
+            ]
+
+    def test_max_present_on_initial_attempt(self):
+        for retry_mode in ('standard', 'adaptive'):
+            config = Config(
+                retries={'mode': retry_mode, 'total_max_attempts': 3}
+            )
+            headers = self._sdk_request_headers(config, [200])
+            self.assertEqual(headers, [b'attempt=1; max=3'])
+
+    def test_max_consistent_across_retries(self):
+        for retry_mode in ('standard', 'adaptive'):
+            config = Config(
+                retries={'mode': retry_mode, 'total_max_attempts': 3}
+            )
+            headers = self._sdk_request_headers(config, [500, 500, 200])
+            self.assertEqual(len(headers), 3)
+            for header in headers:
+                self.assertIn(b'max=3', header)
+
+    def test_service_specific_max_attempts(self):
+        # DynamoDB overrides the default of 3.
+        config = Config(retries={'mode': 'standard'})
+        headers = self._sdk_request_headers(config, [200])
+        self.assertEqual(headers, [b'attempt=1; max=4'])
+
+    def test_seeder_adds_max_to_empty_context(self):
+        request = AWSRequest()
+        standard.MaxAttemptsSeeder(3).seed_max_attempts(request)
+        self.assertEqual(request.context['retries'], {'max': 3})


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
``amz-sdk-request`` omitted ``max`` on the initial attempt because the value was only set once a response was received. Seed it at client registration so it's present on every attempt.

*Testing:*
- Added unit tests asserting ``max`` is present on the initial request , across retries and for service-specific overrides (DynamoDB)
- Full test suite passes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
