### PR TITLE
Fix ImageDeleted/ImageVersionDeleted waiters matching wrong error shape (fixes #3782)

### DIFF
--- a/botocore/data/sagemaker/2017-07-24/waiters-2.json
+++ b/botocore/data/sagemaker/2017-07-24/waiters-2.json
@@ -63,7 +63,7 @@
       "acceptors" : [ {
         "matcher" : "error",
         "state" : "success",
-        "expected" : "ResourceNotFoundException"
+        "expected" : "ResourceNotFound"
       }, {
         "matcher" : "path",
         "argument" : "ImageStatus",
@@ -122,7 +122,7 @@
       "acceptors" : [ {
         "matcher" : "error",
         "state" : "success",
-        "expected" : "ResourceNotFoundException"
+        "expected" : "ResourceNotFound"
       }, {
         "matcher" : "path",
         "argument" : "ImageVersionStatus",

--- a/tests/functional/test_sagemaker.py
+++ b/tests/functional/test_sagemaker.py
@@ -37,3 +37,55 @@ class TestSagemaker(BaseSessionTest):
         self.assertEqual(
             self.hook_calls, ['provide-client-params.sagemaker.ListEndpoints']
         )
+
+
+class TestSagemakerWaiters(BaseSessionTest):
+    """Regression tests for GH #3782.
+
+    DescribeImage/DescribeImageVersion return a ``ResourceNotFound``
+    error (per the service model's declared error shape for these
+    operations) once the resource has actually been deleted, not
+    ``ResourceNotFoundException``. The image_deleted/image_version_deleted
+    waiters previously matched on the wrong (nonexistent) shape name, so
+    a successful deletion was incorrectly reported as a waiter failure.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.region = 'us-west-2'
+        self.client = self.session.create_client('sagemaker', self.region)
+        self.stubber = Stubber(self.client)
+        self.stubber.activate()
+
+    def tearDown(self):
+        super().tearDown()
+        self.stubber.deactivate()
+
+    def test_image_deleted_waiter_succeeds_on_resource_not_found(self):
+        self.stubber.add_client_error(
+            'describe_image',
+            service_error_code='ResourceNotFound',
+            http_status_code=404,
+        )
+        waiter = self.client.get_waiter('image_deleted')
+        # Should not raise: a ResourceNotFound error is the documented
+        # success condition for this waiter (the image is gone). Override
+        # the config so a mismatch fails fast instead of sleeping through
+        # 60s waits before timing out.
+        waiter.wait(
+            ImageName='some-image',
+            WaiterConfig={'Delay': 1, 'MaxAttempts': 1},
+        )
+
+    def test_image_version_deleted_waiter_succeeds_on_resource_not_found(self):
+        self.stubber.add_client_error(
+            'describe_image_version',
+            service_error_code='ResourceNotFound',
+            http_status_code=404,
+        )
+        waiter = self.client.get_waiter('image_version_deleted')
+        waiter.wait(
+            ImageName='some-image',
+            Version=1,
+            WaiterConfig={'Delay': 1, 'MaxAttempts': 1},
+        )


### PR DESCRIPTION
Fixes #3782.

The `sagemaker` `DescribeImage` and `DescribeImageVersion` operations declare `ResourceNotFound` as their error shape (see each operation's `errors` list in `botocore/data/sagemaker/2017-07-24/service-2.json`). There is no `ResourceNotFoundException` shape anywhere in this service's model. The `ImageDeleted` and `ImageVersionDeleted` waiters, however, matched their success acceptor against `ResourceNotFoundException` -- a name that never appears in any real response from these operations.

As a result, once an image (or image version) was actually deleted and `DescribeImage`/`DescribeImageVersion` started returning the real `ResourceNotFound` error, none of the acceptors matched, so the waiter incorrectly raised a `WaiterError` instead of treating the deletion as complete -- exactly the symptom reported in #3782 against the real API.

This fixes both waiters to match on the shape name the operations actually declare and return: `ResourceNotFound`.

**Testing**
- Added `TestSagemakerWaiters` in `tests/functional/test_sagemaker.py`, using `Stubber` to confirm both `image_deleted` and `image_version_deleted` waiters treat a `ResourceNotFound` error as the success condition.
- Reproduced the bug against `develop` with a small script using `Stubber` to inject a `ResourceNotFound` error: the `image_deleted` waiter raised `WaiterError` (matching the reporter's `#3782` traceback), then confirmed it passes with this fix, and that reverting the fix while keeping the new test reproduces the failure again.
- Verified `ResourceNotFoundException` does not exist anywhere in `sagemaker`'s `service-2.json` shapes, while `ResourceNotFound` is the exact shape declared for `DescribeImage`, `DescribeImageVersion`, and several other `Describe*` operations in this service (e.g. `DescribeTrainingJob`, `DescribeProcessingJob`, `DescribeTransformJob`), confirming `ResourceNotFound` is the correct, consistent shape name to match on.
