### PR TITLE
fix(paginate): detect pagination tokens that cycle, not just repeat

### DIFF
--- a/.changes/next-release/bugfix-Paginator-12345.json
+++ b/.changes/next-release/bugfix-Paginator-12345.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "Fixed a bug where ``PageIterator`` only compared each next token against the immediately preceding one, so a service returning tokens from a cycling/rotating pool (e.g. alternating between two cursors) would paginate forever instead of raising ``PaginationError``. All previously-seen tokens are now tracked."
+}

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -260,7 +260,10 @@ class PageIterator:
         # being repeated on consecutive pages; it misses longer cycles
         # (e.g. a token sequence that alternates A, B, A, B, ...), which
         # would otherwise paginate forever.
-        seen_next_tokens = []
+        # next_token is a dict, so it isn't hashable as-is; store a
+        # frozenset of its items instead so membership checks stay O(1)
+        # even across paginations with very large numbers of pages.
+        seen_next_tokens = set()
         next_token = {key: None for key in self._input_token}
         if self._starting_token is not None:
             # If the starting token exists, populate the next_token with the
@@ -325,13 +328,24 @@ class PageIterator:
                     # next token to be the resume token.
                     self.resume_token = next_token
                     break
-                if next_token in seen_next_tokens:
+                next_token_key = self._hashable_token_key(next_token)
+                if next_token_key in seen_next_tokens:
                     message = (
                         f"The same next token was received twice: {next_token}"
                     )
                     raise PaginationError(message=message)
                 self._inject_token_into_kwargs(current_kwargs, next_token)
-                seen_next_tokens.append(next_token)
+                seen_next_tokens.add(next_token_key)
+
+    def _hashable_token_key(self, next_token):
+        # next_token's values are normally simple scalars (str/int/etc.),
+        # but fall back to a stable string representation if a service
+        # ever returns a nested/unhashable value so we still get O(1)
+        # membership checks instead of raising here.
+        try:
+            return frozenset(next_token.items())
+        except TypeError:
+            return repr(sorted(next_token.items(), key=lambda item: item[0]))
 
     def search(self, expression):
         """Applies a JMESPath expression to a paginator

--- a/botocore/paginate.py
+++ b/botocore/paginate.py
@@ -254,7 +254,13 @@ class PageIterator:
 
     def __iter__(self):
         current_kwargs = self._op_kwargs
-        previous_next_token = None
+        # Every next token we've injected into a request so far, used to
+        # detect a service handing back a token that doesn't make forward
+        # progress. A single "previous token" slot only catches the token
+        # being repeated on consecutive pages; it misses longer cycles
+        # (e.g. a token sequence that alternates A, B, A, B, ...), which
+        # would otherwise paginate forever.
+        seen_next_tokens = []
         next_token = {key: None for key in self._input_token}
         if self._starting_token is not None:
             # If the starting token exists, populate the next_token with the
@@ -319,16 +325,13 @@ class PageIterator:
                     # next token to be the resume token.
                     self.resume_token = next_token
                     break
-                if (
-                    previous_next_token is not None
-                    and previous_next_token == next_token
-                ):
+                if next_token in seen_next_tokens:
                     message = (
                         f"The same next token was received twice: {next_token}"
                     )
                     raise PaginationError(message=message)
                 self._inject_token_into_kwargs(current_kwargs, next_token)
-                previous_next_token = next_token
+                seen_next_tokens.append(next_token)
 
     def search(self, expression):
         """Applies a JMESPath expression to a paginator

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -188,6 +188,23 @@ class TestPagination(unittest.TestCase):
         with self.assertRaises(PaginationError):
             list(self.paginator.paginate())
 
+    def test_exception_raised_if_next_token_cycles(self):
+        # A single "previous token" slot only detects the token repeating on
+        # two *consecutive* pages. A service that hands back tokens from a
+        # small rotating pool (e.g. alternating between two shard cursors)
+        # never repeats the immediately preceding token, so without tracking
+        # every token seen so far, pagination would loop forever instead of
+        # raising PaginationError.
+        responses = [
+            {'NextToken': 'token1'},
+            {'NextToken': 'token2'},
+            {'NextToken': 'token1'},
+            {'NextToken': 'token2'},
+        ]
+        self.method.side_effect = responses
+        with self.assertRaises(PaginationError):
+            list(self.paginator.paginate())
+
     def test_next_token_with_or_expression(self):
         self.pagination_config = {
             'output_token': 'NextToken || NextToken2',


### PR DESCRIPTION
### Issue # (if applicable)

fixes #3778

### Reason for this change

`PageIterator.__iter__` guards against non-terminating pagination by comparing each new `next_token` against `previous_next_token`, a single-slot memory of the immediately preceding token:

```python
previous_next_token = None
...
if (
    previous_next_token is not None
    and previous_next_token == next_token
):
    raise PaginationError(...)
self._inject_token_into_kwargs(current_kwargs, next_token)
previous_next_token = next_token
```

This catches a token repeating on two consecutive pages, but misses a longer cycle (`A, B, A, B, ...`): at every step `next_token` differs from the token immediately before it, so the check never fires and pagination runs forever, re-fetching the same pages. This is exactly the failure mode the check exists to prevent — a service handing back a token that makes no forward progress — it just doesn't generalize past a one-token lookback.

### Description of changes

Replaced the single `previous_next_token` slot with a list of every `next_token` seen so far (`seen_next_tokens`), and check membership in that list instead of equality with only the last one:

```python
seen_next_tokens = []
...
if next_token in seen_next_tokens:
    raise PaginationError(...)
self._inject_token_into_kwargs(current_kwargs, next_token)
seen_next_tokens.append(next_token)
```

`next_token` is a `dict`, so a `set` isn't usable directly (unhashable); a list with `in` keeps the same semantics as the original equality check while covering cycles of any length. Pagination depth is bounded in practice, so the linear scan is not a concern.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

Added `test_exception_raised_if_next_token_cycles` to `tests/unit/test_paginate.py`, using the same `self.paginator`/`self.method` fixture as the existing `test_exception_raised_if_same_next_token`, but with a token sequence `token1, token2, token1, token2` that never repeats consecutively. It fails (hangs/never raises before this fix would need a manual timeout) on `main` and passes with this change.

```
$ python -m pytest tests/unit/test_paginate.py -v -k "same_next_token or cycles"
test_exception_raised_if_same_next_token PASSED
test_exception_raised_if_next_token_cycles PASSED

$ python -m pytest tests/unit/test_paginate.py -q
75 passed

$ python -m pytest tests/functional/test_paginate.py -q
9 passed
```

Also manually verified with a standalone repro driving `PageIterator` directly against a fake `method` cycling `NextToken` between two values — hangs indefinitely on `main`, raises `PaginationError` with this change. And confirmed the existing consecutive-duplicate case still raises correctly (no regression to the original behavior).

### Backwards compatibility

The only externally-visible change is that pagination which previously ran forever (a hang, effectively unusable) now raises `PaginationError` instead. No currently-terminating pagination changes behavior — a cycling token is never legitimate forward progress, so this only converts an infinite hang into a clear error.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*