### PR TITLE
Note SigV2 default for presigned URLs

### DIFF
--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -766,7 +766,7 @@ def generate_presigned_url(
         conditionals and ``Range``, are also silently dropped.
 
         It is recommended to configure the S3 client with Signature
-        Version 4, setting ``signature_version='s3v4'`` in the client's
+        Version 4 by setting ``signature_version='s3v4'`` in the client's
         ``Config``.
 
     :type ClientMethod: string

--- a/botocore/signers.py
+++ b/botocore/signers.py
@@ -758,6 +758,17 @@ def generate_presigned_url(
 ):
     """Generate a presigned url given a client, its method, and arguments
 
+    .. warning::
+
+        For backwards compatibility, S3 presigned URLs use Signature
+        Version 2 by default in regions where S3 supports it. As a result,
+        some ``Params`` entries are not signed. Some headers, including the
+        conditionals and ``Range``, are also silently dropped.
+
+        It is recommended to configure the S3 client with Signature
+        Version 4, setting ``signature_version='s3v4'`` in the client's
+        ``Config``.
+
     :type ClientMethod: string
     :param ClientMethod: The client method to presign for
 


### PR DESCRIPTION
*Description of changes:*

Adds a warning to the `generate_presigned_url` docstring noting that S3 presigned URLs use SigV2 by default, and recommending using SigV4.

*Testing:*

- `make clean html` succeeds. 
- `pytest tests/unit/docs tests/functional/docs` passes. 
- Built with `generate_docs` scoped to `['s3', 'dynamodb']` to confirm the warning reaches only the S3 page. Same check repeated against boto3 with this branch installed locally.

The updated documentations for botocore and boto3 will look like the following:

<img width="1156" height="921" alt="image" src="https://github.com/user-attachments/assets/5a98c311-2370-4d5d-9e46-57cfbf2f7563" />
<img width="1170" height="847" alt="image" src="https://github.com/user-attachments/assets/d529f838-5544-4ee8-8f24-9b67287a9da0" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
