### PR TITLE
Preserve sub-second precision when serializing unixTimestamp parameters

### DIFF
--- a/.changes/next-release/bugfix-Serialization-52170.json
+++ b/.changes/next-release/bugfix-Serialization-52170.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "Serialization",
-  "description": "Preserve sub-second precision when serializing ``unixTimestamp`` request parameters. Timestamps with a fractional component are now sent as a fractional value (e.g. ``1704110400.123456``) instead of being truncated to whole seconds. Whole-second timestamps are unchanged. This makes the sub-second precision previously enabled only for ``bedrock-agentcore`` the default for all services (fixes `#3255 <https://github.com/boto/botocore/issues/3255>`__)."
+  "description": "Preserve sub-second precision when serializing ``unixTimestamp`` request parameters. Timestamps with a fractional component are now sent as a fractional value (e.g. ``1704110400.123456``) instead of being truncated to whole seconds. Whole-second timestamps are unchanged. This makes the sub-second precision previously enabled only for ``bedrock-agentcore`` the default for all services (fixes `#3255 <https://github.com/boto/botocore/issues/3255>`__). The previous behavior can be restored by setting ``timestamp_precision`` to ``'legacy'`` in a ``creating-serializer`` event handler."
 }

--- a/.changes/next-release/bugfix-Serialization-52170.json
+++ b/.changes/next-release/bugfix-Serialization-52170.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Serialization",
+  "description": "Preserve sub-second precision when serializing ``unixTimestamp`` request parameters. Timestamps with a fractional component are now sent as a fractional value (e.g. ``1704110400.123456``) instead of being truncated to whole seconds. Whole-second timestamps are unchanged. This makes the sub-second precision previously enabled only for ``bedrock-agentcore`` the default for all services (fixes `#3255 <https://github.com/boto/botocore/issues/3255>`__)."
+}

--- a/.changes/next-release/bugfix-Serialization-52170.json
+++ b/.changes/next-release/bugfix-Serialization-52170.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "Serialization",
-  "description": "Preserve sub-second precision when serializing ``unixTimestamp`` request parameters. Timestamps with a fractional component are now sent as a fractional value (e.g. ``1704110400.123456``) instead of being truncated to whole seconds. Whole-second timestamps are unchanged. This makes the sub-second precision previously enabled only for ``bedrock-agentcore`` the default for all services (fixes `#3255 <https://github.com/boto/botocore/issues/3255>`__). The previous behavior can be restored by setting ``timestamp_precision`` to ``'legacy'`` in a ``creating-serializer`` event handler."
+  "description": "Preserve sub-second precision when serializing ``unixTimestamp`` request parameters. Timestamps with a fractional component are now sent as a fractional value (e.g. ``1704110400.123456``) instead of being truncated to whole seconds (fixes `#3255 <https://github.com/boto/botocore/issues/3255>`__). Whole-second timestamps are unchanged. The previous behavior can be restored by setting ``timestamp_precision`` to ``'legacy'`` in a ``creating-serializer`` event handler."
 }

--- a/botocore/handlers.py
+++ b/botocore/handlers.py
@@ -61,7 +61,6 @@ from botocore.exceptions import (
     UnsupportedTLSVersionWarning,
 )
 from botocore.regions import EndpointResolverBuiltins
-from botocore.serialize import TIMESTAMP_PRECISION_MILLISECOND
 from botocore.signers import (
     add_dsql_generate_db_auth_token_methods,
     add_generate_db_auth_token,
@@ -1089,11 +1088,6 @@ def remove_polly_start_speech_synthesis_stream(class_attributes, **kwargs):
         del class_attributes['start_speech_synthesis_stream']
 
 
-def enable_millisecond_timestamp_precision(serializer_kwargs, **kwargs):
-    """Event handler to enable millisecond precision"""
-    serializer_kwargs['timestamp_precision'] = TIMESTAMP_PRECISION_MILLISECOND
-
-
 def add_retry_headers(request, **kwargs):
     retries_context = request.context.get('retries')
     if not retries_context:
@@ -1537,10 +1531,6 @@ BUILTIN_HANDLERS = [
     (
         'creating-client-class.polly',
         remove_polly_start_speech_synthesis_stream,
-    ),
-    (
-        'creating-serializer.bedrock-agentcore',
-        enable_millisecond_timestamp_precision,
     ),
     ('after-call.iam', json_decode_policies),
     (

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -85,7 +85,8 @@ def create_serializer(
     :param include_validation: Whether to include parameter validation.
     :type include_validation: bool
     :param timestamp_precision: Timestamp precision level.
-        - 'default': Microseconds for ISO timestamps, seconds for Unix and RFC
+        - 'default': Full precision of the provided value (up to
+          microseconds) for ISO and Unix timestamps, seconds for RFC
         - 'millisecond': Millisecond precision (ISO/Unix), seconds for RFC
     :type timestamp_precision: str
     :return: A serializer instance for the given protocol.
@@ -187,13 +188,16 @@ class Serializer:
 
     def _timestamp_unixtimestamp(self, value):
         """Return unix timestamp with precision based on timestamp_precision."""
-        # As of the addition of the precision flag, we support millisecond precision here as well
+        timestamp = calendar.timegm(value.timetuple())
         if self._timestamp_precision == TIMESTAMP_PRECISION_MILLISECOND:
-            base_timestamp = calendar.timegm(value.timetuple())
             milliseconds = (value.microsecond // 1000) / 1000.0
-            return base_timestamp + milliseconds
-        else:
-            return int(calendar.timegm(value.timetuple()))
+            return timestamp + milliseconds
+        elif value.microsecond > 0:
+            # Preserve the sub-second precision the caller provided. Integer
+            # arithmetic followed by a single division yields the correctly
+            # rounded float for the exact microsecond value.
+            return (timestamp * 10**6 + value.microsecond) / 10**6
+        return timestamp
 
     def _timestamp_rfc822(self, value):
         """Return RFC822 timestamp (always second precision - RFC doesn't support sub-second)."""
@@ -660,22 +664,12 @@ class CBORSerializer(Serializer):
         tag = 1  # Use tag 1 for unix timestamp
         initial_byte = self._get_initial_byte(self.TAG_MAJOR_TYPE, tag)
         serialized.extend(initial_byte)  # Tagging the timestamp
-        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
-            timestamp
-        )
-
-        if num_bytes == 0:
-            initial_byte = self._get_initial_byte(
-                self.UNSIGNED_INT_MAJOR_TYPE, timestamp
-            )
-            serialized.extend(initial_byte)
+        # Tag 1 permits either an integer or a floating-point epoch seconds
+        # value; a float is used when sub-second precision is present.
+        if isinstance(timestamp, float):
+            self._serialize_type_double(serialized, timestamp, shape, key)
         else:
-            initial_byte = self._get_initial_byte(
-                self.UNSIGNED_INT_MAJOR_TYPE, additional_info
-            )
-            serialized.extend(
-                initial_byte + timestamp.to_bytes(num_bytes, "big")
-            )
+            self._serialize_type_integer(serialized, timestamp, shape, key)
 
     def _serialize_type_float(self, serialized, value, shape, key):
         if self._is_special_number(value):

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -199,9 +199,10 @@ class Serializer:
         elif self._timestamp_precision == TIMESTAMP_PRECISION_LEGACY:
             return timestamp
         elif value.microsecond > 0:
-            # Preserve the sub-second precision the caller provided. Integer
-            # arithmetic followed by a single division yields the correctly
-            # rounded float for the exact microsecond value.
+            # Add the microseconds as integers before dividing so the float is only
+            # rounded once. Dividing first and then adding rounds twice, which can
+            # produce a slightly different value, e.g. 1 + 3691 / 10**6 gives
+            # 1.0036909999999999 instead of 1.003691.
             return (timestamp * 10**6 + value.microsecond) / 10**6
         return timestamp
 

--- a/botocore/serialize.py
+++ b/botocore/serialize.py
@@ -68,9 +68,11 @@ HOST_PREFIX_RE = re.compile(r"^[A-Za-z0-9\.\-]+$")
 
 TIMESTAMP_PRECISION_DEFAULT = 'default'
 TIMESTAMP_PRECISION_MILLISECOND = 'millisecond'
+TIMESTAMP_PRECISION_LEGACY = 'legacy'
 TIMESTAMP_PRECISION_OPTIONS = (
     TIMESTAMP_PRECISION_DEFAULT,
     TIMESTAMP_PRECISION_MILLISECOND,
+    TIMESTAMP_PRECISION_LEGACY,
 )
 
 
@@ -88,6 +90,8 @@ def create_serializer(
         - 'default': Full precision of the provided value (up to
           microseconds) for ISO and Unix timestamps, seconds for RFC
         - 'millisecond': Millisecond precision (ISO/Unix), seconds for RFC
+        - 'legacy': Behavior prior to sub-second Unix timestamp support.
+          Microseconds for ISO timestamps, seconds for Unix and RFC
     :type timestamp_precision: str
     :return: A serializer instance for the given protocol.
     """
@@ -192,6 +196,8 @@ class Serializer:
         if self._timestamp_precision == TIMESTAMP_PRECISION_MILLISECOND:
             milliseconds = (value.microsecond // 1000) / 1000.0
             return timestamp + milliseconds
+        elif self._timestamp_precision == TIMESTAMP_PRECISION_LEGACY:
+            return timestamp
         elif value.microsecond > 0:
             # Preserve the sub-second precision the caller provided. Integer
             # arithmetic followed by a single division yields the correctly

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -17,6 +17,7 @@ import datetime
 import decimal
 import io
 import json
+import struct
 
 import dateutil.tz
 
@@ -622,7 +623,7 @@ class TestRestXMLUnicodeSerialization(unittest.TestCase):
             self.fail("RestXML serializer failed to serialize unicode text.")
 
 
-class TestTimestampPrecisionParameter(unittest.TestCase):
+class TestTimestampPrecision(unittest.TestCase):
     def setUp(self):
         self.model = {
             'metadata': {'protocol': 'query', 'apiVersion': '2014-01-01'},
@@ -673,62 +674,90 @@ class TestTimestampPrecisionParameter(unittest.TestCase):
             input_params, self.service_model.operation_model('TestOperation')
         )
 
-    def test_second_precision_maintains_existing_behavior(self):
+    def test_whole_seconds_serialize_without_fraction(self):
+        test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        request = self.serialize_to_request(
+            {'UnixTimestamp': test_datetime, 'IsoTimestamp': test_datetime}
+        )
+        self.assertEqual(request['body']['UnixTimestamp'], 1704110400)
+        self.assertIsInstance(request['body']['UnixTimestamp'], int)
+        self.assertEqual(
+            request['body']['IsoTimestamp'], '2024-01-01T12:00:00Z'
+        )
+
+    def test_millisecond_precision_is_preserved(self):
+        test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 123000)
+        request = self.serialize_to_request(
+            {'UnixTimestamp': test_datetime, 'IsoTimestamp': test_datetime}
+        )
+        self.assertEqual(request['body']['UnixTimestamp'], 1704110400.123)
+        self.assertEqual(
+            request['body']['IsoTimestamp'], '2024-01-01T12:00:00.123000Z'
+        )
+
+    def test_microsecond_precision_is_preserved(self):
         test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 123456)
         request = self.serialize_to_request(
             {'UnixTimestamp': test_datetime, 'IsoTimestamp': test_datetime}
         )
-        # To maintain backwards compatibility, unix should not include milliseconds by default
-        self.assertEqual(1704110400, request['body']['UnixTimestamp'])
-
-        # ISO always supported microseconds, so we need to continue supporting this
+        self.assertEqual(request['body']['UnixTimestamp'], 1704110400.123456)
         self.assertEqual(
-            '2024-01-01T12:00:00.123456Z',
-            request['body']['IsoTimestamp'],
+            request['body']['IsoTimestamp'], '2024-01-01T12:00:00.123456Z'
         )
 
-    def test_millisecond_precision_serialization(self):
+    def test_unix_timestamp_fraction_round_trips_through_repr(self):
+        # The float must render with exactly the digits the caller provided
+        # (no binary floating point noise) when written to a request body.
         test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 123456)
-
-        # Check that millisecond precision is used when it is opted in to via the input param
-        request = self.serialize_to_request(
-            {'UnixTimestamp': test_datetime, 'IsoTimestamp': test_datetime},
-            TIMESTAMP_PRECISION_MILLISECOND,
-        )
-        self.assertEqual(1704110400.123, request['body']['UnixTimestamp'])
+        request = self.serialize_to_request({'UnixTimestamp': test_datetime})
         self.assertEqual(
-            '2024-01-01T12:00:00.123Z',
-            request['body']['IsoTimestamp'],
+            str(request['body']['UnixTimestamp']), '1704110400.123456'
         )
 
-    def test_millisecond_precision_with_zero_microseconds(self):
-        test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 0)
-
-        request = self.serialize_to_request(
-            {'UnixTimestamp': test_datetime, 'IsoTimestamp': test_datetime},
-            TIMESTAMP_PRECISION_MILLISECOND,
-        )
-        self.assertEqual(1704110400.0, request['body']['UnixTimestamp'])
-        self.assertEqual(
-            '2024-01-01T12:00:00.000Z',
-            request['body']['IsoTimestamp'],
-        )
+    def test_unix_timestamp_before_epoch_with_fraction(self):
+        test_datetime = datetime.datetime(1969, 12, 31, 23, 59, 59, 250000)
+        request = self.serialize_to_request({'UnixTimestamp': test_datetime})
+        self.assertEqual(request['body']['UnixTimestamp'], -0.75)
 
     def test_rfc822_timestamp_always_uses_second_precision(self):
         # RFC822 format doesn't support sub-second precision.
         test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 123456)
-        request_second = self.serialize_to_request(
-            {'Rfc822Timestamp': test_datetime},
+        request_default = self.serialize_to_request(
+            {'Rfc822Timestamp': test_datetime}
         )
         request_milli = self.serialize_to_request(
             {'Rfc822Timestamp': test_datetime}, TIMESTAMP_PRECISION_MILLISECOND
         )
         self.assertEqual(
-            request_second['body']['Rfc822Timestamp'],
-            request_milli['body']['Rfc822Timestamp'],
+            request_default['body']['Rfc822Timestamp'],
+            'Mon, 01 Jan 2024 12:00:00 GMT',
         )
-        self.assertIn('2024', request_second['body']['Rfc822Timestamp'])
-        self.assertIn('GMT', request_second['body']['Rfc822Timestamp'])
+        self.assertEqual(
+            request_milli['body']['Rfc822Timestamp'],
+            request_default['body']['Rfc822Timestamp'],
+        )
+
+    def test_millisecond_precision_option_truncates_to_milliseconds(self):
+        test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 123456)
+        request = self.serialize_to_request(
+            {'UnixTimestamp': test_datetime, 'IsoTimestamp': test_datetime},
+            TIMESTAMP_PRECISION_MILLISECOND,
+        )
+        self.assertEqual(request['body']['UnixTimestamp'], 1704110400.123)
+        self.assertEqual(
+            request['body']['IsoTimestamp'], '2024-01-01T12:00:00.123Z'
+        )
+
+    def test_millisecond_precision_option_with_zero_microseconds(self):
+        test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 0)
+        request = self.serialize_to_request(
+            {'UnixTimestamp': test_datetime, 'IsoTimestamp': test_datetime},
+            TIMESTAMP_PRECISION_MILLISECOND,
+        )
+        self.assertEqual(request['body']['UnixTimestamp'], 1704110400.0)
+        self.assertEqual(
+            request['body']['IsoTimestamp'], '2024-01-01T12:00:00.000Z'
+        )
 
     def test_invalid_timestamp_precision_raises_error(self):
         with self.assertRaises(ValueError) as context:
@@ -737,6 +766,73 @@ class TestTimestampPrecisionParameter(unittest.TestCase):
                 timestamp_precision='invalid',
             )
         self.assertIn("Invalid timestamp precision", str(context.exception))
+
+
+class TestRpcV2CBORTimestampSerialization(unittest.TestCase):
+    def setUp(self):
+        self.model = {
+            'metadata': {
+                'protocol': 'smithy-rpc-v2-cbor',
+                'apiVersion': '2014-01-01',
+                'serviceId': 'MyService',
+                'targetPrefix': 'sampleservice',
+                'documentation': '',
+            },
+            'operations': {
+                'TestOperation': {
+                    'name': 'TestOperation',
+                    'input': {'shape': 'InputShape'},
+                }
+            },
+            'shapes': {
+                'InputShape': {
+                    'type': 'structure',
+                    'members': {
+                        'Timestamp': {'shape': 'TimestampType'},
+                    },
+                },
+                'TimestampType': {'type': 'timestamp'},
+            },
+        }
+        self.service_model = ServiceModel(self.model)
+
+    def serialize_timestamp(self, value):
+        request_serializer = serialize.create_serializer(
+            self.service_model.metadata['protocol']
+        )
+        request = request_serializer.serialize_to_request(
+            {'Timestamp': value},
+            self.service_model.operation_model('TestOperation'),
+        )
+        # Skip the leading map header and "Timestamp" key; return the
+        # encoded value only.
+        body = bytes(request['body'])
+        prefix = b'\xa1\x69Timestamp'
+        self.assertTrue(body.startswith(prefix))
+        return body[len(prefix) :]
+
+    def test_whole_seconds_serialize_as_tagged_integer(self):
+        encoded = self.serialize_timestamp(
+            datetime.datetime(2024, 1, 1, 12, 0, 0)
+        )
+        # Tag 1, then uint32 1704110400
+        self.assertEqual(encoded, b'\xc1\x1a\x65\x92\xa9\x40')
+
+    def test_fractional_seconds_serialize_as_tagged_double(self):
+        encoded = self.serialize_timestamp(
+            datetime.datetime(2024, 1, 1, 12, 0, 0, 500000)
+        )
+        # Tag 1, then float64 1704110400.5
+        self.assertEqual(
+            encoded, b'\xc1\xfb' + struct.pack('>d', 1704110400.5)
+        )
+
+    def test_negative_timestamp_serializes_as_tagged_negative_integer(self):
+        encoded = self.serialize_timestamp(
+            datetime.datetime(1969, 12, 31, 23, 59, 59)
+        )
+        # Tag 1, then negative integer -1 (major type 1, value 0)
+        self.assertEqual(encoded, b'\xc1\x20')
 
 
 class TestRpcV2CBORHostPrefix(unittest.TestCase):

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -26,6 +26,7 @@ from botocore.exceptions import ParamValidationError
 from botocore.model import ServiceModel
 from botocore.serialize import (
     TIMESTAMP_PRECISION_DEFAULT,
+    TIMESTAMP_PRECISION_LEGACY,
     TIMESTAMP_PRECISION_MILLISECOND,
 )
 from tests import unittest
@@ -757,6 +758,28 @@ class TestTimestampPrecision(unittest.TestCase):
         self.assertEqual(request['body']['UnixTimestamp'], 1704110400.0)
         self.assertEqual(
             request['body']['IsoTimestamp'], '2024-01-01T12:00:00.000Z'
+        )
+
+    def test_legacy_precision_option_truncates_unix_to_seconds(self):
+        test_datetime = datetime.datetime(2024, 1, 1, 12, 0, 0, 123456)
+        request = self.serialize_to_request(
+            {
+                'UnixTimestamp': test_datetime,
+                'IsoTimestamp': test_datetime,
+                'Rfc822Timestamp': test_datetime,
+            },
+            TIMESTAMP_PRECISION_LEGACY,
+        )
+        # Legacy behavior: whole seconds for unix, but ISO8601 has always
+        # carried microseconds.
+        self.assertEqual(request['body']['UnixTimestamp'], 1704110400)
+        self.assertIsInstance(request['body']['UnixTimestamp'], int)
+        self.assertEqual(
+            request['body']['IsoTimestamp'], '2024-01-01T12:00:00.123456Z'
+        )
+        self.assertEqual(
+            request['body']['Rfc822Timestamp'],
+            'Mon, 01 Jan 2024 12:00:00 GMT',
         )
 
     def test_invalid_timestamp_precision_raises_error(self):


### PR DESCRIPTION
## Overview

Botocore currently serializes `unixTimestamp` request parameters as `int(calendar.timegm(...))`, dropping any sub-second precision the caller provided. This affects every `json`, `rest-json`, and `smithy-rpc-v2-cbor` body timestamp. `iso8601` has always carried microseconds, so only the epoch-seconds format had this issue.

In #3568, we applied a customization to work around this for `bedrock-agentcore` through a new `creating-serializer` handler. This PR makes sub-second precision the default for all services and removes that customization.

Fixes #3255.

## Decisions

1. Smithy specifies 1 ms resolution and says receivers should truncate finer values. I chose not to truncate here. `iso8601` has sent microseconds for botocore's whole history, and one rule for both formats is simpler than two. Additionally, I'd rather not alter customer provided precision at all. I'm open to changing this

2. I decided to keep `creating-serializer` and `timestamp_precision` since customers may have become reliant on them. (aiobotocore mirrors the event emission). Only the `bedrock-agentcore` registration and its handler are removed.

3. I added `timestamp_precision='legacy'`. Restores the old behavior, globally or per service, through `creating-serializer[.<service>]`. If a service rejects fractional epoch seconds we can register a handler for it without a serializer change.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
