### PR TITLE
reject event stream messages with inconsistent prelude lengths

### DIFF
--- a/botocore/eventstream.py
+++ b/botocore/eventstream.py
@@ -53,6 +53,17 @@ class InvalidPayloadLength(ParserError):
         super().__init__(message)
 
 
+class InvalidPreludeLength(ParserError):
+    """Prelude lengths are not consistent with each other."""
+
+    def __init__(self, total_length, headers_length):
+        message = (
+            f'Total length of {total_length} is too small to contain the '
+            f'declared header length of {headers_length}'
+        )
+        super().__init__(message)
+
+
 class ChecksumMismatch(ParserError):
     """Calculated checksum did not match the expected checksum."""
 
@@ -458,6 +469,11 @@ class EventStreamBuffer:
     def _validate_prelude(self, prelude):
         if prelude.headers_length > _MAX_HEADERS_LENGTH:
             raise InvalidHeadersLength(prelude.headers_length)
+
+        if prelude.payload_length < 0:
+            raise InvalidPreludeLength(
+                prelude.total_length, prelude.headers_length
+            )
 
         if prelude.payload_length > _MAX_PAYLOAD_LENGTH:
             raise InvalidPayloadLength(prelude.payload_length)

--- a/tests/unit/test_eventstream.py
+++ b/tests/unit/test_eventstream.py
@@ -24,6 +24,7 @@ from botocore.eventstream import (
     EventStreamMessage,
     InvalidHeadersLength,
     InvalidPayloadLength,
+    InvalidPreludeLength,
     MessagePrelude,
     NoInitialResponseError,
 )
@@ -273,6 +274,18 @@ INVALID_PAYLOAD_LENGTH = (
 )
 
 
+# The declared headers length is larger than the total length, so the
+# implied payload length is negative. The checksums are otherwise valid.
+INCONSISTENT_PRELUDE = (
+    b"\x00\x00\x00\x14"  # total length
+    b"\x00\x00\x00\x64"  # headers length
+    b"\xba\x9d\x4b\x6a"  # prelude crc
+    b"\x00\x00\x00\x00"  # remaining bytes up to total length
+    b"\xe6\xbe\x1f\x61",  # message crc
+    InvalidPreludeLength,
+)
+
+
 # Tuples of encoded messages and their expected exception
 NEGATIVE_CASES = [
     CORRUPTED_LENGTH,
@@ -282,6 +295,7 @@ NEGATIVE_CASES = [
     DUPLICATE_HEADER,
     INVALID_HEADERS_LENGTH,
     INVALID_PAYLOAD_LENGTH,
+    INCONSISTENT_PRELUDE,
 ]
 
 
@@ -350,6 +364,7 @@ def test_all_positive_cases():
         "duplicate-headers",
         "invalid-headers-length",
         "invalid-payload-length",
+        "inconsistent-prelude",
     ],
 )
 def test_negative_cases(encoded, exception):


### PR DESCRIPTION
EventStreamBuffer._validate_prelude checks the header and payload lengths against their maximums but never confirms the prelude fields agree with each other, and payload_length is derived as total_length minus headers_length minus the prelude and message-crc sizes. A response whose prelude declares a headers_length larger than total_length makes payload_length negative, which slips past the greater-than-maximum guard, and the decoder then reads headers_end bytes past the message boundary instead of raising a ParserError. Reject a prelude whose implied payload length is negative so malformed framing surfaces as InvalidPreludeLength like the other length checks.