### PR TITLE
Honor AWS_CA_BUNDLE/ca_bundle for container credentials endpoint

### DIFF
--- a/.changes/next-release/bugfix-Credentials-33269.json
+++ b/.changes/next-release/bugfix-Credentials-33269.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Honor the `ca_bundle`/`AWS_CA_BUNDLE` setting when fetching credentials from `AWS_CONTAINER_CREDENTIALS_FULL_URI`, instead of always using the default trust store."
+}

--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -93,6 +93,7 @@ def create_credential_resolver(session, cache=None, region_name=None):
     metadata_timeout = session.get_config_variable('metadata_service_timeout')
     num_attempts = session.get_config_variable('metadata_service_num_attempts')
     disable_env_vars = session.instance_variables().get('profile') is not None
+    ca_bundle = session.get_config_variable('ca_bundle')
 
     imds_config = {
         'ec2_metadata_service_endpoint': session.get_config_variable(
@@ -111,7 +112,9 @@ def create_credential_resolver(session, cache=None, region_name=None):
         cache = {}
 
     env_provider = EnvProvider()
-    container_provider = ContainerProvider()
+    container_provider = ContainerProvider(
+        fetcher=ContainerMetadataFetcher(verify=ca_bundle)
+    )
     instance_metadata_provider = InstanceMetadataProvider(
         iam_role_fetcher=InstanceMetadataFetcher(
             timeout=metadata_timeout,

--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -3077,10 +3077,11 @@ class ContainerMetadataFetcher:
         'localhost',
     ]
 
-    def __init__(self, session=None, sleep=time.sleep):
+    def __init__(self, session=None, sleep=time.sleep, verify=None):
         if session is None:
             session = botocore.httpsession.URLLib3Session(
-                timeout=self.TIMEOUT_SECONDS
+                timeout=self.TIMEOUT_SECONDS,
+                verify=verify if verify is not None else True,
             )
         self._session = session
         self._sleep = sleep

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -2025,6 +2025,19 @@ class TestCreateCredentialResolver(BaseEnvVar):
         cache = resolver.get_provider('assume-role').cache
         self.assertIs(cache, custom_cache)
 
+    def test_container_provider_defaults_to_no_ca_bundle(self):
+        resolver = credentials.create_credential_resolver(self.session)
+        container_provider = resolver.get_provider('container-role')
+        self.assertTrue(container_provider._fetcher._session._verify)
+
+    def test_container_provider_honors_ca_bundle(self):
+        self.config_loader.set_config_variable('ca_bundle', '/path/to/bundle')
+        resolver = credentials.create_credential_resolver(self.session)
+        container_provider = resolver.get_provider('container-role')
+        self.assertEqual(
+            container_provider._fetcher._session._verify, '/path/to/bundle'
+        )
+
 
 class TestCanonicalNameSourceProvider(BaseEnvVar):
     def setUp(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2862,6 +2862,33 @@ class TestContainerMetadataFetcher(unittest.TestCase):
     def test_can_use_external_host_if_https(self):
         self.assert_can_retrieve_metadata_from('https://somewhere.com/foo')
 
+    def test_default_session_verifies_with_default_cert(self):
+        with mock.patch(
+            'botocore.utils.botocore.httpsession.URLLib3Session'
+        ) as mock_session_cls:
+            ContainerMetadataFetcher()
+        mock_session_cls.assert_called_with(
+            timeout=ContainerMetadataFetcher.TIMEOUT_SECONDS, verify=True
+        )
+
+    def test_default_session_honors_ca_bundle(self):
+        with mock.patch(
+            'botocore.utils.botocore.httpsession.URLLib3Session'
+        ) as mock_session_cls:
+            ContainerMetadataFetcher(verify='/path/to/bundle')
+        mock_session_cls.assert_called_with(
+            timeout=ContainerMetadataFetcher.TIMEOUT_SECONDS,
+            verify='/path/to/bundle',
+        )
+
+    def test_injected_session_ignores_verify(self):
+        # If a session is explicitly provided, it is used as-is and the
+        # verify argument has no effect.
+        fetcher = ContainerMetadataFetcher(
+            self.http, sleep=self.sleep, verify='/path/to/bundle'
+        )
+        self.assertIs(fetcher._session, self.http)
+
 
 class TestUnsigned(unittest.TestCase):
     def test_copy_returns_same_object(self):


### PR DESCRIPTION
## Problem

A custom CA bundle configured via `AWS_CA_BUNDLE` (or the `ca_bundle` profile
setting) is silently ignored when botocore fetches credentials from
`AWS_CONTAINER_CREDENTIALS_FULL_URI`. This makes it impossible to serve
container credentials over HTTPS from a locally-trusted (private/self-signed)
CA — the request fails TLS verification even though `AWS_CA_BUNDLE` points at
a bundle that includes the issuing CA.

Tracked upstream as aws/aws-sdk#9016 (cross-SDK, opened 2024-07-08, no
movement).

### Root cause

- `create_credential_resolver` (`botocore/credentials.py`) constructs
  `ContainerProvider()` with no arguments, so it builds its own
  `ContainerMetadataFetcher`.
- `ContainerMetadataFetcher.__init__` (`botocore/utils.py`) defaults to
  `URLLib3Session(timeout=self.TIMEOUT_SECONDS)` with no `verify` argument.
- `URLLib3Session` defaults `verify=True`, and `get_cert_path(True)` returns
  `certifi.where()` — no environment variable or config setting is consulted.
- Meanwhile `configprovider.py` already maps
  `'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None)`, and
  `create_credential_resolver` already has `session` in scope and already
  calls `session.get_config_variable(...)` for other settings (e.g.
  `metadata_service_timeout`) — this setting was just never read.

### Reproduction

With a local HTTPS server on `https://localhost:PORT` presenting a certificate
signed by a private CA, and:

```bash
export AWS_CONTAINER_CREDENTIALS_FULL_URI=https://localhost:PORT/creds
export AWS_CA_BUNDLE=/path/to/private-ca-cert.pem
```

```python
import botocore.session
session = botocore.session.Session()
session.get_credentials()  # SSLError: CERTIFICATE_VERIFY_FAILED
```

fails today with `SSLError: SSL validation failed ... [SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local
issuer certificate`, even though `AWS_CA_BUNDLE` names a bundle that includes
the CA that signed the server's certificate. After this change the same code
succeeds.

## Fix

- `create_credential_resolver` now reads
  `ca_bundle = session.get_config_variable('ca_bundle')` and passes it to a
  `ContainerMetadataFetcher(verify=ca_bundle)`, following the same pattern
  already used for `InstanceMetadataProvider`'s fetcher.
- `ContainerMetadataFetcher.__init__` gains a `verify=None` parameter. When no
  `session` is injected, the default `URLLib3Session` is built with
  `verify=verify if verify is not None else True` — so unconfigured behavior
  (`True` → certifi/default trust store) is unchanged, and a configured
  `ca_bundle` path is passed straight through. If a `session` is injected (the
  existing test seam), `verify` has no effect.

Default behavior is unchanged; this only takes effect when `ca_bundle` /
`AWS_CA_BUNDLE` is explicitly configured.

## Testing

- Added unit tests in `tests/unit/test_credentials.py` covering that
  `create_credential_resolver` wires an unconfigured session to
  `verify=True`, and a configured one to the bundle path.
- Added unit tests in `tests/unit/test_utils.py` covering
  `ContainerMetadataFetcher`'s new `verify` param directly: default session
  verification, custom bundle passthrough, and that an injected session
  ignores `verify` (preserving the existing injection point).
- Ran the full unit + functional suite locally (60,925 passed, 126 skipped).
- Manually verified end-to-end against a local HTTPS server signed by a
  private CA: fails with `CERTIFICATE_VERIFY_FAILED` before this change,
  succeeds via `session.get_credentials()` with `AWS_CA_BUNDLE` set after.

Fixes aws/aws-sdk#9016

Generated by AI tools, and reviewed by Aaron Turner.