### PR TITLE
Add support for per-API invocation read timeouts

### DIFF
--- a/botocore/awsrequest.py
+++ b/botocore/awsrequest.py
@@ -369,8 +369,11 @@ class AWSRequestPreparer:
         body = self._prepare_body(original)
         headers = self._prepare_headers(original, body)
         stream_output = original.stream_output
+        context = original.context
 
-        return AWSPreparedRequest(method, url, headers, body, stream_output)
+        return AWSPreparedRequest(
+            method, url, headers, body, stream_output, context
+        )
 
     def _prepare_url(self, original):
         url = original.url
@@ -499,14 +502,18 @@ class AWSPreparedRequest:
     :ivar headers: The HTTP headers to send.
     :ivar body: The HTTP body.
     :ivar stream_output: If the response for this request should be streamed.
+    :ivar context: The request context from the originating ``AWSRequest``.
     """
 
-    def __init__(self, method, url, headers, body, stream_output):
+    def __init__(
+        self, method, url, headers, body, stream_output, context=None
+    ):
         self.method = method
         self.url = url
         self.headers = headers
         self.body = body
         self.stream_output = stream_output
+        self.context = context
 
     def __repr__(self):
         fmt = (

--- a/botocore/endpoint.py
+++ b/botocore/endpoint.py
@@ -186,7 +186,9 @@ class Endpoint:
             retries_context['invocation-id'] = str(uuid.uuid4())
 
         if success_response:
-            read_timeout = context['client_config'].read_timeout
+            read_timeout = context.get('read_timeout')
+            if read_timeout is None:
+                read_timeout = context['client_config'].read_timeout
             self._set_ttl(retries_context, read_timeout, success_response)
 
     def _send_request(self, request_dict, operation_model):

--- a/botocore/httpsession.py
+++ b/botocore/httpsession.py
@@ -452,6 +452,31 @@ class URLLib3Session:
         transfer_encoding = ensure_bytes(transfer_encoding)
         return transfer_encoding.lower() == b'chunked'
 
+    def _get_request_timeout(self, request):
+        """Resolve a per-request timeout override from the request context.
+
+        Returns a ``urllib3.Timeout`` when the request context contains a
+        ``read_timeout`` override, otherwise ``None`` to defer to the
+        connection pool's default timeout which is configured through client
+        config.
+
+        """
+        # We could use `request.context` directly, but we're being
+        # intentionally cautious here.  `context` is the first addition to
+        # AWSPreparedRequest in many years, and it's possible we might
+        # see an AWSPreparedRequest that doesn't have the `context` attribute.
+        context = getattr(request, 'context', None)
+        if context is None:
+            return None
+        read_timeout = context.get('read_timeout')
+        if read_timeout is None:
+            return None
+        if isinstance(self._timeout, Timeout):
+            connect_timeout = self._timeout.connect_timeout
+        else:
+            connect_timeout = self._timeout
+        return Timeout(connect=connect_timeout, read=read_timeout)
+
     def close(self):
         self._manager.clear()
         for manager in self._proxy_managers.values():
@@ -474,6 +499,13 @@ class URLLib3Session:
                 conn.proxy_headers['host'] = host
 
             request_target = self._get_request_target(request.url, proxy_url)
+            extra_kwargs = {}
+            request_timeout = self._get_request_timeout(request)
+            if request_timeout is not None:
+                # Only include the timeout kwarg when overridden; passing
+                # timeout=None to urlopen would disable timeouts entirely
+                # rather than defer to the pool's default timeout.
+                extra_kwargs['timeout'] = request_timeout
             urllib_response = conn.urlopen(
                 method=request.method,
                 url=request_target,
@@ -484,6 +516,7 @@ class URLLib3Session:
                 preload_content=False,
                 decode_content=False,
                 chunked=self._chunked(request.headers),
+                **extra_kwargs,
             )
 
             http_response = botocore.awsrequest.AWSResponse(

--- a/tests/functional/test_client.py
+++ b/tests/functional/test_client.py
@@ -1,6 +1,7 @@
 import unittest
 
 import botocore
+from tests import BaseSessionTest, ClientHTTPStubber
 
 
 class TestCreateClients(unittest.TestCase):
@@ -19,3 +20,27 @@ class TestCreateClients(unittest.TestCase):
             self.session.create_client(
                 'cloudformation', region_name='invalid region name'
             )
+
+
+class TestRequestContextReadTimeout(BaseSessionTest):
+    def test_read_timeout_override_reaches_prepared_request(self):
+        # A handler can set a per-invocation read timeout in the request
+        # context, which is carried through to the prepared request that
+        # is passed to the http session's send() method.
+        client = self.session.create_client('s3', region_name='us-west-2')
+
+        def set_read_timeout(context, **kwargs):
+            context['read_timeout'] = 300
+
+        client.meta.events.register(
+            'before-parameter-build.s3.ListBuckets', set_read_timeout
+        )
+        with ClientHTTPStubber(client) as http_stubber:
+            http_stubber.add_response(
+                body=b'<?xml version="1.0" encoding="UTF-8"?>'
+                b'<ListAllMyBucketsResult><Buckets></Buckets>'
+                b'</ListAllMyBucketsResult>'
+            )
+            client.list_buckets()
+        prepared_request = http_stubber.requests[0]
+        self.assertEqual(prepared_request.context['read_timeout'], 300)

--- a/tests/functional/test_retry.py
+++ b/tests/functional/test_retry.py
@@ -122,7 +122,12 @@ class TestRetryHeader(BaseRetryTest):
         return test_cases
 
     def _test_amz_sdk_request_header_with_test_case(
-        self, responses, utcnow_side_effects, expected_headers, client_config
+        self,
+        responses,
+        utcnow_side_effects,
+        expected_headers,
+        client_config,
+        read_timeout_override=None,
     ):
         datetime_patcher = mock.patch.object(
             botocore.endpoint.datetime,
@@ -135,6 +140,17 @@ class TestRetryHeader(BaseRetryTest):
         client = self.session.create_client(
             'dynamodb', self.region, config=client_config
         )
+        if read_timeout_override is not None:
+            # Simulate a handler setting a per-invocation read timeout in the
+            # request context. This is the same context dict the endpoint uses
+            # to compute the retry TTL, so the override should take precedence
+            # over the client config's read_timeout.
+            def set_read_timeout(context, **kwargs):
+                context['read_timeout'] = read_timeout_override
+
+            client.meta.events.register(
+                'before-parameter-build.dynamodb.ListTables', set_read_timeout
+            )
         with ClientHTTPStubber(client) as http_stubber:
             for response in responses:
                 http_stubber.add_response(
@@ -157,6 +173,42 @@ class TestRetryHeader(BaseRetryTest):
                 self._test_amz_sdk_request_header_with_test_case(
                     *test_case, client_config=client_config
                 )
+
+    def test_amz_sdk_request_header_uses_read_timeout_override(self):
+        # When a per-invocation read timeout is set in the request context,
+        # the retry TTL is computed from that override rather than the client
+        # config's read_timeout. Here the config read_timeout is 10s but the
+        # override is 300s, so the ttl values are 5 minutes past the mocked
+        # local timestamp instead of 10 seconds past it.
+        responses = [
+            (500, {'Date': 'Sat, 01 Jun 2019 00:00:00 GMT'}),
+            (500, {'Date': 'Sat, 01 Jun 2019 00:00:01 GMT'}),
+            (200, {'Date': 'Sat, 01 Jun 2019 00:00:02 GMT'}),
+        ]
+        utcnow_side_effects = [
+            datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+            datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+            datetime.datetime(2019, 6, 1, 0, 0, 1, 0),
+            datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+            datetime.datetime(2019, 6, 1, 0, 0, 1, 0),
+            datetime.datetime(2019, 6, 1, 0, 0, 2, 0),
+            datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+        ]
+        expected_headers = [
+            b'attempt=1',
+            b'ttl=20190601T000501Z; attempt=2; max=3',
+            b'ttl=20190601T000502Z; attempt=3; max=3',
+        ]
+        for retry_mode in RETRY_MODES:
+            retries_config = {'mode': retry_mode, 'total_max_attempts': 3}
+            client_config = Config(read_timeout=10, retries=retries_config)
+            self._test_amz_sdk_request_header_with_test_case(
+                responses,
+                utcnow_side_effects,
+                expected_headers,
+                client_config=client_config,
+                read_timeout_override=300,
+            )
 
     def test_amz_sdk_invocation_id_header_persists(self):
         for retry_mode in RETRY_MODES:

--- a/tests/unit/test_awsrequest.py
+++ b/tests/unit/test_awsrequest.py
@@ -208,6 +208,12 @@ class TestAWSRequest(unittest.TestCase):
         prepared_request = self.request.prepare()
         self.assertEqual(prepared_request.headers.get('Content-Length'), None)
 
+    def test_prepare_carries_context(self):
+        self.request.context['read_timeout'] = 120
+        prepared_request = self.request.prepare()
+        self.assertIs(prepared_request.context, self.request.context)
+        self.assertEqual(prepared_request.context['read_timeout'], 120)
+
     def test_can_reset_stream_handles_binary(self):
         contents = b'notastream'
         self.prepared_request.body = contents

--- a/tests/unit/test_http_session.py
+++ b/tests/unit/test_http_session.py
@@ -2,6 +2,7 @@ import socket
 from concurrent.futures import CancelledError
 
 import pytest
+from urllib3 import Timeout
 from urllib3.exceptions import NewConnectionError, ProtocolError, ProxyError
 
 from botocore.awsrequest import (
@@ -379,6 +380,42 @@ class TestURLLib3Session(unittest.TestCase):
         session.send(self.request.prepare())
         self.assert_request_sent()
         self.response.stream.assert_called_once_with()
+
+    def test_no_timeout_kwarg_without_context_override(self):
+        session = URLLib3Session(timeout=(10, 20))
+        session.send(self.request.prepare())
+        # assert_request_sent asserts the exact set of kwargs, so this
+        # also verifies that no timeout kwarg was passed to urlopen.
+        self.assert_request_sent()
+        call_kwargs = self.connection.urlopen.call_args[1]
+        self.assertNotIn('timeout', call_kwargs)
+
+    def test_context_read_timeout_overrides_read_timeout(self):
+        session = URLLib3Session(timeout=(10, 20))
+        self.request.context['read_timeout'] = 300
+        session.send(self.request.prepare())
+        timeout = self.connection.urlopen.call_args[1]['timeout']
+        self.assertIsInstance(timeout, Timeout)
+        self.assertEqual(timeout.connect_timeout, 10)
+        self.assertEqual(timeout.read_timeout, 300)
+
+    def test_context_read_timeout_with_scalar_session_timeout(self):
+        session = URLLib3Session(timeout=10)
+        self.request.context['read_timeout'] = 300
+        session.send(self.request.prepare())
+        timeout = self.connection.urlopen.call_args[1]['timeout']
+        self.assertIsInstance(timeout, Timeout)
+        self.assertEqual(timeout.connect_timeout, 10)
+        self.assertEqual(timeout.read_timeout, 300)
+
+    def test_send_no_context_attribute(self):
+        # Request objects that don't have a context attribute should
+        # still be sendable and use the session's default timeout.
+        prepared_request = self.request.prepare()
+        del prepared_request.context
+        session = URLLib3Session()
+        session.send(prepared_request)
+        self.assert_request_sent()
 
     def test_basic_streaming_request(self):
         session = URLLib3Session()


### PR DESCRIPTION
Botocore allows you to specify a read and connect timeout in the client config that's provided during client instantiation.  This sets the timeouts for the entire client.  There is no mechanism to override the timeout for specific operations or on a per-request (per-invocation basis).

Wanting to override timeouts on a more granular level comes up in several cases:

* Some service operations are blocking API calls that wait until some task is complete before returning, e.g. Lambda's `Invoke`, or Bedrock Runtime's `Converse`.
* Some specific invocations have a known minimal timeout based on the values of the parameters provided.  For example, SQS's `ReceiveMessage` has a `WaitTimeSeconds` which is the maximum number of seconds the request will wait for new messages to arrive.  Ideally we don't want a read timeout that's less than the value of `WaitTimeSeconds` if provided.

Per-request timeouts are implemented through an optional override in the request context dictionary as discussed with @jonathan343 . I updated the `URLLib3Session` class to check for a `read_timeout` in the request context and pass that value along to the `urlopen(...)` call if present.  The `urlopen(...)` call happens in the `send` method which only takes `send(self, request: AWSPreparedRequest)`.

In order to preserve that method signature, I opted for the less risky route of adding an optional `context` param to the `AWSPreparedRequest`. It's already in the `AWSRequest` so it didn't seem unreasonable to pass it through to the `AWSPreparedRequest`.  Given this object hasn't add new public attributes in many years, and that this type is publicly documented and accessible in various events emitted, I also opted for a safer `getattr(request, 'context', None)` when checking for a read timeout override.


## Example script

```python
import time

import botocore.session
from botocore.config import Config
from botocore.exceptions import ReadTimeoutError


QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/12345/YOUR-QUEUE'


def set_read_timeout(context, **kwargs):
    context['read_timeout'] = 1
    print("[handler] set read_timeout=1s for this invocation")


def main():
    session = botocore.session.get_session()
    # session.set_debug_logger()
    #
    # Turn off retries so we can see the total wall clock time should be
    # a little more than 1 second.
    client = session.create_client(
        'sqs', config=Config(retries={'total_max_attempts': 1})
    )

    client.meta.events.register(
        'before-call.sqs.ReceiveMessage', set_read_timeout
    )

    print(
        f"Calling SQS ReceiveMessage (WaitTimeSeconds=20 long poll) against\n"
        f"  {QUEUE_URL}\n"
    )
    start = time.monotonic()
    try:
        client.receive_message(QueueUrl=QUEUE_URL, WaitTimeSeconds=20)
    except ReadTimeoutError as e:
        total = time.monotonic() - start
        print(f"\n[OK] Got ReadTimeoutError after {total:.2f}s (expected ~1s)")
        print(f"     {e}")
        print(
            "\nThe client default read_timeout was 60s and the long poll "
            "would hold the connection for 20s, but the per-invocation handler"
            " overrode the\nread timeout to 1s so the call failed fast."
        )
    else:
        print(
            "\n[NOTE] Call returned before 1s (queue had a message ready), "
            "so the\ntimeout did not fire this run.  Re-run against an "
            "empty queue."
        )


if __name__ == '__main__':
    main()
```

**Output**

```
Calling SQS ReceiveMessage (WaitTimeSeconds=20 long poll) against
  https://sqs.us-west-2.amazonaws.com/1234/testq

[handler] set read_timeout=1s for this invocation

[OK] Got ReadTimeoutError after 1.30s (expected ~1s)
     Read timeout on endpoint URL: "https://sqs.us-west-2.amazonaws.com/"

The client default read_timeout was 60s and the long poll would hold the connection for 20s,
but the per-invocation handler overrode the
read timeout to 1s so the call failed fast.
```