### PR TITLE
Add non-recoverable credential refresh errors

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -104,7 +104,7 @@ _NONRECOVERABLE_STS_ERROR_CODES = frozenset(
         'InvalidIdentityToken',
         'MalformedPolicyDocument',
         'PackedPolicyTooLarge',
-        'RegionDisabled',
+        'RegionDisabledException',
     )
 )
 _NONRECOVERABLE_STS_METHODS = frozenset(

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -803,6 +803,8 @@ class RefreshableCredentials(Credentials):
         return None
 
     def _handle_refresh_exception(self, error):
+        # Surface non-recoverable failures immediately because
+        # they require customer action rather than retry or backoff.
         if _is_nonrecoverable_refresh_error(self.method, error):
             self._cache_nonrecoverable_error(error)
             raise error

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -627,14 +627,15 @@ class RefreshableCredentials(Credentials):
             return False
         return self._time_fetcher() < refresh_blocked_until
 
-    def _has_cached_nonrecoverable_error(self):
-        # Only suppress refresh attempts while the cached error's TTL
-        # is in effect.
-        if self._cached_nonrecoverable_error is None:
-            return False
-        return (
-            self._time_fetcher() < self._cached_nonrecoverable_error_expires_at
-        )
+    def _get_cached_nonrecoverable_error(self):
+        # Return the cached non-recoverable error while its TTL is still active.
+        cached_error = self._cached_nonrecoverable_error
+        expires_at = self._cached_nonrecoverable_error_expires_at
+        if cached_error is None or expires_at is None:
+            return None
+        if self._time_fetcher() >= expires_at:
+            return None
+        return cached_error
 
     def _cache_nonrecoverable_error(self, error):
         cache_ttl = random.uniform(
@@ -743,8 +744,9 @@ class RefreshableCredentials(Credentials):
     def _protected_refresh(self, is_mandatory):
         # precondition: this method should only be called if you've acquired
         # the self._refresh_lock.
-        if self._has_cached_nonrecoverable_error():
-            raise self._cached_nonrecoverable_error
+        cached_error = self._get_cached_nonrecoverable_error()
+        if cached_error is not None:
+            raise cached_error
         if self._in_refresh_backoff():
             # Another caller entered refresh backoff while we were waiting
             # for the lock. Skip the refresh attempt.

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -40,17 +40,20 @@ from botocore.compat import (
 )
 from botocore.config import Config
 from botocore.exceptions import (
+    ClientError,
     ConfigNotFound,
     CredentialRetrievalError,
     InfiniteLoopConfigError,
     InvalidConfigError,
     LoginError,
     LoginInsufficientPermissions,
+    LoginInvalidCachedTokenError,
     LoginRefreshRequired,
     LoginTokenLoadError,
     MetadataRetrievalError,
     MissingDependencyException,
     PartialCredentialsError,
+    RefreshNonRecoverableError,
     RefreshWithMFAUnsupportedError,
     UnauthorizedSSOTokenError,
     UnknownCredentialError,
@@ -92,6 +95,36 @@ ReadOnlyCredentials = namedtuple(
 _DEFAULT_MANDATORY_REFRESH_TIMEOUT = 10 * 60  # 10 min
 _DEFAULT_ADVISORY_REFRESH_TIMEOUT = 15 * 60  # 15 min
 _DEFAULT_MANDATORY_REFRESH_TIMEOUT_V2 = 1 * 60  # 1 min
+_NONRECOVERABLE_ERROR_CACHE_MIN_TTL = 1
+_NONRECOVERABLE_ERROR_CACHE_MAX_TTL = 5
+_NONRECOVERABLE_STS_ERROR_CODES = frozenset(
+    (
+        'AccessDenied',
+        'IDPRejectedClaim',
+        'InvalidIdentityToken',
+        'MalformedPolicyDocument',
+        'PackedPolicyTooLarge',
+        'RegionDisabled',
+    )
+)
+_NONRECOVERABLE_STS_METHODS = frozenset(
+    ('assume-role', 'assume-role-with-web-identity')
+)
+
+
+def _is_sts_nonrecoverable_error(method, error):
+    if method not in _NONRECOVERABLE_STS_METHODS:
+        return False
+    if not isinstance(error, ClientError):
+        return False
+    error_code = error.response.get('Error', {}).get('Code')
+    return error_code in _NONRECOVERABLE_STS_ERROR_CODES
+
+
+def _is_nonrecoverable_refresh_error(method, error):
+    return isinstance(
+        error, RefreshNonRecoverableError
+    ) or _is_sts_nonrecoverable_error(method, error)
 
 
 def create_credential_resolver(session, cache=None, region_name=None):
@@ -442,6 +475,8 @@ class RefreshableCredentials(Credentials):
         self._time_fetcher = time_fetcher
         self._refresh_lock = threading.Lock()
         self._refresh_blocked_until = None
+        self._cached_nonrecoverable_error = None
+        self._cached_nonrecoverable_error_expires_at = None
         self.method = method
         self._frozen_credentials = ReadOnlyCredentials(
             access_key, secret_key, token, account_id
@@ -592,6 +627,31 @@ class RefreshableCredentials(Credentials):
             return False
         return self._time_fetcher() < refresh_blocked_until
 
+    def _has_cached_nonrecoverable_error(self):
+        # Only suppress refresh attempts while the cached error's TTL
+        # is in effect.
+        if self._cached_nonrecoverable_error is None:
+            return False
+        return (
+            self._time_fetcher() < self._cached_nonrecoverable_error_expires_at
+        )
+
+    def _cache_nonrecoverable_error(self, error):
+        cache_ttl = random.uniform(
+            _NONRECOVERABLE_ERROR_CACHE_MIN_TTL,
+            _NONRECOVERABLE_ERROR_CACHE_MAX_TTL,
+        )
+        now = self._time_fetcher()
+        self._cached_nonrecoverable_error = error
+        self._cached_nonrecoverable_error_expires_at = (
+            now + datetime.timedelta(seconds=cache_ttl)
+        )
+
+    def _clear_refresh_failure_state(self):
+        self._refresh_blocked_until = None
+        self._cached_nonrecoverable_error = None
+        self._cached_nonrecoverable_error_expires_at = None
+
     def _enter_refresh_backoff(self, error):
         # Apply a jittered 5-10 minute backoff after a failed refresh to avoid
         # overwhelming the credential source during an outage.
@@ -683,6 +743,8 @@ class RefreshableCredentials(Credentials):
     def _protected_refresh(self, is_mandatory):
         # precondition: this method should only be called if you've acquired
         # the self._refresh_lock.
+        if self._has_cached_nonrecoverable_error():
+            raise self._cached_nonrecoverable_error
         if self._in_refresh_backoff():
             # Another caller entered refresh backoff while we were waiting
             # for the lock. Skip the refresh attempt.
@@ -697,7 +759,7 @@ class RefreshableCredentials(Credentials):
             self._handle_invalid_refresh_response(error)
             return
         self._set_from_validated_data(metadata)
-        self._refresh_blocked_until = None
+        self._clear_refresh_failure_state()
         self._frozen_credentials = ReadOnlyCredentials(
             self._access_key, self._secret_key, self._token, self._account_id
         )
@@ -741,6 +803,9 @@ class RefreshableCredentials(Credentials):
         return None
 
     def _handle_refresh_exception(self, error):
+        if _is_nonrecoverable_refresh_error(self.method, error):
+            self._cache_nonrecoverable_error(error)
+            raise error
         self._enter_refresh_backoff(error)
 
     def _handle_invalid_refresh_response(self, error):
@@ -947,6 +1012,8 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
         self._time_fetcher = time_fetcher
         self._refresh_lock = threading.Lock()
         self._refresh_blocked_until = None
+        self._cached_nonrecoverable_error = None
+        self._cached_nonrecoverable_error_expires_at = None
         self.method = method
         self._frozen_credentials = None
         self._explicit_advisory_refresh_timeout = None
@@ -961,6 +1028,9 @@ class DeferredRefreshableCredentials(RefreshableCredentials):
     # Before the first successful deferred fetch, there are no cached
     # credentials to fall back to, so initial failures must be surfaced.
     def _handle_refresh_exception(self, error):
+        if _is_nonrecoverable_refresh_error(self.method, error):
+            super()._handle_refresh_exception(error)
+            return
         if self._frozen_credentials is None:
             raise error
         super()._handle_refresh_exception(error)
@@ -2847,31 +2917,18 @@ class LoginCredentialFetcher:
 
     def load_cached_credentials(self):
         """Loads cached credentials without checking their expiry."""
-        token = self._token_loader.load_token(self._session_name)
-
-        if token is None:
-            raise LoginTokenLoadError(
-                error_msg='Unable to load a existing login session for session '
-                f'{self._session_name}. Please reauthenticate with '
-                "'aws login'.",
-            )
-
-        missing_fields = [
-            key for key in self._REQUIRED_TOKEN_FIELDS if key not in token
-        ]
-        if missing_fields:
-            raise LoginTokenLoadError(
-                error_msg=f'Failed to load access token from token cache, missing required fields: {", ".join(missing_fields)}.'
-            )
-
+        token = self._load_token(LoginTokenLoadError)
         return self._token_to_credentials(token)
 
     def refresh_credentials(self):
         """Refreshes login credentials, including saving them to the cache."""
         if self.feature_ids:
             register_feature_ids(self.feature_ids)
+        invalid_cached_token_error_cls = LoginInvalidCachedTokenError
+        if not DEFAULT_NEW_CREDENTIAL_REFRESH:
+            invalid_cached_token_error_cls = LoginTokenLoadError
         # Reload the token from disk, we need the refresh info
-        token = self._token_loader.load_token(self._session_name)
+        token = self._load_token(invalid_cached_token_error_cls)
         private_key = self._load_private_key(token)
 
         # Check if token has already been refreshed and is still valid
@@ -2949,6 +3006,26 @@ class LoginCredentialFetcher:
         self._token_loader.save_token(self._session_name, token)
 
         return self._token_to_credentials(token)
+
+    def _load_token(self, error_cls):
+        token = self._token_loader.load_token(self._session_name)
+
+        if token is None:
+            raise error_cls(
+                error_msg='Unable to load a existing login session for session '
+                f'{self._session_name}. Please reauthenticate with '
+                "'aws login'.",
+            )
+
+        missing_fields = [
+            key for key in self._REQUIRED_TOKEN_FIELDS if key not in token
+        ]
+        if missing_fields:
+            raise error_cls(
+                error_msg=f'Failed to load access token from token cache, missing required fields: {", ".join(missing_fields)}.'
+            )
+
+        return token
 
     @staticmethod
     def _token_to_credentials(token):

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -759,10 +759,10 @@ class RefreshableCredentials(Credentials):
             self._handle_invalid_refresh_response(error)
             return
         self._set_from_validated_data(metadata)
-        self._clear_refresh_failure_state()
         self._frozen_credentials = ReadOnlyCredentials(
             self._access_key, self._secret_key, self._token, self._account_id
         )
+        self._clear_refresh_failure_state()
 
     def _set_from_validated_data(self, data):
         # Only called once the data has passed ``_validate_data``, so we never

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -216,7 +216,11 @@ class CredentialRetrievalError(BotoCoreError):
 
 
 class RefreshNonRecoverableError:
-    """Marker for refresh failures that should bypass backoff."""
+    """Marker for refresh failures that should bypass backoff.
+
+    This is intended to be mixed into provider-specific exceptions and is not
+    raised directly.
+    """
 
     pass
 

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -215,6 +215,12 @@ class CredentialRetrievalError(BotoCoreError):
     fmt = 'Error when retrieving credentials from {provider}: {error_msg}'
 
 
+class RefreshNonRecoverableError:
+    """Marker for refresh failures that should bypass backoff."""
+
+    pass
+
+
 class UnknownSignatureVersionError(BotoCoreError):
     """
     Requested Signature Version is not known.
@@ -764,11 +770,11 @@ class SSOError(BotoCoreError):
     )
 
 
-class SSOTokenLoadError(SSOError):
+class SSOTokenLoadError(SSOError, RefreshNonRecoverableError):
     fmt = "Error loading SSO Token: {error_msg}"
 
 
-class UnauthorizedSSOTokenError(SSOError):
+class UnauthorizedSSOTokenError(SSOError, RefreshNonRecoverableError):
     fmt = (
         "The SSO session associated with this profile has expired or is "
         "otherwise invalid. To refresh this SSO session run aws sso login "
@@ -783,11 +789,11 @@ class LoginError(BotoCoreError):
     )
 
 
-class LoginRefreshRequired(LoginError):
+class LoginRefreshRequired(LoginError, RefreshNonRecoverableError):
     fmt = "Your session has expired or credentials have changed. Please reauthenticate using 'aws login'."
 
 
-class LoginInsufficientPermissions(LoginError):
+class LoginInsufficientPermissions(LoginError, RefreshNonRecoverableError):
     fmt = (
         "Unable to create or refresh login credentials due to insufficient "
         "permissions. You may be missing permission for the 'signin:CreateOAuth2Token' action."
@@ -796,6 +802,12 @@ class LoginInsufficientPermissions(LoginError):
 
 class LoginTokenLoadError(LoginError):
     fmt = "Error loading login session token: {error_msg}"
+
+
+class LoginInvalidCachedTokenError(
+    LoginTokenLoadError, RefreshNonRecoverableError
+):
+    pass
 
 
 class LoginAuthorizationCodeError(LoginError):

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -1175,264 +1175,259 @@ def test_malformed_expiry_returns_cached_credentials(creds, refresher):
 
 
 # ---------------------------------------------------------------------------
-# Non-recoverable tests: these cover the flag-on-only behavior for immediate
-# surfacing and short-lived retry suppression.
+# Non-recoverable tests: these cover the flag-on-only behavior for providers
+# surfacing non-recoverable errors and short-lived retry suppression.
 # ---------------------------------------------------------------------------
 
 
-def test_advisory_nonrecoverable_error_is_not_retried_within_ttl(mock_time):
-    refresher = mock.Mock(
-        side_effect=_CacheableNonRecoverableError("reauth required")
-    )
-    creds = _create_refreshable_credentials(
-        mock_time,
-        refresher=refresher,
-        expires_in=timedelta(seconds=90),
-        advisory_timeout=120,
-        mandatory_timeout=60,
-    )
+class TestNonRecoverableRefresh:
+    @pytest.fixture
+    def patched_jitter(self):
+        with mock.patch('botocore.credentials.random.uniform', return_value=5):
+            yield
 
-    with mock.patch('botocore.credentials.random.uniform', return_value=5):
+    def _assert_reauth_raised(self, creds):
         with pytest.raises(
             _CacheableNonRecoverableError, match='reauth required'
         ):
             creds.get_frozen_credentials()
 
-    assert refresher.call_count == 1
+    def test_advisory_nonrecoverable_error_is_not_retried_within_ttl(
+        self, patched_jitter, mock_time
+    ):
+        refresher = mock.Mock(
+            side_effect=_CacheableNonRecoverableError("reauth required")
+        )
+        creds = _create_refreshable_credentials(
+            mock_time,
+            refresher=refresher,
+            expires_in=timedelta(seconds=90),
+            advisory_timeout=120,
+            mandatory_timeout=60,
+        )
 
-    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
-        creds.get_frozen_credentials()
+        self._assert_reauth_raised(creds)
+        assert refresher.call_count == 1
 
-    assert refresher.call_count == 1
+        self._assert_reauth_raised(creds)
+        assert refresher.call_count == 1
 
+    def test_mandatory_nonrecoverable_error_is_not_retried_within_ttl(
+        self, patched_jitter, creds, refresher
+    ):
+        refresher.side_effect = _CacheableNonRecoverableError(
+            "reauth required"
+        )
 
-def test_mandatory_nonrecoverable_error_is_not_retried_within_ttl(
-    creds, refresher
-):
-    refresher.side_effect = _CacheableNonRecoverableError("reauth required")
+        self._assert_reauth_raised(creds)
+        assert refresher.call_count == 1
 
-    with mock.patch('botocore.credentials.random.uniform', return_value=5):
-        with pytest.raises(
-            _CacheableNonRecoverableError, match='reauth required'
-        ):
-            creds.get_frozen_credentials()
+        self._assert_reauth_raised(creds)
+        assert refresher.call_count == 1
 
-    assert refresher.call_count == 1
+    def test_advisory_nonrecoverable_error_is_retried_after_ttl_expires(
+        self, patched_jitter, mock_time
+    ):
+        refresher = mock.Mock(
+            side_effect=[
+                _CacheableNonRecoverableError("reauth required"),
+                _valid_metadata(mock_time),
+            ]
+        )
+        issued_at = mock_time()
+        creds = _create_refreshable_credentials(
+            mock_time,
+            refresher=refresher,
+            expires_in=timedelta(seconds=90),
+            advisory_timeout=120,
+            mandatory_timeout=60,
+        )
 
-    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
-        creds.get_frozen_credentials()
+        self._assert_reauth_raised(creds)
 
-    assert refresher.call_count == 1
+        mock_time.return_value = issued_at + timedelta(seconds=6)
+        frozen = creds.get_frozen_credentials()
 
+        assert refresher.call_count == 2
+        assert frozen.access_key == 'NEW-ACCESS'
 
-def test_advisory_nonrecoverable_error_is_retried_after_ttl_expires(
-    mock_time,
-):
-    refresher = mock.Mock(
-        side_effect=[
-            _CacheableNonRecoverableError("reauth required"),
-            _valid_metadata(mock_time),
-        ]
+    def test_deferred_nonrecoverable_error_retries_after_ttl_expires(
+        self, patched_jitter, mock_time
+    ):
+        refresher = mock.Mock(
+            side_effect=[
+                _CacheableNonRecoverableError("reauth required"),
+                _valid_metadata(mock_time),
+            ]
+        )
+        issued_at = mock_time()
+        creds = credentials.DeferredRefreshableCredentials(
+            refresher,
+            'iam-role',
+            time_fetcher=mock_time,
+        )
+
+        self._assert_reauth_raised(creds)
+
+        self._assert_reauth_raised(creds)
+        assert refresher.call_count == 1
+
+        mock_time.return_value = issued_at + timedelta(seconds=6)
+        frozen = creds.get_frozen_credentials()
+
+        assert refresher.call_count == 2
+        assert frozen.access_key == 'NEW-ACCESS'
+
+    @pytest.mark.parametrize(
+        'method',
+        ['assume-role', 'assume-role-with-web-identity'],
     )
-    issued_at = mock_time()
-    creds = _create_refreshable_credentials(
-        mock_time,
-        refresher=refresher,
-        expires_in=timedelta(seconds=90),
-        advisory_timeout=120,
-        mandatory_timeout=60,
-    )
+    def test_sts_nonrecoverable_error_is_not_retried_within_ttl(
+        self, patched_jitter, mock_time, method
+    ):
+        refresher = mock.Mock()
+        refresher.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'InvalidIdentityToken',
+                    'Message': 'bad token',
+                }
+            },
+            'AssumeRole',
+        )
+        creds = _create_refreshable_credentials(
+            mock_time,
+            refresher=refresher,
+            expires_in=timedelta(seconds=30),
+            method=method,
+        )
 
-    with mock.patch('botocore.credentials.random.uniform', return_value=5):
-        with pytest.raises(
-            _CacheableNonRecoverableError, match='reauth required'
-        ):
-            creds.get_frozen_credentials()
-
-    mock_time.return_value = issued_at + timedelta(seconds=6)
-    frozen = creds.get_frozen_credentials()
-
-    assert refresher.call_count == 2
-    assert frozen.access_key == 'NEW-ACCESS'
-
-
-def test_deferred_nonrecoverable_error_retries_after_ttl_expires(mock_time):
-    refresher = mock.Mock(
-        side_effect=[
-            _CacheableNonRecoverableError("reauth required"),
-            _valid_metadata(mock_time),
-        ]
-    )
-    issued_at = mock_time()
-    creds = credentials.DeferredRefreshableCredentials(
-        refresher,
-        'iam-role',
-        time_fetcher=mock_time,
-    )
-
-    with mock.patch('botocore.credentials.random.uniform', return_value=5):
-        with pytest.raises(
-            _CacheableNonRecoverableError, match='reauth required'
-        ):
-            creds.get_frozen_credentials()
-
-    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
-        creds.get_frozen_credentials()
-
-    assert refresher.call_count == 1
-
-    mock_time.return_value = issued_at + timedelta(seconds=6)
-    frozen = creds.get_frozen_credentials()
-
-    assert refresher.call_count == 2
-    assert frozen.access_key == 'NEW-ACCESS'
-
-
-@pytest.mark.parametrize(
-    'method',
-    ['assume-role', 'assume-role-with-web-identity'],
-)
-def test_sts_nonrecoverable_error_is_not_retried_within_ttl(mock_time, method):
-    refresher = mock.Mock()
-    refresher.side_effect = ClientError(
-        {'Error': {'Code': 'InvalidIdentityToken', 'Message': 'bad token'}},
-        'AssumeRole',
-    )
-    creds = _create_refreshable_credentials(
-        mock_time,
-        refresher=refresher,
-        expires_in=timedelta(seconds=30),
-        method=method,
-    )
-
-    with mock.patch('botocore.credentials.random.uniform', return_value=5):
         with pytest.raises(ClientError, match='InvalidIdentityToken'):
             creds.get_frozen_credentials()
 
-    with pytest.raises(ClientError, match='InvalidIdentityToken'):
-        creds.get_frozen_credentials()
+        with pytest.raises(ClientError, match='InvalidIdentityToken'):
+            creds.get_frozen_credentials()
 
-    assert refresher.call_count == 1
+        assert refresher.call_count == 1
+
+    def test_sts_nonrecoverable_codes_do_not_apply_to_non_sts_providers(
+        self, mock_time
+    ):
+        # Even if a non-STS provider raises a ClientError with an STS-listed
+        # non-recoverable code, we should not classify it as STS
+        # non-recoverable unless the provider method is actually STS-backed.
+        refresher = mock.Mock(
+            side_effect=ClientError(
+                {'Error': {'Code': 'AccessDenied', 'Message': 'denied'}},
+                'GetRoleCredentials',
+            )
+        )
+        creds = _create_refreshable_credentials(
+            mock_time,
+            refresher=refresher,
+            expires_in=timedelta(seconds=30),
+            method='sso',
+        )
+
+        frozen = creds.get_frozen_credentials()
+
+        assert frozen.access_key == 'ORIGINAL-ACCESS'
+        assert refresher.call_count == 1
+
+        frozen = creds.get_frozen_credentials()
+
+        assert frozen.access_key == 'ORIGINAL-ACCESS'
+        assert refresher.call_count == 1
 
 
-def test_sts_nonrecoverable_codes_do_not_apply_to_non_sts_providers(mock_time):
-    # Even if a non-STS provider raises a ClientError with an STS-listed
-    # non-recoverable code, we should not classify it as STS non-recoverable
-    # unless the provider method is actually STS-backed.
-    refresher = mock.Mock(
-        side_effect=ClientError(
-            {'Error': {'Code': 'AccessDenied', 'Message': 'denied'}},
+class TestNonRecoverableProviderErrors:
+    def test_sso_unauthorized_service_error_raises_nonrecoverable_error(self):
+        # Service-side unauthorized responses are non-recoverable.
+        token_loader = mock.Mock(
+            return_value={
+                'accessToken': 'some.sso.token',
+                'expiresAt': '2099-10-18T22:26:40Z',
+            }
+        )
+        client = mock.Mock()
+        client.exceptions.UnauthorizedException = ClientError
+        client.get_role_credentials.side_effect = ClientError(
+            {'Error': {'Code': 'UnauthorizedException'}},
             'GetRoleCredentials',
         )
+        fetcher = credentials.SSOCredentialFetcher(
+            start_url='https://d-92671207e4.awsapps.com/start',
+            sso_region='us-east-1',
+            role_name='test-role',
+            account_id='1234567890',
+            client_creator=mock.Mock(return_value=client),
+            token_loader=token_loader,
+            cache={},
+            time_fetcher=mock.Mock(return_value=DATE),
+        )
+
+        with pytest.raises(UnauthorizedSSOTokenError):
+            fetcher.fetch_credentials()
+
+    def test_sso_expired_cached_token_raises_nonrecoverable_error(self):
+        # Client-side expired cached tokens are non-recoverable and should
+        # fail before calling SSO.
+        token_loader = mock.Mock(
+            return_value={
+                'accessToken': 'some.sso.token',
+                'expiresAt': '2018-10-18T22:26:40Z',
+            }
+        )
+        client = mock.Mock()
+        fetcher = credentials.SSOCredentialFetcher(
+            start_url='https://d-92671207e4.awsapps.com/start',
+            sso_region='us-east-1',
+            role_name='test-role',
+            account_id='1234567890',
+            client_creator=mock.Mock(return_value=client),
+            token_loader=token_loader,
+            cache={},
+            time_fetcher=mock.Mock(return_value=DATE),
+        )
+
+        with pytest.raises(UnauthorizedSSOTokenError):
+            fetcher.fetch_credentials()
+        client.get_role_credentials.assert_not_called()
+
+    def test_sso_missing_cached_token_raises_nonrecoverable_error(self):
+        # Client-side token cache load failures are also non-recoverable.
+        loader = utils.SSOTokenLoader(cache={})
+
+        with pytest.raises(SSOTokenLoadError):
+            loader('https://d-92671207e4.awsapps.com/start')
+
+    @pytest.mark.parametrize(
+        'token,error_msg',
+        [
+            (
+                None,
+                'Unable to load a existing login session for session test-session.',
+            ),
+            (
+                {'accessToken': {}, 'refreshToken': 'refresh'},
+                'missing required fields',
+            ),
+        ],
     )
-    creds = _create_refreshable_credentials(
-        mock_time,
-        refresher=refresher,
-        expires_in=timedelta(seconds=30),
-        method='sso',
-    )
-
-    frozen = creds.get_frozen_credentials()
-
-    assert frozen.access_key == 'ORIGINAL-ACCESS'
-    assert refresher.call_count == 1
-
-    frozen = creds.get_frozen_credentials()
-
-    assert frozen.access_key == 'ORIGINAL-ACCESS'
-    assert refresher.call_count == 1
-
-
-def test_sso_unauthorized_service_error_raises_nonrecoverable_error():
-    # Service-side unauthorized responses are non-recoverable.
-    token_loader = mock.Mock(
-        return_value={
-            'accessToken': 'some.sso.token',
-            'expiresAt': '2099-10-18T22:26:40Z',
-        }
-    )
-    client = mock.Mock()
-    client.exceptions.UnauthorizedException = ClientError
-    client.get_role_credentials.side_effect = ClientError(
-        {'Error': {'Code': 'UnauthorizedException'}},
-        'GetRoleCredentials',
-    )
-    fetcher = credentials.SSOCredentialFetcher(
-        start_url='https://d-92671207e4.awsapps.com/start',
-        sso_region='us-east-1',
-        role_name='test-role',
-        account_id='1234567890',
-        client_creator=mock.Mock(return_value=client),
-        token_loader=token_loader,
-        cache={},
-        time_fetcher=mock.Mock(return_value=DATE),
-    )
-
-    with pytest.raises(UnauthorizedSSOTokenError):
-        fetcher.fetch_credentials()
-
-
-def test_sso_expired_cached_token_raises_nonrecoverable_error():
-    # Client-side expired cached tokens are non-recoverable and should
-    # fail before calling SSO.
-    token_loader = mock.Mock(
-        return_value={
-            'accessToken': 'some.sso.token',
-            'expiresAt': '2018-10-18T22:26:40Z',
-        }
-    )
-    client = mock.Mock()
-    fetcher = credentials.SSOCredentialFetcher(
-        start_url='https://d-92671207e4.awsapps.com/start',
-        sso_region='us-east-1',
-        role_name='test-role',
-        account_id='1234567890',
-        client_creator=mock.Mock(return_value=client),
-        token_loader=token_loader,
-        cache={},
-        time_fetcher=mock.Mock(return_value=DATE),
-    )
-
-    with pytest.raises(UnauthorizedSSOTokenError):
-        fetcher.fetch_credentials()
-    client.get_role_credentials.assert_not_called()
-
-
-def test_sso_missing_cached_token_raises_nonrecoverable_error():
-    # Client-side token cache load failures are also non-recoverable.
-    loader = utils.SSOTokenLoader(cache={})
-
-    with pytest.raises(SSOTokenLoadError):
-        loader('https://d-92671207e4.awsapps.com/start')
-
-
-@pytest.mark.parametrize(
-    'token,error_msg',
-    [
-        (
-            None,
-            'Unable to load a existing login session for session test-session.',
-        ),
-        (
-            {'accessToken': {}, 'refreshToken': 'refresh'},
-            'missing required fields',
-        ),
-    ],
-)
-def test_login_refresh_invalid_cached_token_raises_nonrecoverable_error(
-    token, error_msg
-):
-    # Client-side invalid cached login tokens are non-recoverable.
-    token_loader = mock.Mock()
-    token_loader.load_token.return_value = token
-    fetcher = credentials.LoginCredentialFetcher(
-        session_name='test-session',
-        token_loader=token_loader,
-        client_creator=mock.Mock(),
-    )
-
-    with pytest.raises(
-        LoginInvalidCachedTokenError,
-        match=error_msg,
+    def test_login_refresh_invalid_cached_token_raises_nonrecoverable_error(
+        self, token, error_msg
     ):
-        fetcher.refresh_credentials()
+        # Client-side invalid cached login tokens are non-recoverable.
+        token_loader = mock.Mock()
+        token_loader.load_token.return_value = token
+        fetcher = credentials.LoginCredentialFetcher(
+            session_name='test-session',
+            token_loader=token_loader,
+            client_creator=mock.Mock(),
+        )
+
+        with pytest.raises(
+            LoginInvalidCachedTokenError,
+            match=error_msg,
+        ):
+            fetcher.refresh_credentials()

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -39,12 +39,17 @@ from botocore import credentials, utils
 from botocore.awsrequest import AWSResponse
 from botocore.compat import json
 from botocore.exceptions import (
+    ClientError,
     ConnectionClosedError,
     ConnectTimeoutError,
     CredentialRetrievalError,
     InvalidIMDSEndpointError,
+    LoginInvalidCachedTokenError,
     MetadataRetrievalError,
     ReadTimeoutError,
+    RefreshNonRecoverableError,
+    SSOTokenLoadError,
+    UnauthorizedSSOTokenError,
 )
 from tests import (
     BaseEnvVar,
@@ -282,7 +287,7 @@ class TestInstanceMetadataProviderFlagOn(
     # add the shared static-stability coverage below.
     def test_refresh_failure_returns_cached_credentials(self):
         # IMDS should pick up shared static stability from
-        # RefreshableCredentials on the new path.
+        # RefreshableCredentials.
         fetcher = mock.Mock()
         fetcher.retrieve_iam_role_credentials.side_effect = [
             {
@@ -845,6 +850,7 @@ def _create_refreshable_credentials(
     mock_time,
     refresher=None,
     expires_in=timedelta(hours=24),
+    method='iam-role',
     **kwargs,
 ):
     if refresher is None:
@@ -855,10 +861,14 @@ def _create_refreshable_credentials(
         'ORIGINAL-TOKEN',
         mock_time() + expires_in,
         refresher,
-        'iam-role',
+        method,
         time_fetcher=mock_time,
         **kwargs,
     )
+
+
+class _CacheableNonRecoverableError(Exception, RefreshNonRecoverableError):
+    pass
 
 
 # ---------------------------------------------------------------------------
@@ -1162,3 +1172,265 @@ def test_malformed_expiry_returns_cached_credentials(creds, refresher):
 
     assert frozen.access_key == 'ORIGINAL-ACCESS'
     assert refresher.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-recoverable tests: these cover the flag-on-only behavior for immediate
+# surfacing and short-lived retry suppression.
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_nonrecoverable_error_is_not_retried_within_ttl(mock_time):
+    refresher = mock.Mock(
+        side_effect=_CacheableNonRecoverableError("reauth required")
+    )
+    creds = _create_refreshable_credentials(
+        mock_time,
+        refresher=refresher,
+        expires_in=timedelta(seconds=90),
+        advisory_timeout=120,
+        mandatory_timeout=60,
+    )
+
+    with mock.patch('botocore.credentials.random.uniform', return_value=5):
+        with pytest.raises(
+            _CacheableNonRecoverableError, match='reauth required'
+        ):
+            creds.get_frozen_credentials()
+
+    assert refresher.call_count == 1
+
+    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
+        creds.get_frozen_credentials()
+
+    assert refresher.call_count == 1
+
+
+def test_mandatory_nonrecoverable_error_is_not_retried_within_ttl(
+    creds, refresher
+):
+    refresher.side_effect = _CacheableNonRecoverableError("reauth required")
+
+    with mock.patch('botocore.credentials.random.uniform', return_value=5):
+        with pytest.raises(
+            _CacheableNonRecoverableError, match='reauth required'
+        ):
+            creds.get_frozen_credentials()
+
+    assert refresher.call_count == 1
+
+    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
+        creds.get_frozen_credentials()
+
+    assert refresher.call_count == 1
+
+
+def test_nonrecoverable_error_is_retried_after_ttl_expires(mock_time):
+    refresher = mock.Mock(
+        side_effect=[
+            _CacheableNonRecoverableError("reauth required"),
+            _valid_metadata(mock_time),
+        ]
+    )
+    issued_at = mock_time()
+    creds = _create_refreshable_credentials(
+        mock_time,
+        refresher=refresher,
+        expires_in=timedelta(seconds=90),
+        advisory_timeout=120,
+        mandatory_timeout=60,
+    )
+
+    with mock.patch('botocore.credentials.random.uniform', return_value=5):
+        with pytest.raises(
+            _CacheableNonRecoverableError, match='reauth required'
+        ):
+            creds.get_frozen_credentials()
+
+    mock_time.return_value = issued_at + timedelta(seconds=6)
+    frozen = creds.get_frozen_credentials()
+
+    assert refresher.call_count == 2
+    assert frozen.access_key == 'NEW-ACCESS'
+
+
+@pytest.mark.parametrize(
+    'method',
+    ['assume-role', 'assume-role-with-web-identity'],
+)
+def test_sts_nonrecoverable_error_is_not_retried_within_ttl(mock_time, method):
+    refresher = mock.Mock()
+    refresher.side_effect = ClientError(
+        {'Error': {'Code': 'InvalidIdentityToken', 'Message': 'bad token'}},
+        'AssumeRole',
+    )
+    creds = _create_refreshable_credentials(
+        mock_time,
+        refresher=refresher,
+        expires_in=timedelta(seconds=30),
+        method=method,
+    )
+
+    with mock.patch('botocore.credentials.random.uniform', return_value=5):
+        with pytest.raises(ClientError, match='InvalidIdentityToken'):
+            creds.get_frozen_credentials()
+
+    with pytest.raises(ClientError, match='InvalidIdentityToken'):
+        creds.get_frozen_credentials()
+
+    assert refresher.call_count == 1
+
+
+def test_sts_nonrecoverable_codes_do_not_apply_to_non_sts_providers(mock_time):
+    # Even if a non-STS provider raises a ClientError with an STS-listed
+    # non-recoverable code, we should not classify it as STS non-recoverable
+    # unless the provider method is actually STS-backed.
+    refresher = mock.Mock(
+        side_effect=ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'denied'}},
+            'GetRoleCredentials',
+        )
+    )
+    creds = _create_refreshable_credentials(
+        mock_time,
+        refresher=refresher,
+        expires_in=timedelta(seconds=30),
+        method='sso',
+    )
+
+    frozen = creds.get_frozen_credentials()
+
+    assert frozen.access_key == 'ORIGINAL-ACCESS'
+    assert refresher.call_count == 1
+
+    frozen = creds.get_frozen_credentials()
+
+    assert frozen.access_key == 'ORIGINAL-ACCESS'
+    assert refresher.call_count == 1
+
+
+def test_deferred_nonrecoverable_error_retries_after_ttl_expires(mock_time):
+    refresher = mock.Mock(
+        side_effect=[
+            _CacheableNonRecoverableError("reauth required"),
+            _valid_metadata(mock_time),
+        ]
+    )
+    issued_at = mock_time()
+    creds = credentials.DeferredRefreshableCredentials(
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+
+    with mock.patch('botocore.credentials.random.uniform', return_value=5):
+        with pytest.raises(
+            _CacheableNonRecoverableError, match='reauth required'
+        ):
+            creds.get_frozen_credentials()
+
+    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
+        creds.get_frozen_credentials()
+
+    assert refresher.call_count == 1
+
+    mock_time.return_value = issued_at + timedelta(seconds=6)
+    frozen = creds.get_frozen_credentials()
+
+    assert refresher.call_count == 2
+    assert frozen.access_key == 'NEW-ACCESS'
+
+
+def test_sso_unauthorized_service_error_raises_nonrecoverable_error():
+    # Service-side unauthorized responses are non-recoverable.
+    token_loader = mock.Mock(
+        return_value={
+            'accessToken': 'some.sso.token',
+            'expiresAt': '2099-10-18T22:26:40Z',
+        }
+    )
+    client = mock.Mock()
+    client.exceptions.UnauthorizedException = ClientError
+    client.get_role_credentials.side_effect = ClientError(
+        {'Error': {'Code': 'UnauthorizedException'}},
+        'GetRoleCredentials',
+    )
+    fetcher = credentials.SSOCredentialFetcher(
+        start_url='https://d-92671207e4.awsapps.com/start',
+        sso_region='us-east-1',
+        role_name='test-role',
+        account_id='1234567890',
+        client_creator=mock.Mock(return_value=client),
+        token_loader=token_loader,
+        cache={},
+        time_fetcher=mock.Mock(return_value=DATE),
+    )
+
+    with pytest.raises(UnauthorizedSSOTokenError):
+        fetcher.fetch_credentials()
+
+
+def test_sso_expired_cached_token_raises_nonrecoverable_error():
+    # Client-side expired cached tokens are non-recoverable and should
+    # fail before calling SSO.
+    token_loader = mock.Mock(
+        return_value={
+            'accessToken': 'some.sso.token',
+            'expiresAt': '2018-10-18T22:26:40Z',
+        }
+    )
+    client = mock.Mock()
+    fetcher = credentials.SSOCredentialFetcher(
+        start_url='https://d-92671207e4.awsapps.com/start',
+        sso_region='us-east-1',
+        role_name='test-role',
+        account_id='1234567890',
+        client_creator=mock.Mock(return_value=client),
+        token_loader=token_loader,
+        cache={},
+        time_fetcher=mock.Mock(return_value=DATE),
+    )
+
+    with pytest.raises(UnauthorizedSSOTokenError):
+        fetcher.fetch_credentials()
+    client.get_role_credentials.assert_not_called()
+
+
+def test_sso_missing_cached_token_raises_nonrecoverable_error():
+    # Client-side token cache load failures are also non-recoverable.
+    loader = utils.SSOTokenLoader(cache={})
+
+    with pytest.raises(SSOTokenLoadError):
+        loader('https://d-92671207e4.awsapps.com/start')
+
+
+@pytest.mark.parametrize(
+    'token,error_msg',
+    [
+        (
+            None,
+            'Unable to load a existing login session for session test-session.',
+        ),
+        (
+            {'accessToken': {}, 'refreshToken': 'refresh'},
+            'missing required fields',
+        ),
+    ],
+)
+def test_login_refresh_invalid_cached_token_raises_nonrecoverable_error(
+    token, error_msg
+):
+    # Client-side invalid cached login tokens are non-recoverable.
+    token_loader = mock.Mock()
+    token_loader.load_token.return_value = token
+    fetcher = credentials.LoginCredentialFetcher(
+        session_name='test-session',
+        token_loader=token_loader,
+        client_creator=mock.Mock(),
+    )
+
+    with pytest.raises(
+        LoginInvalidCachedTokenError,
+        match=error_msg,
+    ):
+        fetcher.refresh_credentials()

--- a/tests/unit/test_credential_refresh.py
+++ b/tests/unit/test_credential_refresh.py
@@ -1225,7 +1225,9 @@ def test_mandatory_nonrecoverable_error_is_not_retried_within_ttl(
     assert refresher.call_count == 1
 
 
-def test_nonrecoverable_error_is_retried_after_ttl_expires(mock_time):
+def test_advisory_nonrecoverable_error_is_retried_after_ttl_expires(
+    mock_time,
+):
     refresher = mock.Mock(
         side_effect=[
             _CacheableNonRecoverableError("reauth required"),
@@ -1246,6 +1248,38 @@ def test_nonrecoverable_error_is_retried_after_ttl_expires(mock_time):
             _CacheableNonRecoverableError, match='reauth required'
         ):
             creds.get_frozen_credentials()
+
+    mock_time.return_value = issued_at + timedelta(seconds=6)
+    frozen = creds.get_frozen_credentials()
+
+    assert refresher.call_count == 2
+    assert frozen.access_key == 'NEW-ACCESS'
+
+
+def test_deferred_nonrecoverable_error_retries_after_ttl_expires(mock_time):
+    refresher = mock.Mock(
+        side_effect=[
+            _CacheableNonRecoverableError("reauth required"),
+            _valid_metadata(mock_time),
+        ]
+    )
+    issued_at = mock_time()
+    creds = credentials.DeferredRefreshableCredentials(
+        refresher,
+        'iam-role',
+        time_fetcher=mock_time,
+    )
+
+    with mock.patch('botocore.credentials.random.uniform', return_value=5):
+        with pytest.raises(
+            _CacheableNonRecoverableError, match='reauth required'
+        ):
+            creds.get_frozen_credentials()
+
+    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
+        creds.get_frozen_credentials()
+
+    assert refresher.call_count == 1
 
     mock_time.return_value = issued_at + timedelta(seconds=6)
     frozen = creds.get_frozen_credentials()
@@ -1307,38 +1341,6 @@ def test_sts_nonrecoverable_codes_do_not_apply_to_non_sts_providers(mock_time):
 
     assert frozen.access_key == 'ORIGINAL-ACCESS'
     assert refresher.call_count == 1
-
-
-def test_deferred_nonrecoverable_error_retries_after_ttl_expires(mock_time):
-    refresher = mock.Mock(
-        side_effect=[
-            _CacheableNonRecoverableError("reauth required"),
-            _valid_metadata(mock_time),
-        ]
-    )
-    issued_at = mock_time()
-    creds = credentials.DeferredRefreshableCredentials(
-        refresher,
-        'iam-role',
-        time_fetcher=mock_time,
-    )
-
-    with mock.patch('botocore.credentials.random.uniform', return_value=5):
-        with pytest.raises(
-            _CacheableNonRecoverableError, match='reauth required'
-        ):
-            creds.get_frozen_credentials()
-
-    with pytest.raises(_CacheableNonRecoverableError, match='reauth required'):
-        creds.get_frozen_credentials()
-
-    assert refresher.call_count == 1
-
-    mock_time.return_value = issued_at + timedelta(seconds=6)
-    frozen = creds.get_frozen_credentials()
-
-    assert refresher.call_count == 2
-    assert frozen.access_key == 'NEW-ACCESS'
 
 
 def test_sso_unauthorized_service_error_raises_nonrecoverable_error():


### PR DESCRIPTION
*Issue #, if available:*
Python-9033

### Overview
This updates the new credential refresh path to recognize non-recoverable refresh failures and surface them immediately instead of sending them through the normal refresh backoff flow.

For recoverable refresh failures, the SDK should continue using cached credentials and back off before retrying. For non-recoverable failures, the error requires customer action or is otherwise not expected to succeed without external action, so the SDK should raise it immediately. To avoid repeatedly hitting the credential source when callers retry in a loop, these non-recoverable errors are cached for a short jittered TTL and re-raised during that window.

This change adds that behavior for the new refresh path and wires in the current non-recoverable cases for STS, SSO, and Login providers.

#### What changed
- add short-lived caching for non-recoverable refresh errors and re-raise the cached error while its TTL is still in effect
- scope STS non-recoverable classification to STS-backed providers only
- treat SSO unauthorized service responses as non-recoverable
- treat SSO cached-token load failures and expired cached SSO tokens as non-recoverable
- introduce `LoginInvalidCachedTokenError` to distinguish invalid cached login tokens during refresh from other `LoginTokenLoadError` failures
- limit `LoginInvalidCachedTokenError` to missing token or missing required field cases during refresh and keep private-key parsing and invalid service response failures on the existing `LoginTokenLoadError` path

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
