### PR TITLE
fix: reject empty and newline-terminated region names in validate_region_name

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1335,7 +1335,9 @@ def validate_region_name(region_name):
     """Provided region_name must be a valid host label."""
     if region_name is None:
         return
-    valid_host_label = re.compile(r'^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$')
+    valid_host_label = re.compile(
+        r'^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{1,63}(?<!-)\Z'
+    )
     valid = valid_host_label.match(region_name)
     if not valid:
         raise InvalidRegionError(region_name=region_name)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -102,6 +102,7 @@ from botocore.utils import (
     switch_host_s3_accelerate,
     switch_to_virtual_host_style,
     validate_jmespath_for_set,
+    validate_region_name,
 )
 from tests import FreezeTime, RawResponse, create_session, mock, unittest
 
@@ -3817,3 +3818,36 @@ class TestJSONFileCacheAtomicWrites(unittest.TestCase):
         self.assertEqual(
             len(temp_files), 0, f'Temp files not cleaned: {temp_files}'
         )
+
+
+class TestValidateRegionName(unittest.TestCase):
+    def test_valid_region_names(self):
+        for name in ['us-east-1', 'eu-west-1', 'ap-southeast-2', 'us-gov-west-1']:
+            validate_region_name(name)
+
+    def test_rejects_empty_string(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('')
+
+    def test_rejects_trailing_newline(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('us-east-1\n')
+
+    def test_rejects_spaces(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('invalid region!')
+
+    def test_rejects_leading_hyphen(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('-us-east-1')
+
+    def test_rejects_trailing_hyphen(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('us-east-1-')
+
+    def test_rejects_numeric_only(self):
+        with self.assertRaises(InvalidRegionError):
+            validate_region_name('12345')
+
+    def test_none_returns_none(self):
+        self.assertIsNone(validate_region_name(None))


### PR DESCRIPTION
fixes #3786

tightened the host-label regex in `validate_region_name` (`botocore/utils.py:1338`):
- `{,63}` changed to `{1,63}` — rejects empty string, which isnt a valid host label
- `$` changed to `\Z` — rejects trailing newlines (python's `$` matches before a trailing `\n`)

the validator runs on S3 cross-region redirect path where region comes from server-controlled headers. practical severity is low (downstream `http.client` catches control chars, and empty region still resolves under `amazonaws.com`), but function's contract says "valid host label" and these inputs violate that.

added `TestValidateRegionName` with 8 tests covering valid regions, empty string, trailing newline, spaces, leading/trailing hyphens, numeric-only, and `None`. verified with the exact reproduction script from the issue.