### PR TITLE
fix: deep-copy nested dict options in Config.merge

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -475,10 +475,12 @@ class Config:
             config objects.
         """
         # Make a copy of the current attributes in the config object.
-        config_options = copy.copy(self._user_provided_options)
+        config_options = copy.deepcopy(self._user_provided_options)
 
         # Merge in the user provided options from the other config
-        config_options.update(other_config._user_provided_options)
+        config_options.update(
+            copy.deepcopy(other_config._user_provided_options)
+        )
 
         # Return a new config object with the merged properties.
         return Config(**config_options)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1926,6 +1926,40 @@ class TestConfig(unittest.TestCase):
         self.assertIsNot(new_config, config)
         self.assertIsNot(new_config, other_config)
 
+    def test_merge_deep_copies_nested_dict_options(self):
+        config = botocore.config.Config(
+            retries={'max_attempts': 3, 'mode': 'standard'},
+            s3={'addressing_style': 'auto'},
+            proxies={'https': 'https://proxy.example.com'},
+        )
+        other_config = botocore.config.Config(region_name='us-west-2')
+        new_config = config.merge(other_config)
+
+        self.assertIsNot(new_config.retries, config.retries)
+        self.assertIsNot(new_config.s3, config.s3)
+        self.assertIsNot(new_config.proxies, config.proxies)
+        self.assertEqual(new_config.retries, config.retries)
+        self.assertEqual(new_config.s3, config.s3)
+        self.assertEqual(new_config.proxies, config.proxies)
+
+        new_config.retries['max_attempts'] = 10
+        new_config.s3['addressing_style'] = 'path'
+        self.assertEqual(config.retries['max_attempts'], 3)
+        self.assertEqual(config.s3['addressing_style'], 'auto')
+
+    def test_merge_deep_copies_other_config_nested_dict_options(self):
+        config = botocore.config.Config(region_name='us-east-1')
+        other_config = botocore.config.Config(
+            retries={'max_attempts': 5, 'mode': 'standard'}
+        )
+        new_config = config.merge(other_config)
+
+        self.assertIsNot(new_config.retries, other_config.retries)
+        self.assertEqual(new_config.retries, other_config.retries)
+
+        new_config.retries['max_attempts'] = 10
+        self.assertEqual(other_config.retries['max_attempts'], 5)
+
     def test_general_merge_keeps_default_values(self):
         config = botocore.config.Config()
         other_config = botocore.config.Config()


### PR DESCRIPTION
*Issue #, if available:*
#3792

*Description of changes:*
When `Config.merge()` merges options, it previously performed a shallow copy (`copy.copy`) of `_user_provided_options`. As a result, mutable nested dictionary options (such as `retries`, `s3`, `proxies`, `proxies_config`, `client_context_params`) retained shared references between the merged configuration and the input configurations. Mutating a nested dictionary on the returned `Config` would in-place modify the source `Config` object.

This change uses `copy.deepcopy` when collecting options in `Config.merge()`, ensuring that all nested dictionary options are independently copied and changes made to the merged configuration do not mutate the original configs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.